### PR TITLE
release: v2.3.2 — fix cargo publish for server, add functions/storage to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     name: Validate Release Prerequisites
     environment: release
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       RUSTC_WRAPPER: ""
     steps:
@@ -60,11 +60,39 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
-      - name: Dry-run publish to crates.io
+      # Upstream gate that catches packaging-rules regressions (e.g.
+      # gitignored files or build.rs side effects swept into the .crate
+      # tarball) before they reach the actual publish step. Added after
+      # v2.3.0 / v2.3.1 shipped tags but failed to publish fraiseql-server
+      # (the previous version of this step only dry-ran fraiseql-error).
+      - name: Dry-run publish for every publishable crate
+        shell: bash
         run: |
-          echo "Testing crates.io token validity with dry-run..."
-          cargo publish --dry-run --token ${{ secrets.CARGO_TOKEN }} -p fraiseql-error 2>&1 | head -20 || exit 1
-          echo "✅ crates.io token is valid"
+          set -uo pipefail
+          CRATES="fraiseql-error fraiseql-auth fraiseql-webhooks fraiseql-wire \
+                  fraiseql-db fraiseql-storage fraiseql-federation fraiseql-core \
+                  fraiseql-arrow fraiseql-secrets fraiseql-observers \
+                  fraiseql-functions fraiseql-server fraiseql-cli fraiseql"
+          FAILED=0
+          for c in $CRATES; do
+            echo "::group::dry-run publish: $c"
+            log="/tmp/dryrun-$c.log"
+            cargo publish --dry-run --token "${{ secrets.CARGO_TOKEN }}" -p "$c" > "$log" 2>&1
+            status=$?
+            tail -30 "$log"
+            if [ "$status" -eq 0 ]; then
+              echo "OK: $c dry-run passed"
+            else
+              echo "FAIL: $c dry-run exited $status"
+              FAILED=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more crates failed dry-run publish — see expanded groups above"
+            exit 1
+          fi
+          echo "All crates passed dry-run publish"
 
   # Create GitHub release using gh CLI
   create-github-release:
@@ -284,10 +312,20 @@ jobs:
             cargo publish --package fraiseql-db --token ${{ secrets.CARGO_TOKEN }}
           fi
 
+      - name: Publish fraiseql-storage
+        id: publish-storage
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "$(curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: fraiseql-ci' "https://crates.io/api/v1/crates/fraiseql-storage/$VERSION")" = "200" ]; then
+            echo "fraiseql-storage $VERSION already published, skipping"
+          else
+            cargo publish --package fraiseql-storage --token ${{ secrets.CARGO_TOKEN }}
+          fi
+
       - name: Wait for crates.io indexing (Tier 2)
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          for crate in fraiseql-db; do
+          for crate in fraiseql-db fraiseql-storage; do
             echo "Waiting for $crate to be indexed on crates.io..."
             for i in $(seq 1 30); do
               if [ "$(curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: fraiseql-ci' "https://crates.io/api/v1/crates/$crate/$VERSION")" = "200" ]; then
@@ -408,7 +446,32 @@ jobs:
             done
           done
 
-      # Tier 7: Depends on fraiseql-arrow, fraiseql-auth, fraiseql-core, fraiseql-error, fraiseql-observers, fraiseql-secrets, fraiseql-webhooks
+      # Tier 6.5: Depends on fraiseql-error, fraiseql-observers (+ optional core/db/storage)
+      - name: Publish fraiseql-functions
+        id: publish-functions
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "$(curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: fraiseql-ci' "https://crates.io/api/v1/crates/fraiseql-functions/$VERSION")" = "200" ]; then
+            echo "fraiseql-functions $VERSION already published, skipping"
+          else
+            cargo publish --package fraiseql-functions --token ${{ secrets.CARGO_TOKEN }}
+          fi
+
+      - name: Wait for crates.io indexing (Tier 6.5)
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          for crate in fraiseql-functions; do
+            echo "Waiting for $crate to be indexed on crates.io..."
+            for i in $(seq 1 30); do
+              if [ "$(curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: fraiseql-ci' "https://crates.io/api/v1/crates/$crate/$VERSION")" = "200" ]; then
+                echo "✅ $crate indexed"
+                break
+              fi
+              sleep 10
+            done
+          done
+
+      # Tier 7: Depends on fraiseql-arrow, fraiseql-auth, fraiseql-core, fraiseql-error, fraiseql-functions, fraiseql-observers, fraiseql-secrets, fraiseql-storage, fraiseql-webhooks
       - name: Publish fraiseql-server
         id: publish-server
         run: |
@@ -479,11 +542,13 @@ jobs:
             "${{ steps.publish-webhooks.outcome }}" \
             "${{ steps.publish-wire.outcome }}" \
             "${{ steps.publish-db.outcome }}" \
+            "${{ steps.publish-storage.outcome }}" \
             "${{ steps.publish-federation.outcome }}" \
             "${{ steps.publish-core.outcome }}" \
             "${{ steps.publish-arrow.outcome }}" \
             "${{ steps.publish-secrets.outcome }}" \
             "${{ steps.publish-observers.outcome }}" \
+            "${{ steps.publish-functions.outcome }}" \
             "${{ steps.publish-server.outcome }}" \
             "${{ steps.publish-cli.outcome }}" \
             "${{ steps.publish-root.outcome }}"; do
@@ -508,11 +573,13 @@ jobs:
           [ "${{ steps.publish-webhooks.outcome }}" = "success" ] && echo "- ✅ fraiseql-webhooks" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-webhooks" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-wire.outcome }}" = "success" ] && echo "- ✅ fraiseql-wire" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-wire" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-db.outcome }}" = "success" ] && echo "- ✅ fraiseql-db" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-db" >> $GITHUB_STEP_SUMMARY
