### PR TITLE
fix(security): refuse FRAISEQL_OBSERVERS_ALLOW_INSECURE in production (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   3. `POST /auth/revoke-all` now requires the caller's authenticated `sub` to match `body.sub`, unless the caller holds the `admin` scope. Cross-user revocation requests return `403 Forbidden` with a `caller_sub`/`target_sub` warning logged for incident response.
 
+- **`FRAISEQL_OBSERVERS_ALLOW_INSECURE` bypass is refused in production environments** (#347). Pre-v2.4.0 the env var disabled every outbound SSRF guard (scheme allowlist, private-IP blocklist, DNS-rebinding defence) in observer dispatch — `validate_outbound_url`, `dns_resolve_and_check`, `executor::dispatch::validate_url_ssrf` — with a `std::sync::Once` warn-on-first-use that was easy to miss in streaming log aggregators. Combined with #348 (anonymous observer install), this was a one-step path to AWS metadata-service credential exfiltration: install an observer pointing at `http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>`, wait for the next mutation.
+
+  The fix centralises the bypass policy in a new `fraiseql_observers::insecure_guard` module. The check now refuses the bypass when ANY production-marker env var is set:
+
+  - `KUBERNETES_SERVICE_HOST` (automatic in any K8s pod).
+  - `FRAISEQL_ENV=production` (case-insensitive, also accepts `prod`).
+  - `FRAISEQL_PROFILE=production` (case-insensitive, also accepts `prod`).
+
+  When the bypass is refused in production, a structured `ERROR` is logged once per process and a `WARN` is emitted at every outbound dispatch (so operators see the bypass-attempt at every dispatch, not just once at startup). When the bypass is honored in dev, a `WARN` is emitted on every dispatch — the `std::sync::Once` warn-once is gone.
+
 - **Observer admin API now requires authentication** (#348, FW-21 class). All four observer HTTP routers — `observer_routes` (CRUD), `observer_changelog_routes`, `observer_runtime_routes` (`/runtime/health`, `/runtime/reload`), and `observer_dlq_routes` (`/api/observers/dlq/*`) — were previously mounted with no auth middleware. Handlers used `OptionalSecurityContext` (which returns `None` on anonymous calls) or no auth extractor at all, so any unauthenticated client could:
 
   - `POST /api/observers` — install an attacker-controlled webhook observer pointing at any URL (combined with #347, a one-step path to AWS metadata-service credential exfiltration).

--- a/crates/fraiseql-observers/src/actions.rs
+++ b/crates/fraiseql-observers/src/actions.rs
@@ -7,11 +7,11 @@
 //!
 //! Each action handles template rendering, retry logic, and error handling.
 
-use std::{collections::HashMap, sync::Once, time::Duration};
+use std::{collections::HashMap, time::Duration};
 
 use reqwest::Client;
 use serde_json::{Value, json};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::{
     error::{ObserverError, Result},
@@ -24,9 +24,6 @@ use crate::{
 /// indefinitely.  Operators can override this by constructing the client
 /// manually via [`WebhookAction::with_timeout`].
 pub(crate) const DEFAULT_WEBHOOK_TIMEOUT_SECS: u64 = 30;
-
-/// Warn once when insecure mode is enabled.
-static INSECURE_WARN_ONCE: Once = Once::new();
 
 /// Validate an outbound URL for SSRF risk before sending a request.
 ///
@@ -45,15 +42,11 @@ static INSECURE_WARN_ONCE: Once = Once::new();
 /// Returns `ObserverError::ActionPermanentlyFailed` if the URL uses a
 /// non-HTTP(S) scheme or resolves to a blocked address range.
 pub(crate) fn validate_outbound_url(url: &str) -> Result<()> {
-    // When `FRAISEQL_OBSERVERS_ALLOW_INSECURE=true` all SSRF guards are disabled.
-    // Intended for local development and integration testing only.
-    let allow_insecure = std::env::var("FRAISEQL_OBSERVERS_ALLOW_INSECURE")
-        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        .unwrap_or(false);
-    if allow_insecure {
-        INSECURE_WARN_ONCE.call_once(|| {
-            warn!("FRAISEQL_OBSERVERS_ALLOW_INSECURE=true — HTTPS enforcement disabled for outbound webhook delivery");
-        });
+    // The `FRAISEQL_OBSERVERS_ALLOW_INSECURE` bypass is honored only in
+    // development environments; the centralised guard refuses it when any
+    // production marker is set (KUBERNETES_SERVICE_HOST, FRAISEQL_ENV=production,
+    // FRAISEQL_PROFILE=production).  See `insecure_guard` module docs.
+    if crate::insecure_guard::is_outbound_insecure_allowed() {
         return Ok(());
     }
 

--- a/crates/fraiseql-observers/src/executor/dispatch.rs
+++ b/crates/fraiseql-observers/src/executor/dispatch.rs
@@ -96,12 +96,10 @@ pub(super) fn resolve_url(
 /// a connect-time check at the HTTP client level and is beyond the scope of
 /// this static validation.
 fn validate_url_ssrf(url: &str) -> Result<()> {
-    // When `FRAISEQL_OBSERVERS_ALLOW_INSECURE=true` all SSRF guards are disabled.
-    // Intended for local development and integration testing only.
-    let allow_insecure = std::env::var("FRAISEQL_OBSERVERS_ALLOW_INSECURE")
-        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        .unwrap_or(false);
-    if allow_insecure {
+    // The `FRAISEQL_OBSERVERS_ALLOW_INSECURE` bypass is honored only in
+    // development environments; refused when any production marker is set.
+    // See `crate::insecure_guard` for the full policy.
+    if crate::insecure_guard::is_outbound_insecure_allowed() {
         return Ok(());
     }
 

--- a/crates/fraiseql-observers/src/insecure_guard.rs
+++ b/crates/fraiseql-observers/src/insecure_guard.rs
@@ -1,0 +1,122 @@
+//! Centralised guard for `FRAISEQL_OBSERVERS_ALLOW_INSECURE`.
+//!
+//! The env var disables every outbound SSRF check (scheme allowlist,
+//! private-IP blocklist, DNS-rebinding defence) in the observer outbound
+//! dispatch path.  Pre-v2.4.0 it was checked independently at four sites
+//! (`actions.rs`, `ssrf.rs` x2, `executor/dispatch.rs`) and warned exactly
+//! once on first use (`std::sync::Once`).
+//!
+//! This module is the single source of truth.  All four sites now call
+//! [`is_outbound_insecure_allowed`] which:
+//!
+//! - **Refuses** to honor the bypass when any production-marker env var is set, logging a
+//!   structured `ERROR` once per process and a per-call `WARN` so the bypass attempt is visible in
+//!   the log stream.
+//! - **Honors** the bypass in development/test environments only when the env var is set to `1` or
+//!   `true` (case-insensitive), and emits a `WARN` on *every* dispatch — operators must see the
+//!   bypass active in the log stream, not just once at startup (#347).
+//!
+//! ## Production markers
+//!
+//! Any of the following env vars indicate a production deployment and
+//! cause the bypass to be refused even when the bypass var is set:
+//!
+//! - `KUBERNETES_SERVICE_HOST` — automatic in any Kubernetes pod.
+//! - `FRAISEQL_ENV=production` (case-insensitive).
+//! - `FRAISEQL_PROFILE=production` (case-insensitive).
+//!
+//! Adding new production markers: extend [`is_production_environment`].
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tracing::{error, warn};
+
+/// Env var that requests the SSRF bypass.  Accepted values: `1`, `true`
+/// (case-insensitive).  Any other value (or absence) leaves SSRF guards
+/// engaged.
+pub const ALLOW_INSECURE_ENV: &str = "FRAISEQL_OBSERVERS_ALLOW_INSECURE";
+
+/// Whether the production refusal has already been logged at ERROR.  We
+/// only want the structured ERROR once per process (it would otherwise
+/// fire on every webhook dispatch and overwhelm log aggregation), but the
+/// per-call `WARN` from [`is_outbound_insecure_allowed`] still fires
+/// every time so operators see the bypass attempt at every dispatch.
+static PRODUCTION_REFUSAL_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// Returns `true` when any production-marker env var is set.
+///
+/// Markers are intentionally broad — false-positives (refusing the
+/// bypass in something that "looks like" production) are acceptable;
+/// false-negatives (silently allowing the bypass in real production)
+/// are not.
+#[must_use]
+pub fn is_production_environment() -> bool {
+    if std::env::var_os("KUBERNETES_SERVICE_HOST").is_some() {
+        return true;
+    }
+    if matches_production(&std::env::var("FRAISEQL_ENV").unwrap_or_default()) {
+        return true;
+    }
+    if matches_production(&std::env::var("FRAISEQL_PROFILE").unwrap_or_default()) {
+        return true;
+    }
+    false
+}
+
+// Reason: `eq_ignore_ascii_case` is not const-stable yet (rust-lang/rust#129041);
+// keeping this fn non-const lets us use the idiomatic str method.
+#[allow(clippy::missing_const_for_fn)]
+fn matches_production(value: &str) -> bool {
+    value.eq_ignore_ascii_case("production") || value.eq_ignore_ascii_case("prod")
+}
+
+/// Returns `true` only when the bypass env var is set AND no production
+/// marker is present.
+///
+/// In production with the bypass set, this logs a structured `ERROR`
+/// once per process plus a per-call `WARN` so the refused bypass is
+/// visible at every dispatch.
+///
+/// In dev with the bypass set, this emits a `WARN` on every call (the
+/// old `std::sync::Once` warn-once was too easy to miss in a streaming
+/// log aggregator after the first webhook).
+#[must_use]
+pub fn is_outbound_insecure_allowed() -> bool {
+    let requested = std::env::var(ALLOW_INSECURE_ENV)
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+
+    if !requested {
+        return false;
+    }
+
+    if is_production_environment() {
+        if PRODUCTION_REFUSAL_LOGGED
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            error!(
+                "{ALLOW_INSECURE_ENV}=true requested in a production environment \
+                 (KUBERNETES_SERVICE_HOST set, FRAISEQL_ENV=production, or \
+                 FRAISEQL_PROFILE=production). SSRF guards remain engaged. \
+                 This bypass is intended for local development and integration \
+                 testing only and is refused in production."
+            );
+        }
+        warn!(
+            target: "fraiseql_observers::insecure_guard",
+            "Refused {ALLOW_INSECURE_ENV} bypass in production environment"
+        );
+        return false;
+    }
+
+    warn!(
+        target: "fraiseql_observers::insecure_guard",
+        "{ALLOW_INSECURE_ENV}=true — SSRF guards bypassed for this outbound \
+         dispatch. This MUST NOT be set in production."
+    );
+    true
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-observers/src/insecure_guard/tests.rs
+++ b/crates/fraiseql-observers/src/insecure_guard/tests.rs
@@ -1,0 +1,122 @@
+//! Tests for the centralised SSRF-bypass guard.
+
+#![allow(clippy::unwrap_used)]
+
+use super::*;
+
+const ENV_KEYS: [&str; 4] = [
+    ALLOW_INSECURE_ENV,
+    "FRAISEQL_ENV",
+    "FRAISEQL_PROFILE",
+    "KUBERNETES_SERVICE_HOST",
+];
+
+/// Build a vars vector that explicitly clears every env key we care about
+/// (so a stray ambient value from the runner's shell can't leak in),
+/// then overrides the keys the caller cares about.
+fn env_overlay(overrides: &[(&str, Option<&str>)]) -> Vec<(String, Option<String>)> {
+    let mut out: Vec<(String, Option<String>)> =
+        ENV_KEYS.iter().map(|k| ((*k).to_owned(), None)).collect();
+    for (k, v) in overrides {
+        if let Some(slot) = out.iter_mut().find(|(name, _)| name == k) {
+            slot.1 = v.map(str::to_owned);
+        } else {
+            out.push(((*k).to_owned(), v.map(str::to_owned)));
+        }
+    }
+    out
+}
+
+fn run_with_env(overrides: &[(&str, Option<&str>)], f: impl FnOnce() + std::panic::UnwindSafe) {
+    let vars: Vec<(String, Option<String>)> = env_overlay(overrides);
+    let vars_ref: Vec<(&str, Option<&str>)> =
+        vars.iter().map(|(k, v)| (k.as_str(), v.as_deref())).collect();
+    temp_env::with_vars(vars_ref, f);
+}
+
+#[test]
+fn no_env_var_means_bypass_refused() {
+    run_with_env(&[], || {
+        assert!(!is_outbound_insecure_allowed());
+    });
+}
+
+#[test]
+fn bypass_set_in_dev_is_honored() {
+    run_with_env(&[(ALLOW_INSECURE_ENV, Some("true"))], || {
+        assert!(is_outbound_insecure_allowed());
+    });
+}
+
+#[test]
+fn bypass_set_with_kubernetes_marker_is_refused() {
+    run_with_env(
+        &[
+            (ALLOW_INSECURE_ENV, Some("true")),
+            ("KUBERNETES_SERVICE_HOST", Some("10.96.0.1")),
+        ],
+        || {
+            assert!(!is_outbound_insecure_allowed());
+        },
+    );
+}
+
+#[test]
+fn bypass_set_with_fraiseql_env_production_is_refused() {
+    run_with_env(
+        &[
+            (ALLOW_INSECURE_ENV, Some("1")),
+            ("FRAISEQL_ENV", Some("production")),
+        ],
+        || {
+            assert!(!is_outbound_insecure_allowed());
+        },
+    );
+}
+
+#[test]
+fn bypass_set_with_fraiseql_env_production_uppercase_is_refused() {
+    run_with_env(
+        &[
+            (ALLOW_INSECURE_ENV, Some("true")),
+            ("FRAISEQL_ENV", Some("PRODUCTION")),
+        ],
+        || {
+            assert!(!is_outbound_insecure_allowed());
+        },
+    );
+}
+
+#[test]
+fn bypass_set_with_fraiseql_profile_prod_is_refused() {
+    run_with_env(
+        &[
+            (ALLOW_INSECURE_ENV, Some("true")),
+            ("FRAISEQL_PROFILE", Some("prod")),
+        ],
+        || {
+            assert!(!is_outbound_insecure_allowed());
+        },
+    );
+}
+
+#[test]
+fn invalid_bypass_value_is_refused() {
+    run_with_env(&[(ALLOW_INSECURE_ENV, Some("yes"))], || {
+        assert!(!is_outbound_insecure_allowed());
+    });
+}
+
+#[test]
+fn is_production_environment_returns_false_without_markers() {
+    run_with_env(&[], || {
+        assert!(!is_production_environment());
+    });
+}
+
+#[test]
+fn is_production_environment_returns_true_with_kubernetes() {
+    run_with_env(&[("KUBERNETES_SERVICE_HOST", Some("10.96.0.1"))], || {
+        assert!(is_production_environment());
+    });
+}

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -56,6 +56,7 @@ pub mod config;
 pub mod dedup;
 #[cfg(feature = "dedup")]
 pub mod deduped_executor;
+pub mod insecure_guard;
 
 #[cfg(feature = "arrow")]
 pub mod arrow_bridge;

--- a/crates/fraiseql-observers/src/ssrf.rs
+++ b/crates/fraiseql-observers/src/ssrf.rs
@@ -14,13 +14,10 @@ use crate::error::ObserverError;
 /// Returns `ObserverError::InvalidConfig` if the URL is unparseable or targets
 /// a forbidden host.
 pub fn validate_outbound_url(url: &str) -> crate::error::Result<()> {
-    // When `FRAISEQL_OBSERVERS_ALLOW_INSECURE=true` all SSRF guards are disabled.
-    // This is intended for local development and integration testing only —
-    // never set in production.
-    let allow_insecure = std::env::var("FRAISEQL_OBSERVERS_ALLOW_INSECURE")
-        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        .unwrap_or(false);
-    if allow_insecure {
+    // The `FRAISEQL_OBSERVERS_ALLOW_INSECURE` bypass is honored only in
+    // development environments; refused when any production marker is set.
+    // See `crate::insecure_guard` for the full policy.
+    if crate::insecure_guard::is_outbound_insecure_allowed() {
         return Ok(());
     }
 
@@ -70,12 +67,10 @@ pub fn validate_outbound_url(url: &str) -> crate::error::Result<()> {
 /// Returns `ObserverError::InvalidConfig` if DNS resolution fails, returns no
 /// addresses, or any resolved address is in a private/reserved range.
 pub async fn dns_resolve_and_check(url: &str) -> crate::error::Result<()> {
-    // When `FRAISEQL_OBSERVERS_ALLOW_INSECURE=true` all SSRF guards are disabled.
-    // Intended for local development and integration testing only.
-    let allow_insecure = std::env::var("FRAISEQL_OBSERVERS_ALLOW_INSECURE")
-        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-        .unwrap_or(false);
-    if allow_insecure {
+    // The `FRAISEQL_OBSERVERS_ALLOW_INSECURE` bypass is honored only in
+    // development environments; refused when any production marker is set.
+    // See `crate::insecure_guard` for the full policy.
+    if crate::insecure_guard::is_outbound_insecure_allowed() {
         return Ok(());
     }
 


### PR DESCRIPTION
Closes #347.

## Summary

\`FRAISEQL_OBSERVERS_ALLOW_INSECURE=true|1\` disabled every outbound SSRF guard in observer dispatch (scheme allowlist, private-IP blocklist, DNS-rebinding defence) and was checked independently at four sites:

- \`crates/fraiseql-observers/src/actions.rs::validate_outbound_url\`
- \`crates/fraiseql-observers/src/ssrf.rs::validate_outbound_url\`
- \`crates/fraiseql-observers/src/ssrf.rs::dns_resolve_and_check\`
- \`crates/fraiseql-observers/src/executor/dispatch.rs::validate_url_ssrf\`

The pre-v2.4.0 code used \`std::sync::Once\` to warn exactly once on the first webhook dispatch where the bypass was active — easy to miss in streaming log aggregators, and trivially set in a \`docker-compose.yml\` that gets reused (with edits elsewhere) for staging or prod. **Combined with #348 (anonymous observer install, fixed in PR #365), this was a one-step path to AWS metadata-service credential exfiltration:** install an observer pointing at \`http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>\`, wait for the next mutation.

## Fix

1. **New \`fraiseql_observers::insecure_guard\` module is the single source of truth.** All four bypass sites now call \`is_outbound_insecure_allowed()\`. The check refuses the bypass when ANY production-marker env var is set:

   - \`KUBERNETES_SERVICE_HOST\` (automatic in any K8s pod).
   - \`FRAISEQL_ENV=production\` (case-insensitive, also accepts \`prod\`).
   - \`FRAISEQL_PROFILE=production\` (case-insensitive, also accepts \`prod\`).

2. **\`std::sync::Once\` removed.** When the bypass is honored in dev, a \`WARN\` is emitted on *every* dispatch — operators must see the bypass active in the log stream, not just once at startup (per the issue body's suggested fix #4).

3. **Production refusal is logged loudly.** When the bypass is refused, a structured \`ERROR\` is emitted once per process (CompareAndExchange-gated to avoid log-aggregation overwhelm) and a \`WARN\` is emitted at every outbound dispatch so the refused-bypass-attempt is visible at every dispatch.

## Tests

9 new tests in \`fraiseql_observers::insecure_guard::tests\`, all passing:

- \`no_env_var_means_bypass_refused\`
- \`bypass_set_in_dev_is_honored\`
- \`bypass_set_with_kubernetes_marker_is_refused\`
- \`bypass_set_with_fraiseql_env_production_is_refused\`
- \`bypass_set_with_fraiseql_env_production_uppercase_is_refused\`
- \`bypass_set_with_fraiseql_profile_prod_is_refused\`
- \`invalid_bypass_value_is_refused\`
- \`is_production_environment_returns_false_without_markers\`
- \`is_production_environment_returns_true_with_kubernetes\`

Tests use \`temp_env::with_vars\` so they're concurrency-safe (no \`unsafe { std::env::set_var }\` calls). The test helper explicitly clears every relevant env key before applying overrides, so a stray ambient value from the runner's shell can't leak in.

## Verification

- [x] \`cargo nextest run -p fraiseql-observers --lib\` → 418/418 pass
- [x] \`cargo nextest run -p fraiseql-server --lib\` → 1026/1026 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` → clean
- [x] \`cargo +nightly fmt --all -- --check\` → clean

## What this PR does NOT fix

- **Wider production-marker coverage** (serverless platforms: AWS Lambda, GAE, Fly, Railway, Render). The current marker set covers K8s + explicit FraiseQL env vars; extending to serverless / PaaS deployments is a follow-up because it requires per-platform research on which env vars are reliable signals.
- **The bypass-in-development still works** — by design. Dev environments need to hit \`http://localhost\` and private-IP targets routinely; the bypass remains the documented escape hatch for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)