### PR TITLE
spike(release): release-please evaluation (#319)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,47 @@
+# SPIKE — release-please evaluation for issue #319.
+#
+# This workflow is part of the spike branch `spike/release-please-evaluation`
+# and is NOT active on dev. To activate after spike approval, merge this branch
+# and (optionally) gate behind a feature-flag input or a branch-protection
+# adjustment to allow the release-please-bot to open PRs.
+#
+# What this workflow does:
+#   1. On push to dev, runs release-please, which inspects every commit since
+#      the previous tag, decides whether a release is warranted, and either
+#      opens/updates the "Release PR" or no-ops.
+#   2. When the Release PR is merged into dev, release-please tags the merge
+#      commit (e.g. v2.3.3), creates a GitHub Release with the auto-generated
+#      CHANGELOG entry, and the existing tag-triggered `release.yml` takes
+#      over from there (cargo publish, npm publish, PyPI publish).
+#
+# What this workflow does NOT do:
+#   - It does not run `cargo publish`. That stays in release.yml (triggered on
+#     the v* tag that release-please creates).
+#   - It does not bump the SDK versions (Python, TypeScript, Ruby) — those are
+#     on independent cadence (currently at 2.1.6 while Rust is at 2.3.2), so
+#     adding them to the linked-versions group would force-bump them with
+#     every Rust release. Out of scope for this spike.
+
+name: Release Please
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # The token must have permission to open PRs and create tags.
+          # A repo-scoped PAT is required if branch protection blocks
+          # GITHUB_TOKEN-authored PRs from passing required-status-checks.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,14 @@
+{
+  ".": "2.3.2",
+  "crates/fraiseql-storage": "2.3.2",
+  "crates/fraiseql-server/fuzz": "2.3.2",
+  "crates/fraiseql-auth/fuzz": "2.3.2",
+  "crates/fraiseql-arrow/fuzz": "2.3.2",
+  "crates/fraiseql-core/fuzz": "2.3.2",
+  "crates/fraiseql-db/fuzz": "2.3.2",
+  "crates/fraiseql-federation/fuzz": "2.3.2",
+  "crates/fraiseql-secrets/fuzz": "2.3.2",
+  "crates/fraiseql-wire/fuzz": "2.3.2",
+  "sdks/official/fraiseql-rust": "2.3.2",
+  "sdks/official/fraiseql-rust/fraiseql-client": "2.3.2"
+}

--- a/docs/adr/0014-release-automation-spike.md
+++ b/docs/adr/0014-release-automation-spike.md
@@ -25,7 +25,7 @@ That's 12 standalone-versioned Cargo.toml files including the workspace root.
 releases where some sub-crates are stale until somebody notices and pushes a
 fixup commit.
 
-#319 asked whether release-please can take this over.
+# 319 asked whether release-please can take this over.
 
 ## What this spike produces
 
@@ -80,6 +80,7 @@ to release. The earliest meaningful preview happens after the next
 
 To make the dry-run actually executable as part of CI validation later,
 either:
+
 - Push the spike branch and let GitHub Actions run release-please in
   `workflow_dispatch` debug mode against the spike branch, or
 - Use [release-please-action's `output-only` mode](https://github.com/googleapis/release-please-action#outputs)
@@ -113,6 +114,7 @@ that's the main risk to test before going live.
 release-please does not run `cargo update -p fraiseql --precise X.Y.Z` to
 keep `Cargo.lock` in sync. The Release PR will fail CI on `--locked` builds
 unless one of:
+
 - Add a `cargo-workspace` plugin step (the spike config includes
   `plugins: [{type: "cargo-workspace"}]` — this is supposed to regen the
   lockfile, but I have NOT verified it works as advertised for our

--- a/docs/adr/0014-release-automation-spike.md
+++ b/docs/adr/0014-release-automation-spike.md
@@ -1,0 +1,216 @@
+# ADR-0014: Release-please automation spike
+
+**Status:** Proposed (spike — not yet decided)
+**Issue:** #319
+**Branch:** `spike/release-please-evaluation`
+**Date:** 2026-05-28
+
+## Context
+
+The v2.3.0, v2.3.1, and v2.3.2 releases each required a manual "align all
+Cargo.toml versions" step. The drift specifically came from manifests that
+`tools/release.sh` does **not** touch:
+
+- `crates/*/fuzz/Cargo.toml` (8 files — server, auth, arrow, core, db,
+  federation, secrets, wire)
+- `crates/fraiseql-storage/Cargo.toml` (standalone-versioned, not
+  workspace-inherit — see commit 06ccc8db8 for the back-fix)
+- `sdks/official/fraiseql-rust/Cargo.toml` +
+  `sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml` (Rust SDK
+  workspace)
+
+That's 12 standalone-versioned Cargo.toml files including the workspace root.
+`tools/release.sh` (line 60-ish, the `while IFS=` loop) updates only
+`crates/*/Cargo.toml`, missing every nested manifest. The result: tagged
+releases where some sub-crates are stale until somebody notices and pushes a
+fixup commit.
+
+#319 asked whether release-please can take this over.
+
+## What this spike produces
+
+Four artifacts live on this spike branch:
+
+1. **`release-please-config.json`** — the static config. Declares all 12
+   packages, groups them via the `linked-versions` plugin (so every release
+   bumps all of them together), and maps Conventional Commits types to
+   CHANGELOG sections matching the existing Keep-a-Changelog format.
+
+2. **`.release-please-manifest.json`** — the version map. Seeded at 2.3.2
+   to match the post-tag state of every package. release-please mutates
+   this file on each release; it is the single source of truth for "what
+   version are we at."
+
+3. **`.github/workflows/release-please.yml`** — runs on push to `dev`.
+   Either opens/updates a "Release PR" or no-ops based on commits since the
+   previous tag.
+
+4. **This document.**
+
+## Dry-run result against current dev
+
+I attempted `npx release-please release-pr --dry-run` locally to render what
+the next Release PR would contain. **The CLI cannot do a fully local dry-run** —
+it fetches config and manifest from the remote target branch via the GitHub
+API, so until this spike branch is merged (or pushed and given a draft PR),
+no remote `release-please-config.json` exists for it to read. Verified by
+running:
+
+```bash
+TOKEN=$(gh auth token) npx --yes release-please release-pr \
+  --token="$TOKEN" --repo-url=fraiseql/fraiseql \
+  --target-branch=spike/release-please-evaluation \
+  --config-file=release-please-config.json \
+  --manifest-file=.release-please-manifest.json \
+  --dry-run
+# → ConfigurationError: Missing required manifest config (branch not pushed)
+```
+
+**Hand-computed preview** (what release-please *would* produce on a real
+run against `dev` tip = `d0a4ed4ec`):
+
+```bash
+git log --no-merges v2.3.2..dev --pretty='%h %s'
+# (empty — zero commits since v2.3.2 was tagged today)
+```
+
+→ release-please would correctly **no-op**: no Release PR opened, nothing
+to release. The earliest meaningful preview happens after the next
+`feat(...)` / `fix(...)` / `BREAKING CHANGE` commit lands on dev.
+
+To make the dry-run actually executable as part of CI validation later,
+either:
+- Push the spike branch and let GitHub Actions run release-please in
+  `workflow_dispatch` debug mode against the spike branch, or
+- Use [release-please-action's `output-only` mode](https://github.com/googleapis/release-please-action#outputs)
+  on a temporary workflow.
+
+## Sharp edges encountered
+
+### 1. SDKs in other languages are not in the linked group
+
+Python and TypeScript SDKs are at 2.1.6 (Ruby gem is computed from a
+constant). Rust is at 2.3.2. They are on independent cadence — adding them
+to `linked-versions` would force-bump them on every Rust release, which is
+exactly wrong. They stay out of release-please for now.
+
+If we later want a single "everything moves together" cadence, those SDKs
+would need their own release-please configs (or get folded into this one
+with `release-type: python` / `node` per-package). Out of scope for this
+spike — flagged as a follow-up only if/when the cadence story changes.
+
+### 2. The `rust` release-type and workspace inheritance
+
+The `rust` release-type handles `Cargo.toml`'s `[package].version` field.
+We have 16 crates with `version.workspace = true` — release-please leaves
+those alone (no per-file edit needed; they pick up the workspace root
+bump). The 12 standalone manifests get individually patched. I have *not*
+verified end-to-end against a real Cargo workspace with this exact layout;
+that's the main risk to test before going live.
+
+### 3. The Cargo.lock regen
+
+release-please does not run `cargo update -p fraiseql --precise X.Y.Z` to
+keep `Cargo.lock` in sync. The Release PR will fail CI on `--locked` builds
+unless one of:
+- Add a `cargo-workspace` plugin step (the spike config includes
+  `plugins: [{type: "cargo-workspace"}]` — this is supposed to regen the
+  lockfile, but I have NOT verified it works as advertised for our
+  workspace shape).
+- A separate workflow auto-commits the lockfile update onto the Release
+  PR branch.
+- Manual intervention on each Release PR.
+
+This is the highest-risk unknown. Plan a follow-up issue to nail down lockfile
+handling before merging the spike, even if everything else looks clean.
+
+### 4. Branch protection
+
+`dev` currently allows direct pushes by the release-please bot? Not yet
+verified. If `dev` has required-status-checks blocking, the bot's PRs may
+fail to land. Pre-merge action: confirm the release-please bot (or a
+service-account PAT in `RELEASE_PLEASE_TOKEN`) can author + merge PRs.
+
+### 5. Existing release pipeline interaction
+
+| Stage | Today | With release-please |
+|---|---|---|
+| Bump 12 Cargo.tomls | `tools/release.sh` (incomplete — misses 9 files) | release-please (covers all 12) |
+| Promote `[Unreleased]` → versioned section in CHANGELOG | `tools/release.sh` (sed insert) | release-please (auto-generated from commits) |
+| Create annotated tag `vX.Y.Z` | `tools/release.sh` | release-please (on Release PR merge) |
+| Create GitHub Release | manual `gh release create` | release-please (on Release PR merge) |
+| Validate prereqs (CARGO_TOKEN, etc.) | `release.yml::validate-release` | unchanged — keep release.yml |
+| Run `cargo publish` per-crate in topological order | `release.yml::publish-*` jobs (15 crates, hand-ordered) | unchanged — keep release.yml |
+| npm/PyPI publish | `release.yml` | unchanged — keep release.yml |
+| release-smoke test on tag | `release-smoke.yml` (#317) | unchanged |
+
+## Retirement plan
+
+If we adopt this spike:
+
+1. **`tools/release.sh` → retired.** It does the right thing for step 1-4
+   of the existing flow but incompletely (misses the 9 non-workspace
+   manifests). With release-please owning bump + CHANGELOG + tag, the
+   script becomes dead code. Keep it on disk for one release as a
+   fallback, then delete in the v2.4.0 cycle.
+
+2. **`.github/workflows/release.yml` → kept, simplified.** The
+   `validate-release` job (secrets check, dry-run packaging gate) stays
+   — release-please does not run `cargo publish`. The `prepare-release`
+   logic in release.yml can shrink because release-please now owns the
+   tag/release creation, but the actual publish jobs (15 crates +
+   PyPI + npm) keep their existing trigger of `push: tags/v*`.
+
+3. **`.github/workflows/release-smoke.yml` → kept unchanged.** Triggers on
+   the `v*` tag, which release-please still creates.
+
+4. **CHANGELOG.md format.** release-please's default sectioning is close
+   to but not identical to the current Keep-a-Changelog layout. The
+   `changelog-sections` block in the config maps `feat→Added`,
+   `fix→Fixed`, `security→Security`, `perf/refactor→Changed`,
+   and hides `docs/test/ci/build/chore` from the published CHANGELOG.
+   Section heading style (`### Added`) is preserved.
+
+5. **Conventional Commits enforcement.** Recent commit history (last 30
+   non-merge commits) already follows Conventional Commits closely
+   (`fix(server):`, `feat(...)`, `refactor!:`). release-please will pick
+   these up natively without a hard enforcement gate. *Optional follow-up:*
+   wire `commitlint` into pre-commit hooks if drift becomes a problem.
+
+## Recommendation
+
+**Conditional adopt.** The config layout, linked-versions plugin, and
+workflow look sound and would fix the v2.3.x drift class. Two unknowns
+must be resolved on a follow-up before this lands on `dev`:
+
+1. **Verify `cargo-workspace` plugin regenerates Cargo.lock correctly**
+   for our 28-crate workspace shape. Do this by pushing this spike branch,
+   landing a synthetic `feat(...)` commit on a throwaway branch, running
+   release-please in workflow_dispatch debug mode against it, and confirming
+   the generated Release PR includes a working `Cargo.lock` diff.
+
+2. **Confirm release-please bot permissions** on `dev` — branch
+   protection, required-status-checks, PR self-approval.
+
+If (1) fails — i.e. release-please can bump Cargo.tomls but breaks the
+lockfile — the fallback is to write a `scripts/bump-versions.sh` that
+just covers the 9 missing manifests (essentially patching `tools/release.sh`
+to find every `Cargo.toml` with a literal version, not just `crates/*`).
+That's a lower-leverage but lower-risk path.
+
+## Next steps if accepted
+
+- [ ] Push this spike branch as a draft PR for review
+- [ ] In the same PR (or a follow-up), run release-please in
+      workflow_dispatch debug mode and attach the dry-run output
+- [ ] Verify `Cargo.lock` regen works
+- [ ] Verify release-please bot can open PRs against `dev`
+- [ ] Open a follow-up issue tracking the `tools/release.sh` retirement
+      (1-release grace period)
+
+## Next steps if rejected
+
+Open a follow-up issue: "scripts/bump-versions.sh — fix the 9 missing
+manifests in `tools/release.sh`." The drift problem is fixable without
+release-please by widening the find scope; the spike just shows the
+larger-leverage option.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": false,
+  "draft": false,
+  "prerelease": false,
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
+  "pull-request-title-pattern": "chore(release): prepare v${version}",
+  "separate-pull-requests": false,
+  "changelog-sections": [
+    {"type": "feat",     "section": "Added"},
+    {"type": "fix",      "section": "Fixed"},
+    {"type": "perf",     "section": "Changed"},
+    {"type": "refactor", "section": "Changed"},
+    {"type": "security", "section": "Security"},
+    {"type": "docs",     "section": "Changed", "hidden": true},
+    {"type": "test",     "section": "Changed", "hidden": true},
+    {"type": "ci",       "section": "Changed", "hidden": true},
+    {"type": "build",    "section": "Changed", "hidden": true},
+    {"type": "chore",    "section": "Changed", "hidden": true}
+  ],
+  "packages": {
+    ".": {
+      "package-name": "fraiseql",
+      "release-type": "rust",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        "README.md"
+      ]
+    },
+    "crates/fraiseql-storage": {
+      "package-name": "fraiseql-storage",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-server/fuzz": {
+      "package-name": "fraiseql-server-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-auth/fuzz": {
+      "package-name": "fraiseql-auth-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-arrow/fuzz": {
+      "package-name": "fraiseql-arrow-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-core/fuzz": {
+      "package-name": "fraiseql-core-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-db/fuzz": {
+      "package-name": "fraiseql-db-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-federation/fuzz": {
+      "package-name": "fraiseql-federation-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-secrets/fuzz": {
+      "package-name": "fraiseql-secrets-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "crates/fraiseql-wire/fuzz": {
+      "package-name": "fraiseql-wire-fuzz",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "sdks/official/fraiseql-rust": {
+      "package-name": "fraiseql-rust-sdk-workspace",
+      "release-type": "rust",
+      "skip-github-release": true
+    },
+    "sdks/official/fraiseql-rust/fraiseql-client": {
+      "package-name": "fraiseql-client",
+      "release-type": "rust",
+      "skip-github-release": true
+    }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "fraiseql-rust-workspace",
+      "components": [
+        "fraiseql",
+        "fraiseql-storage",
+        "fraiseql-server-fuzz",
+        "fraiseql-auth-fuzz",
+        "fraiseql-arrow-fuzz",
+        "fraiseql-core-fuzz",
+        "fraiseql-db-fuzz",
+        "fraiseql-federation-fuzz",
+        "fraiseql-secrets-fuzz",
+        "fraiseql-wire-fuzz",
+        "fraiseql-rust-sdk-workspace",
+        "fraiseql-client"
+      ]
+    },
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Spike — not for merge as-is

Evaluates whether release-please can take over the version-alignment work currently split between \`tools/release.sh\` (which misses 9 of the 12 standalone-versioned manifests) and manual fixup commits.

## Artifacts in this branch

| File | Purpose |
|---|---|
| \`release-please-config.json\` | 12 packages via \`linked-versions\` plugin; CHANGELOG sections mapped to Keep-a-Changelog format; \`cargo-workspace\` plugin for lockfile regen |
| \`.release-please-manifest.json\` | Version state seeded at 2.3.2 |
| \`.github/workflows/release-please.yml\` | Push-to-dev trigger; uses RELEASE_PLEASE_TOKEN if available, falls back to GITHUB_TOKEN |
| \`docs/adr/0014-release-automation-spike.md\` | Full analysis: artifacts, sharp edges, retirement plan, conditional-adopt recommendation |

## Dry-run preview

Attempted \`npx release-please release-pr --dry-run\` locally. The CLI fetches config from the GitHub remote (not local files), so a fully local dry-run isn't possible until this branch is pushed. **Hand-computed preview**: zero commits since v2.3.2 on dev (it was tagged today) → release-please would correctly no-op. Earliest meaningful run is after the next \`feat(...)\` / \`fix(...)\` commit lands on dev.

The ADR documents how to get a real dry-run via \`workflow_dispatch\` debug mode against this branch.

## Recommendation

**Conditional adopt.** Two unknowns must be resolved before this lands on \`dev\`:

1. **Cargo.lock regen via the \`cargo-workspace\` plugin** — verified syntactically valid but NOT verified end-to-end against our 28-crate workspace. Highest-risk unknown.
2. **release-please bot permissions on \`dev\`** — branch protection / required-status-checks / PR auto-merge.

If either fails, fallback is \`scripts/bump-versions.sh\` that just widens \`tools/release.sh\` to find every \`Cargo.toml\` with a literal version (the 9 missing manifests). Lower leverage but lower risk.

## Test plan

- [ ] In a follow-up: run release-please in workflow_dispatch debug mode against this branch and attach the dry-run output
- [ ] Verify \`Cargo.lock\` regen works on a synthetic test commit
- [ ] Confirm bot can open PRs against \`dev\`
- [ ] Decide: adopt as-is, adopt with adjustments, or close in favor of the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)