### PR TITLE
fix(security): auth-gate /auth/revoke + /auth/revoke-all (#358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`POST /auth/revoke` and `POST /auth/revoke-all` are now authenticated** (#358, FW-21 class). In v2.3.x and earlier, both routes were mounted with no auth middleware, so any unauthenticated client could revoke any harvested JWT (by `jti`) or wipe every active session for any user (by `sub`). The handlers used `jsonwebtoken::dangerous::insecure_decode` to extract the `jti` from a body-supplied token without any proof-of-possession, so the attack required nothing beyond a network path to the server. Affected anyone running `[security.token_revocation] enabled = true`.
+
+  The fix has three parts:
+
+  1. The revocation router is now mounted behind `oidc_auth_middleware` — unauthenticated requests get `401 Unauthorized` before reaching the handler. If `[security.token_revocation]` is configured without a corresponding `[auth]` OIDC validator, the routes are *not* mounted at all and a startup warning is emitted, rather than mounting them open.
+
+  2. `POST /auth/revoke` no longer trusts a token submitted in the body. It revokes the `jti` of the bearer token used to authenticate the request — surfaced as a new `SessionJti` request extension populated by the auth middleware. The body's `token` field is still accepted on the wire for compatibility but is ignored. This closes the residual attack where an authenticated alice could `insecure_decode` a body token claiming `sub: "alice"` but carrying a victim's `jti`.
+
+  3. `POST /auth/revoke-all` now requires the caller's authenticated `sub` to match `body.sub`, unless the caller holds the `admin` scope. Cross-user revocation requests return `403 Forbidden` with a `caller_sub`/`target_sub` warning logged for incident response.
+
+### Breaking changes
+
+- **`POST /auth/revoke` request body changed.** The `token` field is now `Option<String>` and ignored. Clients that previously submitted a body token will continue to receive `200 OK`, but the revocation now targets the *authentication* token, not the body token. Update any flow that depended on revoking an arbitrary harvested token via this endpoint — there is no longer such a primitive.
+
+- **`POST /auth/revoke` and `POST /auth/revoke-all` now require a valid bearer token.** Anonymous calls return `401 Unauthorized`. Update any internal tooling that called these endpoints unauthenticated.
+
+- **Token revocation requires `[auth]` to be configured.** If `[security.token_revocation] enabled = true` but no OIDC validator is present, the revocation routes are skipped at startup (with a `WARN` log) rather than mounted open. Configure `[auth]` in `fraiseql.toml` to restore the routes.
+
 ## [2.3.2] - 2026-05-28
 
 ### Fixed

--- a/crates/fraiseql-server/src/middleware/mod.rs
+++ b/crates/fraiseql-server/src/middleware/mod.rs
@@ -18,7 +18,7 @@ pub use cors::{cors_layer, cors_layer_restricted, security_headers_middleware};
 pub use header_limits::header_limits_middleware;
 pub use hs256_auth::{Hs256AuthState, hs256_auth_middleware};
 pub use metrics::metrics_middleware;
-pub use oidc_auth::{AuthUser, OidcAuthState, oidc_auth_middleware};
+pub use oidc_auth::{AuthUser, OidcAuthState, SessionJti, oidc_auth_middleware};
 pub use rate_limit::{
     RateLimitConfig, RateLimiter, RateLimitingSecurityConfig, rate_limit_middleware,
 };

--- a/crates/fraiseql-server/src/middleware/oidc_auth.rs
+++ b/crates/fraiseql-server/src/middleware/oidc_auth.rs
@@ -36,6 +36,28 @@ impl OidcAuthState {
 #[derive(Clone, Debug)]
 pub struct AuthUser(pub AuthenticatedUser);
 
+/// Request extension containing the `jti` claim of the validated bearer token.
+///
+/// Populated by [`oidc_auth_middleware`] immediately after `validate_token`
+/// succeeds — at that point the token's signature, expiry, audience, and
+/// (when enabled) replay-cache check have all been verified, so re-decoding
+/// the payload to extract `jti` carries no integrity risk.
+///
+/// `None` indicates the token had no `jti` claim. Handlers that must revoke
+/// the caller's current session (e.g. `POST /auth/revoke`) should treat
+/// `Some(jti)` as the only valid input — there is no per-request identifier
+/// to revoke without it.
+#[derive(Clone, Debug)]
+pub struct SessionJti(pub Option<String>);
+
+/// Minimal JWT payload deserializer used to extract `jti` from an
+/// already-validated bearer token. The validator has performed the heavy
+/// integrity checks; this struct only pulls out the per-token identifier.
+#[derive(serde::Deserialize)]
+struct JtiOnlyClaims {
+    jti: Option<String>,
+}
+
 /// Extract the bearer token from a raw `Cookie` header value.
 ///
 /// Looks for `__Host-access_token=<value>` in the semicolon-separated cookie
@@ -140,8 +162,17 @@ pub async fn oidc_auth_middleware(
                         scopes = ?user.scopes,
                         "User authenticated successfully"
                     );
-                    // Add authenticated user to request extensions
+                    // Re-decode the (already-validated) token payload to surface
+                    // the `jti` claim for downstream handlers that need to
+                    // revoke the caller's current session.  `insecure_decode`
+                    // is safe here because `validate_token` above has already
+                    // checked signature, expiry, audience, and (when enabled)
+                    // replay-cache state.
+                    let jti = jsonwebtoken::dangerous::insecure_decode::<JtiOnlyClaims>(&token)
+                        .ok()
+                        .and_then(|d| d.claims.jti);
                     request.extensions_mut().insert(AuthUser(user));
+                    request.extensions_mut().insert(SessionJti(jti));
                     next.run(request).await
                 },
                 Err(e) => {

--- a/crates/fraiseql-server/src/routes/auth.rs
+++ b/crates/fraiseql-server/src/routes/auth.rs
@@ -22,14 +22,17 @@
 use std::sync::Arc;
 
 use axum::{
-    Json,
+    Extension, Json,
     extract::{Query, State},
     http::{StatusCode, header},
     response::{IntoResponse, Redirect, Response},
 };
 use serde::{Deserialize, Serialize};
 
-use crate::auth::{OidcServerClient, PkceStateStore};
+use crate::{
+    auth::{OidcServerClient, PkceStateStore},
+    middleware::{AuthUser, SessionJti},
+};
 
 /// Shared state injected into both PKCE route handlers.
 pub struct AuthPkceState {
@@ -266,10 +269,18 @@ pub async fn auth_callback(
 // ---------------------------------------------------------------------------
 
 /// Request body for token revocation.
+///
+/// As of v2.4.0, the route revokes the caller's currently-authenticated
+/// session — identified by the `jti` of the validated bearer token, not by
+/// any token submitted in the request body. The `token` field is accepted
+/// for wire-shape backwards compatibility but is ignored by the handler.
 #[derive(Deserialize)]
 pub struct RevokeTokenRequest {
-    /// The JWT to revoke (we extract `jti` and `exp` from it).
-    pub token: String,
+    /// Legacy field; ignored as of v2.4.0. The route revokes the caller's
+    /// own session, identified by the `jti` of the bearer token used to
+    /// authenticate the request.
+    #[serde(default)]
+    pub token: Option<String>,
 }
 
 /// Response body for token revocation.
@@ -288,59 +299,52 @@ pub struct RevocationRouteState {
     pub revocation_manager: std::sync::Arc<crate::token_revocation::TokenRevocationManager>,
 }
 
-/// Revoke a single JWT by its `jti` claim.
+/// Revoke the caller's currently-authenticated session.
 ///
-/// The token is decoded (without verification — we only need the claims) to
-/// extract `jti` and `exp`.  The revocation entry TTL is set to the remaining
-/// token lifetime so the store auto-cleans.
+/// The route is mounted behind `oidc_auth_middleware`, so the bearer token has
+/// been validated by the time this handler runs.  The `jti` of that validated
+/// token is what gets revoked — never an attacker-supplied token from the
+/// body.  This closes the FW-21 class anonymous-revocation primitive
+/// (issue #358) as well as the authenticated-spoof primitive that the
+/// previous `insecure_decode(body.token)` design left open.
 ///
 /// # Responses
 ///
 /// - `200` — token revoked successfully.
-/// - `400` — token is missing or has no `jti` claim.
+/// - `401` — no valid session (enforced by `oidc_auth_middleware` before this
+///   handler is called).
+/// - `409` — the validated token has no `jti` claim, so there is no per-token
+///   identifier the revocation store can record.
 pub async fn revoke_token(
     State(state): State<std::sync::Arc<RevocationRouteState>>,
-    Json(body): Json<RevokeTokenRequest>,
+    Extension(auth_user): Extension<AuthUser>,
+    Extension(session_jti): Extension<SessionJti>,
+    Json(_body): Json<RevokeTokenRequest>,
 ) -> Response {
-    #[derive(serde::Deserialize)]
-    struct MinimalClaims {
-        jti: Option<String>,
-        exp: Option<u64>,
-    }
-
-    // Decode without signature verification — we only need the claims for revocation.
-    let claims = match jsonwebtoken::dangerous::insecure_decode::<MinimalClaims>(&body.token) {
-        Ok(data) => data.claims,
-        Err(e) => {
-            return auth_error(StatusCode::BAD_REQUEST, &format!("Invalid token: {e}"));
-        },
-    };
-
-    let jti = match claims.jti {
+    let jti = match session_jti.0 {
         Some(j) if !j.is_empty() => j,
         _ => {
-            return auth_error(StatusCode::BAD_REQUEST, "Token has no jti claim");
+            return auth_error(
+                StatusCode::CONFLICT,
+                "Bearer token has no jti claim; cannot revoke",
+            );
         },
     };
 
-    // TTL = remaining token lifetime, or 24h if no exp.
-    let ttl_secs = claims
-        .exp
-        .and_then(|exp| {
-            let now = chrono::Utc::now().timestamp().cast_unsigned();
-            exp.checked_sub(now)
-        })
-        .unwrap_or(86400);
+    // TTL = remaining token lifetime, clamped to >= 0. If the token were
+    // already expired, the auth middleware would have rejected the request,
+    // so a positive TTL is the only path that reaches this point.
+    let ttl_secs = {
+        let remaining = (auth_user.0.expires_at - chrono::Utc::now()).num_seconds();
+        u64::try_from(remaining).unwrap_or(0)
+    };
 
     if let Err(e) = state.revocation_manager.revoke(&jti, ttl_secs).await {
         tracing::error!(error = %e, "Failed to revoke token");
         return auth_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to revoke token");
     }
 
-    let expires_at = claims.exp.map(|exp| {
-        chrono::DateTime::from_timestamp(exp.cast_signed(), 0)
-            .map_or_else(|| exp.to_string(), |dt| dt.to_rfc3339())
-    });
+    let expires_at = Some(auth_user.0.expires_at.to_rfc3339());
 
     Json(RevokeTokenResponse {
         revoked: true,
@@ -367,18 +371,45 @@ pub struct RevokeAllResponse {
     pub revoked_count: u64,
 }
 
+/// Scope name that grants the bearer permission to revoke other users'
+/// sessions via `POST /auth/revoke-all`.
+const REVOKE_ALL_ADMIN_SCOPE: &str = "admin";
+
 /// Revoke all tokens for a user.
+///
+/// The route is mounted behind `oidc_auth_middleware`. The caller may only
+/// revoke sessions for their own `sub` unless they hold the
+/// `REVOKE_ALL_ADMIN_SCOPE` scope. This closes the FW-21 class
+/// anonymous-revocation primitive (issue #358) as well as cross-user
+/// revocation via authenticated requests.
 ///
 /// # Responses
 ///
 /// - `200` — tokens revoked.
 /// - `400` — `sub` is missing or empty.
+/// - `401` — no valid session (enforced by `oidc_auth_middleware`).
+/// - `403` — caller's `sub` does not match `body.sub` and caller lacks the
+///   admin scope.
 pub async fn revoke_all_tokens(
     State(state): State<std::sync::Arc<RevocationRouteState>>,
+    Extension(auth_user): Extension<AuthUser>,
     Json(body): Json<RevokeAllRequest>,
 ) -> Response {
     if body.sub.is_empty() {
         return auth_error(StatusCode::BAD_REQUEST, "sub is required");
+    }
+
+    let caller_sub = auth_user.0.user_id.as_str();
+    if caller_sub != body.sub && !auth_user.0.has_scope(REVOKE_ALL_ADMIN_SCOPE) {
+        tracing::warn!(
+            caller_sub = %caller_sub,
+            target_sub = %body.sub,
+            "Cross-user revoke-all rejected: caller is not admin"
+        );
+        return auth_error(
+            StatusCode::FORBIDDEN,
+            "Cannot revoke another user's sessions",
+        );
     }
 
     match state.revocation_manager.revoke_all_for_user(&body.sub).await {

--- a/crates/fraiseql-server/src/routes/auth.rs
+++ b/crates/fraiseql-server/src/routes/auth.rs
@@ -311,10 +311,9 @@ pub struct RevocationRouteState {
 /// # Responses
 ///
 /// - `200` — token revoked successfully.
-/// - `401` — no valid session (enforced by `oidc_auth_middleware` before this
-///   handler is called).
-/// - `409` — the validated token has no `jti` claim, so there is no per-token
-///   identifier the revocation store can record.
+/// - `401` — no valid session (enforced by `oidc_auth_middleware` before this handler is called).
+/// - `409` — the validated token has no `jti` claim, so there is no per-token identifier the
+///   revocation store can record.
 pub async fn revoke_token(
     State(state): State<std::sync::Arc<RevocationRouteState>>,
     Extension(auth_user): Extension<AuthUser>,
@@ -388,8 +387,7 @@ const REVOKE_ALL_ADMIN_SCOPE: &str = "admin";
 /// - `200` — tokens revoked.
 /// - `400` — `sub` is missing or empty.
 /// - `401` — no valid session (enforced by `oidc_auth_middleware`).
-/// - `403` — caller's `sub` does not match `body.sub` and caller lacks the
-///   admin scope.
+/// - `403` — caller's `sub` does not match `body.sub` and caller lacks the admin scope.
 pub async fn revoke_all_tokens(
     State(state): State<std::sync::Arc<RevocationRouteState>>,
     Extension(auth_user): Extension<AuthUser>,
@@ -406,10 +404,7 @@ pub async fn revoke_all_tokens(
             target_sub = %body.sub,
             "Cross-user revoke-all rejected: caller is not admin"
         );
-        return auth_error(
-            StatusCode::FORBIDDEN,
-            "Cannot revoke another user's sessions",
-        );
+        return auth_error(StatusCode::FORBIDDEN, "Cannot revoke another user's sessions");
     }
 
     match state.revocation_manager.revoke_all_for_user(&body.sub).await {

--- a/crates/fraiseql-server/src/routes/tests.rs
+++ b/crates/fraiseql-server/src/routes/tests.rs
@@ -398,6 +398,186 @@ mod auth_tests {
     }
 }
 
+mod revoke_tests {
+    //! Handler-level authorization tests for `POST /auth/revoke` and
+    //! `POST /auth/revoke-all` (issue #358).
+    //!
+    //! Routing-level "401 without auth" is enforced by mounting the routes
+    //! behind `oidc_auth_middleware` in `server/routing/auth.rs`; the
+    //! handler tests below cover the additional in-handler checks:
+    //!
+    //! - `revoke_token` revokes the bearer-token's own `jti` (not an
+    //!   attacker-supplied body token).
+    //! - `revoke_all_tokens` enforces caller-`sub` == `body.sub` unless the
+    //!   caller holds the `admin` scope.
+
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics acceptable
+
+    use std::sync::Arc;
+
+    use axum::{
+        Extension, Router,
+        body::Body,
+        http::{Request, StatusCode, header},
+        routing::post,
+    };
+    use chrono::Utc;
+    use tower::ServiceExt as _;
+
+    use super::super::auth::{RevocationRouteState, revoke_all_tokens, revoke_token};
+    use crate::{
+        middleware::{AuthUser, SessionJti},
+        token_revocation::{InMemoryRevocationStore, TokenRevocationManager},
+    };
+
+    fn make_manager() -> Arc<TokenRevocationManager> {
+        Arc::new(TokenRevocationManager::new(
+            Arc::new(InMemoryRevocationStore::new()),
+            true,
+            false,
+        ))
+    }
+
+    fn make_auth_user(sub: &str, scopes: Vec<&str>) -> AuthUser {
+        AuthUser(fraiseql_core::security::AuthenticatedUser {
+            user_id:      fraiseql_core::types::UserId::new(sub),
+            scopes:       scopes.into_iter().map(str::to_owned).collect(),
+            expires_at:   Utc::now() + chrono::Duration::hours(1),
+            email:        None,
+            display_name: None,
+            extra_claims: std::collections::HashMap::new(),
+        })
+    }
+
+    fn revoke_app(manager: Arc<TokenRevocationManager>) -> Router {
+        let state = Arc::new(RevocationRouteState {
+            revocation_manager: manager,
+        });
+        Router::new()
+            .route("/auth/revoke", post(revoke_token))
+            .route("/auth/revoke-all", post(revoke_all_tokens))
+            .with_state(state)
+    }
+
+    fn post_json(uri: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_owned()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn revoke_token_uses_session_jti_not_body() {
+        let manager = make_manager();
+        let app = revoke_app(Arc::clone(&manager));
+
+        // Authenticated as "alice" with jti "alice-jti-1". The request body's
+        // token field carries an attacker-controlled stub that would have
+        // revoked "victim-jti" under the old insecure_decode design.
+        let attacker_body = r#"{"token":"eyJhbGciOiJub25lIn0.eyJqdGkiOiJ2aWN0aW0tanRpIn0."}"#;
+        let req = post_json("/auth/revoke", attacker_body);
+
+        let resp = app
+            .layer(Extension(make_auth_user("alice", vec![])))
+            .layer(Extension(SessionJti(Some("alice-jti-1".to_string()))))
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK, "revoke should succeed");
+        assert!(
+            manager.check_token(Some("alice-jti-1")).await.is_err(),
+            "alice's bearer-token jti must be the one revoked"
+        );
+        assert!(
+            manager.check_token(Some("victim-jti")).await.is_ok(),
+            "attacker-supplied body.token jti must NOT be revoked"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_token_returns_409_when_token_has_no_jti() {
+        let manager = make_manager();
+        let app = revoke_app(manager);
+
+        let req = post_json("/auth/revoke", r"{}");
+        let resp = app
+            .layer(Extension(make_auth_user("alice", vec![])))
+            .layer(Extension(SessionJti(None)))
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn revoke_all_self_succeeds() {
+        let manager = make_manager();
+        let app = revoke_app(Arc::clone(&manager));
+
+        let req = post_json("/auth/revoke-all", r#"{"sub":"alice"}"#);
+        let resp = app
+            .layer(Extension(make_auth_user("alice", vec![])))
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn revoke_all_cross_user_without_admin_scope_returns_403() {
+        let manager = make_manager();
+        let app = revoke_app(Arc::clone(&manager));
+
+        let req = post_json("/auth/revoke-all", r#"{"sub":"bob"}"#);
+        let resp = app
+            .layer(Extension(make_auth_user("alice", vec!["read", "write"])))
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "alice without admin scope must not revoke bob's sessions"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_all_cross_user_with_admin_scope_succeeds() {
+        let manager = make_manager();
+        let app = revoke_app(Arc::clone(&manager));
+
+        let req = post_json("/auth/revoke-all", r#"{"sub":"bob"}"#);
+        let resp = app
+            .layer(Extension(make_auth_user("alice", vec!["admin"])))
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn revoke_all_empty_body_sub_returns_400() {
+        let manager = make_manager();
+        let app = revoke_app(manager);
+
+        let req = post_json("/auth/revoke-all", r#"{"sub":""}"#);
+        let resp = app
+            .layer(Extension(make_auth_user("alice", vec!["admin"])))
+            .oneshot(req)
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}
+
 mod health_tests {
     #![allow(clippy::unwrap_used)] // Reason: test code, panics acceptable
     #![allow(clippy::cast_precision_loss)] // Reason: test metrics reporting

--- a/crates/fraiseql-server/src/routes/tests.rs
+++ b/crates/fraiseql-server/src/routes/tests.rs
@@ -406,10 +406,9 @@ mod revoke_tests {
     //! behind `oidc_auth_middleware` in `server/routing/auth.rs`; the
     //! handler tests below cover the additional in-handler checks:
     //!
-    //! - `revoke_token` revokes the bearer-token's own `jti` (not an
-    //!   attacker-supplied body token).
-    //! - `revoke_all_tokens` enforces caller-`sub` == `body.sub` unless the
-    //!   caller holds the `admin` scope.
+    //! - `revoke_token` revokes the bearer-token's own `jti` (not an attacker-supplied body token).
+    //! - `revoke_all_tokens` enforces caller-`sub` == `body.sub` unless the caller holds the
+    //!   `admin` scope.
 
     #![allow(clippy::unwrap_used)] // Reason: test code, panics acceptable
 

--- a/crates/fraiseql-server/src/server/routing/auth.rs
+++ b/crates/fraiseql-server/src/server/routing/auth.rs
@@ -100,17 +100,33 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             );
         }
 
-        // Token revocation routes — mounted only when revocation is configured.
+        // Token revocation routes — mounted only when revocation is configured
+        // AND an OIDC validator is available to gate the requests. Without an
+        // OIDC validator, these routes would be reachable unauthenticated —
+        // an anonymous force-logout primitive (#358). Skipping the mount with
+        // a loud warning is safer than silently mounting them open.
         if let Some(ref rev_mgr) = self.revocation_manager {
-            let rev_state = Arc::new(crate::routes::RevocationRouteState {
-                revocation_manager: Arc::clone(rev_mgr),
-            });
-            let rev_router = Router::new()
-                .route("/auth/revoke", post(crate::routes::revoke_token))
-                .route("/auth/revoke-all", post(crate::routes::revoke_all_tokens))
-                .with_state(rev_state);
-            app = app.merge(rev_router);
-            info!("Token revocation routes mounted: POST /auth/revoke, POST /auth/revoke-all");
+            if let Some(ref validator) = self.oidc_validator {
+                let rev_state = Arc::new(crate::routes::RevocationRouteState {
+                    revocation_manager: Arc::clone(rev_mgr),
+                });
+                let auth_state = OidcAuthState::new(Arc::clone(validator));
+                let rev_router = Router::new()
+                    .route("/auth/revoke", post(crate::routes::revoke_token))
+                    .route("/auth/revoke-all", post(crate::routes::revoke_all_tokens))
+                    .route_layer(middleware::from_fn_with_state(auth_state, oidc_auth_middleware))
+                    .with_state(rev_state);
+                app = app.merge(rev_router);
+                info!(
+                    "Token revocation routes mounted (auth-gated): POST /auth/revoke, POST /auth/revoke-all"
+                );
+            } else {
+                tracing::warn!(
+                    "Token revocation is configured but no OIDC validator is available; \
+                     refusing to mount /auth/revoke and /auth/revoke-all unauthenticated. \
+                     Configure [auth] in fraiseql.toml to enable token revocation."
+                );
+            }
         }
 
         app


### PR DESCRIPTION
Closes #358.

## Summary

Token-revocation routes (`POST /auth/revoke`, `POST /auth/revoke-all`) were mounted without any auth middleware. Any unauthenticated client could:
- Revoke any harvested JWT by `jti` (no proof-of-possession required — `jsonwebtoken::dangerous::insecure_decode` was applied to the body token).
- Wipe every active session for any `sub` by submitting `{"sub":"..."}` with no token at all.

Anonymous force-logout against the auth subsystem; bypasses every CIA assumption of the revocation feature. **FW-21 class, critical**.

## Fix

Three layers:

1. **Mount-time gate.** `mount_auth_routes` only mounts the revocation router when both `revocation_manager` *and* an OIDC validator are configured. The router is wrapped with `route_layer(oidc_auth_middleware)`. If revocation is enabled but `[auth]` is missing, the routes are *not* mounted and a `WARN` is logged at startup rather than silently mounting them open.

2. **`POST /auth/revoke` revokes the bearer.** A new `SessionJti(Option<String>)` request extension is populated by the OIDC middleware immediately after `validate_token` succeeds (`insecure_decode` of the validated token is safe at that point). The handler uses `SessionJti` as the revocation target — never the body's `token` field. This closes the residual attack where an authenticated alice could submit a body token claiming `sub: "alice"` but carrying a victim's `jti`. The `RevokeTokenRequest.token` field is kept as `Option<String>` so existing clients don't break; the handler ignores it.

3. **`POST /auth/revoke-all` enforces self-or-admin.** The handler now requires `auth_user.user_id == body.sub` OR `auth_user.has_scope(\"admin\")`. Cross-user requests by non-admins return `403 Forbidden` and emit a structured `WARN` with `caller_sub`/`target_sub` for incident response.

## Tests

`routes::tests::revoke_tests` (6 new tests, all passing):

- `revoke_token_uses_session_jti_not_body` — proves an attacker-supplied body token with `jti: victim-jti` does NOT cause victim revocation; only the caller's bearer `jti` is revoked.
- `revoke_token_returns_409_when_token_has_no_jti` — graceful failure when the bearer has no `jti` claim.
- `revoke_all_self_succeeds` — happy path for self-revocation.
- `revoke_all_cross_user_without_admin_scope_returns_403` — cross-user attack returns 403.
- `revoke_all_cross_user_with_admin_scope_succeeds` — admin recovery path works.
- `revoke_all_empty_body_sub_returns_400` — input validation unchanged.

## Verification

- [x] `cargo nextest run -p fraiseql-server --lib` → 1026/1026 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] CHANGELOG entries added under `### Security` + `### Breaking changes`

## Breaking changes (documented in CHANGELOG)

1. `POST /auth/revoke` no longer revokes a body-supplied token; revokes the caller's bearer.
2. Both routes now return 401 to anonymous callers.
3. Token revocation requires `[auth]` to be configured. Without it, the routes are not mounted (WARN at startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)