+          [ "${{ steps.publish-storage.outcome }}" = "success" ] && echo "- ✅ fraiseql-storage" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-storage" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-federation.outcome }}" = "success" ] && echo "- ✅ fraiseql-federation" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-federation" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-core.outcome }}" = "success" ] && echo "- ✅ fraiseql-core" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-core" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-arrow.outcome }}" = "success" ] && echo "- ✅ fraiseql-arrow" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-arrow" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-secrets.outcome }}" = "success" ] && echo "- ✅ fraiseql-secrets" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-secrets" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-observers.outcome }}" = "success" ] && echo "- ✅ fraiseql-observers" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-observers" >> $GITHUB_STEP_SUMMARY
+          [ "${{ steps.publish-functions.outcome }}" = "success" ] && echo "- ✅ fraiseql-functions" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-functions" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-server.outcome }}" = "success" ] && echo "- ✅ fraiseql-server" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-server" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-cli.outcome }}" = "success" ] && echo "- ✅ fraiseql-cli" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql-cli" >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.publish-root.outcome }}" = "success" ] && echo "- ✅ fraiseql (root)" >> $GITHUB_STEP_SUMMARY || echo "- ❌ fraiseql (root)" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] - 2026-05-28
+
+### Fixed
+
+- **`cargo publish` for `fraiseql-server`, `fraiseql-cli`, and `fraiseql` (umbrella)** — `crates/fraiseql-server/build.rs` ran `npm install` and `npm run build` inside `crates/fraiseql-server/studio/`, populating `studio/node_modules/` (~45 MB) and `studio/dist/` during cargo's verify step. Cargo correctly flagged this as `Source directory was modified by build.rs during cargo publish` and refused to publish on the v2.3.1 release run (CI run 26516845920). `build.rs` now stages the Studio package into `$OUT_DIR/studio/` and runs npm/esbuild there, so the source tree is no longer touched. The `[package].exclude` for `studio/{node_modules,dist,.cache,.npm,*.log}` is added as defensive insurance against stale on-disk copies leaking into the `.crate` tarball. **This is the first v2.3.x release where `cargo install fraiseql-server` actually works** — v2.3.0 and v2.3.1 were tagged but never published successfully via automation. (Crates.io's `fraiseql-server@2.3.0` was published manually outside the workflow.)
+
+- **`fraiseql-functions` and `fraiseql-storage` missing from release automation** — both crates are publishable (`publish = true` / unset) and `fraiseql-functions` is a mandatory dep of `fraiseql-server`, but neither appeared in `release.yml`'s publish job. Both are now published alongside the other 13 crates on tag push, in correct topological position (`fraiseql-storage` in Tier 2, `fraiseql-functions` in a new Tier 6.5 between observers and server).
+
+### Changed
+
+- **`release.yml` validate-release dry-run now covers every publishable crate** (15 total) instead of only `fraiseql-error`. The packaging-rules failure that blocked v2.3.0 and v2.3.1 publish for `fraiseql-server` would have been caught here. Timeout bumped to 30 minutes to accommodate the longer loop.
+
+### Migration
+
+Consumers currently pinned to `fraiseql-server = "2.3.1"`, `fraiseql-cli = "2.3.1"`, or `fraiseql = "2.3.1"` will get a `cargo install` failure (those versions are not on crates.io). Upgrade to `2.3.2`. Pins to `fraiseql-server = "2.3.0"` continue to resolve but are missing the #316 axum-0.8 startup-panic fix.
+
 ## [2.3.1] - 2026-05-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "fraiseql-arrow",
  "fraiseql-cli",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-arrow"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-auth"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cli"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-core"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "ahash",
  "arrow",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-db"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-error"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "axum",
  "serde",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-federation"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-functions"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-observers"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "arrow",
  "async-nats",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-secrets"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-server"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-storage"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-utils"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "async-trait",
  "fraiseql-core",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-webhooks"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-wire"
