### PR TITLE
fix(server): axum 0.8 path-capture migration (closes #316)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -439,6 +439,18 @@ RUST_LOG=debug cargo test
 
 ---
 
+## Bumping axum
+
+axum's major releases periodically rework path-capture syntax (0.7 → 0.8 swapped `:param` for `{param}` and made the old form a build-time panic). Issue #316 shipped because a single literal slipped through the migration. Three gates exist now — run all three on any future axum bump:
+
+1. **Static gate.** `make lint-routes` (`tools/check-route-syntax.sh`) greps for the old `:param` form across `crates/` and `examples/`, including a load-bearing multi-line `awk` pass that catches `.route(\n  "...",\n  ...)` calls the single-line grep misses. The CI job is `axum-route-syntax-check` in `.github/workflows/ci.yml`.
+
+2. **Construction tests.** Five `*_constructs` tests in `crates/fraiseql-server/src/observers/tests.rs::router_construction` and `crates/fraiseql-server/src/api/rbac_management/tests.rs::router_construction` call each public `Router` constructor under `#[tokio::test]`. axum validates path-capture syntax inside `Router::route`, so any lingering bad literal panics in `cargo test`, not at first server boot. Extend the pattern to any new router constructor.
+
+3. **Release smoke.** `.github/workflows/release-smoke.yml` boots the server against a fixture schema on `release/*` branches and `v*` tags and asserts the health endpoint responds within ~10s. This is the catch-all for the broader "code compiles but server panics on boot" class — covers route syntax, missing env vars, lazy-init failures, etc., across every constructor the binary actually mounts.
+
+---
+
 ## Next Steps
 
 See `roadmap.md` (repository root) for detailed feature implementation status and priority order. Current focus areas:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,18 @@ jobs:
       - name: Check test imports
         run: bash tools/check-test-imports.sh
 
+  # Static gate against axum 0.7-style `:param` path captures.
+  # axum 0.8 panics at Router::route build time on the old syntax — see issue #316.
+  axum-route-syntax-check:
+    name: Axum Route Syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Check axum route capture syntax
+        run: bash tools/check-route-syntax.sh
+
   # Lint with Clippy
   clippy:
     name: Clippy Lints

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,100 @@
+name: Release Smoke
+
+# Purpose: catch any startup-only panic before crates.io publish.
+# This is the explicit safety net for router-constructor sites that aren't
+# unit-tested individually (see `crates/fraiseql-server/src/server/routing/`
+# auth/admin/graphql sub-routers). Issue #316 — an axum 0.7 `:param` capture
+# missed by the 0.7 → 0.8 migration — only surfaced because a user ran the
+# published binary; the bug class is "code compiles, server panics on boot."
+#
+# Boots `fraiseql-server` against the existing e2e fixture (docker/e2e/) and
+# asserts the default health endpoint responds within ~30s. Mirrors the
+# `integration-http-e2e` job in ci.yml but is wired to release-track events
+# so a failure blocks the release.
+
+on:
+  push:
+    branches:
+      - 'release/*'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'release/*'
+  workflow_dispatch:
+
+concurrency:
+  group: release-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Server boot smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: fraiseql_test_password
+          POSTGRES_USER: fraiseql_test
+          POSTGRES_DB: test_fraiseql
+        options: >-
+          --health-cmd "pg_isready -U fraiseql_test -d test_fraiseql"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5433:5432
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Apply E2E database schema
+        run: |
+          PGPASSWORD=fraiseql_test_password psql \
+            -h localhost -p 5433 -U fraiseql_test -d test_fraiseql \
+            -f docker/e2e/init-postgres.sql
+
+      - name: Build fraiseql-server (release profile)
+        run: cargo build --release -p fraiseql-server
+
+      - name: Start fraiseql-server
+        run: |
+          ./target/release/fraiseql-server &
+          echo $! > /tmp/fraiseql-server.pid
+        env:
+          DATABASE_URL: postgresql://fraiseql_test:fraiseql_test_password@localhost:5433/test_fraiseql
+          FRAISEQL_SCHEMA_PATH: docker/e2e/schema.compiled.json
+          FRAISEQL_BIND_ADDR: 127.0.0.1:8815
+          FRAISEQL_INTROSPECTION_ENABLED: "true"
+          FRAISEQL_INTROSPECTION_REQUIRE_AUTH: "false"
+          FRAISEQL_ENV: development
+          RUST_LOG: info
+
+      - name: Wait for /health to respond
+        run: |
+          set -eu
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8815/health; then
+              echo
+              echo "Server is up after ~$((i * 1)) attempt(s)."
+              exit 0
+            fi
+            # If the process already died, surface that instead of waiting 30s.
+            if ! kill -0 "$(cat /tmp/fraiseql-server.pid)" 2>/dev/null; then
+              echo "::error::fraiseql-server process exited before /health responded — likely a startup panic." >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "::error::Timed out waiting for /health after 30s." >&2
+          exit 1
+
+      - name: Stop server
+        if: always()
+        run: kill "$(cat /tmp/fraiseql-server.pid 2>/dev/null)" 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -419,6 +419,12 @@ lint-tests-layout:
 	fi; \
 	echo "OK: no inline test blocks in workspace src/"
 
+# Gate: ensure no axum 0.7-style `:param` captures slip back into `.route()` calls.
+# Issue #316 prevention — see `tools/check-route-syntax.sh` for the load-bearing multi-line awk.
+.PHONY: lint-routes
+lint-routes:
+	@bash tools/check-route-syntax.sh
+
 # Format code (nightly rustfmt for advanced formatting options)
 fmt:
 	cargo +nightly fmt --all

--- a/crates/fraiseql-server/src/api/rbac_management.rs
+++ b/crates/fraiseql-server/src/api/rbac_management.rs
@@ -118,13 +118,16 @@ pub fn rbac_management_router(state: RbacManagementState) -> Router {
     Router::new()
         // Role endpoints
         .route("/api/roles", post(create_role).get(list_roles))
-        .route("/api/roles/:role_id", get(get_role).put(update_role).delete(delete_role))
+        .route("/api/roles/{role_id}", get(get_role).put(update_role).delete(delete_role))
         // Permission endpoints
         .route("/api/permissions", post(create_permission).get(list_permissions))
-        .route("/api/permissions/:permission_id", get(get_permission).delete(delete_permission))
+        .route(
+            "/api/permissions/{permission_id}",
+            get(get_permission).delete(delete_permission),
+        )
         // User-role assignment endpoints
         .route("/api/user-roles", post(assign_role).get(list_user_roles))
-        .route("/api/user-roles/:user_id/:role_id", delete(revoke_role))
+        .route("/api/user-roles/{user_id}/{role_id}", delete(revoke_role))
         // Audit endpoints
         .route("/api/audit/permissions", get(query_permission_audit))
         .with_state(Arc::new(state))

--- a/crates/fraiseql-server/src/api/rbac_management/tests.rs
+++ b/crates/fraiseql-server/src/api/rbac_management/tests.rs
@@ -400,3 +400,31 @@ mod db_backend_tests {
         assert_eq!(format!("{}", RbacDbError::RoleDuplicate), "Role already exists");
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)] // Reason: test code; pool ctor errors must panic to surface test setup failures
+mod router_construction {
+    //! See `crates/fraiseql-server/src/observers/routes.rs::tests` for context:
+    //! axum validates path-capture syntax inside `Router::route`, so any
+    //! lingering `:param` literal panics here at build time (issue #316).
+
+    use std::sync::Arc;
+
+    use sqlx::PgPool;
+
+    use crate::api::rbac_management::{
+        RbacManagementState, db_backend::RbacDbBackend, rbac_management_router,
+    };
+
+    fn lazy_pool() -> PgPool {
+        PgPool::connect_lazy("postgres://test:test@localhost/test").unwrap()
+    }
+
+    #[tokio::test]
+    async fn rbac_router_constructs() {
+        let state = RbacManagementState {
+            db: Arc::new(RbacDbBackend::new(lazy_pool())),
+        };
+        let _ = rbac_management_router(state);
+    }
+}

--- a/crates/fraiseql-server/src/observers/changelog_handlers/mod.rs
+++ b/crates/fraiseql-server/src/observers/changelog_handlers/mod.rs
@@ -96,7 +96,7 @@ pub struct CheckpointResponse {
     pub updated_at:  Option<String>,
 }
 
-/// Request body for `PUT /api/observers/checkpoint/:listener_id`.
+/// Request body for `PUT /api/observers/checkpoint/{listener_id}`.
 #[derive(Debug, Deserialize)]
 pub struct SaveCheckpointRequest {
     /// The cursor value to persist.
@@ -213,7 +213,7 @@ pub async fn changelog_list_handler(
     }
 }
 
-/// `GET /api/observers/checkpoint/:listener_id`
+/// `GET /api/observers/checkpoint/{listener_id}`
 ///
 /// Read the current checkpoint for a given listener.
 pub async fn checkpoint_get_handler(
@@ -257,7 +257,7 @@ pub async fn checkpoint_get_handler(
     }
 }
 
-/// `PUT /api/observers/checkpoint/:listener_id`
+/// `PUT /api/observers/checkpoint/{listener_id}`
 ///
 /// Create or update a checkpoint. Uses `ON CONFLICT … DO UPDATE` (upsert).
 pub async fn checkpoint_save_handler(

--- a/crates/fraiseql-server/src/observers/dlq_handlers/mod.rs
+++ b/crates/fraiseql-server/src/observers/dlq_handlers/mod.rs
@@ -203,7 +203,7 @@ pub async fn dlq_list_handler(
     (StatusCode::OK, Json(response))
 }
 
-/// `GET /api/observers/dlq/:id`
+/// `GET /api/observers/dlq/{id}`
 ///
 /// Returns a single DLQ item by ID.
 pub async fn dlq_get_handler(
@@ -225,7 +225,7 @@ pub async fn dlq_get_handler(
     }
 }
 
-/// `POST /api/observers/dlq/:id/retry`
+/// `POST /api/observers/dlq/{id}/retry`
 ///
 /// Re-processes a single DLQ item through the observer executor, then
 /// removes it from the DLQ on success.

--- a/crates/fraiseql-server/src/observers/handlers.rs
+++ b/crates/fraiseql-server/src/observers/handlers.rs
@@ -52,7 +52,7 @@ pub async fn list_observers(
 
 /// Get a single observer by ID.
 ///
-/// GET /api/observers/:id
+/// GET /api/observers/{id}
 pub async fn get_observer(
     State(state): State<ObserverState>,
     Path(id): Path<Uuid>,
@@ -137,7 +137,7 @@ pub async fn create_observer(
 
 /// Update an existing observer.
 ///
-/// PATCH /api/observers/:id
+/// PATCH /api/observers/{id}
 pub async fn update_observer(
     State(state): State<ObserverState>,
     OptionalSecurityContext(security_context): OptionalSecurityContext,
@@ -182,7 +182,7 @@ pub async fn update_observer(
 
 /// Delete an observer (soft delete).
 ///
-/// DELETE /api/observers/:id
+/// DELETE /api/observers/{id}
 pub async fn delete_observer(
     State(state): State<ObserverState>,
     Path(id): Path<Uuid>,
@@ -211,7 +211,7 @@ pub async fn delete_observer(
 /// Get observer statistics.
 ///
 /// GET /api/observers/stats
-/// GET /api/observers/:id/stats
+/// GET /api/observers/{id}/stats
 pub async fn get_observer_stats(
     State(state): State<ObserverState>,
     observer_id: Option<Path<Uuid>>,
@@ -236,7 +236,7 @@ pub async fn get_observer_stats(
 /// List observer execution logs.
 ///
 /// GET /api/observers/logs
-/// GET /api/observers/:id/logs
+/// GET /api/observers/{id}/logs
 pub async fn list_observer_logs(
     State(state): State<ObserverState>,
     Path(observer_id): Path<Option<Uuid>>,
@@ -268,7 +268,7 @@ pub async fn list_observer_logs(
 
 /// Enable an observer.
 ///
-/// POST /api/observers/:id/enable
+/// POST /api/observers/{id}/enable
 pub async fn enable_observer(
     State(state): State<ObserverState>,
     Path(id): Path<Uuid>,
@@ -302,7 +302,7 @@ pub async fn enable_observer(
 
 /// Disable an observer.
 ///
-/// POST /api/observers/:id/disable
+/// POST /api/observers/{id}/disable
 pub async fn disable_observer(
     State(state): State<ObserverState>,
     Path(id): Path<Uuid>,

--- a/crates/fraiseql-server/src/observers/routes.rs
+++ b/crates/fraiseql-server/src/observers/routes.rs
@@ -28,13 +28,13 @@ use super::{
 /// - `POST   /`           - Create a new observer
 /// - `GET    /stats`      - Get statistics for all observers
 /// - `GET    /logs`       - List execution logs for all observers
-/// - `GET    /:id`        - Get a specific observer
-/// - `PATCH  /:id`        - Update a specific observer
-/// - `DELETE /:id`        - Delete a specific observer (soft delete)
-/// - `POST   /:id/enable` - Enable a specific observer
-/// - `POST   /:id/disable`- Disable a specific observer
-/// - `GET    /:id/stats`  - Get statistics for a specific observer
-/// - `GET    /:id/logs`   - List execution logs for a specific observer
+/// - `GET    /{id}`        - Get a specific observer
+/// - `PATCH  /{id}`        - Update a specific observer
+/// - `DELETE /{id}`        - Delete a specific observer (soft delete)
+/// - `POST   /{id}/enable` - Enable a specific observer
+/// - `POST   /{id}/disable`- Disable a specific observer
+/// - `GET    /{id}/stats`  - Get statistics for a specific observer
+/// - `GET    /{id}/logs`   - List execution logs for a specific observer
 pub fn observer_routes(state: ObserverState) -> Router {
     Router::new()
         // Collection routes
@@ -42,11 +42,11 @@ pub fn observer_routes(state: ObserverState) -> Router {
         .route("/stats", get(get_all_stats))
         .route("/logs", get(list_all_logs))
         // Individual observer routes
-        .route("/:id", get(get_observer).patch(update_observer).delete(delete_observer))
-        .route("/:id/enable", post(enable_observer))
-        .route("/:id/disable", post(disable_observer))
-        .route("/:id/stats", get(get_single_stats))
-        .route("/:id/logs", get(list_single_logs))
+        .route("/{id}", get(get_observer).patch(update_observer).delete(delete_observer))
+        .route("/{id}/enable", post(enable_observer))
+        .route("/{id}/disable", post(disable_observer))
+        .route("/{id}/stats", get(get_single_stats))
+        .route("/{id}/logs", get(list_single_logs))
         .with_state(state)
 }
 
@@ -101,16 +101,16 @@ pub fn observer_runtime_routes(state: RuntimeHealthState) -> Router {
 ///
 /// - `GET  /delivery/health`       - Observer delivery health summary
 /// - `GET  /dlq`                   - List DLQ items (paginated, filterable)
-/// - `GET  /dlq/:id`               - Get a single DLQ item
-/// - `POST /dlq/:id/retry`         - Re-process a single DLQ item
+/// - `GET  /dlq/{id}`              - Get a single DLQ item
+/// - `POST /dlq/{id}/retry`        - Re-process a single DLQ item
 /// - `POST /dlq/retry-all`         - Re-process all DLQ items
 pub fn observer_dlq_routes(state: DlqState) -> Router {
     Router::new()
         .route("/delivery/health", get(delivery_health_handler))
         .route("/dlq", get(dlq_list_handler))
         .route("/dlq/retry-all", post(dlq_retry_all_handler))
-        .route("/dlq/:id", get(dlq_get_handler))
-        .route("/dlq/:id/retry", post(dlq_retry_handler))
+        .route("/dlq/{id}", get(dlq_get_handler))
+        .route("/dlq/{id}/retry", post(dlq_retry_handler))
         .with_state(state)
 }
 
@@ -119,13 +119,13 @@ pub fn observer_dlq_routes(state: DlqState) -> Router {
 /// # Routes
 ///
 /// - `GET /changelog`                  - Poll changelog entries (paginated, filterable)
-/// - `GET /checkpoint/:listener_id`    - Read a listener's checkpoint
-/// - `PUT /checkpoint/:listener_id`    - Save / update a listener's checkpoint
+/// - `GET /checkpoint/{listener_id}`   - Read a listener's checkpoint
+/// - `PUT /checkpoint/{listener_id}`   - Save / update a listener's checkpoint
 pub fn observer_changelog_routes(state: ChangelogState) -> Router {
     Router::new()
         .route("/changelog", get(changelog_list_handler))
         .route(
-            "/checkpoint/:listener_id",
+            "/checkpoint/{listener_id}",
             get(checkpoint_get_handler).put(checkpoint_save_handler),
         )
         .with_state(state)

--- a/crates/fraiseql-server/src/observers/tests.rs
+++ b/crates/fraiseql-server/src/observers/tests.rs
@@ -291,3 +291,67 @@ mod runtime_index_atomicity_tests {
         }
     }
 }
+
+mod router_construction {
+    //! Router-construction tests.
+    //!
+    //! Each test calls a router constructor and lets the returned `Router`
+    //! drop. Axum validates path-capture syntax inside `Router::route`, so any
+    //! lingering axum-0.7 `:param` literal panics here at build time — this is
+    //! exactly the bug class behind issue #316.
+    //!
+    //! The platform E2E suite is gated behind `FRAISEQL_PLATFORM_E2E=1` and
+    //! never mounts these routers in default `cargo test` runs, so without
+    //! these tests the panic only surfaces at first server boot.
+
+    #![allow(clippy::unwrap_used)] // Reason: test code; pool ctor errors must panic to surface test setup failures
+
+    use std::sync::Arc;
+
+    use sqlx::PgPool;
+    use tokio::sync::RwLock;
+
+    use crate::observers::{
+        ChangelogState, DlqState, ObserverRepository, ObserverState, RuntimeHealthState,
+        observer_changelog_routes, observer_dlq_routes, observer_routes, observer_runtime_routes,
+        runtime::{ObserverRuntime, ObserverRuntimeConfig},
+    };
+
+    fn lazy_pool() -> PgPool {
+        PgPool::connect_lazy("postgres://test:test@localhost/test").unwrap()
+    }
+
+    fn stub_runtime() -> Arc<RwLock<ObserverRuntime>> {
+        Arc::new(RwLock::new(ObserverRuntime::new(ObserverRuntimeConfig::new(lazy_pool()))))
+    }
+
+    #[tokio::test]
+    async fn observer_routes_constructs() {
+        let state = ObserverState {
+            repository: ObserverRepository::new(lazy_pool()),
+        };
+        let _ = observer_routes(state);
+    }
+
+    #[tokio::test]
+    async fn observer_runtime_routes_constructs() {
+        let state = RuntimeHealthState {
+            runtime: stub_runtime(),
+        };
+        let _ = observer_runtime_routes(state);
+    }
+
+    #[tokio::test]
+    async fn observer_dlq_routes_constructs() {
+        let state = DlqState {
+            runtime: stub_runtime(),
+        };
+        let _ = observer_dlq_routes(state);
+    }
+
+    #[tokio::test]
+    async fn observer_changelog_routes_constructs() {
+        let state = ChangelogState { pool: lazy_pool() };
+        let _ = observer_changelog_routes(state);
+    }
+}

--- a/crates/fraiseql-server/src/routes/rest/router/helpers.rs
+++ b/crates/fraiseql-server/src/routes/rest/router/helpers.rs
@@ -8,9 +8,10 @@ use serde_json::json;
 
 use super::{RestError, RestResponse, StatusCode};
 
-/// Convert a base path and route path to an Axum-compatible path pattern.
+/// Join a base path and route path into an Axum-compatible path pattern.
 ///
-/// Converts `{id}` path parameters to Axum's `:id` syntax.
+/// Path parameters in `route_path` (axum 0.8 `{id}` syntax) are passed through
+/// unchanged.
 pub(super) fn to_axum_path(base_path: &str, route_path: &str) -> String {
     let base = base_path.trim_end_matches('/');
     format!("{base}{route_path}")

--- a/tools/check-route-syntax.sh
+++ b/tools/check-route-syntax.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# check-route-syntax.sh — fail if any axum `.route(...)` literal still uses 0.7-style `:param` captures.
+#
+# Background (issue #316): the axum 0.7 → 0.8 bump replaced path captures `:param` with `{param}`.
+# axum 0.8's `Router::route(...)` hard-panics at build time on the old syntax, so a missed
+# migration ships as a server-startup crash, not a compile error.
+#
+# CRITICAL: the multi-line `awk` branch below is load-bearing. The literal that shipped in
+# fraiseql-server v2.3.0 — `"/checkpoint/:listener_id"` at observers/routes.rs:128 — sat on
+# its own line inside a `.route(\n  "path",\n  handler\n)` call. The single-line `grep` form
+# matched zero lines for that bug. Do NOT delete or "simplify" the awk pass.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+found=0
+
+# Single-line form: `.route("/foo/:bar", handler)`
+if matches=$(grep -rn -E '\.route\(\s*"[^"]*/:[a-zA-Z_]' crates/ examples/ --include='*.rs' 2>/dev/null); then
+  if [ -n "$matches" ]; then
+    echo "ERROR: axum 0.7-style :param captures found (single-line .route()):" >&2
+    echo "$matches" >&2
+    found=1
+  fi
+fi
+
+# Multi-line form: `.route(`-on-its-own-line followed by a quoted path containing `/:ident`
+# on a subsequent line, before any other top-level argument terminates the call.
+multi_matches=$(
+  find crates examples -name '*.rs' -not -path '*/target/*' -print0 \
+    | xargs -0 awk '
+        # Match `.route(` at end of line (possibly trailing whitespace).
+        /\.route\(\s*$/                       { in_route = 1; next }
+        # Inside an open `.route(` call, look for a quoted axum 0.7 capture literal.
+        in_route && /"[^"]*\/:[a-zA-Z_]/      { printf("%s:%d:%s\n", FILENAME, FNR, $0); hits++; }
+        # End of arg list when we hit a closing paren at start of a line.
+        in_route && /^\s*\)/                  { in_route = 0 }
+      END { exit (hits ? 1 : 0) }
+    ' 2>/dev/null
+) && multi_exit=0 || multi_exit=$?
+
+if [ "$multi_exit" -ne 0 ]; then
+  echo "ERROR: axum 0.7-style :param captures found (multi-line .route()):" >&2
+  echo "$multi_matches" >&2
+  found=1
+fi
+
+if [ "$found" -ne 0 ]; then
+  cat >&2 <<'EOF'
+
+Migrate to axum 0.8 capture syntax:
+  .route("/users/:id", handler)        →  .route("/users/{id}", handler)
+  .route("/a/:x/b/:y", handler)        →  .route("/a/{x}/b/{y}", handler)
+
+See issue #316 for the bug class this gate prevents.
+EOF
+  exit 1
+fi
+
+echo "OK: no axum 0.7-style :param captures in crates/ or examples/."


### PR DESCRIPTION
## Summary

- Migrates the one remaining axum 0.7 `:param` literal at `observers/routes.rs:128` (`/checkpoint/:listener_id`) to axum 0.8 `{listener_id}` syntax. This is the only literal that actually shipped broken in fraiseql-server 2.3.0 — every other call site was migrated in the partial fix already in `dev`'s working tree.
- Adds 5 router-construction unit tests (`observer_routes`, `observer_runtime_routes`, `observer_dlq_routes`, `observer_changelog_routes`, `rbac_management_router`) so axum's startup validation runs in `cargo test`, not at first server boot.
- Adds two CI gates so this bug class fails statically: a `tools/check-route-syntax.sh` grep+awk gate (`axum-route-syntax-check` job) and a `.github/workflows/release-smoke.yml` job that boots the server against the `docker/e2e` fixture on `release/*` branches and `v*` tags.

## Why this regressed

Five things lined up against us:

1. The `axum = "0.7"` → `"0.8"` bump was buried in a multi-thousand-line catch-all commit. No dedicated migration checklist, no follow-up issue.
2. `observer_routes`, `observer_runtime_routes`, `observer_dlq_routes`, `observer_changelog_routes`, and `rbac_management_router` had **no unit tests at all**. The panic fires inside `Router::route` at build time — handler-only tests can't trip it.
3. The mount path (`server/routing/extensions.rs:36`) only runs when the observer feature is enabled with a real subsystem. Platform E2E is `#[ignore]`'d behind `FRAISEQL_PLATFORM_E2E=1`, so default `cargo test` never constructs these routers.
4. The bug literal sat on its own line inside a multi-line `.route(\n  "...",\n  handler\n)` call. A single-line grep over `\.route\(\s*"[^"]*/:` matches **zero** lines for it. The `axum-route-syntax-check` gate keeps both the single-line regex and a load-bearing multi-line `awk` pass — do not "simplify" the awk away.
5. No release-time smoke. `cargo publish` builds fine; the panic is at runtime startup. End users caught it, not us. `release-smoke.yml` closes that gap.

## RED proof (panic from the new construction test before the fix)

```
thread 'observers::routes::tests::observer_changelog_routes_constructs' panicked at
crates/fraiseql-server/src/observers/routes.rs:127:10:
Path segments must not start with `:`. For capture groups, use `{capture}`.
If you meant to literally match a segment starting with a colon, call
`without_v07_checks` on the router.
```

After the fix, all 5 construction tests pass; the `axum-route-syntax-check` gate also fires (multi-line awk branch only) when line 128 is reverted, confirming the awk pass is load-bearing.

## Scope note

This PR's construction tests cover the 5 router constructors in `observers/routes.rs` and `api/rbac_management.rs` — i.e. the two files containing axum 0.7 syntax. The ~10 other `Router::new()` sites in `server/routing/` (auth/admin/graphql sub-routers) are explicitly covered by the new `release-smoke.yml` workflow, which boots the binary so every constructor runs.

## Test plan

- [x] `cargo nextest run -p fraiseql-server --features observers` — 1053 pass incl. 5 new
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `make lint-tests-layout && make lint-routes`
- [x] Verified locally: temporarily reverting line 128 makes `tools/check-route-syntax.sh` exit 1 via the multi-line `awk` branch; the single-line grep stays silent (confirms awk is load-bearing).
- [ ] CI green on push.
- [ ] After merge, cut v2.3.1 (workspace bump, CHANGELOG, publish in dep order) and close #316 with the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)