### PR TITLE
chore(release): prepare v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-05-27
+
+### Fixed
+
+- **Server panic at startup on observer router mount** (#316, #317) — the axum 0.7 → 0.8 migration left one path-capture literal at the old `:listener_id` syntax (`crates/fraiseql-server/src/observers/routes.rs:128`, `/checkpoint/:listener_id`). axum 0.8 hard-panics at `Router::route` build time on the old syntax, so any deployment that mounted the observer changelog router crashed before binding the listener. The literal is now `{listener_id}` and the panic site is gone.
+
+### Added
+
+- **Router-construction tests** (#317) — `observer_routes`, `observer_runtime_routes`, `observer_dlq_routes`, `observer_changelog_routes`, and `rbac_management_router` each have a `#[tokio::test]` that constructs the router (see `crates/fraiseql-server/src/observers/tests.rs::router_construction` and `crates/fraiseql-server/src/api/rbac_management/tests.rs::router_construction`). axum's path-capture validation runs inside `Router::route`, so the same bug class would now surface in `cargo test`, not at first server boot.
+
+- **`axum-route-syntax-check` CI gate** (#317) — `tools/check-route-syntax.sh` greps for `:param` literals inside `.route(...)` calls across `crates/` and `examples/`. Combines a single-line regex with a load-bearing multi-line `awk` pass that catches `.route(\n  "...",\n  handler\n)` calls (the v2.3.0 bug literal was invisible to a single-line regex). Wired as a job in `.github/workflows/ci.yml`; `make lint-routes` runs it locally.
+
+- **`release-smoke` workflow** (#317) — `.github/workflows/release-smoke.yml` boots `fraiseql-server` (release profile) against the `docker/e2e/` fixtures on `release/*` branches and `v*` tags and asserts `/health` responds within ~30s. Catch-all for the "code compiles, server panics on boot" bug class — covers every router constructor the binary actually mounts, not just the ones unit-tested individually.
+
 ## [2.3.0] - 2026-05-25
 
 *v2.3.0 supersedes the abandoned 2026-05-14 release attempt — see commit history for the revival. Migration guide for adopters: `docs/migration/v2.2-to-v2.3.md`.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "fraiseql-arrow",
  "fraiseql-cli",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-arrow"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-auth"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cli"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-core"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "ahash",
  "arrow",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-db"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-error"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "axum",
  "serde",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-federation"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-functions"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-observers"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "arrow",
  "async-nats",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-secrets"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-server"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-storage"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-utils"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "async-trait",
  "fraiseql-core",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-webhooks"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-wire"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,4 +340,4 @@ keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
 rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
-version = "2.3.0"
+version = "2.3.1"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [docs/database-compatibility.md](docs/database-compatibility.md) for the ful
 
 ```toml
 [dependencies]
-fraiseql = { version = "2.3.0", features = ["server"] }
+fraiseql = { version = "2.3.1", features = ["server"] }
 ```
 
 **Schema authoring:**

--- a/crates/fraiseql-arrow/fuzz/Cargo.toml
+++ b/crates/fraiseql-arrow/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-arrow-fuzz"
 publish = false
-version = "2.3.0"
+version = "2.3.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-auth-fuzz"
-version = "2.3.0"
+version = "2.3.1"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-core/fuzz/Cargo.toml
+++ b/crates/fraiseql-core/fuzz/Cargo.toml
@@ -51,7 +51,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-core-fuzz"
 publish = false
-version = "2.3.0"
+version = "2.3.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-db/fuzz/Cargo.toml
+++ b/crates/fraiseql-db/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-db-fuzz"
 publish = false
-version = "2.3.0"
+version = "2.3.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-federation/fuzz/Cargo.toml
+++ b/crates/fraiseql-federation/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ path = "../../fraiseql-error"
 edition = "2021"
 name = "fraiseql-federation-fuzz"
 publish = false
-version = "2.3.0"
+version = "2.3.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-secrets/fuzz/Cargo.toml
+++ b/crates/fraiseql-secrets/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-secrets-fuzz"
-version = "2.3.0"
+version = "2.3.1"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-server/fuzz/Cargo.toml
+++ b/crates/fraiseql-server/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-server-fuzz"
 publish = false
-version = "2.3.0"
+version = "2.3.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-storage/Cargo.toml
+++ b/crates/fraiseql-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-storage"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"

--- a/crates/fraiseql-wire/fuzz/Cargo.toml
+++ b/crates/fraiseql-wire/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-wire-fuzz"
 publish = false
-version = "2.3.0"
+version = "2.3.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdks/official/fraiseql-rust/Cargo.toml
+++ b/sdks/official/fraiseql-rust/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["graphql", "authorization", "rbac", "schema"]
 license = "Apache-2.0"
 name = "fraiseql-rust"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "2.3.0"
+version = "2.3.1"
 
 [[test]]
 name = "integration_test"

--- a/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
+++ b/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-client"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Async HTTP client for FraiseQL GraphQL servers"


### PR DESCRIPTION
Draft until #317 (the actual fix for issue #316) merges. **Do not mark ready-for-review or merge before #317.**

## Summary

- Bumps the workspace and 11 standalone Cargo.toml files from 2.3.0 → 2.3.1.
- Adds the `## [2.3.1] - 2026-05-27` section to `CHANGELOG.md` summarizing #317.
- Bumps the install-snippet version in `README.md`.

This commit deliberately contains **no code changes** — the actual fix and the three new prevention gates land via #317. After #317 merges, this branch will rebase cleanly onto dev and the merge of this PR will be the commit that gets tagged `v2.3.1`.

## Files bumped (12 \[package\].version sites)

| Path | Notes |
|---|---|
| `Cargo.toml` | workspace.package.version |
| `crates/fraiseql-storage/Cargo.toml` | standalone (not workspace-inherit) |
| `crates/fraiseql-*/fuzz/Cargo.toml` × 8 | all `publish = false` |
| `sdks/official/fraiseql-rust/Cargo.toml` | Rust SDK |
| `sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml` | Rust SDK sub-crate |

All 16 workspace-member crates that use `version.workspace = true` inherit the bump from the root `Cargo.toml`.

## Verification

- [x] `cargo check --workspace` clean.
- [x] `grep '^version = "2.3.0"'` over `Cargo.toml`, `crates/*/Cargo.toml`, `crates/*/fuzz/Cargo.toml`, and the Rust SDK paths returns zero hits.
- [x] `Cargo.lock` regenerated; 16 first-party entries now at 2.3.1 (only `id-arena 2.3.0` remains, which is an unrelated external crate).
- [ ] #317 merged to dev.
- [ ] Rebase `release/v2.3.1` onto post-merge dev tip.
- [ ] Merge this PR; tag the resulting dev commit as `v2.3.1`.
- [ ] `cargo publish` workspace deps first, then `fraiseql-server` last.
- [ ] Close #316 with the release tag.

Closes #316 (jointly with #317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)