### PR TITLE
🐛 Fix dynamic filter construction for dictionary where clauses

### DIFF
--- a/tests/integration/database/repository/test_dynamic_filter_construction.py
+++ b/tests/integration/database/repository/test_dynamic_filter_construction.py
@@ -1,0 +1,315 @@
+"""Test that demonstrates and fixes the dynamic filter construction bug.
+
+When a GraphQL resolver dynamically modifies or adds filters to the `where` parameter,
+the filters should be properly applied to the database query.
+
+Related issue: /tmp/fraiseql_filter_not_applied_issue.md
+"""
+
+import pytest
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+from decimal import Decimal
+
+pytestmark = pytest.mark.database
+
+# Import database fixtures
+from tests.fixtures.database.database_conftest import *  # noqa: F403
+
+from fraiseql.db import FraiseQLRepository, register_type_for_view
+
+
+@pytest.mark.asyncio
+class TestDynamicFilterConstruction:
+    """Test suite for dynamic filter construction in repository find() method."""
+
+    async def test_dynamic_dict_filter_construction(self, db_pool):
+        """Test that dictionary where clauses are properly processed when constructed dynamically."""
+
+        # Set up test data
+        async with db_pool.connection() as conn:
+            # Create test table
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS test_allocation (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    name TEXT NOT NULL,
+                    is_current BOOLEAN NOT NULL DEFAULT false,
+                    tenant_id UUID NOT NULL,
+                    quantity NUMERIC(10, 2) NOT NULL,
+                    created_at TIMESTAMPTZ DEFAULT NOW()
+                )
+            """)
+
+            # Clear existing data
+            await conn.execute("DELETE FROM test_allocation")
+
+            # Insert test data
+            tenant_id = "22222222-2222-2222-2222-222222222222"
+            test_data = []
+
+            # Insert 10 current allocations and 15 past allocations
+            for i in range(25):
+                is_current = i < 10  # First 10 are current
+                test_data.append((
+                    f"Allocation {i+1}",
+                    is_current,
+                    tenant_id,
+                    Decimal(100 + i * 10)
+                ))
+
+            async with conn.cursor() as cursor:
+                await cursor.executemany(
+                    """
+                    INSERT INTO test_allocation (name, is_current, tenant_id, quantity)
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    test_data
+                )
+            await conn.commit()
+
+        # Create repository instance in production mode (returns dicts)
+        repo = FraiseQLRepository(db_pool, context={"mode": "production"})
+
+        # Simulate the pattern from the bug report: dynamically building where clause
+        where = None
+        period = "CURRENT"  # Simulating enum value
+
+        # Dynamic filter construction (the problematic pattern)
+        if period == "CURRENT":
+            if where is None:
+                where = {}
+            where["is_current"] = {"eq": True}
+
+        # This should return only current allocations (10 items)
+        results = await repo.find(
+            "test_allocation",
+            tenant_id=tenant_id,
+            where=where,
+            limit=100
+        )
+
+        # Verify the filter was applied
+        assert len(results) == 10, f"Expected 10 current allocations, got {len(results)}"
+
+        # Check if results are dicts (development mode)
+        for r in results:
+            assert r["is_current"] is True, f"Result has is_current={r['is_current']}, expected True"
+
+    async def test_merged_dict_filters(self, db_pool):
+        """Test merging multiple dynamic filters into a where clause."""
+
+        # Set up test data
+        async with db_pool.connection() as conn:
+            # Create test table
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS test_product (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    name TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    price NUMERIC(10, 2) NOT NULL,
+                    is_active BOOLEAN NOT NULL DEFAULT true,
+                    tenant_id UUID NOT NULL
+                )
+            """)
+
+            # Clear existing data
+            await conn.execute("DELETE FROM test_product")
+
+            # Insert test data
+            tenant_id = "33333333-3333-3333-3333-333333333333"
+
+            products = [
+                ("Widget A", "electronics", Decimal("99.99"), True),
+                ("Widget B", "electronics", Decimal("149.99"), True),
+                ("Gadget A", "accessories", Decimal("49.99"), True),
+                ("Gadget B", "accessories", Decimal("79.99"), False),
+                ("Tool A", "tools", Decimal("199.99"), True),
+                ("Tool B", "tools", Decimal("299.99"), False),
+            ]
+
+            async with conn.cursor() as cursor:
+                for name, category, price, is_active in products:
+                    await cursor.execute(
+                        """
+                        INSERT INTO test_product (name, category, price, is_active, tenant_id)
+                        VALUES (%s, %s, %s, %s, %s)
+                        """,
+                        (name, category, price, is_active, tenant_id)
+                    )
+            await conn.commit()
+
+        # Register type for development mode
+        class TestProduct:
+            pass
+        register_type_for_view("test_product", TestProduct)
+
+        repo = FraiseQLRepository(db_pool, context={"mode": "production"})
+
+        # Build dynamic where clause with multiple conditions
+        where = {}
+
+        # Add category filter dynamically
+        filter_category = "electronics"
+        if filter_category:
+            where["category"] = {"eq": filter_category}
+
+        # Add price range filter dynamically
+        min_price = 100
+        if min_price:
+            if "price" not in where:
+                where["price"] = {}
+            where["price"]["gte"] = min_price
+
+        # Add active filter dynamically
+        only_active = True
+        if only_active:
+            where["is_active"] = {"eq": True}
+
+        # Execute query with dynamic filters
+        results = await repo.find(
+            "test_product",
+            tenant_id=tenant_id,
+            where=where
+        )
+
+        # Should return only Widget B (electronics, price >= 100, active)
+        assert len(results) == 1, f"Expected 1 product, got {len(results)}"
+        assert results[0]["name"] == "Widget B"
+        assert results[0]["category"] == "electronics"
+        assert float(results[0]["price"]) == 149.99
+        assert results[0]["is_active"] is True
+
+    async def test_empty_dict_where_to_populated(self, db_pool):
+        """Test that starting with empty dict and populating it works."""
+
+        # Set up test data
+        async with db_pool.connection() as conn:
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS test_items (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    name TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    tenant_id UUID NOT NULL
+                )
+            """)
+
+            await conn.execute("DELETE FROM test_items")
+
+            tenant_id = "44444444-4444-4444-4444-444444444444"
+
+            items = [
+                ("Item 1", "pending"),
+                ("Item 2", "active"),
+                ("Item 3", "active"),
+                ("Item 4", "inactive"),
+                ("Item 5", "pending"),
+            ]
+
+            async with conn.cursor() as cursor:
+                for name, status in items:
+                    await cursor.execute(
+                        """
+                        INSERT INTO test_items (name, status, tenant_id)
+                        VALUES (%s, %s, %s)
+                        """,
+                        (name, status, tenant_id)
+                    )
+            await conn.commit()
+
+        # Register type for development mode
+        class TestItem:
+            pass
+        register_type_for_view("test_items", TestItem)
+
+        repo = FraiseQLRepository(db_pool, context={"mode": "production"})
+
+        # Start with empty where dict (common pattern in resolvers)
+        where = {}
+
+        # Dynamically add filter based on some condition
+        filter_status = "active"
+        if filter_status:
+            where["status"] = {"eq": filter_status}
+
+        results = await repo.find(
+            "test_items",
+            tenant_id=tenant_id,
+            where=where
+        )
+
+        # Should return only active items
+        assert len(results) == 2, f"Expected 2 active items, got {len(results)}"
+        assert all(r["status"] == "active" for r in results)
+
+    async def test_complex_nested_dict_filters(self, db_pool):
+        """Test complex dictionary filters with multiple operators."""
+
+        # Set up test data
+        async with db_pool.connection() as conn:
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS test_events (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    attendees INTEGER NOT NULL,
+                    tenant_id UUID NOT NULL
+                )
+            """)
+
+            await conn.execute("DELETE FROM test_events")
+
+            tenant_id = "55555555-5555-5555-5555-555555555555"
+
+            events = [
+                ("Small Meeting", "Team sync", 5),
+                ("Department Meeting", "Monthly review", 20),
+                ("All Hands", "Company update", 150),
+                ("Workshop", "Training session", 30),
+                ("Conference", "Annual conference", 500),
+            ]
+
+            async with conn.cursor() as cursor:
+                for title, desc, attendees in events:
+                    await cursor.execute(
+                        """
+                        INSERT INTO test_events (title, description, attendees, tenant_id)
+                        VALUES (%s, %s, %s, %s)
+                        """,
+                        (title, desc, attendees, tenant_id)
+                    )
+            await conn.commit()
+
+        # Register type for development mode
+        class TestEvent:
+            pass
+        register_type_for_view("test_events", TestEvent)
+
+        repo = FraiseQLRepository(db_pool, context={"mode": "production"})
+
+        # Build complex where clause dynamically
+        where = {}
+
+        # Add text search filter
+        search_term = "meeting"
+        if search_term:
+            where["title"] = {"ilike": f"%{search_term}%"}
+
+        # Add range filter with multiple operators
+        min_attendees = 10
+        max_attendees = 100
+        where["attendees"] = {
+            "gte": min_attendees,
+            "lte": max_attendees
+        }
+
+        results = await repo.find(
+            "test_events",
+            tenant_id=tenant_id,
+            where=where
+        )
+
+        # Should return Department Meeting (title contains "meeting", 20 attendees in range)
+        assert len(results) == 1, f"Expected 1 event, got {len(results)}"
+        assert results[0]["title"] == "Department Meeting"
+        assert results[0]["attendees"] == 20

--- a/tests/integration/database/repository/test_jsonb_vs_dict_filtering.py
+++ b/tests/integration/database/repository/test_jsonb_vs_dict_filtering.py
@@ -1,0 +1,208 @@
+"""Test to verify that both JSONB WhereInput and dictionary filters work correctly.
+
+This test ensures that:
+1. WhereInput types use JSONB paths for views with JSONB data columns
+2. Dictionary filters use direct column names for regular tables
+"""
+
+import pytest
+from decimal import Decimal
+from uuid import uuid4
+
+pytestmark = pytest.mark.database
+
+from tests.fixtures.database.database_conftest import *  # noqa: F403
+
+import fraiseql
+from fraiseql.db import FraiseQLRepository, register_type_for_view
+from fraiseql.sql.where_generator import safe_create_where_type
+
+
+@fraiseql.type
+class TestProduct:
+    """Product type for testing."""
+    id: str
+    name: str
+    price: Decimal
+    category: str
+    is_active: bool
+
+
+# Generate WhereInput type for JSONB filtering
+TestProductWhere = safe_create_where_type(TestProduct)
+
+
+class TestJSONBvsDictFiltering:
+    """Test that both JSONB and direct column filtering work correctly."""
+
+    @pytest.fixture
+    async def setup_test_data(self, db_pool):
+        """Create both regular table and JSONB view for testing."""
+        async with db_pool.connection() as conn:
+            # Create regular table (no JSONB column)
+            await conn.execute("""
+                CREATE TABLE IF NOT EXISTS test_products_regular (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    name TEXT NOT NULL,
+                    price NUMERIC(10, 2) NOT NULL,
+                    category TEXT NOT NULL,
+                    is_active BOOLEAN NOT NULL DEFAULT true
+                )
+            """)
+
+            # Create view with JSONB data column
+            await conn.execute("""
+                CREATE OR REPLACE VIEW test_products_jsonb AS
+                SELECT
+                    id, name, price, category, is_active,
+                    jsonb_build_object(
+                        'id', id,
+                        'name', name,
+                        'price', price,
+                        'category', category,
+                        'is_active', is_active
+                    ) as data
+                FROM test_products_regular
+            """)
+
+            # Clear and insert test data
+            await conn.execute("DELETE FROM test_products_regular")
+
+            products = [
+                (str(uuid4()), "Widget A", Decimal("99.99"), "electronics", True),
+                (str(uuid4()), "Widget B", Decimal("149.99"), "electronics", True),
+                (str(uuid4()), "Gadget A", Decimal("49.99"), "accessories", False),
+                (str(uuid4()), "Tool A", Decimal("199.99"), "tools", True),
+            ]
+
+            async with conn.cursor() as cursor:
+                for id_val, name, price, category, is_active in products:
+                    await cursor.execute(
+                        """
+                        INSERT INTO test_products_regular
+                        (id, name, price, category, is_active)
+                        VALUES (%s, %s, %s, %s, %s)
+                        """,
+                        (id_val, name, price, category, is_active)
+                    )
+            await conn.commit()
+
+            return len(products)
+
+    @pytest.mark.asyncio
+    async def test_whereinput_uses_jsonb_paths(self, db_pool, setup_test_data):
+        """Test that WhereInput types correctly use JSONB paths for views with data column."""
+        # setup_test_data is already executed as a fixture
+
+        # Register type for development mode
+        register_type_for_view("test_products_jsonb", TestProduct)
+
+        repo = FraiseQLRepository(db_pool, context={"mode": "development"})
+
+        # Use WhereInput type - this should use JSONB paths (data->>'field')
+        where = TestProductWhere(
+            category={"eq": "electronics"},
+            is_active={"eq": True}
+        )
+
+        # This should work because the view has a 'data' JSONB column
+        results = await repo.find("test_products_jsonb", where=where)
+
+        assert len(results) == 2  # Widget A and Widget B
+        for product in results:
+            assert product.category == "electronics"
+            assert product.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_dict_filters_use_direct_columns(self, db_pool, setup_test_data):
+        """Test that dictionary filters use direct column names for regular tables."""
+        # setup_test_data is already executed as a fixture
+
+        repo = FraiseQLRepository(db_pool, context={"mode": "production"})
+
+        # Use dictionary filter - this should use direct column names
+        where = {
+            "category": {"eq": "electronics"},
+            "is_active": {"eq": True}
+        }
+
+        # This should work on the regular table (no JSONB column)
+        results = await repo.find("test_products_regular", where=where)
+
+        assert len(results) == 2  # Widget A and Widget B
+        for product in results:
+            assert product["category"] == "electronics"
+            assert product["is_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_dynamic_dict_filter_construction(self, db_pool, setup_test_data):
+        """Test dynamic filter construction pattern (the original bug case)."""
+        # setup_test_data is already executed as a fixture
+
+        repo = FraiseQLRepository(db_pool, context={"mode": "production"})
+
+        # Simulate dynamic filter construction in a resolver
+        where = {}
+
+        # Dynamically add filters based on conditions
+        filter_active = True
+        if filter_active:
+            where["is_active"] = {"eq": True}
+
+        min_price = 100
+        if min_price:
+            where["price"] = {"gte": min_price}
+
+        # This should work on regular table
+        results = await repo.find("test_products_regular", where=where)
+
+        # Should return products that are active AND price >= 100
+        assert len(results) == 2  # Widget B and Tool A
+        for product in results:
+            assert product["is_active"] is True
+            assert float(product["price"]) >= 100
+
+    @pytest.mark.asyncio
+    async def test_whereinput_on_regular_table_fails(self, db_pool, setup_test_data):
+        """Test that WhereInput fails gracefully on tables without JSONB data column."""
+        # setup_test_data is already executed as a fixture
+
+        register_type_for_view("test_products_regular", TestProduct)
+        repo = FraiseQLRepository(db_pool, context={"mode": "development"})
+
+        # WhereInput type expects JSONB paths
+        where = TestProductWhere(category={"eq": "electronics"})
+
+        # This should fail because regular table doesn't have 'data' column
+        with pytest.raises(Exception) as exc_info:
+            await repo.find("test_products_regular", where=where)
+
+        # Should get a column does not exist error
+        assert "column" in str(exc_info.value).lower()
+        assert "data" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_mixed_whereinput_and_kwargs(self, db_pool, setup_test_data):
+        """Test combining WhereInput with additional kwargs filters."""
+        # setup_test_data is already executed as a fixture
+
+        register_type_for_view("test_products_jsonb", TestProduct)
+        repo = FraiseQLRepository(db_pool, context={"mode": "development"})
+
+        # Use WhereInput for complex filtering
+        where = TestProductWhere(price={"gte": 50, "lte": 150})
+
+        # Add simple kwargs filter
+        results = await repo.find(
+            "test_products_jsonb",
+            where=where,
+            is_active=True  # Additional simple filter
+        )
+
+        # Should return products with price between 50-150 AND active
+        # That's Widget A (99.99) but NOT Widget B (149.99) because it's at the upper bound
+        # Actually Widget B is 149.99 which is <= 150, so both should match
+        assert len(results) == 2  # Widget A and Widget B
+        for product in results:
+            assert product.is_active is True
+            assert 50 <= float(product.price) <= 150


### PR DESCRIPTION
## Summary
Fixes issue where dynamically constructed dictionary filters in GraphQL resolvers were not being applied to database queries.

## Problem
When resolvers dynamically build where clauses as plain dictionaries (not WhereInput types), the filters were incorrectly using JSONB paths (`data->>'field_name'`) instead of direct column names. This caused queries to fail with "column 'data' does not exist" errors on regular tables.

## Solution
- Modified `_build_dict_where_condition()` to use `Identifier(field_name)` instead of JSONB path expressions
- Updated `_build_basic_dict_condition()` fallback to use direct column names
- Added support for 'ilike' and 'like' operators in fallback conditions
- Added comprehensive documentation explaining the distinction

## Key Distinction
FraiseQL now properly distinguishes between:
1. **WhereInput types** (created with `safe_create_where_type()`) - Use JSONB paths for views with `data` columns
2. **Dictionary filters** (plain Python dicts) - Use direct column names for regular tables

## Changes
- Fixed dictionary filter SQL generation in `src/fraiseql/db.py`
- Added comprehensive tests in `test_dynamic_filter_construction.py`
- Added validation tests in `test_jsonb_vs_dict_filtering.py` 
- Updated documentation in `docs/core-concepts/filtering-and-where-clauses.md`

## Testing
- ✅ All existing tests pass
- ✅ New tests verify both JSONB and dictionary filtering work correctly
- ✅ Tests confirm the fix enables dynamic filter construction patterns

## Example Usage
```python
# Dynamic filter construction now works correctly
@fraiseql.query
async def allocations(info, period: Period | None = None) -> list[Allocation]:
    where = {}
    
    # Dynamically add filters based on arguments
    if period == Period.CURRENT:
        where["is_current"] = {"eq": True}  # This now generates: is_current = true
    
    return await repo.find("tb_allocation", where=where)
```

## Related Issue
Fixes filter issue reported in `/tmp/fraiseql_filter_not_applied_issue.md`

🤖 Generated with [Claude Code](https://claude.ai/code)