### PR TITLE
ci: route Clippy + Redis integration tests to fraiseql-8core

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+---
+# actionlint configuration — registers custom org-provisioned runner labels
+# so the `runner-label` lint accepts them. Add new entries here when a new
+# larger-runner is provisioned at the org level and used by any workflow.
+self-hosted-runner:
+  labels:
+    # 8 vCPU / 32 GB / 300 GB SSD, Ubuntu 24.04, org-provisioned via
+    # GitHub-hosted larger runners. Cap: maximum_runners: 2 per org.
+    # See `gh api /orgs/fraiseql/actions/hosted-runners`.
+    - fraiseql-8core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,11 @@ jobs:
   # Lint with Clippy
   clippy:
     name: Clippy Lints
-    runs-on: ubuntu-latest
+    # CPU-bound: full workspace compile + all-features lint pass.
+    # Routed to fraiseql-8core (8 vCPU / 32 GB) to roughly halve wall time.
+    # Org-level larger runner is capped at maximum_runners: 2 — confirm only
+    # one other job on this PR also routes here before adding a third.
+    runs-on: fraiseql-8core
     # Full workspace compilation + linting
     timeout-minutes: 25
     steps:
@@ -541,7 +545,12 @@ jobs:
   # Integration tests for Redis (APQ storage, observer queue and lease)
   integration-redis:
     name: Integration Tests (Redis)
-    runs-on: ubuntu-latest
+    # Longest-pole job at the v2.3.2 frozen-SHA snapshot (~11.6 min).
+    # Mixed I/O + CPU: Redis container fixed startup ~10s, then parallel
+    # cargo test threads dominate. Routed to fraiseql-8core for the test-
+    # thread parallelism. Cap is maximum_runners: 2 org-wide; ensure no
+    # third concurrent job lands on this label.
+    runs-on: fraiseql-8core
     timeout-minutes: 45
 
     services:


### PR DESCRIPTION
## Summary

The org-provisioned `fraiseql-8core` larger runner (8 vCPU / 32 GB / 300 GB SSD, Ubuntu 24.04) had been sitting idle because every workflow targets `ubuntu-latest`. This PR routes the two longest CI jobs to it.

## Selected jobs

Top two by wall time on the most recent dev-tip CI run (run `26676576987`):

| Job | Old runner | Wall time | New runner |
|---|---|---|---|
| Integration Tests (Redis) | ubuntu-latest (2 vCPU) | 697s | fraiseql-8core (8 vCPU) |
| Clippy Lints | ubuntu-latest (2 vCPU) | 544s | fraiseql-8core (8 vCPU) |

`Clippy Lints` is pure CPU-bound (full workspace compile + all-features lint pass) — should roughly halve. `Integration Tests (Redis)` is mixed I/O+CPU; container startup is a fixed cost but the parallel cargo test threads benefit from the extra cores.

## Capacity constraint (documented in YAML)

`gh api /orgs/fraiseql/actions/hosted-runners` shows the runner has `maximum_runners: 2` — only two concurrent jobs can run on this label. Inline comments at both `runs-on:` sites warn future maintainers not to route a third heavy job here without rebalancing, otherwise queueing serializes the load and CI gets *slower*, not faster.

## Test plan

- [ ] This PR's CI run shows `Integration Tests (Redis)` and `Clippy Lints` landing on `fraiseql-8core` (verify via `gh run view`).
- [ ] Both jobs complete successfully.
- [ ] Wall time on both jobs drops materially vs the dev baseline (697s and 544s).
- [ ] No other workflow regressed (only these two `runs-on` lines changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)