### PR TITLE
fix(deps): bump fuzz jsonwebtoken 9 → 10 (CVE-2026-25537)

### DIFF
--- a/crates/fraiseql-auth/fuzz/Cargo.lock
+++ b/crates/fraiseql-auth/fuzz/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
  "hex",
  "hmac",
  "http",
- "jsonwebtoken 10.4.0",
+ "jsonwebtoken",
  "rand 0.9.4",
  "reqwest",
  "serde",
@@ -699,7 +699,7 @@ name = "fraiseql-auth-fuzz"
 version = "2.1.0"
 dependencies = [
  "fraiseql-auth",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "libfuzzer-sys",
 ]
 
@@ -1208,21 +1208,6 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ doc = false
 
 [dependencies]
 libfuzzer-sys = "0.4"
-jsonwebtoken = "9"
+jsonwebtoken = "10"
 
 [dependencies.fraiseql-auth]
 path = ".."


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #49 (GHSA-h395-gr6q-cpjc / CVE-2026-25537, patched in jsonwebtoken 10.3.0).

The fuzz crate `crates/fraiseql-auth/fuzz` was pinned to `jsonwebtoken = "9"` while the workspace runtime crate has been on v10 for some time. This single-line bump aligns them.

## Blast radius

Fuzz-only crate. No production code path. The `JwtValidator::new` / `validate_hmac` API surface used in `fuzz_targets/jwt_parse.rs` is unchanged across v9 → v10.

## Verification

- ✅ `cargo check` from the fuzz crate compiles clean
- ✅ `Cargo.lock` resolves to jsonwebtoken 10.4.0
- ⚠️ `cargo +nightly fuzz build` not run locally (nightly toolchain not installed); CI fuzz job will exercise the targets.

## Test plan

- [x] Fuzz crate `cargo check` builds
- [ ] CI fuzz workflow exercises targets without panic
- [ ] Dependabot rescans and closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)