### PR TITLE
fix(server): add missing DLQ handler methods on InMemoryDlq

### DIFF
--- a/crates/fraiseql-server/src/observers/runtime.rs
+++ b/crates/fraiseql-server/src/observers/runtime.rs
@@ -672,7 +672,7 @@ impl ObserverRuntime {
 }
 
 /// Simple in-memory Dead Letter Queue for development
-struct InMemoryDlq {
+pub(crate) struct InMemoryDlq {
     items: std::sync::Mutex<Vec<fraiseql_observers::DlqItem>>,
 }
 
@@ -681,6 +681,34 @@ impl InMemoryDlq {
         Self {
             items: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    /// Returns the number of items currently in the DLQ.
+    pub(crate) fn count(&self) -> usize {
+        self.items.lock().expect("items mutex poisoned").len()
+    }
+
+    /// Returns all DLQ items as a cloned snapshot.
+    pub(crate) fn list_all(&self) -> Vec<fraiseql_observers::DlqItem> {
+        self.items.lock().expect("items mutex poisoned").clone()
+    }
+
+    /// Returns a single DLQ item by ID, if it exists.
+    pub(crate) fn get(&self, id: uuid::Uuid) -> Option<fraiseql_observers::DlqItem> {
+        self.items
+            .lock()
+            .expect("items mutex poisoned")
+            .iter()
+            .find(|item| item.id == id)
+            .cloned()
+    }
+
+    /// Removes a DLQ item by ID.
+    pub(crate) fn remove(&self, id: uuid::Uuid) {
+        self.items
+            .lock()
+            .expect("items mutex poisoned")
+            .retain(|item| item.id != id);
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -69,8 +69,6 @@ name = "aws-smithy-http"
 reason = "aws-sdk-s3 transitively depends on two smithy-http versions"
 version = "=0.62.6"
 
-# ── New duplicates from wasmtime 18.x / deno_core 0.290 (added in v2.2.0) ──────
-
 [[bans.skip]]
 name = "aws-smithy-json"
 reason = "aws-sdk-s3 transitively depends on two smithy-json versions"
@@ -245,7 +243,6 @@ version = "=0.10.6"
 name = "winnow"
 reason = "transitive via toml_edit 0.22; ecosystem migrating to winnow 1.0"
 version = "=0.7.15"
-
 
 [[bans.skip]]
 name = "base64-simd"


### PR DESCRIPTION
## Summary
- Add `count()`, `list_all()`, `get(id)`, and `remove(id)` methods to `InMemoryDlq`
- Make `InMemoryDlq` `pub(crate)` so `dlq_handlers.rs` can resolve the type
- Fixes compile error on `dev` where DLQ HTTP handlers called nonexistent methods on `&Arc<InMemoryDlq>`

## Test plan
- [x] `cargo check -p fraiseql-server --features observers-enterprise` passes
- [ ] Verify DLQ endpoints work in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)