### PR TITLE
chore(deny): allow aws-sdk-s3/sqlx-mysql transitive lru + sha1

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -248,8 +248,13 @@ version = "=0.12.1"
 
 [[bans.skip]]
 name = "lru"
-reason = "transitive via newer dependency pulling lru 0.16"
-version = "=0.16.4"
+reason = "transitive via aws-sdk-s3 (pinned to lru 0.12.x); workspace direct on lru 0.18"
+version = "=0.12.5"
+
+[[bans.skip]]
+name = "sha1"
+reason = "transitive via sqlx-mysql (pinned to sha1 0.10.x); workspace direct on sha1 0.11"
+version = "=0.10.6"
 
 [[bans.skip]]
 name = "outref"


### PR DESCRIPTION
## Summary

Updates `bans.skip` rules so Dependabot PRs #282 (lru 0.16.4 → 0.18.0) and #284 (sha1 0.10.6 → 0.11.0) can merge without triggering `License Compliance` duplicate-version errors.

## Why

`cargo deny check` fails on those PRs because:
- aws-sdk-s3 transitively requires `lru = "^0.12"` → resolves to 0.12.5
- sqlx-mysql transitively requires `sha1 = "^0.10"` → resolves to 0.10.6

When the workspace direct deps move above the aws-sdk / sqlx-mysql pins, two versions of each crate end up in the lockfile and cargo-deny's duplicate-bans rule fires.

## Changes

- `lru` skip: `=0.16.4` → `=0.12.5` (now matches the aws-sdk-s3 transitive pin; allows our direct dep to move freely).
- `sha1` skip: new entry for `=0.10.6` (sqlx-mysql transitive).

## Verification

- ✅ `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok
- ⚠️ One "unnecessary-skip" warning for sha1 until #284 lands (sha1 only has one version on dev today)
- ⚠️ One "unnecessary-skip" warning for lru until #282 lands (lru 0.12.5 not in current tree)

Both warnings auto-resolve once those PRs merge.

## Test plan

- [x] Local `cargo deny check` clean
- [ ] CI green on this PR
- [ ] After merge: re-run CI on #282 + #284; verify License Compliance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)