### PR TITLE
Revert "chore(deps): bump sha1 from 0.10.6 to 0.11.0 (#284)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1 0.10.6",
+ "sha1",
  "time",
  "tokio",
  "tracing",
@@ -958,7 +958,7 @@ dependencies = [
  "http-body 0.4.6",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1 0.10.6",
+ "sha1",
  "sha2 0.10.9",
  "tracing",
 ]
@@ -1214,7 +1214,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -3249,7 +3249,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha1 0.11.0",
+ "sha1",
  "sha2 0.10.9",
  "sqlx",
  "subtle",
@@ -3603,7 +3603,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sha1 0.11.0",
+ "sha1",
  "sha2 0.10.9",
  "sqlx",
  "subtle",
@@ -3697,7 +3697,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha1 0.11.0",
+ "sha1",
  "sha2 0.10.9",
  "sqlx",
  "subtle",
@@ -7800,17 +7800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8194,7 +8183,7 @@ dependencies = [
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1 0.10.6",
+ "sha1",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -9039,7 +9028,7 @@ dependencies = [
  "constant_time_eq",
  "hmac 0.12.1",
  "rand 0.9.4",
- "sha1 0.10.6",
+ "sha1",
  "sha2 0.10.9",
  "url",
  "urlencoding",
@@ -9234,7 +9223,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls 0.23.40",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -9251,7 +9240,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1 0.10.6",
+ "sha1",
  "thiserror 2.0.18",
 ]
 

--- a/crates/fraiseql-auth/Cargo.toml
+++ b/crates/fraiseql-auth/Cargo.toml
@@ -18,7 +18,7 @@ redis = {version = "1", features = ["aio", "tokio-comp", "connection-manager"], 
 reqwest = {workspace = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha1 = "0.11"
+sha1 = "0.10"
 sha2 = "0.10"
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio", "uuid", "chrono"]}
 subtle = "2.5"

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -94,7 +94,7 @@ rust-embed = {version = "8", features = ["interpolate-folder-path"]}
 # Serialization
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha1 = "0.11"
+sha1 = "0.10"
 sha2 = "0.10"
 # Database
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio", "uuid", "chrono"]}

--- a/crates/fraiseql-webhooks/Cargo.toml
+++ b/crates/fraiseql-webhooks/Cargo.toml
@@ -7,7 +7,7 @@ hmac = "0.12"
 p256 = {version = "0.13", features = ["ecdsa", "pem"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha1 = "0.11"
+sha1 = "0.10"
 sha2 = "0.10"
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio"]}
 subtle = "2.5"

--- a/deny.toml
+++ b/deny.toml
@@ -252,11 +252,6 @@ reason = "transitive via aws-sdk-s3 (pinned to lru 0.12.x); workspace direct on 
 version = "=0.12.5"
 
 [[bans.skip]]
-name = "sha1"
-reason = "transitive via sqlx-mysql (pinned to sha1 0.10.x); workspace direct on sha1 0.11"
-version = "=0.10.6"
-
-[[bans.skip]]
 name = "outref"
 reason = "transitive via older dependency chain"
 version = "=0.1.0"


### PR DESCRIPTION
## Summary

Reverts #284. **sha1 0.11.0 broke compilation** in `fraiseql-webhooks` because it changed its trait implementations in a way that's incompatible with `hmac 0.12` (the workspace's hmac version).

## Error

```
error[E0277]: the trait bound `sha1::Sha1: hmac::digest::core_api::CoreProxy` is not satisfied
    required for `HmacCore<sha1::Sha1>` to implement `hmac::digest::core_api::BlockSizeUser`
```

Affects all webhook signature verifiers: `postmark.rs`, `generic.rs`, `lemonsqueezy.rs`, `twilio.rs`. They all use the standard `Hmac::<Sha1>::new_from_slice(secret)` pattern, which `hmac 0.12` rejects when paired with `sha1 0.11`.

## Why revert (not fix-forward)

- PR #284 wasn't security-driven; it was Dependabot hygiene.
- Fixing forward would require bumping `hmac` 0.12 → 0.13 (the version compatible with sha1 0.11) and reviewing all four signature verifier call sites — a separate, scoped piece of work.
- The dev branch was effectively broken between #284 landing and this revert.

## Changes

- Reverts `crates/fraiseql-server/Cargo.toml` and `crates/fraiseql-webhooks/Cargo.toml` `sha1` from `"0.11"` back to `"0.10"`.
- Reverts `Cargo.lock`.
- **Also reverts** the `[[bans.skip]] sha1 = =0.10.6` entry I added in PR #297 (cleanup — it was pre-positioned for #284 and is now unnecessary; can be re-added later alongside an hmac bump).

## Verification

- ✅ `cargo check -p fraiseql-webhooks --all-features` clean
- ✅ `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok

## Follow-up

- Track sha1 0.11 + hmac 0.13 bump as a separate task. Both crates need to move together; touch all four signature verifier call sites; verify webhook integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)