### PR TITLE
fix(security): auth-gate observer admin HTTP API (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   3. `POST /auth/revoke-all` now requires the caller's authenticated `sub` to match `body.sub`, unless the caller holds the `admin` scope. Cross-user revocation requests return `403 Forbidden` with a `caller_sub`/`target_sub` warning logged for incident response.
 
+- **Observer admin API now requires authentication** (#348, FW-21 class). All four observer HTTP routers — `observer_routes` (CRUD), `observer_changelog_routes`, `observer_runtime_routes` (`/runtime/health`, `/runtime/reload`), and `observer_dlq_routes` (`/api/observers/dlq/*`) — were previously mounted with no auth middleware. Handlers used `OptionalSecurityContext` (which returns `None` on anonymous calls) or no auth extractor at all, so any unauthenticated client could:
+
+  - `POST /api/observers` — install an attacker-controlled webhook observer pointing at any URL (combined with #347, a one-step path to AWS metadata-service credential exfiltration).
+  - `PATCH /api/observers/{id}` — silently re-route an existing observer to an attacker URL.
+  - `DELETE /api/observers/{id}` — wipe an observer.
+  - `POST /runtime/reload` — denial-of-service against the observer runtime.
+  - `GET /api/observers/{id}` — read bearer-token secrets stored in `actions[].headers`.
+  - `POST /api/observers/dlq/retry-all` — replay queued events through whatever URL the (now attacker-controlled) observer points at.
+
+  All four router nests now mount behind `oidc_auth_middleware` via `route_layer`. If the `observers` feature is enabled but `[auth]` is not configured (no OIDC validator available), the HTTP admin API is *not* mounted and a `WARN` is logged at startup. The in-process observer runtime — triggers, dispatch, DLQ retention — is unaffected; only the HTTP control plane is gated. Affected anyone running the `observers` feature.
+
 ### Breaking changes
 
 - **`POST /auth/revoke` request body changed.** The `token` field is now `Option<String>` and ignored. Clients that previously submitted a body token will continue to receive `200 OK`, but the revocation now targets the *authentication* token, not the body token. Update any flow that depended on revoking an arbitrary harvested token via this endpoint — there is no longer such a primitive.
@@ -26,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`POST /auth/revoke` and `POST /auth/revoke-all` now require a valid bearer token.** Anonymous calls return `401 Unauthorized`. Update any internal tooling that called these endpoints unauthenticated.
 
 - **Token revocation requires `[auth]` to be configured.** If `[security.token_revocation] enabled = true` but no OIDC validator is present, the revocation routes are skipped at startup (with a `WARN` log) rather than mounted open. Configure `[auth]` in `fraiseql.toml` to restore the routes.
+
+- **Observer admin HTTP API requires `[auth]` to be configured.** If `[auth]` is absent, `/api/observers/*`, `/runtime/health`, and `/runtime/reload` are not mounted (with a `WARN` log at startup) rather than mounted open. Any internal tooling that called these endpoints unauthenticated must now present a valid bearer token. Reverse-proxy auth (mTLS or a bearer-token gate) is no longer the only line of defence.
 
 ## [2.3.2] - 2026-05-28
 

--- a/crates/fraiseql-server/src/server/routing/observers.rs
+++ b/crates/fraiseql-server/src/server/routing/observers.rs
@@ -1,10 +1,11 @@
 //! Observer management route mounting.
 
-use axum::Router;
+use axum::{Router, middleware};
 use fraiseql_core::db::traits::DatabaseAdapter;
 use tracing::info;
 
 use super::super::Server;
+use crate::middleware::{OidcAuthState, oidc_auth_middleware};
 
 impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// Add observer-related routes to the router.
@@ -16,8 +17,21 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// `db_pool` argument. If no pool is provided, observer management routes are skipped
     /// and an error is logged rather than panicking, so the server can still serve other
     /// requests. Callers should treat a missing pool as a configuration error.
+    ///
+    /// # Authentication requirement (since v2.4.0)
+    ///
+    /// The observer admin API — create / update / delete observers, reload runtime,
+    /// inspect DLQ, read the changelog — exposes write-side cluster-state mutations
+    /// and read-side endpoints that return bearer-token secrets stored in observer
+    /// `actions[].headers`.  All four routers are gated behind `oidc_auth_middleware`.
+    /// If no OIDC validator is configured (`[auth]` absent in `fraiseql.toml`), the
+    /// routes are *not* mounted and a `WARN` is logged at startup, rather than
+    /// mounting them open.  This closes the FW-21 class anonymous-write primitive
+    /// (issue #348).
     #[cfg(feature = "observers")]
     pub(super) fn add_observer_routes(&self, app: Router) -> Router {
+        use std::sync::Arc;
+
         use crate::observers::{
             ChangelogState, DlqState, ObserverRepository, ObserverState, RuntimeHealthState,
             observer_changelog_routes, observer_dlq_routes, observer_routes,
@@ -33,20 +47,41 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             return app;
         };
 
+        let Some(ref validator) = self.oidc_validator else {
+            tracing::warn!(
+                "Observer admin API not mounted: \
+                 the observer routes expose cluster-state mutations and bearer-token \
+                 secrets (in actions[].headers) and so require an OIDC validator. \
+                 Configure [auth] in fraiseql.toml to enable observer endpoints. \
+                 The observer runtime itself (in-process triggers and dispatch) is \
+                 unaffected — only the HTTP admin API is skipped."
+            );
+            return app;
+        };
+
         let observer_state = ObserverState {
             repository: ObserverRepository::new(db_pool.clone()),
         };
 
         let changelog_state = ChangelogState { pool: db_pool };
 
+        let auth_layer = || {
+            let auth_state = OidcAuthState::new(Arc::clone(validator));
+            middleware::from_fn_with_state(auth_state, oidc_auth_middleware)
+        };
+
         let app = app
-            .nest("/api/observers", observer_routes(observer_state))
-            .nest("/api/observers", observer_changelog_routes(changelog_state));
+            .nest("/api/observers", observer_routes(observer_state).route_layer(auth_layer()))
+            .nest(
+                "/api/observers",
+                observer_changelog_routes(changelog_state).route_layer(auth_layer()),
+            );
 
         if let Some(ref runtime) = self.observer_runtime {
             info!(
                 path = "/api/observers",
-                "Observer management, runtime health, and DLQ delivery status endpoints enabled"
+                "Observer management, runtime health, and DLQ delivery status endpoints \
+                 enabled (auth-gated)"
             );
 
             let runtime_state = RuntimeHealthState {
@@ -57,8 +92,8 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                 runtime: runtime.clone(),
             };
 
-            app.merge(observer_runtime_routes(runtime_state))
-                .nest("/api/observers", observer_dlq_routes(dlq_state))
+            app.merge(observer_runtime_routes(runtime_state).route_layer(auth_layer()))
+                .nest("/api/observers", observer_dlq_routes(dlq_state).route_layer(auth_layer()))
         } else {
             app
         }


### PR DESCRIPTION
Closes #348.

## Summary

The four observer HTTP routers — CRUD (\`observer_routes\`), changelog (\`observer_changelog_routes\`), runtime (\`observer_runtime_routes\` for \`/runtime/health\` and \`/runtime/reload\`), and DLQ (\`observer_dlq_routes\`) — were mounted with no auth middleware. Handlers used \`OptionalSecurityContext\` (which returns \`None\` on anonymous requests) or no auth extractor at all.

Result: any unauthenticated client could install an attacker-controlled webhook observer (combined with #347, a one-step path to AWS metadata-service credential exfiltration), wipe observers, denial-of-service the runtime via \`/runtime/reload\` floods, read bearer-token secrets stored in \`actions[].headers\`, or replay queued events through an attacker URL via DLQ retry-all. **FW-21 class, critical**.

## Fix

Same pattern as PR #362 (\`/auth/revoke\` gating):

1. **Mount-time gate.** \`add_observer_routes\` now requires \`self.oidc_validator\` to be \`Some\`. If \`[auth]\` is absent in \`fraiseql.toml\`, the four observer HTTP routers are skipped at startup and a \`WARN\` is logged, rather than mounted unauthenticated.

2. **Per-router auth-middleware layer.** Each of the four nests is wrapped with \`route_layer(oidc_auth_middleware)\`. Anonymous requests get 401 before reaching any handler.

3. **In-process runtime unaffected.** Triggers, dispatch, and DLQ retention still run as before; only the HTTP control plane is gated.

The handlers themselves (in \`observers/handlers.rs\` and \`observers/dlq_handlers/\`) are unchanged — once the middleware is in place, no anonymous request can reach them, so the existing \`OptionalSecurityContext\` extractor's \`None\`-on-anonymous behaviour is effectively dead code on this path.

## Verification

- [x] \`cargo nextest run -p fraiseql-server --lib\` → 1026/1026 pass
- [x] \`cargo clippy -p fraiseql-server --all-targets -- -D warnings\` → clean
- [x] \`cargo +nightly fmt --all -- --check\` → clean

## Breaking changes (documented in CHANGELOG)

Observer admin HTTP API requires \`[auth]\` to be configured. Without it, the routes are skipped (with a \`WARN\` log at startup) rather than mounted open. Internal tooling that previously called these endpoints unauthenticated must now present a valid bearer token.

## What this PR does NOT fix

- **Admin-scope enforcement.** The fix gates against anonymous access but allows any authenticated user. Issue #348 suggests adding a \`RequireRole(\"observers:write\")\` or similar admin scope — that's deeper than this security patch and tracked for a follow-up.
- **#347 (\`FRAISEQL_OBSERVERS_ALLOW_INSECURE\` SSRF bypass).** Separate B-task on the v2.4.0 stack.
- **FW-13 (root-mount of \`/runtime/*\`).** The runtime routes still merge at root rather than nesting under \`/api/observers\`. That's a discoverability concern but no longer an auth-bypass concern — the routes are gated regardless of mount path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)