### PR TITLE
🐛 Fix nested object filtering in JSONB WHERE clauses

### DIFF
--- a/tests/integration/database/sql/test_where_generator.py
+++ b/tests/integration/database/sql/test_where_generator.py
@@ -475,7 +475,8 @@ class TestSafeCreateWhereType:
 
         # Validate complete SQL - adjusted for our casting approach
         assert "((data ->> 'id'))::numeric = 1" in sql_str
-        assert "(data ->> 'name') = 'test'" in sql_str
+        # Child's name should now be accessed via nested path: data -> 'child' ->> 'name'
+        assert "(data -> 'child' ->> 'name') = 'test'" in sql_str
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## Summary
- Fixed incorrect SQL generation for nested object filters in GraphQL WHERE clauses
- Nested filters now correctly generate JSONB paths like `data -> 'machine' ->> 'id'` instead of accessing fields at root level

## Problem
When using nested object filters in GraphQL WHERE clauses with JSONB-backed tables, FraiseQL was generating incorrect SQL that didn't properly handle the nested object path. This caused filters to fail silently and return unfiltered results.

**Before (incorrect):**
```sql
WHERE (data ->> 'id') = '01513100-0000-0000-0000-000000000066'
```

**After (correct):**
```sql
WHERE (data -> 'machine' ->> 'id') = '01513100-0000-0000-0000-000000000066'
```

## Changes
- Modified `where_generator.py` to pass `parent_path` through the `to_sql()` method chain
- Added `_build_nested_path()` helper function for cleaner path construction
- Updated the `DynamicType` Protocol to include the new parameter
- Fixed logical operators (AND, OR, NOT) to also pass parent_path
- Enhanced tests to validate correct JSONB path generation
- Added deep nesting test coverage (3+ levels)
- Updated existing test that expected the old (incorrect) behavior

## Test plan
- [x] All existing tests pass (3283 tests)
- [x] New test validates correct nested path generation
- [x] Deep nesting (3+ levels) test added and passes
- [x] Ruff linter passes
- [x] No regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)