-version = "2.3.1"
+version = "2.3.2"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,4 +340,4 @@ keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
 rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
-version = "2.3.1"
+version = "2.3.2"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See [docs/database-compatibility.md](docs/database-compatibility.md) for the ful
 
 ```toml
 [dependencies]
-fraiseql = { version = "2.3.1", features = ["server"] }
+fraiseql = { version = "2.3.2", features = ["server"] }
 ```
 
 **Schema authoring:**

--- a/crates/fraiseql-arrow/fuzz/Cargo.toml
+++ b/crates/fraiseql-arrow/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-arrow-fuzz"
 publish = false
-version = "2.3.1"
+version = "2.3.2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-auth-fuzz"
-version = "2.3.1"
+version = "2.3.2"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-core/fuzz/Cargo.toml
+++ b/crates/fraiseql-core/fuzz/Cargo.toml
@@ -51,7 +51,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-core-fuzz"
 publish = false
-version = "2.3.1"
+version = "2.3.2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-db/fuzz/Cargo.toml
+++ b/crates/fraiseql-db/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-db-fuzz"
 publish = false
-version = "2.3.1"
+version = "2.3.2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-federation/fuzz/Cargo.toml
+++ b/crates/fraiseql-federation/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ path = "../../fraiseql-error"
 edition = "2021"
 name = "fraiseql-federation-fuzz"
 publish = false
-version = "2.3.1"
+version = "2.3.2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-secrets/fuzz/Cargo.toml
+++ b/crates/fraiseql-secrets/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-secrets-fuzz"
-version = "2.3.1"
+version = "2.3.2"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -211,6 +211,13 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
+exclude = [
+    "studio/node_modules/**",
+    "studio/dist/**",
+    "studio/.cache/**",
+    "studio/.npm/**",
+    "studio/*.log",
+]
 
 [[test]]
 name = "secrets_manager_integration_test"

--- a/crates/fraiseql-server/build.rs
+++ b/crates/fraiseql-server/build.rs
@@ -3,33 +3,49 @@
 //! Runs the Studio SPA build (`TypeScript` → esbuild → `dist/app.js`) before
 //! the crate compiles so that `rust-embed` can embed the resulting assets.
 //!
+//! All build artifacts (npm `node_modules`, esbuild output) are written to
+//! `$OUT_DIR/studio/` so the source tree is never modified — this keeps
+//! `cargo publish`'s source-modification check happy.
+//!
 //! Requires Node.js and npm on the build machine. The build is skipped
 //! gracefully when `node` is not found, allowing `cargo check` to work
 //! without a Node environment.
 
-#![allow(clippy::panic, clippy::print_stdout, clippy::print_stderr)] // Reason: test code, panics acceptable
+#![allow(clippy::panic, clippy::print_stdout, clippy::print_stderr)] // Reason: build script
 use std::{
-    env, fs,
+    env, fs, io,
     path::{Path, PathBuf},
     process::Command,
 };
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    let studio_dir = Path::new(&manifest_dir).join("studio");
-    let dist_dir = studio_dir.join("dist");
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let studio_src = Path::new(&manifest_dir).join("studio");
+    let build_dir = Path::new(&out_dir).join("studio");
+    let dist_dir = build_dir.join("dist");
 
     // Tell cargo to re-run if the studio source changes.
     println!("cargo:rerun-if-changed=studio/src/app.ts");
     println!("cargo:rerun-if-changed=studio/package.json");
+    println!("cargo:rerun-if-changed=studio/package-lock.json");
     println!("cargo:rerun-if-changed=studio/tsconfig.json");
 
-    // Run `npm install` if node_modules is absent.
-    let node_modules = studio_dir.join("node_modules");
+    // Stage the studio package into OUT_DIR so npm/esbuild only touch the
+    // build directory, not the source tree.
+    if let Err(e) = stage_studio(&studio_src, &build_dir) {
+        eprintln!("cargo:warning=failed to stage studio sources: {e}");
+        emit_fallback_dist(&dist_dir);
+        println!("cargo:rustc-env=FRAISEQL_STUDIO_DIST={}", dist_dir.display());
+        return;
+    }
+
+    // Run `npm install` if node_modules is absent in the staging dir.
+    let node_modules = build_dir.join("node_modules");
     if !node_modules.exists() {
         let status = Command::new("npm")
-            .args(["install", "--prefer-offline"])
-            .current_dir(&studio_dir)
+            .args(["install", "--prefer-offline", "--no-audit", "--no-fund"])
+            .current_dir(&build_dir)
             .status();
 
         match status {
@@ -45,8 +61,8 @@ fn main() {
         }
     }
 
-    // Run `npm run build`.
-    let status = Command::new("npm").args(["run", "build"]).current_dir(&studio_dir).status();
+    // Run `npm run build` in the staging dir.
+    let status = Command::new("npm").args(["run", "build"]).current_dir(&build_dir).status();
 
     match status {
         Ok(s) if s.success() => {},
@@ -59,6 +75,38 @@ fn main() {
 
     // Export the dist path so rust-embed can locate it.
     println!("cargo:rustc-env=FRAISEQL_STUDIO_DIST={}", dist_dir.display());
+}
+
+/// Copy `studio/{package.json, package-lock.json, tsconfig.json, src/}` from
+/// the source tree into the staging build directory.
+fn stage_studio(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for file in ["package.json", "package-lock.json", "tsconfig.json"] {
+        let from = src.join(file);
+        if from.exists() {
+            fs::copy(&from, dst.join(file))?;
+        }
+    }
+    let src_dir = src.join("src");
+    if src_dir.exists() {
+        copy_dir_all(&src_dir, &dst.join("src"))?;
+    }
+    Ok(())
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dst_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), &dst_path)?;
+        }
+    }
+    Ok(())
 }
 
 /// Write a minimal fallback `dist/app.js` when Node.js is unavailable.

