### PR TITLE
fix(deps): bump rmcp 0.16 → 1.4 (CVE-2026-42559)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -192,7 +192,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2936,7 +2936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4468,7 +4468,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4784,7 +4784,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5507,7 +5507,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6587,7 +6587,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6624,7 +6624,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7124,9 +7124,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7154,9 +7154,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7298,7 +7298,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7990,7 +7990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8440,7 +8440,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10068,7 +10068,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -84,7 +84,7 @@ reqwest = {workspace = true}
 # MessagePack serialization for Redis idempotency store
 rmp-serde = {version = "1", optional = true}
 # MCP (Model Context Protocol) server (optional)
-rmcp = {version = "0.16", default-features = false, features = ["server", "macros", "transport-async-rw", "transport-streamable-http-server"], optional = true}
+rmcp = {version = "1.4", default-features = false, features = ["server", "macros", "transport-async-rw", "transport-streamable-http-server"], optional = true}
 # TLS/SSL support
 rustls = "0.23"
 rustls-pemfile = "2.2"

--- a/crates/fraiseql-server/src/mcp/executor.rs
+++ b/crates/fraiseql-server/src/mcp/executor.rs
@@ -153,6 +153,7 @@ pub(crate) fn graphql_value(value: &serde_json::Value) -> String {
 ///
 /// Walks the `TypeDefinition.fields` and returns names of fields whose type
 /// is a scalar (not `Object`, not `List(Object)`).
+#[must_use]
 pub fn scalar_fields_for_type(type_name: &str, schema: &CompiledSchema) -> Vec<String> {
     let Some(type_def) = schema.types.iter().find(|t| t.name == type_name) else {
         return vec![];
@@ -194,10 +195,5 @@ pub(crate) fn is_scalar_field_type(field_type: &FieldType) -> bool {
 }
 
 fn error_result(message: &str) -> CallToolResult {
-    CallToolResult {
-        content: vec![Content::text(message.to_string())],
-        structured_content: None,
-        is_error: Some(true),
-        meta: None,
-    }
+    CallToolResult::error(vec![Content::text(message.to_string())])
 }

--- a/crates/fraiseql-server/src/mcp/handler.rs
+++ b/crates/fraiseql-server/src/mcp/handler.rs
@@ -48,6 +48,7 @@ pub struct FraiseQLMcpService<A: DatabaseAdapter> {
 
 impl<A: DatabaseAdapter> FraiseQLMcpService<A> {
     /// Create a new MCP service.
+    #[must_use]
     pub fn new(schema: Arc<CompiledSchema>, executor: Arc<Executor<A>>, config: McpConfig) -> Self {
         let tools = super::tools::schema_to_tools(&schema, &config);
         Self {
@@ -61,11 +62,8 @@ impl<A: DatabaseAdapter> FraiseQLMcpService<A> {
 
 impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> ServerHandler for FraiseQLMcpService<A> {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some("FraiseQL GraphQL database — query and mutate via MCP tools".into()),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("FraiseQL GraphQL database — query and mutate via MCP tools")
     }
 
     fn list_tools(

--- a/crates/fraiseql-server/src/mcp/tools.rs
+++ b/crates/fraiseql-server/src/mcp/tools.rs
@@ -12,6 +12,7 @@ use rmcp::model::{JsonObject, Tool};
 use super::McpConfig;
 
 /// Convert the compiled schema into a list of MCP tools.
+#[must_use]
 pub fn schema_to_tools(schema: &CompiledSchema, config: &McpConfig) -> Vec<Tool> {
     let mut tools = Vec::new();
 
@@ -33,6 +34,7 @@ pub fn schema_to_tools(schema: &CompiledSchema, config: &McpConfig) -> Vec<Tool>
 }
 
 /// Check whether a given operation name should be included based on config filters.
+#[must_use]
 pub fn should_include(name: &str, config: &McpConfig) -> bool {
     if !config.include.is_empty() && !config.include.iter().any(|i| i == name) {
         return false;
@@ -47,17 +49,11 @@ pub fn should_include(name: &str, config: &McpConfig) -> bool {
 fn query_to_tool(query: &QueryDefinition, display_name: &str) -> Tool {
     let description = query.description.clone().unwrap_or_else(|| format!("Query: {display_name}"));
 
-    Tool {
-        name: Cow::Owned(display_name.to_string()),
-        title: None,
-        description: Some(Cow::Owned(description)),
-        input_schema: Arc::new(arguments_to_json_schema(&query.arguments)),
-        annotations: None,
-        output_schema: None,
-        execution: None,
-        icons: None,
-        meta: None,
-    }
+    Tool::new(
+        Cow::Owned(display_name.to_string()),
+        Cow::Owned(description),
+        Arc::new(arguments_to_json_schema(&query.arguments)),
+    )
 }
 
 /// Convert a mutation definition into an MCP tool.
@@ -67,17 +63,11 @@ fn mutation_to_tool(mutation: &MutationDefinition, display_name: &str) -> Tool {
         .clone()
         .unwrap_or_else(|| format!("Mutation: {display_name}"));
 
-    Tool {
-        name: Cow::Owned(display_name.to_string()),
-        title: None,
-        description: Some(Cow::Owned(description)),
-        input_schema: Arc::new(arguments_to_json_schema(&mutation.arguments)),
-        annotations: None,
-        output_schema: None,
-        execution: None,
-        icons: None,
-        meta: None,
-    }
+    Tool::new(
+        Cow::Owned(display_name.to_string()),
+        Cow::Owned(description),
+        Arc::new(arguments_to_json_schema(&mutation.arguments)),
+    )
 }
 
 /// Convert argument definitions into a JSON Schema object for MCP tool input.


### PR DESCRIPTION
## Summary

Resolves Dependabot alerts #138, #139 (rmcp HIGH, GHSA-89vp-x53w-74fx / CVE-2026-42559).

- rmcp `0.16.0` → `1.4` (resolves to `1.7.0` in lockfile, latest semver-compatible).
- The 0.x → 1.x bump made `Tool`, `CallToolResult`, `ServerInfo`/`InitializeResult` `#[non_exhaustive]`. Replaced four struct-literal call sites with the new builder/constructor methods.
- Added `#[must_use]` to four `fraiseql-server` public fns that the workspace-wide `must_use_candidate = "deny"` (set 2026-05-18 in AR-1) missed because the `mcp` feature isn't in defaults.

## Blast radius

The `mcp` feature is optional (`default = ["auth", "cli"]`). Users not opting into MCP are unaffected by either the CVE or this bump.

## Verification

- ✅ `cargo check -p fraiseql-server --features mcp`
- ✅ `cargo clippy -p fraiseql-server --features mcp --all-targets -- -D warnings`
- ✅ `cargo nextest run -p fraiseql-server --features mcp` — 2048 passed, 10 skipped, 0 failed

## Test plan

- [x] Unit + integration tests pass with `--features mcp`
- [x] Clippy clean with pedantic + must_use_candidate (deny)
- [ ] Verify Dependabot rescans and closes #138, #139 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)