### PR TITLE
fix(arrow): feature-gate parquet to remove thrift CVE-2026-43868

### DIFF
--- a/crates/fraiseql-arrow/Cargo.toml
+++ b/crates/fraiseql-arrow/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 reqwest = {workspace = true}
 # JWT handling (for session token creation and validation)
 jsonwebtoken = "10"
-parquet = "57"
+parquet = {version = "57", optional = true}
 prost = "0.14"
 # Serialization
 serde = {version = "1", features = ["derive"]}
@@ -59,6 +59,9 @@ uuid = {version = "1", features = ["v4"]}
 [features]
 clickhouse = ["dep:clickhouse"]
 default = []
+# Reason: parquet pulls thrift 0.17 (CVE-2026-43868 — unmaintained upstream
+# since 2022). Off by default; opt in if you need Parquet export.
+parquet = ["dep:parquet"]
 testing = []
 
 [lib]

--- a/crates/fraiseql-arrow/src/export.rs
+++ b/crates/fraiseql-arrow/src/export.rs
@@ -10,7 +10,10 @@ use arrow::array::RecordBatch;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ExportFormat {
-    /// Apache Parquet columnar format
+    /// Apache Parquet columnar format.
+    ///
+    /// Available only when the `parquet` feature is enabled.
+    #[cfg(feature = "parquet")]
     Parquet,
     /// Comma-separated values
     Csv,
@@ -23,7 +26,14 @@ impl FromStr for ExportFormat {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            #[cfg(feature = "parquet")]
             "parquet" => Ok(Self::Parquet),
+            #[cfg(not(feature = "parquet"))]
+            "parquet" => Err(
+                "Parquet export requires the `parquet` Cargo feature (disabled by default due \
+                 to CVE-2026-43868 in transitive thrift dep)"
+                    .into(),
+            ),
             "csv" => Ok(Self::Csv),
             "json" => Ok(Self::Json),
             _ => Err(format!("Unsupported export format: {}", s)),
@@ -51,6 +61,7 @@ impl ExportFormat {
     #[must_use]
     pub const fn extension(&self) -> &'static str {
         match self {
+            #[cfg(feature = "parquet")]
             Self::Parquet => "parquet",
             Self::Csv => "csv",
             Self::Json => "jsonl",
@@ -61,6 +72,7 @@ impl ExportFormat {
     #[must_use]
     pub const fn mime_type(&self) -> &'static str {
         match self {
+            #[cfg(feature = "parquet")]
             Self::Parquet => "application/octet-stream",
             Self::Csv => "text/csv",
             Self::Json => "application/x-ndjson",
@@ -88,6 +100,7 @@ impl BulkExporter {
     /// Returns error if export fails (e.g., Parquet encoding error)
     pub fn export_batch(batch: &RecordBatch, format: ExportFormat) -> Result<Vec<u8>, String> {
         match format {
+            #[cfg(feature = "parquet")]
             ExportFormat::Parquet => Self::export_parquet(batch),
             ExportFormat::Csv => Self::export_csv(batch),
             ExportFormat::Json => Self::export_json(batch),
@@ -98,6 +111,7 @@ impl BulkExporter {
     ///
     /// Parquet provides efficient columnar storage with compression.
     /// Ideal for large datasets and analytical workloads.
+    #[cfg(feature = "parquet")]
     fn export_parquet(batch: &RecordBatch) -> Result<Vec<u8>, String> {
         use parquet::arrow::ArrowWriter;
 

--- a/crates/fraiseql-arrow/src/export/tests.rs
+++ b/crates/fraiseql-arrow/src/export/tests.rs
@@ -23,12 +23,23 @@ fn create_test_batch() -> RecordBatch {
 
 #[test]
 fn test_export_format_from_str() {
-    assert_eq!(ExportFormat::from_str("parquet").unwrap(), ExportFormat::Parquet);
     assert_eq!(ExportFormat::from_str("csv").unwrap(), ExportFormat::Csv);
     assert_eq!(ExportFormat::from_str("json").unwrap(), ExportFormat::Json);
 
-    // Case-insensitive
-    assert_eq!(ExportFormat::from_str("PARQUET").unwrap(), ExportFormat::Parquet);
+    #[cfg(feature = "parquet")]
+    {
+        assert_eq!(ExportFormat::from_str("parquet").unwrap(), ExportFormat::Parquet);
+        // Case-insensitive
+        assert_eq!(ExportFormat::from_str("PARQUET").unwrap(), ExportFormat::Parquet);
+    }
+
+    #[cfg(not(feature = "parquet"))]
+    {
+        // Without the `parquet` feature, "parquet" should yield a feature-gated error.
+        let err = ExportFormat::from_str("parquet")
+            .expect_err("expected Err for parquet without feature");
+        assert!(err.contains("parquet"), "unexpected error: {err}");
+    }
 
     // Invalid format
     assert!(
@@ -39,16 +50,18 @@ fn test_export_format_from_str() {
 
 #[test]
 fn test_export_format_extension() {
-    assert_eq!(ExportFormat::Parquet.extension(), "parquet");
     assert_eq!(ExportFormat::Csv.extension(), "csv");
     assert_eq!(ExportFormat::Json.extension(), "jsonl");
+    #[cfg(feature = "parquet")]
+    assert_eq!(ExportFormat::Parquet.extension(), "parquet");
 }
 
 #[test]
 fn test_export_format_mime_type() {
-    assert_eq!(ExportFormat::Parquet.mime_type(), "application/octet-stream");
     assert_eq!(ExportFormat::Csv.mime_type(), "text/csv");
     assert_eq!(ExportFormat::Json.mime_type(), "application/x-ndjson");
+    #[cfg(feature = "parquet")]
+    assert_eq!(ExportFormat::Parquet.mime_type(), "application/octet-stream");
 }
 
 #[test]
@@ -82,6 +95,7 @@ fn test_export_json() {
     assert!(json_str.contains("Alice"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn test_export_parquet() {
     let batch = create_test_batch();
@@ -117,14 +131,17 @@ fn test_export_empty_batch() {
     let batch = RecordBatch::try_new(Arc::new(schema), vec![empty_array])
         .expect("should create empty batch");
 
-    // All formats should handle empty batches
     let csv = BulkExporter::export_batch(&batch, ExportFormat::Csv);
     let json = BulkExporter::export_batch(&batch, ExportFormat::Json);
-    let parquet = BulkExporter::export_batch(&batch, ExportFormat::Parquet);
 
     csv.unwrap_or_else(|e| panic!("expected Ok for empty-batch CSV export: {e}"));
     json.unwrap_or_else(|e| panic!("expected Ok for empty-batch JSON export: {e}"));
-    parquet.unwrap_or_else(|e| panic!("expected Ok for empty-batch Parquet export: {e}"));
+
+    #[cfg(feature = "parquet")]
+    {
+        let parquet = BulkExporter::export_batch(&batch, ExportFormat::Parquet);
+        parquet.unwrap_or_else(|e| panic!("expected Ok for empty-batch Parquet export: {e}"));
+    }
 }
 
 // --- Additional export format tests ---
@@ -141,6 +158,7 @@ fn test_export_format_parse_trait_uppercase_json() {
     assert_eq!(fmt, ExportFormat::Json);
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn test_export_format_parse_trait_mixed_case_parquet() {
     let fmt: ExportFormat = "Parquet".parse().unwrap();
@@ -156,7 +174,7 @@ fn test_export_format_parse_unknown_returns_err() {
 
 #[test]
 fn test_export_format_clone_and_eq() {
-    let fmt = ExportFormat::Parquet;
+    let fmt = ExportFormat::Csv;
     let cloned = fmt;
     assert_eq!(fmt, cloned);
 }
@@ -179,6 +197,7 @@ fn test_json_export_contains_all_row_data() {
     assert!(json_str.contains("Charlie"));
 }
 
+#[cfg(feature = "parquet")]
 #[test]
 fn test_parquet_export_ends_with_magic_bytes() {
     let batch = create_test_batch();

--- a/crates/fraiseql-arrow/src/flight_server/service.rs
+++ b/crates/fraiseql-arrow/src/flight_server/service.rs
@@ -945,12 +945,17 @@ impl FraiseQLFlightService {
         format: Option<String>,
         security_context: &fraiseql_core::security::SecurityContext,
     ) -> std::result::Result<Response<FlightDataStream>, Status> {
-        // Parse export format (default to Parquet)
+        // Parse export format. Default is Parquet when the `parquet` feature is enabled,
+        // otherwise JSON Lines (Parquet pulls in the unmaintained thrift 0.17 crate;
+        // see deny.toml / security-vulnerabilities.md for context).
         let export_format = match format.as_deref() {
             Some(f) => f
                 .parse::<ExportFormat>()
                 .map_err(|e| Status::invalid_argument(format!("Invalid format: {}", e)))?,
+            #[cfg(feature = "parquet")]
             None => ExportFormat::Parquet,
+            #[cfg(not(feature = "parquet"))]
+            None => ExportFormat::Json,
         };
 
         info!(


### PR DESCRIPTION
## Summary

Resolves Dependabot alerts #145, #146 (thrift CVE-2026-43868 / GHSA-2f9f-gq7v-9h6m) by removing thrift from the default dependency tree.

**The hard truth**: Parquet's file format spec requires Thrift-encoded metadata. No Rust crate can write spec-compliant Parquet without `thrift`. `thrift` 0.17.0 (2022) is unmaintained — no upstream fix path; no drop-in alternative (`pilota`, `thrift_codec` have different APIs and parquet won't accept them without a fork).

**Mitigation**: feature-gate `parquet` in `fraiseql-arrow` (default OFF). Users who don't need Parquet export never pull `thrift`. Users who do need it opt in via `fraiseql-arrow = { ..., features = ["parquet"] }`.

## Verified

```
$ cargo tree -p fraiseql-arrow | grep thrift
(empty)

$ cargo tree -p fraiseql-arrow --features parquet | grep thrift
├── thrift v0.17.0
```

## Changes

- `fraiseql-arrow/Cargo.toml`: `parquet` → optional dep; new `parquet = ["dep:parquet"]` feature, default OFF, with CVE rationale comment.
- `fraiseql-arrow/src/export.rs`: `ExportFormat::Parquet` variant cfg-gated. Without the feature, `from_str("parquet")` returns a clear feature-gated error directing users to the Cargo opt-in.
- `fraiseql-arrow/src/flight_server/service.rs`: default Flight format falls back to `Json` when `parquet` feature is disabled (was unconditionally `Parquet`).
- `fraiseql-arrow/src/export/tests.rs`: tests cfg-gated; added a negative test for the no-feature error path.

## Breaking change

`ExportFormat::Parquet` no longer resolves on default builds. Users hit a clear compile error pointing to the missing feature. Migration:

```toml
[dependencies]
fraiseql-arrow = { version = "...", features = ["parquet"] }
# or for downstream crates:
fraiseql = { version = "...", features = ["arrow"] }
fraiseql-arrow = { version = "...", features = ["parquet"] }
```

## Test plan

- [x] `cargo check -p fraiseql-arrow` (default)
- [x] `cargo check -p fraiseql-arrow --features parquet`
- [x] `cargo check --workspace` and `--all-features`
- [x] `cargo clippy -p fraiseql-arrow --all-targets -- -D warnings` (both feature configs)
- [x] `cargo nextest run -p fraiseql-arrow` — 346 passed, 0 skipped
- [x] `cargo deny check` — clean
- [x] `cargo tree`: thrift absent from default tree
- [ ] Dependabot rescans and closes #145/#146 after merge

## Follow-up

- Phase 5: add `security-vulnerabilities.md` "Accepted Risks" entry referencing this mitigation (draft staged in `/tmp/phase5-security-vulnerabilities-draft.md`).
- Consider adding convenience features `fraiseql/arrow-parquet`, `fraiseql-server/arrow-parquet` for downstream UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)