--- a/crates/fraiseql-server/fuzz/Cargo.toml
+++ b/crates/fraiseql-server/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-server-fuzz"
 publish = false
-version = "2.3.1"
+version = "2.3.2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-storage/Cargo.toml
+++ b/crates/fraiseql-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-storage"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"

--- a/crates/fraiseql-wire/fuzz/Cargo.toml
+++ b/crates/fraiseql-wire/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-wire-fuzz"
 publish = false
-version = "2.3.1"
+version = "2.3.2"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdks/official/fraiseql-rust/Cargo.toml
+++ b/sdks/official/fraiseql-rust/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["graphql", "authorization", "rbac", "schema"]
 license = "Apache-2.0"
 name = "fraiseql-rust"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "2.3.1"
+version = "2.3.2"
 
 [[test]]
 name = "integration_test"

--- a/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
+++ b/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-client"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 rust-version = "1.80"
 description = "Async HTTP client for FraiseQL GraphQL servers"


### PR DESCRIPTION
## Summary

Releases v2.3.2, the first v2.3.x version where `cargo install fraiseql-server` actually works. v2.3.0 and v2.3.1 shipped GitHub tags but their `fraiseql-server`, `fraiseql-cli`, and `fraiseql` publish runs failed against crates.io. The #316 axum-0.8 startup-panic fix from v2.3.1 never reached crates.io.

Three commits:

- **`fix(server): isolate Studio SPA build to OUT_DIR`** — root-cause fix. `build.rs` used to run `npm install` + `npm run build` inside `crates/fraiseql-server/studio/`, populating `studio/node_modules/` (~45 MB) and `studio/dist/` during cargo's verify step. Cargo flagged this as `Source directory was modified by build.rs during cargo publish` and refused the upload. `build.rs` now stages `studio/{src,package.json,package-lock.json,tsconfig.json}` into `$OUT_DIR/studio/` and runs npm/esbuild there. The source tree is no longer touched. `[package].exclude` for `studio/{node_modules,dist,…}` is added as defensive insurance.
- **`ci(release): expand dry-run gate to all crates; publish functions and storage`** — `validate-release` now dry-runs every publishable crate (15) instead of only `fraiseql-error`, so this class of bug fails upstream of the publish step. `fraiseql-functions` (Tier 6.5) and `fraiseql-storage` (Tier 2) are added to the publish job — both are mandatory deps of `fraiseql-server` but neither had a publish step (they were manually published at 2.3.0 outside the workflow).
- **`chore(release): prepare v2.3.2`** — 12 Cargo.toml bumps, CHANGELOG entry, README install snippet, Cargo.lock regen (16 first-party entries, no third-party churn).

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo publish --dry-run -p fraiseql-server` (with verify) succeeds locally; tarball is 362 files / 749 KB compressed; 0 entries under `studio/node_modules` or `studio/dist`
- [x] `cargo test -p fraiseql-server --lib routes::studio` passes (26 tests)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` parses
- [ ] CI `validate-release` job passes the expanded dry-run loop
- [ ] After merge + tag: `cargo install fraiseql-server --version 2.3.2 --locked` from a fresh shell succeeds; all 5 server-side crates (`fraiseql-functions`, `fraiseql-storage`, `fraiseql-server`, `fraiseql-cli`, `fraiseql`) live on crates.io at 2.3.2

## Note on the runbook deviation

The runbook (`/tmp/fraiseql-v2.3.2-publish-fix/execution-plan.md`) proposed `[package].exclude` as the fix. That's necessary but insufficient — exclude only affects which files go *into* the package, not whether `build.rs` modifies the package directory during cargo's verify step. The OUT_DIR refactor is the canonical fix and was chosen after a §2 pause point. Exclude is kept for defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)