### PR TITLE
feat(realtime): Phase 16 — CDC wiring, broadcast, presence, tenant filtering

### DIFF
--- a/crates/fraiseql-core/src/runtime/subscription/manager.rs
+++ b/crates/fraiseql-core/src/runtime/subscription/manager.rs
@@ -357,6 +357,23 @@ impl SubscriptionManager {
         event: &SubscriptionEvent,
         subscription: &ActiveSubscription,
     ) -> bool {
+        // Tenant isolation: if the subscription has a tenant_id, only deliver
+        // events from the same tenant. Events without a tenant_id bypass the check.
+        if let Some(ref sub_tenant) = subscription.tenant_id {
+            match event.tenant_id {
+                Some(ref event_tenant) if event_tenant != sub_tenant => {
+                    tracing::trace!(
+                        subscription_id = %subscription.id,
+                        sub_tenant = sub_tenant,
+                        event_tenant = event_tenant,
+                        "Tenant mismatch — event filtered"
+                    );
+                    return false;
+                }
+                _ => {} // match or no tenant on event (pass through)
+            }
+        }
+
         // Check entity type matches (subscription return_type maps to entity)
         if subscription.definition.return_type != event.entity_type {
             return false;

--- a/crates/fraiseql-core/src/runtime/subscription/tests.rs
+++ b/crates/fraiseql-core/src/runtime/subscription/tests.rs
@@ -247,6 +247,7 @@ fn test_webhook_payload_from_event() {
         old_data:        None,
         timestamp:       chrono::Utc::now(),
         sequence_number: 42,
+        tenant_id:       None,
     };
 
     let payload = WebhookPayload::from_event(&event, "order_created");
@@ -319,6 +320,7 @@ fn test_kafka_message_from_event() {
         old_data:        Some(serde_json::json!({"id": "usr_123", "name": "Jane"})),
         timestamp:       chrono::Utc::now(),
         sequence_number: 100,
+        tenant_id:       None,
     };
 
     let message = KafkaMessage::from_event(&event, "user_updated");
@@ -344,6 +346,7 @@ fn test_kafka_message_key() {
         old_data:        None,
         timestamp:       chrono::Utc::now(),
         sequence_number: 1,
+        tenant_id:       None,
     };
 
     let message = KafkaMessage::from_event(&event, "test_sub");

--- a/crates/fraiseql-core/src/runtime/subscription/types.rs
+++ b/crates/fraiseql-core/src/runtime/subscription/types.rs
@@ -92,6 +92,10 @@ pub struct SubscriptionEvent {
     /// Optional old data (for UPDATE operations).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub old_data: Option<serde_json::Value>,
+
+    /// Tenant identifier for multi-tenant isolation (from `fk_customer_org`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
 }
 
 impl SubscriptionEvent {
@@ -112,6 +116,7 @@ impl SubscriptionEvent {
             sequence_number: 0, // Set by manager
             data,
             old_data: None,
+            tenant_id: None,
         }
     }
 
@@ -126,6 +131,13 @@ impl SubscriptionEvent {
     #[must_use]
     pub const fn with_sequence(mut self, seq: u64) -> Self {
         self.sequence_number = seq;
+        self
+    }
+
+    /// Set the tenant identifier for multi-tenant filtering.
+    #[must_use]
+    pub fn with_tenant_id(mut self, tenant_id: impl Into<String>) -> Self {
+        self.tenant_id = Some(tenant_id.into());
         self
     }
 }
@@ -160,6 +172,12 @@ pub struct ActiveSubscription {
     /// when **every** condition matches the event data (AND semantics).
     /// An empty list means no RLS filtering (admin or no RLS policy).
     pub rls_conditions: Vec<(String, serde_json::Value)>,
+
+    /// Tenant identifier for multi-tenant isolation.
+    ///
+    /// When set, only events with a matching `tenant_id` are delivered.
+    /// Extracted from the subscriber's JWT `fk_customer_org` claim at subscribe time.
+    pub tenant_id: Option<String>,
 }
 
 impl ActiveSubscription {
@@ -189,6 +207,7 @@ impl ActiveSubscription {
             created_at: chrono::Utc::now(),
             connection_id: connection_id.into(),
             rls_conditions: Vec::new(),
+            tenant_id: None,
         }
     }
 

--- a/crates/fraiseql-core/tests/e2e_python_authoring.rs
+++ b/crates/fraiseql-core/tests/e2e_python_authoring.rs
@@ -187,13 +187,15 @@ fn test_python_requires_directive() {
     order_type.set_field_directives(
         "shippingEstimate".to_string(),
         FieldFederationDirectives {
-            requires:  vec![FieldPathSelection {
+            requires:      vec![FieldPathSelection {
                 path:     vec!["weight".to_string()],
                 typename: "Order".to_string(),
             }],
-            provides:  vec![],
-            external:  false,
-            shareable: false,
+            provides:      vec![],
+            external:      false,
+            shareable:     false,
+            inaccessible:  false,
+            override_from: None,
         },
     );
 

--- a/crates/fraiseql-core/tests/e2e_typescript_authoring.rs
+++ b/crates/fraiseql-core/tests/e2e_typescript_authoring.rs
@@ -476,10 +476,12 @@ fn test_typescript_shareable_directive() {
     user_type.set_field_directives(
         "id".to_string(),
         FieldFederationDirectives {
-            requires:  vec![],
-            provides:  vec![],
-            external:  false,
-            shareable: true,
+            requires:      vec![],
+            provides:      vec![],
+            external:      false,
+            shareable:     true,
+            inaccessible:  false,
+            override_from: None,
         },
     );
 

--- a/crates/fraiseql-core/tests/federation/common.rs
+++ b/crates/fraiseql-core/tests/federation/common.rs
@@ -240,15 +240,16 @@ pub fn metadata_extended_type(
         enabled: true,
         version: "v2".to_string(),
         types:   vec![FederatedType {
-            name:             type_name.to_string(),
-            keys:             vec![KeyDirective {
+            name:                type_name.to_string(),
+            keys:                vec![KeyDirective {
                 fields:     vec![key_field.to_string()],
                 resolvable: true,
             }],
-            is_extends:       true,
-            external_fields:  external_fields.iter().map(|s| (*s).to_string()).collect(),
-            shareable_fields: shareable_fields.iter().map(|s| (*s).to_string()).collect(),
-            field_directives: std::collections::HashMap::new(),
+            is_extends:          true,
+            external_fields:     external_fields.iter().map(|s| (*s).to_string()).collect(),
+            shareable_fields:    shareable_fields.iter().map(|s| (*s).to_string()).collect(),
+            inaccessible_fields: vec![],
+            field_directives:    std::collections::HashMap::new(),
         }],
     }
 }

--- a/crates/fraiseql-core/tests/federation_directives.rs
+++ b/crates/fraiseql-core/tests/federation_directives.rs
@@ -102,11 +102,11 @@ fn test_external_field_single() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       true,
-        external_fields:  vec!["email".to_string()],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          true,
+        external_fields:     vec!["email".to_string()],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert!(fed_type.external_fields.contains(&"email".to_string()));
@@ -122,11 +122,11 @@ fn test_external_field_multiple() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       true,
-        external_fields:  vec!["customerId".to_string(), "customerEmail".to_string()],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          true,
+        external_fields:     vec!["customerId".to_string(), "customerEmail".to_string()],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert_eq!(fed_type.external_fields.len(), 2);
@@ -143,11 +143,11 @@ fn test_external_field_key_field() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       true,
-        external_fields:  vec!["id".to_string()],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          true,
+        external_fields:     vec!["id".to_string()],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     // Key field "id" is also external in this extended type
@@ -167,11 +167,11 @@ fn test_extends_directive_owned_entity() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       false,
-        external_fields:  vec![],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          false,
+        external_fields:     vec![],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert!(!fed_type.is_extends, "Local entity should not be extended");
@@ -186,11 +186,11 @@ fn test_extends_directive_extended_entity() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       true,
-        external_fields:  vec!["email".to_string()],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          true,
+        external_fields:     vec!["email".to_string()],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert!(fed_type.is_extends, "Extended entity should have is_extends=true");
@@ -208,6 +208,7 @@ fn test_extends_with_external_fields() {
         is_extends:       true,
         external_fields:  vec!["customerId".to_string()],
         shareable_fields: vec!["total".to_string()],
+        inaccessible_fields: Vec::new(),
         field_directives: std::collections::HashMap::new(),
     };
 
@@ -232,6 +233,7 @@ fn test_shareable_field_single() {
         is_extends:       false,
         external_fields:  vec![],
         shareable_fields: vec!["email".to_string()],
+        inaccessible_fields: Vec::new(),
         field_directives: std::collections::HashMap::new(),
     };
 
@@ -250,6 +252,7 @@ fn test_shareable_field_multiple() {
         is_extends:       false,
         external_fields:  vec![],
         shareable_fields: vec!["name".to_string(), "description".to_string()],
+        inaccessible_fields: Vec::new(),
         field_directives: std::collections::HashMap::new(),
     };
 
@@ -270,6 +273,7 @@ fn test_shareable_field_in_extended_type() {
         is_extends:       true,
         external_fields:  vec!["customerId".to_string()],
         shareable_fields: vec!["status".to_string()],
+        inaccessible_fields: Vec::new(),
         field_directives: std::collections::HashMap::new(),
     };
 
@@ -290,11 +294,11 @@ fn test_composite_key_multi_tenant() {
             fields:     vec!["tenantId".to_string(), "id".to_string()],
             resolvable: true,
         }],
-        is_extends:       false,
-        external_fields:  vec![],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          false,
+        external_fields:     vec![],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert_eq!(fed_type.keys[0].fields.len(), 2);
@@ -416,11 +420,11 @@ fn test_field_cannot_be_both_external_and_key() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       true,
-        external_fields:  vec!["id".to_string()],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          true,
+        external_fields:     vec!["id".to_string()],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     // This is valid for extended types (key fields are external)
@@ -436,11 +440,11 @@ fn test_owned_type_cannot_have_external_fields() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       false,
-        external_fields:  vec![], // Must be empty for owned types
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          false,
+        external_fields:     vec![], // Must be empty for owned types
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert!(!fed_type.is_extends);
@@ -487,11 +491,11 @@ fn test_extended_type_must_have_key() {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       true,
-        external_fields:  vec!["customerId".to_string()],
-        shareable_fields: vec![],
-                inaccessible_fields: vec![],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          true,
+        external_fields:     vec!["customerId".to_string()],
+        shareable_fields:    vec![],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     assert!(fed_type.is_extends);

--- a/crates/fraiseql-core/tests/federation_field_directives.rs
+++ b/crates/fraiseql-core/tests/federation_field_directives.rs
@@ -104,15 +104,16 @@ fn test_field_directive_shareable_flag() {
     // THEN: shareable flag should be true
 
     let mut product_type = FederatedType {
-        name:             "Product".to_string(),
-        keys:             vec![KeyDirective {
+        name:                "Product".to_string(),
+        keys:                vec![KeyDirective {
             fields:     vec!["id".to_string()],
             resolvable: true,
         }],
-        is_extends:       false,
-        external_fields:  vec![],
-        shareable_fields: vec!["name".to_string()],
-        field_directives: std::collections::HashMap::new(),
+        is_extends:          false,
+        external_fields:     vec![],
+        shareable_fields:    vec!["name".to_string()],
+        inaccessible_fields: vec![],
+        field_directives:    std::collections::HashMap::new(),
     };
 
     // Simulate adding a @shareable directive to the "name" field

--- a/crates/fraiseql-core/tests/federation_multi_subgraph.rs
+++ b/crates/fraiseql-core/tests/federation_multi_subgraph.rs
@@ -80,15 +80,16 @@ fn test_federation_postgres_to_mysql() {
                 field_directives: std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Order".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Order".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false, // MySQL owns Order
-                external_fields:  vec![],
-                shareable_fields: vec!["user_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false, // MySQL owns Order
+                external_fields:     vec![],
+                shareable_fields:    vec!["user_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };
@@ -147,26 +148,28 @@ fn test_federation_three_database_chain() {
                 field_directives: std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Order".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Order".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["user_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["user_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Product".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Product".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["order_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["order_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };
@@ -205,15 +208,16 @@ fn test_federation_two_subgraph_simple() {
                 field_directives: std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Order".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Order".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["user_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["user_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };
@@ -247,26 +251,28 @@ fn test_federation_three_subgraph_federation() {
                 field_directives: std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Order".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Order".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["user_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["user_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Product".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Product".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["order_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["order_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };
@@ -418,26 +424,28 @@ fn test_federation_circular_references_handling() {
         version: "v2".to_string(),
         types:   vec![
             FederatedType {
-                name:             "User".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "User".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["posts".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["posts".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Post".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Post".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["author".to_string()], // References User,
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["author".to_string()], // References User,
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };
@@ -459,26 +467,28 @@ fn test_federation_shared_entity_fields() {
         version: "v2".to_string(),
         types:   vec![
             FederatedType {
-                name:             "User".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "User".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["email".to_string(), "name".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["email".to_string(), "name".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "UserProfile".to_string(), // Extended version with more fields
-                keys:             vec![KeyDirective {
+                name:                "UserProfile".to_string(), // Extended version with more fields
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       true,
-                external_fields:  vec!["id".to_string(), "email".to_string()],
-                shareable_fields: vec!["bio".to_string(), "avatar".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          true,
+                external_fields:     vec!["id".to_string(), "email".to_string()],
+                shareable_fields:    vec!["bio".to_string(), "avatar".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };
@@ -756,15 +766,16 @@ fn test_federation_apollo_router_composition() {
                 field_directives: std::collections::HashMap::new(),
             },
             FederatedType {
-                name:             "Order".to_string(),
-                keys:             vec![KeyDirective {
+                name:                "Order".to_string(),
+                keys:                vec![KeyDirective {
                     fields:     vec!["id".to_string()],
                     resolvable: true,
                 }],
-                is_extends:       false,
-                external_fields:  vec![],
-                shareable_fields: vec!["user_id".to_string()],
-                field_directives: std::collections::HashMap::new(),
+                is_extends:          false,
+                external_fields:     vec![],
+                shareable_fields:    vec!["user_id".to_string()],
+                inaccessible_fields: vec![],
+                field_directives:    std::collections::HashMap::new(),
             },
         ],
     };

--- a/crates/fraiseql-core/tests/federation_scenarios.rs
+++ b/crates/fraiseql-core/tests/federation_scenarios.rs
@@ -488,15 +488,16 @@ fn test_shareable_field_resolution() {
         enabled: true,
         version: "v2".to_string(),
         types:   vec![FederatedType {
-            name:             "Product".to_string(),
-            keys:             vec![KeyDirective {
+            name:                "Product".to_string(),
+            keys:                vec![KeyDirective {
                 fields:     vec!["id".to_string()],
                 resolvable: true,
             }],
-            is_extends:       false,
-            external_fields:  vec![],
-            shareable_fields: vec!["price".to_string(), "name".to_string()],
-            field_directives: std::collections::HashMap::new(),
+            is_extends:          false,
+            external_fields:     vec![],
+            shareable_fields:    vec!["price".to_string(), "name".to_string()],
+            inaccessible_fields: vec![],
+            field_directives:    std::collections::HashMap::new(),
         }],
     };
 

--- a/crates/fraiseql-observers/src/listener/change_log.rs
+++ b/crates/fraiseql-observers/src/listener/change_log.rs
@@ -226,6 +226,13 @@ impl ChangeLogEntry {
         // Use fk_contact as user_id if available
         let user_id = self.fk_contact.clone();
 
+        // Propagate fk_customer_org as tenant_id for multi-tenant filtering
+        let tenant_id = if self.fk_customer_org.is_empty() {
+            None
+        } else {
+            Some(self.fk_customer_org.clone())
+        };
+
         Ok(EntityEvent {
             id: Uuid::parse_str(&self.pk_entity_change_log).unwrap_or_else(|_| Uuid::new_v4()),
             event_type: event_kind,
@@ -234,7 +241,7 @@ impl ChangeLogEntry {
             data,
             changes,
             user_id,
-            tenant_id: None,
+            tenant_id,
             timestamp,
         })
     }

--- a/crates/fraiseql-server/src/observers/runtime.rs
+++ b/crates/fraiseql-server/src/observers/runtime.rs
@@ -452,12 +452,16 @@ impl ObserverRuntime {
                                             // Forward processed event to EventBridge for
                                             // GraphQL subscription delivery.
                                             if let Some(ref sender) = bridge_sender {
-                                                let bridge_event = BridgeEntityEvent::new(
+                                                let mut bridge_event = BridgeEntityEvent::new(
                                                     &event.entity_type,
                                                     event.entity_id.to_string(),
                                                     event.event_type.as_str(),
                                                     event.data.clone(),
                                                 );
+                                                // Propagate tenant_id for multi-tenant filtering
+                                                if let Some(ref tid) = event.tenant_id {
+                                                    bridge_event = bridge_event.with_tenant_id(tid);
+                                                }
                                                 if let Err(e) = sender.try_send(bridge_event) {
                                                     warn!("Failed to forward event {} to EventBridge: {}", event.id, e);
                                                 }

--- a/crates/fraiseql-server/src/observers/runtime.rs
+++ b/crates/fraiseql-server/src/observers/runtime.rs
@@ -29,6 +29,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     ServerError,
     observers::{Observer, ObserverRepository},
+    subscriptions::event_bridge::EntityEvent as BridgeEntityEvent,
 };
 
 /// Configuration for the observer runtime
@@ -126,6 +127,8 @@ pub struct ObserverRuntime {
     matcher:           Arc<RwLock<Option<EventMatcher>>>,
     executor:          Arc<RwLock<Option<Arc<ObserverExecutor>>>>,
     entity_type_index: Arc<RwLock<HashMap<(String, String), Vec<i64>>>>,
+    /// Optional sender to forward CDC events to `EventBridge` for GraphQL subscriptions
+    event_bridge_sender: Option<mpsc::Sender<BridgeEntityEvent>>,
 }
 
 impl ObserverRuntime {
@@ -146,7 +149,13 @@ impl ObserverRuntime {
             matcher: Arc::new(RwLock::new(None)),
             executor: Arc::new(RwLock::new(None)),
             entity_type_index: Arc::new(RwLock::new(HashMap::new())),
+            event_bridge_sender: None,
         }
+    }
+
+    /// Set the `EventBridge` sender so CDC events are forwarded to GraphQL subscriptions.
+    pub fn set_event_bridge_sender(&mut self, sender: mpsc::Sender<BridgeEntityEvent>) {
+        self.event_bridge_sender = Some(sender);
     }
 
     /// Load observers from the database and convert to `ObserverDefinitions`.
@@ -299,6 +308,9 @@ impl ObserverRuntime {
         let executor_ref = Arc::clone(&self.executor);
         let entity_type_index_ref = Arc::clone(&self.entity_type_index);
 
+        // Clone optional EventBridge sender for forwarding CDC events to subscriptions
+        let bridge_sender = self.event_bridge_sender.clone();
+
         // Extract non-optional initial values for the background task.
         // SAFETY: These were populated immediately above in this function before we
         // reach this point, so the Option is always Some here.  We surface a proper
@@ -434,6 +446,20 @@ impl ObserverRuntime {
                                                     .bind(duration_ms)
                                                     .execute(&pool)
                                                     .await;
+                                                }
+                                            }
+
+                                            // Forward processed event to EventBridge for
+                                            // GraphQL subscription delivery.
+                                            if let Some(ref sender) = bridge_sender {
+                                                let bridge_event = BridgeEntityEvent::new(
+                                                    &event.entity_type,
+                                                    event.entity_id.to_string(),
+                                                    event.event_type.as_str(),
+                                                    event.data.clone(),
+                                                );
+                                                if let Err(e) = sender.try_send(bridge_event) {
+                                                    warn!("Failed to forward event {} to EventBridge: {}", event.id, e);
                                                 }
                                             }
                                         }

--- a/crates/fraiseql-server/src/routes/mod.rs
+++ b/crates/fraiseql-server/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod health;
 pub mod introspection;
 pub mod metrics;
 pub mod playground;
+pub mod realtime;
 pub mod subscriptions;
 pub mod well_known;
 
@@ -28,5 +29,6 @@ pub use health::{health_handler, readiness_handler};
 pub use introspection::introspection_handler;
 pub use metrics::{metrics_handler, metrics_json_handler};
 pub use playground::{PlaygroundState, playground_handler};
+pub use realtime::{BroadcastState, broadcast_handler};
 pub use subscriptions::{SubscriptionState, subscription_handler, subscription_metrics};
 pub use well_known::security_txt_handler;

--- a/crates/fraiseql-server/src/routes/realtime.rs
+++ b/crates/fraiseql-server/src/routes/realtime.rs
@@ -1,0 +1,203 @@
+//! Realtime REST endpoints: broadcast publish.
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::subscriptions::BroadcastManager;
+
+/// Shared state for the realtime broadcast endpoint.
+#[derive(Clone)]
+pub struct BroadcastState {
+    manager: Arc<BroadcastManager>,
+}
+
+impl BroadcastState {
+    /// Create new broadcast state wrapping the given manager.
+    #[must_use]
+    pub const fn new(manager: Arc<BroadcastManager>) -> Self {
+        Self { manager }
+    }
+}
+
+/// Request body for `POST /realtime/v1/broadcast`.
+#[derive(Debug, Deserialize)]
+pub struct BroadcastRequest {
+    /// Named channel to publish to (e.g., "chat:room1").
+    pub channel: String,
+
+    /// Event name (e.g., "message", "typing").
+    pub event: String,
+
+    /// Arbitrary JSON payload.
+    pub payload: serde_json::Value,
+}
+
+/// Response body for broadcast publish.
+#[derive(Debug, Serialize)]
+pub struct BroadcastResponse {
+    /// Number of subscribers that received the message.
+    pub receivers: usize,
+}
+
+/// `POST /realtime/v1/broadcast` — publish a message to a named channel.
+pub async fn broadcast_handler(
+    State(state): State<BroadcastState>,
+    Json(req): Json<BroadcastRequest>,
+) -> impl IntoResponse {
+    if req.channel.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "channel must not be empty"})),
+        )
+            .into_response();
+    }
+
+    if req.event.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "event must not be empty"})),
+        )
+            .into_response();
+    }
+
+    match state.manager.publish(&req.channel, req.event, req.payload).await {
+        Ok(receivers) => {
+            (StatusCode::OK, Json(BroadcastResponse { receivers })).into_response()
+        }
+        Err(e) => {
+            let status = StatusCode::from_u16(e.status_code())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            (status, Json(serde_json::json!({"error": e.to_string()}))).into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+    use axum::{
+        Router,
+        body::Body,
+        http::Request,
+        routing::post,
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::subscriptions::BroadcastConfig;
+
+    fn test_app() -> Router {
+        let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+        let state = BroadcastState::new(manager);
+        Router::new()
+            .route("/realtime/v1/broadcast", post(broadcast_handler))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_publish_ok() {
+        let app = test_app();
+
+        let body = serde_json::json!({
+            "channel": "room:1",
+            "event": "message",
+            "payload": {"text": "hello"}
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/realtime/v1/broadcast")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["receivers"], 0); // no subscribers
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_empty_channel_rejected() {
+        let app = test_app();
+
+        let body = serde_json::json!({
+            "channel": "",
+            "event": "message",
+            "payload": {}
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/realtime/v1/broadcast")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_empty_event_rejected() {
+        let app = test_app();
+
+        let body = serde_json::json!({
+            "channel": "room:1",
+            "event": "",
+            "payload": {}
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/realtime/v1/broadcast")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_broadcast_with_subscriber() {
+        let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+        let state = BroadcastState::new(manager.clone());
+        let app = Router::new()
+            .route("/realtime/v1/broadcast", post(broadcast_handler))
+            .with_state(state);
+
+        // Subscribe first
+        let _rx = manager.subscribe("room:1").await.unwrap();
+
+        let body = serde_json::json!({
+            "channel": "room:1",
+            "event": "message",
+            "payload": {"text": "hello"}
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/realtime/v1/broadcast")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["receivers"], 1);
+    }
+}

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -403,6 +403,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             pool_tuning_config: None,
             adapter_cache_enabled: false,
             broadcast_manager: None,
+            presence_manager: None,
         })
     }
 
@@ -427,6 +428,13 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     #[must_use]
     pub fn with_broadcast(mut self, config: crate::subscriptions::BroadcastConfig) -> Self {
         self.broadcast_manager = Some(Arc::new(crate::subscriptions::BroadcastManager::new(config)));
+        self
+    }
+
+    /// Enable room-based presence tracking.
+    #[must_use]
+    pub fn with_presence(mut self, config: crate::subscriptions::PresenceConfig) -> Self {
+        self.presence_manager = Some(Arc::new(crate::subscriptions::PresenceManager::new(config)));
         self
     }
 

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -402,6 +402,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             mcp_config: None,
             pool_tuning_config: None,
             adapter_cache_enabled: false,
+            broadcast_manager: None,
         })
     }
 
@@ -419,6 +420,13 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     #[must_use]
     pub const fn with_max_subscriptions_per_connection(mut self, max: u32) -> Self {
         self.max_subscriptions_per_connection = Some(max);
+        self
+    }
+
+    /// Enable ephemeral broadcast channels (`POST /realtime/v1/broadcast`).
+    #[must_use]
+    pub fn with_broadcast(mut self, config: crate::subscriptions::BroadcastConfig) -> Self {
+        self.broadcast_manager = Some(Arc::new(crate::subscriptions::BroadcastManager::new(config)));
         self
     }
 

--- a/crates/fraiseql-server/src/server/extensions.rs
+++ b/crates/fraiseql-server/src/server/extensions.rs
@@ -345,6 +345,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             db_pool,
             flight_service,
             adapter_cache_enabled: false,
+            broadcast_manager: None,
         })
     }
 

--- a/crates/fraiseql-server/src/server/extensions.rs
+++ b/crates/fraiseql-server/src/server/extensions.rs
@@ -346,6 +346,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             flight_service,
             adapter_cache_enabled: false,
             broadcast_manager: None,
+            presence_manager: None,
         })
     }
 

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -6,6 +6,9 @@ use tracing::{error, info, warn};
 
 use super::{DatabaseAdapter, Result, Server, ServerError, TlsSetup};
 
+#[cfg(feature = "observers")]
+use crate::subscriptions::event_bridge::{EventBridge, EventBridgeConfig};
+
 impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// Start server and listen for requests.
     ///
@@ -109,21 +112,40 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             "Starting FraiseQL server"
         );
 
-        // Start observer runtime if configured
+        // Start observer runtime if configured, wiring CDC events to EventBridge
         #[cfg(feature = "observers")]
-        if let Some(ref runtime) = self.observer_runtime {
-            info!("Starting observer runtime...");
-            let mut guard = runtime.write().await;
+        #[allow(unused_variables)] // Reason: _bridge_handle is kept alive to prevent task cancellation
+        let _bridge_handle = {
+            let mut handle: Option<tokio::task::JoinHandle<()>> = None;
+            if let Some(ref runtime) = self.observer_runtime {
+                info!("Starting observer runtime...");
 
-            match guard.start().await {
-                Ok(()) => info!("Observer runtime started"),
-                Err(e) => {
-                    error!("Failed to start observer runtime: {}", e);
-                    warn!("Server will continue without observers");
-                },
+                // Create EventBridge to forward CDC events to GraphQL subscriptions
+                let bridge = EventBridge::new(
+                    self.subscription_manager.clone(),
+                    EventBridgeConfig::new(),
+                );
+                let sender = bridge.sender();
+
+                let mut guard = runtime.write().await;
+                guard.set_event_bridge_sender(sender);
+
+                match guard.start().await {
+                    Ok(()) => {
+                        info!("Observer runtime started");
+                        // Spawn EventBridge after observer runtime is running
+                        handle = Some(bridge.spawn());
+                        info!("EventBridge started — CDC events will be forwarded to subscriptions");
+                    }
+                    Err(e) => {
+                        error!("Failed to start observer runtime: {}", e);
+                        warn!("Server will continue without observers");
+                    },
+                }
+                drop(guard);
             }
-            drop(guard);
-        }
+            handle
+        };
 
         // Explicitly enable TCP_NODELAY (disable Nagle's algorithm) on every
         // accepted connection to minimise latency for small GraphQL responses.

--- a/crates/fraiseql-server/src/server/mod.rs
+++ b/crates/fraiseql-server/src/server/mod.rs
@@ -24,9 +24,10 @@ use crate::{
         metrics_middleware, oidc_auth_middleware, require_json_content_type, trace_layer,
     },
     routes::{
-        PlaygroundState, SubscriptionState, api, graphql::AppState, graphql_get_handler,
-        graphql_handler, health_handler, introspection_handler, metrics_handler,
-        metrics_json_handler, playground_handler, readiness_handler, subscription_handler,
+        BroadcastState, PlaygroundState, SubscriptionState, api, broadcast_handler,
+        graphql::AppState, graphql_get_handler, graphql_handler, health_handler,
+        introspection_handler, metrics_handler, metrics_json_handler, playground_handler,
+        readiness_handler, subscription_handler,
     },
     server_config::ServerConfig,
     tls::TlsSetup,
@@ -110,4 +111,7 @@ pub struct Server<A: DatabaseAdapter> {
     /// Set to `true` when `ServerConfig::cache_enabled = true` and the server was built
     /// with `Server::new` or `Server::with_relay_pagination`.
     pub(super) adapter_cache_enabled: bool,
+
+    /// Broadcast channel manager for ephemeral realtime pub/sub.
+    pub(super) broadcast_manager: Option<Arc<crate::subscriptions::BroadcastManager>>,
 }

--- a/crates/fraiseql-server/src/server/mod.rs
+++ b/crates/fraiseql-server/src/server/mod.rs
@@ -114,4 +114,7 @@ pub struct Server<A: DatabaseAdapter> {
 
     /// Broadcast channel manager for ephemeral realtime pub/sub.
     pub(super) broadcast_manager: Option<Arc<crate::subscriptions::BroadcastManager>>,
+
+    /// Presence manager for room-based member tracking.
+    pub(super) presence_manager: Option<Arc<crate::subscriptions::PresenceManager>>,
 }

--- a/crates/fraiseql-server/src/server/routing.rs
+++ b/crates/fraiseql-server/src/server/routing.rs
@@ -14,11 +14,11 @@ use tower_http::compression::{CompressionLayer, predicate::SizeAbove};
 use tracing::{info, warn};
 
 use super::{
-    AppState, BearerAuthState, OidcAuthState, PlaygroundState, Server, SubscriptionState, api,
-    bearer_auth_middleware, cors_layer_restricted, graphql_get_handler, graphql_handler,
-    health_handler, introspection_handler, metrics_handler, metrics_json_handler,
-    metrics_middleware, oidc_auth_middleware, playground_handler, readiness_handler,
-    require_json_content_type, subscription_handler, trace_layer,
+    AppState, BearerAuthState, BroadcastState, OidcAuthState, PlaygroundState, Server,
+    SubscriptionState, api, bearer_auth_middleware, broadcast_handler, cors_layer_restricted,
+    graphql_get_handler, graphql_handler, health_handler, introspection_handler, metrics_handler,
+    metrics_json_handler, metrics_middleware, oidc_auth_middleware, playground_handler,
+    readiness_handler, require_json_content_type, subscription_handler, trace_layer,
 };
 #[cfg(feature = "auth")]
 use super::{AuthMeState, AuthPkceState, auth_callback, auth_me, auth_start};
@@ -307,6 +307,16 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                 .route(&self.config.subscription_path, get(subscription_handler))
                 .with_state(subscription_state);
             app = app.merge(subscription_router);
+        }
+
+        // Conditionally add broadcast endpoint
+        if let Some(ref broadcast_manager) = self.broadcast_manager {
+            let broadcast_state = BroadcastState::new(broadcast_manager.clone());
+            info!("Broadcast endpoint enabled at /realtime/v1/broadcast");
+            let broadcast_router = Router::new()
+                .route("/realtime/v1/broadcast", post(broadcast_handler))
+                .with_state(broadcast_state);
+            app = app.merge(broadcast_router);
         }
 
         // Conditionally add introspection endpoint (with optional auth)

--- a/crates/fraiseql-server/src/subscriptions/broadcast.rs
+++ b/crates/fraiseql-server/src/subscriptions/broadcast.rs
@@ -1,0 +1,427 @@
+//! Ephemeral broadcast channels for realtime pub/sub.
+//!
+//! Provides in-memory named channels that clients can publish to via REST
+//! (`POST /realtime/v1/broadcast`) and subscribe to via `WebSocket`.
+//! No database persistence — messages are lost on server restart.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use tokio::sync::{RwLock, broadcast};
+use tracing::debug;
+
+/// Configuration for the broadcast subsystem.
+#[derive(Debug, Clone)]
+pub struct BroadcastConfig {
+    /// Per-channel buffer capacity (number of messages retained for slow subscribers).
+    pub channel_capacity: usize,
+
+    /// Maximum number of named channels that can exist simultaneously.
+    pub max_channels: usize,
+
+    /// Maximum message payload size in bytes.
+    pub max_message_bytes: usize,
+}
+
+impl BroadcastConfig {
+    /// Create config with production defaults.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            channel_capacity: 128,
+            max_channels: 1_000,
+            max_message_bytes: 65_536,
+        }
+    }
+}
+
+impl Default for BroadcastConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Statistics for the broadcast subsystem.
+#[derive(Debug, Clone)]
+pub struct BroadcastStats {
+    /// Total messages published across all channels.
+    pub messages_published: u64,
+
+    /// Number of active channels.
+    pub active_channels: usize,
+
+    /// Total active receivers across all channels.
+    pub active_receivers: usize,
+}
+
+/// A single named broadcast channel.
+#[derive(Debug)]
+struct BroadcastChannel {
+    sender: broadcast::Sender<BroadcastMessage>,
+    created_at: Instant,
+}
+
+/// A message published to a broadcast channel.
+#[derive(Debug, Clone)]
+pub struct BroadcastMessage {
+    /// The channel this message was published to.
+    pub channel: String,
+
+    /// The event name (e.g., `cursor_move`, `typing`).
+    pub event: String,
+
+    /// Arbitrary JSON payload.
+    pub payload: serde_json::Value,
+}
+
+/// Manages named broadcast channels.
+///
+/// Thread-safe via interior mutability (`RwLock` for channel map, atomics for counters).
+#[derive(Debug)]
+pub struct BroadcastManager {
+    channels: RwLock<HashMap<String, BroadcastChannel>>,
+    config: BroadcastConfig,
+    messages_published: AtomicU64,
+}
+
+impl BroadcastManager {
+    /// Create a new broadcast manager.
+    #[must_use]
+    pub fn new(config: BroadcastConfig) -> Self {
+        Self {
+            channels: RwLock::new(HashMap::new()),
+            config,
+            messages_published: AtomicU64::new(0),
+        }
+    }
+
+    /// Publish a message to a named channel.
+    ///
+    /// Creates the channel if it doesn't exist. Returns the number of receivers
+    /// that were notified (0 if nobody is listening).
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the channel limit is exceeded or the payload is too large.
+    pub async fn publish(
+        &self,
+        channel: &str,
+        event: String,
+        payload: serde_json::Value,
+    ) -> Result<usize, BroadcastError> {
+        // Validate payload size
+        let payload_str = serde_json::to_string(&payload)
+            .map_err(|e| BroadcastError::InvalidPayload(e.to_string()))?;
+        if payload_str.len() > self.config.max_message_bytes {
+            return Err(BroadcastError::PayloadTooLarge {
+                size: payload_str.len(),
+                max: self.config.max_message_bytes,
+            });
+        }
+
+        let message = BroadcastMessage {
+            channel: channel.to_string(),
+            event,
+            payload,
+        };
+
+        // Try to send on existing channel first (read lock — fast path)
+        {
+            let channels = self.channels.read().await;
+            if let Some(ch) = channels.get(channel) {
+                let receivers = ch.sender.send(message).unwrap_or(0);
+                self.messages_published.fetch_add(1, Ordering::Relaxed);
+                debug!(channel, receivers, "broadcast message sent (existing channel)");
+                return Ok(receivers);
+            }
+        }
+
+        // Channel doesn't exist — create it (write lock)
+        let mut channels = self.channels.write().await;
+
+        // Double-check after acquiring write lock
+        if let Some(ch) = channels.get(channel) {
+            let receivers = ch.sender.send(message).unwrap_or(0);
+            self.messages_published.fetch_add(1, Ordering::Relaxed);
+            return Ok(receivers);
+        }
+
+        // Check channel limit
+        if channels.len() >= self.config.max_channels {
+            return Err(BroadcastError::TooManyChannels {
+                max: self.config.max_channels,
+            });
+        }
+
+        let (sender, _) = broadcast::channel(self.config.channel_capacity);
+        let receivers = sender.send(message).unwrap_or(0);
+        channels.insert(
+            channel.to_string(),
+            BroadcastChannel {
+                sender,
+                created_at: Instant::now(),
+            },
+        );
+        self.messages_published.fetch_add(1, Ordering::Relaxed);
+        debug!(channel, "broadcast channel created");
+
+        Ok(receivers)
+    }
+
+    /// Subscribe to a named channel. Creates the channel if it doesn't exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the channel limit is exceeded.
+    pub async fn subscribe(
+        &self,
+        channel: &str,
+    ) -> Result<broadcast::Receiver<BroadcastMessage>, BroadcastError> {
+        // Fast path: read lock
+        {
+            let channels = self.channels.read().await;
+            if let Some(ch) = channels.get(channel) {
+                return Ok(ch.sender.subscribe());
+            }
+        }
+
+        // Create channel
+        let mut channels = self.channels.write().await;
+
+        // Double-check
+        if let Some(ch) = channels.get(channel) {
+            return Ok(ch.sender.subscribe());
+        }
+
+        if channels.len() >= self.config.max_channels {
+            return Err(BroadcastError::TooManyChannels {
+                max: self.config.max_channels,
+            });
+        }
+
+        let (sender, receiver) = broadcast::channel(self.config.channel_capacity);
+        channels.insert(
+            channel.to_string(),
+            BroadcastChannel {
+                sender,
+                created_at: Instant::now(),
+            },
+        );
+        debug!(channel, "broadcast channel created for subscriber");
+
+        Ok(receiver)
+    }
+
+    /// Remove channels with no active subscribers to prevent memory leaks.
+    pub async fn gc_empty_channels(&self) -> usize {
+        let mut channels = self.channels.write().await;
+        let before = channels.len();
+        channels.retain(|name, ch| {
+            let has_receivers = ch.sender.receiver_count() > 0;
+            if !has_receivers {
+                debug!(channel = %name, age_secs = ch.created_at.elapsed().as_secs(), "gc: removing empty broadcast channel");
+            }
+            has_receivers
+        });
+        before - channels.len()
+    }
+
+    /// Get current broadcast statistics.
+    pub async fn stats(&self) -> BroadcastStats {
+        let channels = self.channels.read().await;
+        let active_receivers: usize = channels.values().map(|ch| ch.sender.receiver_count()).sum();
+        BroadcastStats {
+            messages_published: self.messages_published.load(Ordering::Relaxed),
+            active_channels: channels.len(),
+            active_receivers,
+        }
+    }
+
+    /// Get the number of active channels.
+    pub async fn channel_count(&self) -> usize {
+        self.channels.read().await.len()
+    }
+}
+
+/// Errors from broadcast operations.
+#[derive(Debug, thiserror::Error)]
+pub enum BroadcastError {
+    /// Payload exceeds maximum allowed size.
+    #[error("payload too large: {size} bytes exceeds max {max}")]
+    PayloadTooLarge {
+        /// Actual payload size.
+        size: usize,
+        /// Maximum allowed size.
+        max: usize,
+    },
+
+    /// Too many named channels exist.
+    #[error("channel limit exceeded: max {max} channels")]
+    TooManyChannels {
+        /// Maximum allowed channels.
+        max: usize,
+    },
+
+    /// Invalid payload data.
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+}
+
+impl BroadcastError {
+    /// HTTP status code for this error.
+    #[must_use]
+    pub const fn status_code(&self) -> u16 {
+        match self {
+            Self::PayloadTooLarge { .. } => 413,
+            Self::TooManyChannels { .. } => 503,
+            Self::InvalidPayload(_) => 400,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_publish_creates_channel_on_demand() {
+        let manager = BroadcastManager::new(BroadcastConfig::new());
+
+        let receivers = manager
+            .publish("chat:room1", "message".into(), serde_json::json!({"text": "hello"}))
+            .await
+            .unwrap();
+
+        // No subscribers yet, so 0 receivers
+        assert_eq!(receivers, 0);
+        assert_eq!(manager.channel_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_then_publish() {
+        let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+        let mut rx = manager.subscribe("chat:room1").await.unwrap();
+
+        let receivers = manager
+            .publish(
+                "chat:room1",
+                "message".into(),
+                serde_json::json!({"text": "hello"}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(receivers, 1);
+
+        let msg = rx.recv().await.unwrap();
+        assert_eq!(msg.channel, "chat:room1");
+        assert_eq!(msg.event, "message");
+        assert_eq!(msg.payload["text"], "hello");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_subscribers() {
+        let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+        let mut rx1 = manager.subscribe("events").await.unwrap();
+        let mut rx2 = manager.subscribe("events").await.unwrap();
+
+        let receivers = manager
+            .publish("events", "update".into(), serde_json::json!({"v": 1}))
+            .await
+            .unwrap();
+
+        assert_eq!(receivers, 2);
+
+        let msg1 = rx1.recv().await.unwrap();
+        let msg2 = rx2.recv().await.unwrap();
+        assert_eq!(msg1.payload, msg2.payload);
+    }
+
+    #[tokio::test]
+    async fn test_payload_too_large() {
+        let config = BroadcastConfig {
+            max_message_bytes: 10,
+            ..BroadcastConfig::new()
+        };
+        let manager = BroadcastManager::new(config);
+
+        let result = manager
+            .publish("ch", "e".into(), serde_json::json!({"big": "data that is too large"}))
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status_code(), 413);
+    }
+
+    #[tokio::test]
+    async fn test_too_many_channels() {
+        let config = BroadcastConfig {
+            max_channels: 2,
+            ..BroadcastConfig::new()
+        };
+        let manager = BroadcastManager::new(config);
+
+        manager.publish("ch1", "e".into(), serde_json::json!({})).await.unwrap();
+        manager.publish("ch2", "e".into(), serde_json::json!({})).await.unwrap();
+        let result = manager.publish("ch3", "e".into(), serde_json::json!({})).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status_code(), 503);
+    }
+
+    #[tokio::test]
+    async fn test_gc_empty_channels() {
+        let manager = BroadcastManager::new(BroadcastConfig::new());
+
+        // Create a channel with a subscriber
+        let _rx = manager.subscribe("active").await.unwrap();
+        // Create a channel with no subscribers
+        manager.publish("orphan", "e".into(), serde_json::json!({})).await.unwrap();
+
+        assert_eq!(manager.channel_count().await, 2);
+
+        let removed = manager.gc_empty_channels().await;
+        assert_eq!(removed, 1);
+        assert_eq!(manager.channel_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+        let _rx = manager.subscribe("ch1").await.unwrap();
+        manager.publish("ch1", "e".into(), serde_json::json!({})).await.unwrap();
+        manager.publish("ch2", "e".into(), serde_json::json!({})).await.unwrap();
+
+        let stats = manager.stats().await;
+        assert_eq!(stats.messages_published, 2);
+        assert_eq!(stats.active_channels, 2);
+        assert_eq!(stats.active_receivers, 1);
+    }
+
+    #[tokio::test]
+    async fn test_channel_isolation() {
+        let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+        let mut rx_a = manager.subscribe("channel_a").await.unwrap();
+        let _rx_b = manager.subscribe("channel_b").await.unwrap();
+
+        manager
+            .publish("channel_a", "event".into(), serde_json::json!({"for": "a"}))
+            .await
+            .unwrap();
+
+        let msg = rx_a.recv().await.unwrap();
+        assert_eq!(msg.payload["for"], "a");
+
+        // channel_b subscriber should not have received anything
+        // (try_recv would return Empty, not a message)
+    }
+}

--- a/crates/fraiseql-server/src/subscriptions/event_bridge.rs
+++ b/crates/fraiseql-server/src/subscriptions/event_bridge.rs
@@ -145,7 +145,7 @@ impl EventBridge {
     }
 
     /// Convert `EntityEvent` to `SubscriptionEvent`
-    fn convert_event(entity_event: EntityEvent) -> SubscriptionEvent {
+    pub fn convert_event(entity_event: EntityEvent) -> SubscriptionEvent {
         // Convert operation string to SubscriptionOperation
         let operation = match entity_event.operation.to_uppercase().as_str() {
             "INSERT" => SubscriptionOperation::Create,

--- a/crates/fraiseql-server/src/subscriptions/event_bridge.rs
+++ b/crates/fraiseql-server/src/subscriptions/event_bridge.rs
@@ -318,4 +318,49 @@ mod tests {
         // Clean up
         handle.abort();
     }
+
+    #[tokio::test]
+    async fn test_event_bridge_end_to_end_forwarding() {
+        let schema = Arc::new(CompiledSchema::new());
+        let manager = Arc::new(SubscriptionManager::new(schema));
+        let config = EventBridgeConfig::new();
+
+        let bridge = EventBridge::new(manager, config);
+        let sender = bridge.sender();
+        let handle = bridge.spawn();
+
+        // Send multiple events through the channel
+        for i in 0..3 {
+            let event = EntityEvent::new(
+                "Order",
+                format!("order_{i}"),
+                "INSERT",
+                serde_json::json!({"id": format!("order_{i}"), "total": 99.95}),
+            );
+            sender.send(event).await.expect("channel should be open");
+        }
+
+        // Allow the bridge task to process all events
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // The bridge should still be running (didn't panic processing events)
+        assert!(!handle.is_finished(), "bridge should still be running after processing events");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_event_bridge_sender_cloning() {
+        let schema = Arc::new(CompiledSchema::new());
+        let manager = Arc::new(SubscriptionManager::new(schema));
+        let config = EventBridgeConfig::new();
+
+        let bridge = EventBridge::new(manager, config);
+        let sender1 = bridge.sender();
+        let sender2 = bridge.sender();
+
+        // Both senders should be usable (cloned from the same channel)
+        assert!(sender1.try_reserve().is_ok());
+        assert!(sender2.try_reserve().is_ok());
+    }
 }

--- a/crates/fraiseql-server/src/subscriptions/event_bridge.rs
+++ b/crates/fraiseql-server/src/subscriptions/event_bridge.rs
@@ -74,6 +74,9 @@ pub struct EntityEvent {
 
     /// Optional old data (for UPDATE operations)
     pub old_data: Option<serde_json::Value>,
+
+    /// Tenant identifier for multi-tenant filtering (`fk_customer_org`).
+    pub tenant_id: Option<String>,
 }
 
 impl EntityEvent {
@@ -91,6 +94,7 @@ impl EntityEvent {
             operation: operation.into(),
             data,
             old_data: None,
+            tenant_id: None,
         }
     }
 
@@ -98,6 +102,13 @@ impl EntityEvent {
     #[must_use]
     pub fn with_old_data(mut self, old_data: serde_json::Value) -> Self {
         self.old_data = Some(old_data);
+        self
+    }
+
+    /// Set tenant identifier for multi-tenant filtering.
+    #[must_use]
+    pub fn with_tenant_id(mut self, tenant_id: impl Into<String>) -> Self {
+        self.tenant_id = Some(tenant_id.into());
         self
     }
 }
@@ -157,6 +168,11 @@ impl EventBridge {
         // Add old data if present
         if let Some(old_data) = entity_event.old_data {
             event = event.with_old_data(old_data);
+        }
+
+        // Propagate tenant_id for multi-tenant filtering
+        if let Some(tenant_id) = entity_event.tenant_id {
+            event = event.with_tenant_id(tenant_id);
         }
 
         event

--- a/crates/fraiseql-server/src/subscriptions/mod.rs
+++ b/crates/fraiseql-server/src/subscriptions/mod.rs
@@ -8,11 +8,13 @@
 pub mod broadcast;
 pub mod event_bridge;
 pub mod lifecycle;
+pub mod presence;
 pub mod protocol;
 pub mod webhook_lifecycle;
 
 pub use broadcast::{BroadcastConfig, BroadcastManager, BroadcastMessage};
 pub use event_bridge::{EntityEvent, EventBridge, EventBridgeConfig};
+pub use presence::{PresenceConfig, PresenceManager};
 pub use lifecycle::{NoopLifecycle, SubscriptionLifecycle};
 pub use protocol::{ProtocolCodec, ProtocolError, WsProtocol};
 pub use webhook_lifecycle::WebhookLifecycle;

--- a/crates/fraiseql-server/src/subscriptions/mod.rs
+++ b/crates/fraiseql-server/src/subscriptions/mod.rs
@@ -5,11 +5,13 @@
 //! - `WebSocket` handler: Implements graphql-ws protocol
 //! - Subscription management: Tracks active subscriptions
 
+pub mod broadcast;
 pub mod event_bridge;
 pub mod lifecycle;
 pub mod protocol;
 pub mod webhook_lifecycle;
 
+pub use broadcast::{BroadcastConfig, BroadcastManager, BroadcastMessage};
 pub use event_bridge::{EntityEvent, EventBridge, EventBridgeConfig};
 pub use lifecycle::{NoopLifecycle, SubscriptionLifecycle};
 pub use protocol::{ProtocolCodec, ProtocolError, WsProtocol};

--- a/crates/fraiseql-server/src/subscriptions/presence.rs
+++ b/crates/fraiseql-server/src/subscriptions/presence.rs
@@ -1,0 +1,592 @@
+//! Room-based presence tracking for realtime member awareness.
+//!
+//! Clients join a "room" with an initial state payload.  The server tracks
+//! membership and emits `PRESENCE_STATE` (full roster on join) and
+//! `PRESENCE_DIFF` (join/leave/update deltas) events.
+//!
+//! All state is in-memory — lost on server restart (acceptable for v1).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::debug;
+
+// ──────────────────────── Configuration ────────────────────────
+
+/// Configuration for the presence subsystem.
+#[derive(Debug, Clone)]
+pub struct PresenceConfig {
+    /// Maximum members per room (prevents memory abuse).
+    pub max_members_per_room: usize,
+
+    /// Maximum number of rooms that can exist simultaneously.
+    pub max_rooms: usize,
+
+    /// Heartbeat timeout — members are evicted after this duration without a ping.
+    pub heartbeat_timeout: Duration,
+}
+
+impl PresenceConfig {
+    /// Create config with production defaults.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            max_members_per_room: 500,
+            max_rooms: 10_000,
+            heartbeat_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl Default for PresenceConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ──────────────────────── Types ────────────────────────
+
+/// A member's presence in a room.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresenceMember {
+    /// Unique identifier for this member (typically connection ID or user ID).
+    pub id: String,
+
+    /// Arbitrary JSON state (e.g., cursor position, status, avatar).
+    pub state: serde_json::Value,
+
+    /// When this member last sent a heartbeat.
+    #[serde(skip, default = "Instant::now")]
+    pub last_seen: Instant,
+}
+
+/// Full room state — sent to a client on join (`PRESENCE_STATE`).
+#[derive(Debug, Clone, Serialize)]
+pub struct PresenceState {
+    /// Room name.
+    pub room: String,
+
+    /// All current members.
+    pub members: Vec<PresenceMember>,
+}
+
+/// Delta event — sent when members join, leave, or update (`PRESENCE_DIFF`).
+#[derive(Debug, Clone, Serialize)]
+pub struct PresenceDiff {
+    /// Room name.
+    pub room: String,
+
+    /// Members who joined.
+    pub joins: Vec<PresenceMember>,
+
+    /// Member IDs who left (or were evicted).
+    pub leaves: Vec<String>,
+}
+
+// ──────────────────────── Room ────────────────────────
+
+/// A single presence room.
+#[derive(Debug)]
+struct PresenceRoom {
+    /// Members indexed by their ID.
+    members: HashMap<String, PresenceMember>,
+}
+
+impl PresenceRoom {
+    fn new() -> Self {
+        Self {
+            members: HashMap::new(),
+        }
+    }
+}
+
+// ──────────────────────── Manager ────────────────────────
+
+/// Statistics for the presence subsystem.
+#[derive(Debug, Clone)]
+pub struct PresenceStats {
+    /// Total rooms currently tracked.
+    pub active_rooms: usize,
+
+    /// Total members across all rooms.
+    pub total_members: usize,
+
+    /// Total join events processed.
+    pub joins_total: u64,
+
+    /// Total leave events processed.
+    pub leaves_total: u64,
+
+    /// Total heartbeat evictions.
+    pub evictions_total: u64,
+}
+
+/// Manages room-based presence state.
+///
+/// Thread-safe via `RwLock` for the room map and atomics for counters.
+#[derive(Debug)]
+pub struct PresenceManager {
+    rooms: RwLock<HashMap<String, PresenceRoom>>,
+    config: PresenceConfig,
+    joins_total: AtomicU64,
+    leaves_total: AtomicU64,
+    evictions_total: AtomicU64,
+}
+
+impl PresenceManager {
+    /// Create a new presence manager.
+    #[must_use]
+    pub fn new(config: PresenceConfig) -> Self {
+        Self {
+            rooms: RwLock::new(HashMap::new()),
+            config,
+            joins_total: AtomicU64::new(0),
+            leaves_total: AtomicU64::new(0),
+            evictions_total: AtomicU64::new(0),
+        }
+    }
+
+    /// Join a room with initial state.
+    ///
+    /// Returns `PresenceState` (current members including the new one) and
+    /// a `PresenceDiff` (announcing the join) for broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the room is full or room limit is exceeded.
+    pub async fn join(
+        &self,
+        room: &str,
+        member_id: &str,
+        state: serde_json::Value,
+    ) -> Result<(PresenceState, PresenceDiff), PresenceError> {
+        let mut rooms = self.rooms.write().await;
+
+        // Create room if needed
+        if !rooms.contains_key(room) {
+            if rooms.len() >= self.config.max_rooms {
+                return Err(PresenceError::TooManyRooms {
+                    max: self.config.max_rooms,
+                });
+            }
+            rooms.insert(room.to_string(), PresenceRoom::new());
+        }
+
+        let Some(presence_room) = rooms.get_mut(room) else {
+            // Unreachable: we just inserted the room above if it was missing.
+            return Err(PresenceError::TooManyRooms {
+                max: self.config.max_rooms,
+            });
+        };
+
+        // Check room capacity (only if this is a new member, not a rejoin)
+        if !presence_room.members.contains_key(member_id)
+            && presence_room.members.len() >= self.config.max_members_per_room
+        {
+            return Err(PresenceError::RoomFull {
+                room: room.to_string(),
+                max: self.config.max_members_per_room,
+            });
+        }
+
+        let member = PresenceMember {
+            id: member_id.to_string(),
+            state,
+            last_seen: Instant::now(),
+        };
+
+        presence_room.members.insert(member_id.to_string(), member.clone());
+        self.joins_total.fetch_add(1, Ordering::Relaxed);
+
+        let presence_state = PresenceState {
+            room: room.to_string(),
+            members: presence_room.members.values().cloned().collect(),
+        };
+
+        let diff = PresenceDiff {
+            room: room.to_string(),
+            joins: vec![member],
+            leaves: vec![],
+        };
+
+        debug!(room, member_id, members = presence_room.members.len(), "presence: member joined");
+        Ok((presence_state, diff))
+    }
+
+    /// Leave a room.
+    ///
+    /// Returns a `PresenceDiff` for broadcasting, or `None` if the member
+    /// wasn't in the room.
+    pub async fn leave(&self, room: &str, member_id: &str) -> Option<PresenceDiff> {
+        let mut rooms = self.rooms.write().await;
+
+        let presence_room = rooms.get_mut(room)?;
+        presence_room.members.remove(member_id)?;
+        self.leaves_total.fetch_add(1, Ordering::Relaxed);
+
+        debug!(room, member_id, members = presence_room.members.len(), "presence: member left");
+
+        let diff = PresenceDiff {
+            room: room.to_string(),
+            joins: vec![],
+            leaves: vec![member_id.to_string()],
+        };
+
+        // Clean up empty rooms
+        if presence_room.members.is_empty() {
+            rooms.remove(room);
+            debug!(room, "presence: room removed (empty)");
+        }
+
+        Some(diff)
+    }
+
+    /// Record a heartbeat for a member, resetting their eviction timer.
+    ///
+    /// Returns `true` if the heartbeat was accepted (member exists in room).
+    pub async fn heartbeat(&self, room: &str, member_id: &str) -> bool {
+        let mut rooms = self.rooms.write().await;
+
+        if let Some(presence_room) = rooms.get_mut(room) {
+            if let Some(member) = presence_room.members.get_mut(member_id) {
+                member.last_seen = Instant::now();
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Update a member's state payload.
+    ///
+    /// Returns a `PresenceDiff` with the updated member in `joins` (same
+    /// semantics as Supabase Realtime — updates appear as joins).
+    pub async fn update_state(
+        &self,
+        room: &str,
+        member_id: &str,
+        new_state: serde_json::Value,
+    ) -> Option<PresenceDiff> {
+        let mut rooms = self.rooms.write().await;
+        let presence_room = rooms.get_mut(room)?;
+        let member = presence_room.members.get_mut(member_id)?;
+
+        member.state = new_state;
+        member.last_seen = Instant::now();
+
+        Some(PresenceDiff {
+            room: room.to_string(),
+            joins: vec![member.clone()],
+            leaves: vec![],
+        })
+    }
+
+    /// Evict members whose heartbeat has expired.
+    ///
+    /// Returns `PresenceDiff` events for each room that had evictions.
+    pub async fn evict_stale(&self) -> Vec<PresenceDiff> {
+        let timeout = self.config.heartbeat_timeout;
+        let mut rooms = self.rooms.write().await;
+        let mut diffs = Vec::new();
+        let mut empty_rooms = Vec::new();
+
+        for (room_name, room) in rooms.iter_mut() {
+            let mut evicted = Vec::new();
+
+            room.members.retain(|id, member| {
+                if member.last_seen.elapsed() > timeout {
+                    evicted.push(id.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+
+            if !evicted.is_empty() {
+                let count = evicted.len();
+                self.evictions_total
+                    .fetch_add(count as u64, Ordering::Relaxed);
+                debug!(room = %room_name, evicted = count, "presence: evicted stale members");
+
+                diffs.push(PresenceDiff {
+                    room: room_name.clone(),
+                    joins: vec![],
+                    leaves: evicted,
+                });
+            }
+
+            if room.members.is_empty() {
+                empty_rooms.push(room_name.clone());
+            }
+        }
+
+        for room_name in empty_rooms {
+            rooms.remove(&room_name);
+        }
+
+        diffs
+    }
+
+    /// Get current members of a room.
+    pub async fn get_room(&self, room: &str) -> Option<PresenceState> {
+        let rooms = self.rooms.read().await;
+        let presence_room = rooms.get(room)?;
+
+        Some(PresenceState {
+            room: room.to_string(),
+            members: presence_room.members.values().cloned().collect(),
+        })
+    }
+
+    /// Get statistics.
+    pub async fn stats(&self) -> PresenceStats {
+        let rooms = self.rooms.read().await;
+        let total_members: usize = rooms.values().map(|r| r.members.len()).sum();
+
+        PresenceStats {
+            active_rooms: rooms.len(),
+            total_members,
+            joins_total: self.joins_total.load(Ordering::Relaxed),
+            leaves_total: self.leaves_total.load(Ordering::Relaxed),
+            evictions_total: self.evictions_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Errors from presence operations.
+#[derive(Debug, thiserror::Error)]
+pub enum PresenceError {
+    /// Room has reached its member cap.
+    #[error("room '{room}' is full: max {max} members")]
+    RoomFull {
+        /// Room name.
+        room: String,
+        /// Maximum members.
+        max: usize,
+    },
+
+    /// Too many rooms exist.
+    #[error("room limit exceeded: max {max} rooms")]
+    TooManyRooms {
+        /// Maximum rooms.
+        max: usize,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+    use super::*;
+
+    fn default_manager() -> PresenceManager {
+        PresenceManager::new(PresenceConfig::new())
+    }
+
+    #[tokio::test]
+    async fn test_join_returns_state_and_diff() {
+        let mgr = default_manager();
+
+        let (state, diff) = mgr
+            .join("room1", "alice", serde_json::json!({"status": "online"}))
+            .await
+            .unwrap();
+
+        assert_eq!(state.room, "room1");
+        assert_eq!(state.members.len(), 1);
+        assert_eq!(state.members[0].id, "alice");
+        assert_eq!(diff.joins.len(), 1);
+        assert!(diff.leaves.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_multiple_members_in_room() {
+        let mgr = default_manager();
+
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+        let (state, diff) = mgr
+            .join("room1", "bob", serde_json::json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(state.members.len(), 2);
+        assert_eq!(diff.joins.len(), 1);
+        assert_eq!(diff.joins[0].id, "bob");
+    }
+
+    #[tokio::test]
+    async fn test_leave_returns_diff() {
+        let mgr = default_manager();
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+
+        let diff = mgr.leave("room1", "alice").await.unwrap();
+        assert_eq!(diff.leaves, vec!["alice"]);
+        assert!(diff.joins.is_empty());
+
+        // Room should be cleaned up
+        assert!(mgr.get_room("room1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_leave_nonexistent_returns_none() {
+        let mgr = default_manager();
+        assert!(mgr.leave("room1", "alice").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat() {
+        let mgr = default_manager();
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+
+        assert!(mgr.heartbeat("room1", "alice").await);
+        assert!(!mgr.heartbeat("room1", "nobody").await);
+        assert!(!mgr.heartbeat("noroom", "alice").await);
+    }
+
+    #[tokio::test]
+    async fn test_update_state() {
+        let mgr = default_manager();
+        mgr.join("room1", "alice", serde_json::json!({"status": "online"}))
+            .await
+            .unwrap();
+
+        let diff = mgr
+            .update_state("room1", "alice", serde_json::json!({"status": "away"}))
+            .await
+            .unwrap();
+
+        assert_eq!(diff.joins.len(), 1);
+        assert_eq!(diff.joins[0].state["status"], "away");
+
+        let state = mgr.get_room("room1").await.unwrap();
+        assert_eq!(state.members[0].state["status"], "away");
+    }
+
+    #[tokio::test]
+    async fn test_evict_stale_members() {
+        let config = PresenceConfig {
+            heartbeat_timeout: Duration::from_millis(1),
+            ..PresenceConfig::new()
+        };
+        let mgr = PresenceManager::new(config);
+
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+        mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+        // Wait for heartbeat to expire
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let diffs = mgr.evict_stale().await;
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].leaves.len(), 2);
+
+        // Room should be cleaned up
+        assert!(mgr.get_room("room1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_prevents_eviction() {
+        let config = PresenceConfig {
+            heartbeat_timeout: Duration::from_millis(50),
+            ..PresenceConfig::new()
+        };
+        let mgr = PresenceManager::new(config);
+
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+        mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+        // Wait a bit, then heartbeat only alice
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        mgr.heartbeat("room1", "alice").await;
+
+        // Wait for bob to expire but not alice
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let diffs = mgr.evict_stale().await;
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].leaves, vec!["bob"]);
+
+        // Alice should still be in the room
+        let state = mgr.get_room("room1").await.unwrap();
+        assert_eq!(state.members.len(), 1);
+        assert_eq!(state.members[0].id, "alice");
+    }
+
+    #[tokio::test]
+    async fn test_room_full() {
+        let config = PresenceConfig {
+            max_members_per_room: 2,
+            ..PresenceConfig::new()
+        };
+        let mgr = PresenceManager::new(config);
+
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+        mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+        let result = mgr.join("room1", "charlie", serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_too_many_rooms() {
+        let config = PresenceConfig {
+            max_rooms: 2,
+            ..PresenceConfig::new()
+        };
+        let mgr = PresenceManager::new(config);
+
+        mgr.join("room1", "a", serde_json::json!({})).await.unwrap();
+        mgr.join("room2", "b", serde_json::json!({})).await.unwrap();
+
+        let result = mgr.join("room3", "c", serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_rejoin_same_member_updates_state() {
+        let mgr = default_manager();
+
+        mgr.join("room1", "alice", serde_json::json!({"v": 1})).await.unwrap();
+        let (state, _) = mgr
+            .join("room1", "alice", serde_json::json!({"v": 2}))
+            .await
+            .unwrap();
+
+        // Should still be 1 member, not 2
+        assert_eq!(state.members.len(), 1);
+        assert_eq!(state.members[0].state["v"], 2);
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let mgr = default_manager();
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+        mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+        mgr.join("room2", "charlie", serde_json::json!({})).await.unwrap();
+        mgr.leave("room1", "alice").await;
+
+        let stats = mgr.stats().await;
+        assert_eq!(stats.active_rooms, 2);
+        assert_eq!(stats.total_members, 2);
+        assert_eq!(stats.joins_total, 3);
+        assert_eq!(stats.leaves_total, 1);
+    }
+
+    #[tokio::test]
+    async fn test_room_isolation() {
+        let mgr = default_manager();
+        mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+        mgr.join("room2", "bob", serde_json::json!({})).await.unwrap();
+
+        let state1 = mgr.get_room("room1").await.unwrap();
+        let state2 = mgr.get_room("room2").await.unwrap();
+
+        assert_eq!(state1.members.len(), 1);
+        assert_eq!(state1.members[0].id, "alice");
+        assert_eq!(state2.members.len(), 1);
+        assert_eq!(state2.members[0].id, "bob");
+    }
+}

--- a/crates/fraiseql-server/tests/realtime_integration_test.rs
+++ b/crates/fraiseql-server/tests/realtime_integration_test.rs
@@ -1,0 +1,386 @@
+//! Integration tests for Phase 16 realtime enhancements:
+//! CDC → `EventBridge` wiring, broadcast channels, presence, and tenant filtering.
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use fraiseql_core::runtime::subscription::{SubscriptionEvent, SubscriptionManager, SubscriptionOperation};
+use fraiseql_core::schema::CompiledSchema;
+use fraiseql_server::subscriptions::broadcast::{BroadcastConfig, BroadcastManager};
+use fraiseql_server::subscriptions::event_bridge::{EntityEvent, EventBridge, EventBridgeConfig};
+use fraiseql_server::subscriptions::presence::{PresenceConfig, PresenceManager};
+
+// ============================================================================
+// CDC → EventBridge Wiring
+// ============================================================================
+
+#[tokio::test]
+async fn test_cdc_event_bridge_end_to_end() {
+    let schema = Arc::new(CompiledSchema::new());
+    let manager = Arc::new(SubscriptionManager::new(schema));
+    let bridge = EventBridge::new(manager, EventBridgeConfig::new());
+    let sender = bridge.sender();
+    let handle = bridge.spawn();
+
+    // Simulate CDC event from ChangeLogListener
+    let event = EntityEvent::new("Order", "order_1", "INSERT", serde_json::json!({"id": "order_1"}));
+    sender.send(event).await.unwrap();
+
+    // Allow processing
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(!handle.is_finished(), "bridge should remain running");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_cdc_event_bridge_multiple_events() {
+    let schema = Arc::new(CompiledSchema::new());
+    let manager = Arc::new(SubscriptionManager::new(schema));
+    let bridge = EventBridge::new(manager, EventBridgeConfig::new());
+    let sender = bridge.sender();
+    let handle = bridge.spawn();
+
+    // Send a batch of events like the observer runtime would
+    for i in 0..10 {
+        let op = match i % 3 {
+            0 => "INSERT",
+            1 => "UPDATE",
+            _ => "DELETE",
+        };
+        let event = EntityEvent::new("Product", format!("prod_{i}"), op, serde_json::json!({"id": i}));
+        sender.send(event).await.unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(!handle.is_finished(), "bridge should handle batch without errors");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_cdc_event_bridge_tenant_propagation() {
+    let schema = Arc::new(CompiledSchema::new());
+    let manager = Arc::new(SubscriptionManager::new(schema));
+
+    // Subscribe to the broadcast channel to receive events
+    let _rx = manager.receiver();
+
+    let bridge = EventBridge::new(manager, EventBridgeConfig::new());
+    let sender = bridge.sender();
+    let handle = bridge.spawn();
+
+    // Send event with tenant_id
+    let event = EntityEvent::new("User", "user_1", "INSERT", serde_json::json!({"id": "user_1"}))
+        .with_tenant_id("org_42");
+    sender.send(event).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // The event was published (even though no subscription matches,
+    // the bridge should not error)
+    assert!(!handle.is_finished());
+
+    // The bridge processed the event without errors
+    handle.abort();
+}
+
+// ============================================================================
+// Broadcast Channels
+// ============================================================================
+
+#[tokio::test]
+async fn test_broadcast_publish_and_receive() {
+    let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+    let mut rx = manager.subscribe("chat:lobby").await.unwrap();
+
+    manager
+        .publish("chat:lobby", "message".into(), serde_json::json!({"text": "hello world"}))
+        .await
+        .unwrap();
+
+    let msg = rx.recv().await.unwrap();
+    assert_eq!(msg.channel, "chat:lobby");
+    assert_eq!(msg.event, "message");
+    assert_eq!(msg.payload["text"], "hello world");
+}
+
+#[tokio::test]
+async fn test_broadcast_channel_isolation() {
+    let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+    let mut rx_a = manager.subscribe("room:a").await.unwrap();
+    let _rx_b = manager.subscribe("room:b").await.unwrap();
+
+    // Publish only to room:a
+    manager
+        .publish("room:a", "event".into(), serde_json::json!({"v": 1}))
+        .await
+        .unwrap();
+
+    let msg = rx_a.recv().await.unwrap();
+    assert_eq!(msg.payload["v"], 1);
+}
+
+#[tokio::test]
+async fn test_broadcast_multiple_subscribers() {
+    let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+    let mut rx1 = manager.subscribe("events").await.unwrap();
+    let mut rx2 = manager.subscribe("events").await.unwrap();
+
+    let count = manager
+        .publish("events", "update".into(), serde_json::json!({"n": 42}))
+        .await
+        .unwrap();
+
+    assert_eq!(count, 2, "should notify 2 subscribers");
+
+    let m1 = rx1.recv().await.unwrap();
+    let m2 = rx2.recv().await.unwrap();
+    assert_eq!(m1.payload, m2.payload);
+}
+
+#[tokio::test]
+async fn test_broadcast_payload_size_limit() {
+    let config = BroadcastConfig {
+        max_message_bytes: 32,
+        ..BroadcastConfig::new()
+    };
+    let manager = BroadcastManager::new(config);
+
+    let result = manager
+        .publish("ch", "e".into(), serde_json::json!({"big": "this payload exceeds the 32 byte limit"}))
+        .await;
+
+    assert!(result.is_err(), "oversized payload should be rejected");
+}
+
+#[tokio::test]
+async fn test_broadcast_gc_empty_channels() {
+    let manager = BroadcastManager::new(BroadcastConfig::new());
+
+    // Create a channel with a subscriber (active)
+    let _rx = manager.subscribe("active").await.unwrap();
+    // Create a channel without subscribers (orphan)
+    manager
+        .publish("orphan", "e".into(), serde_json::json!({}))
+        .await
+        .unwrap();
+
+    assert_eq!(manager.channel_count().await, 2);
+
+    let removed = manager.gc_empty_channels().await;
+    assert_eq!(removed, 1);
+    assert_eq!(manager.channel_count().await, 1);
+}
+
+// ============================================================================
+// Presence
+// ============================================================================
+
+#[tokio::test]
+async fn test_presence_join_and_state() {
+    let mgr = PresenceManager::new(PresenceConfig::new());
+
+    let (state, diff) = mgr
+        .join("room1", "alice", serde_json::json!({"status": "online"}))
+        .await
+        .unwrap();
+
+    assert_eq!(state.room, "room1");
+    assert_eq!(state.members.len(), 1);
+    assert_eq!(state.members[0].id, "alice");
+    assert_eq!(state.members[0].state["status"], "online");
+
+    assert_eq!(diff.joins.len(), 1);
+    assert!(diff.leaves.is_empty());
+}
+
+#[tokio::test]
+async fn test_presence_join_multiple_members() {
+    let mgr = PresenceManager::new(PresenceConfig::new());
+
+    mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+    let (state, diff) = mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+    assert_eq!(state.members.len(), 2);
+    assert_eq!(diff.joins.len(), 1);
+    assert_eq!(diff.joins[0].id, "bob");
+}
+
+#[tokio::test]
+async fn test_presence_leave_and_cleanup() {
+    let mgr = PresenceManager::new(PresenceConfig::new());
+
+    mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+    let diff = mgr.leave("room1", "alice").await.unwrap();
+
+    assert_eq!(diff.leaves, vec!["alice"]);
+    assert!(mgr.get_room("room1").await.is_none(), "empty room should be cleaned up");
+}
+
+#[tokio::test]
+async fn test_presence_heartbeat_eviction() {
+    let config = PresenceConfig {
+        heartbeat_timeout: Duration::from_millis(5),
+        ..PresenceConfig::new()
+    };
+    let mgr = PresenceManager::new(config);
+
+    mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+    mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+    // Wait for heartbeat to expire
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let diffs = mgr.evict_stale().await;
+    assert_eq!(diffs.len(), 1);
+    assert_eq!(diffs[0].leaves.len(), 2, "both members should be evicted");
+    assert!(mgr.get_room("room1").await.is_none(), "room should be cleaned up");
+}
+
+#[tokio::test]
+async fn test_presence_heartbeat_keeps_member_alive() {
+    let config = PresenceConfig {
+        heartbeat_timeout: Duration::from_millis(50),
+        ..PresenceConfig::new()
+    };
+    let mgr = PresenceManager::new(config);
+
+    mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+    mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+    // Wait a bit, then heartbeat only alice
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    mgr.heartbeat("room1", "alice").await;
+
+    // Wait for bob's heartbeat to expire but not alice's
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let diffs = mgr.evict_stale().await;
+    assert_eq!(diffs.len(), 1);
+    assert_eq!(diffs[0].leaves, vec!["bob"]);
+
+    let state = mgr.get_room("room1").await.unwrap();
+    assert_eq!(state.members.len(), 1);
+    assert_eq!(state.members[0].id, "alice");
+}
+
+#[tokio::test]
+async fn test_presence_update_state() {
+    let mgr = PresenceManager::new(PresenceConfig::new());
+
+    mgr.join("room1", "alice", serde_json::json!({"cursor": [0, 0]}))
+        .await
+        .unwrap();
+
+    let diff = mgr
+        .update_state("room1", "alice", serde_json::json!({"cursor": [100, 200]}))
+        .await
+        .unwrap();
+
+    // Update appears as a join in the diff (Supabase convention)
+    assert_eq!(diff.joins.len(), 1);
+    assert_eq!(diff.joins[0].state["cursor"][0], 100);
+}
+
+#[tokio::test]
+async fn test_presence_room_capacity() {
+    let config = PresenceConfig {
+        max_members_per_room: 2,
+        ..PresenceConfig::new()
+    };
+    let mgr = PresenceManager::new(config);
+
+    mgr.join("room1", "alice", serde_json::json!({})).await.unwrap();
+    mgr.join("room1", "bob", serde_json::json!({})).await.unwrap();
+
+    let result = mgr.join("room1", "charlie", serde_json::json!({})).await;
+    assert!(result.is_err(), "third member should be rejected");
+}
+
+// ============================================================================
+// Tenant-Aware CDC Filtering
+// ============================================================================
+
+#[tokio::test]
+async fn test_tenant_filtering_subscription_event() {
+    // Verify SubscriptionEvent carries tenant_id
+    let event = SubscriptionEvent::new(
+        "Order",
+        "order_1",
+        SubscriptionOperation::Create,
+        serde_json::json!({"id": "order_1"}),
+    )
+    .with_tenant_id("org_42");
+
+    assert_eq!(event.tenant_id.as_deref(), Some("org_42"));
+}
+
+#[tokio::test]
+async fn test_tenant_filtering_bridge_event() {
+    // Verify EntityEvent carries tenant_id through the bridge
+    let event = EntityEvent::new("User", "user_1", "INSERT", serde_json::json!({"id": "user_1"}))
+        .with_tenant_id("org_99");
+
+    assert_eq!(event.tenant_id.as_deref(), Some("org_99"));
+}
+
+#[tokio::test]
+async fn test_tenant_filtering_event_conversion() {
+    // Verify EventBridge.convert_event preserves tenant_id
+    let entity_event =
+        EntityEvent::new("Order", "order_1", "INSERT", serde_json::json!({"id": "order_1"}))
+            .with_tenant_id("org_42");
+
+    let sub_event = EventBridge::convert_event(entity_event);
+    assert_eq!(sub_event.tenant_id.as_deref(), Some("org_42"));
+    assert_eq!(sub_event.entity_type, "Order");
+}
+
+#[tokio::test]
+async fn test_tenant_filtering_no_tenant_passes_through() {
+    // Events without a tenant_id should pass through to all subscribers
+    let entity_event =
+        EntityEvent::new("Order", "order_1", "INSERT", serde_json::json!({"id": "order_1"}));
+
+    let sub_event = EventBridge::convert_event(entity_event);
+    assert!(sub_event.tenant_id.is_none());
+}
+
+// ============================================================================
+// Combined: Broadcast + Presence stats
+// ============================================================================
+
+#[tokio::test]
+async fn test_broadcast_stats() {
+    let manager = Arc::new(BroadcastManager::new(BroadcastConfig::new()));
+
+    let _rx = manager.subscribe("ch1").await.unwrap();
+    manager.publish("ch1", "e".into(), serde_json::json!({})).await.unwrap();
+    manager.publish("ch2", "e".into(), serde_json::json!({})).await.unwrap();
+
+    let stats = manager.stats().await;
+    assert_eq!(stats.messages_published, 2);
+    assert_eq!(stats.active_channels, 2);
+    assert_eq!(stats.active_receivers, 1);
+}
+
+#[tokio::test]
+async fn test_presence_stats() {
+    let mgr = PresenceManager::new(PresenceConfig::new());
+
+    mgr.join("r1", "alice", serde_json::json!({})).await.unwrap();
+    mgr.join("r1", "bob", serde_json::json!({})).await.unwrap();
+    mgr.join("r2", "charlie", serde_json::json!({})).await.unwrap();
+    mgr.leave("r1", "alice").await;
+
+    let stats = mgr.stats().await;
+    assert_eq!(stats.active_rooms, 2);
+    assert_eq!(stats.total_members, 2);
+    assert_eq!(stats.joins_total, 3);
+    assert_eq!(stats.leaves_total, 1);
+}


### PR DESCRIPTION
## Summary

- **Cycle 1**: Wire CDC `ObserverRuntime` to `EventBridge` — processed CDC events from `tb_entity_change_log` are now forwarded to GraphQL subscriptions via `try_send` on an mpsc channel
- **Cycle 2**: Add `BroadcastManager` with named in-memory channels and `POST /realtime/v1/broadcast` REST endpoint for ephemeral pub/sub (no DB persistence)
- **Cycle 3**: Add `PresenceManager` with room-based member tracking, heartbeat eviction (30s timeout), `PRESENCE_STATE`/`PRESENCE_DIFF` event types, configurable room caps
- **Cycle 4**: Propagate `fk_customer_org` from `ChangeLogEntry` through the entire pipeline (`EntityEvent` → `BridgeEntityEvent` → `SubscriptionEvent` → `ActiveSubscription`) with tenant isolation check in `matches_subscription`
- **Cycle 5**: 21 integration tests covering all features + fix pre-existing federation test struct literals

## Test plan

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -p fraiseql-server --lib --all-features` — 1323 pass
- [x] `cargo test -p fraiseql-core --lib` — 2226 pass
- [x] `cargo test -p fraiseql-observers --lib` — 409 pass
- [x] `cargo test -p fraiseql-server --test realtime_integration_test` — 21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)