### PR TITLE
fix(security): require audience in [auth_hs256] (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   3. `POST /auth/revoke-all` now requires the caller's authenticated `sub` to match `body.sub`, unless the caller holds the `admin` scope. Cross-user revocation requests return `403 Forbidden` with a `caller_sub`/`target_sub` warning logged for incident response.
 
+- **`[auth_hs256]` now requires `audience` to be set** (#359). The HS256 shared-secret testing path is the most likely place for two services to share a signing key (test fixtures, internal service meshes, monorepo CI); pre-v2.4.0 it accepted any token whose `aud` matched the unset (`None`) configuration — i.e., any token from any service. A token minted for service A was accepted by service B, exactly the cross-service token-confusion attack the v2.3 S40 OIDC hardening closes for the OIDC path. `Hs256Config::validate` now returns an error when `audience` is `None`, called from `build_hs256_auth` at server startup with a clear actionable message. Mirrors `OidcConfig::validate` exactly.
+
 - **`FRAISEQL_OBSERVERS_ALLOW_INSECURE` bypass is refused in production environments** (#347). Pre-v2.4.0 the env var disabled every outbound SSRF guard (scheme allowlist, private-IP blocklist, DNS-rebinding defence) in observer dispatch — `validate_outbound_url`, `dns_resolve_and_check`, `executor::dispatch::validate_url_ssrf` — with a `std::sync::Once` warn-on-first-use that was easy to miss in streaming log aggregators. Combined with #348 (anonymous observer install), this was a one-step path to AWS metadata-service credential exfiltration: install an observer pointing at `http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>`, wait for the next mutation.
 
   The fix centralises the bypass policy in a new `fraiseql_observers::insecure_guard` module. The check now refuses the bypass when ANY production-marker env var is set:
@@ -45,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`POST /auth/revoke` request body changed.** The `token` field is now `Option<String>` and ignored. Clients that previously submitted a body token will continue to receive `200 OK`, but the revocation now targets the *authentication* token, not the body token. Update any flow that depended on revoking an arbitrary harvested token via this endpoint — there is no longer such a primitive.
 
 - **`POST /auth/revoke` and `POST /auth/revoke-all` now require a valid bearer token.** Anonymous calls return `401 Unauthorized`. Update any internal tooling that called these endpoints unauthenticated.
+
+- **`[auth_hs256]` refuses to boot without `audience`.** Deployments using HS256 auth with no `audience` will fail startup with an actionable error message. Set `audience = "..."` in the `[auth_hs256]` section of `fraiseql.toml` to your API identifier. There is no compatibility shim — the cross-service token-confusion attack the fix closes (#359) is not acceptable in a "warn-and-continue" mode.
 
 - **Token revocation requires `[auth]` to be configured.** If `[security.token_revocation] enabled = true` but no OIDC validator is present, the revocation routes are skipped at startup (with a `WARN` log) rather than mounted open. Configure `[auth]` in `fraiseql.toml` to restore the routes.
 

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -20,6 +20,12 @@ pub(super) fn build_hs256_auth(config: &ServerConfig) -> Result<Option<Arc<AuthM
     let Some(ref hs) = config.auth_hs256 else {
         return Ok(None);
     };
+    // Reject incompatible config shapes *before* loading the secret, so a
+    // dev environment with a real secret env-var but missing audience still
+    // surfaces the audience error rather than silently booting.  Closes the
+    // cross-service token-confusion gap for the HS256 path (#359).
+    hs.validate()
+        .map_err(|e| ServerError::ConfigError(format!("Failed to initialize HS256 auth: {e}")))?;
     let secret = hs
         .load_secret()
         .map_err(|e| ServerError::ConfigError(format!("Failed to initialize HS256 auth: {e}")))?;

--- a/crates/fraiseql-server/src/server_config/hs256.rs
+++ b/crates/fraiseql-server/src/server_config/hs256.rs
@@ -54,4 +54,44 @@ impl Hs256Config {
         }
         Ok(value)
     }
+
+    /// Validate the `[auth_hs256]` config shape at startup.
+    ///
+    /// `audience` is required.  When two HS256-protected services share a
+    /// signing secret (common in test fixtures, internal service meshes,
+    /// monorepo CI), a token minted for service A is accepted by service
+    /// B if B leaves `audience` unset — exactly the cross-service
+    /// token-confusion attack the v2.3 S40 OIDC hardening closes for the
+    /// OIDC path.  Mirroring that guard here closes the same gap for the
+    /// shared-secret testing path.
+    ///
+    /// `secret_env` is required to be non-empty so configuration errors
+    /// surface at validation time rather than at first auth request.
+    ///
+    /// `issuer` remains optional — `OidcConfig::validate` also treats
+    /// the matching field as optional.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable error string when:
+    /// - `secret_env` is empty.
+    /// - `audience` is `None`.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.secret_env.is_empty() {
+            return Err("auth_hs256: `secret_env` is required and must name the \
+                        environment variable holding the shared secret"
+                .to_owned());
+        }
+        if self.audience.is_none() {
+            return Err("auth_hs256: `audience` is REQUIRED for security. Set it to your API \
+                 identifier to prevent cross-service token-confusion attacks where a \
+                 token minted by one service is accepted by another. \
+                 Example: audience = \"my-api\" or audience = \"https://api.example.com\""
+                .to_owned());
+        }
+        Ok(())
+    }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/server_config/hs256/tests.rs
+++ b/crates/fraiseql-server/src/server_config/hs256/tests.rs
@@ -1,0 +1,61 @@
+//! Tests for `Hs256Config::validate`.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use super::Hs256Config;
+
+fn config_with(secret_env: &str, audience: Option<&str>) -> Hs256Config {
+    Hs256Config {
+        secret_env: secret_env.to_owned(),
+        issuer:     None,
+        audience:   audience.map(str::to_owned),
+    }
+}
+
+#[test]
+fn validate_succeeds_when_secret_env_and_audience_set() {
+    let cfg = config_with("FRAISEQL_HS256_SECRET", Some("my-api"));
+    assert!(cfg.validate().is_ok());
+}
+
+#[test]
+fn validate_fails_when_audience_missing() {
+    let cfg = config_with("FRAISEQL_HS256_SECRET", None);
+    let err = cfg.validate().expect_err("audience is required");
+    assert!(err.contains("audience"), "error message must mention the missing field: {err}");
+    assert!(
+        err.contains("REQUIRED"),
+        "error message must flag the security implication: {err}"
+    );
+}
+
+#[test]
+fn validate_fails_when_secret_env_empty() {
+    let cfg = config_with("", Some("my-api"));
+    let err = cfg.validate().expect_err("secret_env is required");
+    assert!(
+        err.contains("secret_env"),
+        "error message must mention the missing field: {err}"
+    );
+}
+
+#[test]
+fn validate_treats_empty_audience_string_as_set() {
+    // Audience is `Some("")` — the validator only checks `is_some()`.
+    // We intentionally do NOT block an empty string here because
+    // `AuthMiddleware::validate_token_with_signature` will reject any
+    // token whose `aud` doesn't match exactly, including empty-vs-empty.
+    // Catching the empty-string case is a follow-up if it surfaces.
+    let cfg = config_with("FRAISEQL_HS256_SECRET", Some(""));
+    assert!(cfg.validate().is_ok());
+}
+
+#[test]
+fn validate_succeeds_with_issuer_and_audience() {
+    let cfg = Hs256Config {
+        secret_env: "FRAISEQL_HS256_SECRET".to_owned(),
+        issuer:     Some("https://my-test-suite".to_owned()),
+        audience:   Some("my-api".to_owned()),
+    };
+    assert!(cfg.validate().is_ok());
+}


### PR DESCRIPTION
Closes #359.

## Summary

\`[auth_hs256]\` accepted boot without an \`audience\` field; the resulting \`AuthMiddleware\` then accepted any non-empty \`aud\` claim. The OIDC \`[auth]\` code path enforces audience via \`OidcConfig::validate()\` (since v2.3 S40 hardening) — the HS256 testing path had no equivalent guard. Asymmetric defence against the same cross-service token-confusion attack.

Two HS256-protected services A and B sharing a signing secret (common in test fixtures, internal service meshes, monorepo CI) meant a token minted for A was accepted by B if B left audience unset. The audience-confusion attack the v2.3 OIDC hardening closes was open for the shared-secret testing path — which is precisely the path most likely to share a secret across services.

## Fix

Mirrors \`OidcConfig::validate\` exactly:

1. **\`Hs256Config::validate()\`** returns an error when \`secret_env\` is empty or \`audience\` is \`None\`, with an actionable error message including an example.
2. **\`build_hs256_auth\`** calls \`validate()\` before loading the secret, so misconfigured HS256 fails server startup at a known location.
3. **No compatibility shim** — the cross-service token-confusion attack is not acceptable in a "warn-and-continue" mode.

## Tests

5 new tests in \`server_config::hs256::tests\`, all passing:

- \`validate_succeeds_when_secret_env_and_audience_set\`
- \`validate_fails_when_audience_missing\` (asserts message mentions \"audience\" and \"REQUIRED\")
- \`validate_fails_when_secret_env_empty\`
- \`validate_treats_empty_audience_string_as_set\` (the validator only checks \`is_some()\`; documenting the intentional gap)
- \`validate_succeeds_with_issuer_and_audience\`

## Verification

- [x] \`cargo nextest run -p fraiseql-server --lib hs256\` → 10/10 pass (5 new + 5 pre-existing)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` → clean
- [x] \`cargo +nightly fmt --all -- --check\` → clean
- [x] Confirmed no integration test or example fixture uses HS256 without audience

## Breaking changes (documented in CHANGELOG)

\`[auth_hs256]\` refuses to boot without \`audience\`. Set \`audience = \"...\"\` in \`fraiseql.toml\` to your API identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)