### PR TITLE
fix(db): pin session variables to operation's connection (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Observer admin HTTP API requires `[auth]` to be configured.** If `[auth]` is absent, `/api/observers/*`, `/runtime/health`, and `/runtime/reload` are not mounted (with a `WARN` log at startup) rather than mounted open. Any internal tooling that called these endpoints unauthenticated must now present a valid bearer token. Reverse-proxy auth (mTLS or a bearer-token gate) is no longer the only line of defence.
 
+### Fixed
+
+- **Session variables now reach mutation SQL functions and RLS policies (#329).**
+  Before this release, `current_setting('app.x', true)` inside a mutation
+  function, an RLS-protected view, a relay-paginated list, or an aggregate
+  always returned NULL: `PostgresAdapter::set_session_variables` ran
+  `SELECT set_config(..., true)` on a pooled connection in its own autocommit
+  transaction — transaction-local *and* on a different connection than the
+  subsequent operation. Session variables are now applied transaction-locally
+  on the **same connection** as the operation. Applications that worked around
+  this by passing tenant/user ids as mutation arguments via `inject_params` can
+  continue to do so, or now rely on session variables.
+
+### Changed (additive, non-breaking)
+
+- `DatabaseAdapter` gains `execute_function_call_with_session`,
+  `execute_with_projection_arc_with_session`,
+  `execute_where_query_arc_with_session`, and
+  `execute_parameterized_aggregate_with_session`; `RelayDatabaseAdapter` gains
+  `execute_relay_page_with_session`. All have default implementations that
+  delegate to the existing methods, so custom adapter implementors need not
+  change anything.
+- `DatabaseAdapter::set_session_variables` is `#[deprecated]` and is no longer
+  called by the executor. It will be removed in `2.4`.
+
+### Security
+
+- Tenant-scoped reads through `CachedDatabaseAdapter` now bypass the result
+  cache when session variables are configured, until the cache key is extended
+  to include a hash of the applied session variables (tracked as a follow-up).
+  Before this release the cache key was likewise not session-variable-aware,
+  but the bug masked any actual leak by making session variables invisible to
+  RLS policies.
+
+### Known follow-ups (#329)
+
+- Relay `node(id:)` lookups, partial-period aggregate UNION branches, and gRPC
+  mutations do not yet thread a `SecurityContext`/session-variable config, so
+  `current_setting()`-backed RLS is not configured on those paths. Each call
+  site is annotated in the source.
+
 ## [2.3.2] - 2026-05-28
 
 ### Fixed

--- a/crates/fraiseql-core/src/cache/adapter/mod.rs
+++ b/crates/fraiseql-core/src/cache/adapter/mod.rs
@@ -704,6 +704,19 @@ impl<A: DatabaseAdapter> DatabaseAdapter for CachedDatabaseAdapter<A> {
         self.adapter.execute_parameterized_aggregate(sql, params).await
     }
 
+    async fn execute_parameterized_aggregate_with_session(
+        &self,
+        sql: &str,
+        params: &[serde_json::Value],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        // Not cached (see execute_parameterized_aggregate); forward with session
+        // affinity so current_setting()-backed aggregate RLS sees the values (#329).
+        self.adapter
+            .execute_parameterized_aggregate_with_session(sql, params, session_vars)
+            .await
+    }
+
     async fn execute_function_call(
         &self,
         function_name: &str,
@@ -711,6 +724,73 @@ impl<A: DatabaseAdapter> DatabaseAdapter for CachedDatabaseAdapter<A> {
     ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
         // Mutations are never cached — always delegate to the underlying adapter
         self.adapter.execute_function_call(function_name, args).await
+    }
+
+    async fn execute_function_call_with_session(
+        &self,
+        function_name: &str,
+        args: &[serde_json::Value],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        // Mutations are never cached; pass through with session affinity.
+        self.adapter
+            .execute_function_call_with_session(function_name, args, session_vars)
+            .await
+    }
+
+    async fn execute_where_query_arc_with_session(
+        &self,
+        view: &str,
+        where_clause: Option<&WhereClause>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+        order_by: Option<&[OrderByClause]>,
+        session_vars: &[(&str, &str)],
+    ) -> Result<Arc<Vec<JsonbValue>>> {
+        // No session variables => preserve the cached read path unchanged.
+        if session_vars.is_empty() {
+            return self.execute_where_query_impl(view, where_clause, limit, offset, order_by).await;
+        }
+        // Security: the result-cache key is NOT session-variable-aware, so a
+        // tenant-scoped read (RLS via current_setting) could otherwise leak
+        // another tenant's cached rows. Bypass the cache and run the read with
+        // session affinity on the inner adapter. Tracked for a cache-key fix:
+        // see #329 follow-up.
+        self.adapter
+            .execute_where_query_arc_with_session(
+                view,
+                where_clause,
+                limit,
+                offset,
+                order_by,
+                session_vars,
+            )
+            .await
+    }
+
+    async fn execute_with_projection_arc_with_session(
+        &self,
+        request: &crate::db::ProjectionRequest<'_>,
+        session_vars: &[(&str, &str)],
+    ) -> Result<Arc<Vec<JsonbValue>>> {
+        // No session variables => preserve the cached read path unchanged.
+        if session_vars.is_empty() {
+            return self
+                .execute_with_projection_impl(
+                    request.view,
+                    request.projection,
+                    request.where_clause,
+                    request.limit,
+                    request.offset,
+                    request.order_by,
+                )
+                .await;
+        }
+        // Security: see execute_where_query_arc_with_session — bypass the
+        // non-tenant-aware cache for session-scoped reads.
+        self.adapter
+            .execute_with_projection_arc_with_session(request, session_vars)
+            .await
     }
 
     async fn invalidate_views(&self, views: &[fraiseql_db::ViewName]) -> Result<u64> {

--- a/crates/fraiseql-core/src/cache/adapter/mod.rs
+++ b/crates/fraiseql-core/src/cache/adapter/mod.rs
@@ -749,7 +749,9 @@ impl<A: DatabaseAdapter> DatabaseAdapter for CachedDatabaseAdapter<A> {
     ) -> Result<Arc<Vec<JsonbValue>>> {
         // No session variables => preserve the cached read path unchanged.
         if session_vars.is_empty() {
-            return self.execute_where_query_impl(view, where_clause, limit, offset, order_by).await;
+            return self
+                .execute_where_query_impl(view, where_clause, limit, offset, order_by)
+                .await;
         }
         // Security: the result-cache key is NOT session-variable-aware, so a
         // tenant-scoped read (RLS via current_setting) could otherwise leak

--- a/crates/fraiseql-core/src/cache/relay_cache.rs
+++ b/crates/fraiseql-core/src/cache/relay_cache.rs
@@ -37,4 +37,36 @@ impl<A: RelayDatabaseAdapter + DatabaseAdapter> RelayDatabaseAdapter for CachedD
             )
             .await
     }
+
+    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments plus session vars; no natural grouping
+    async fn execute_relay_page_with_session(
+        &self,
+        view: &str,
+        cursor_column: &str,
+        after: Option<crate::db::traits::CursorValue>,
+        before: Option<crate::db::traits::CursorValue>,
+        limit: u32,
+        forward: bool,
+        where_clause: Option<&crate::db::where_clause::WhereClause>,
+        order_by: Option<&[crate::compiler::aggregation::OrderByClause]>,
+        include_total_count: bool,
+        session_vars: &[(&str, &str)],
+    ) -> Result<crate::db::traits::RelayPageResult> {
+        // Relay results are not cached; forward with session affinity so RLS
+        // pagination sees the configured session variables (#329).
+        self.adapter
+            .execute_relay_page_with_session(
+                view,
+                cursor_column,
+                after,
+                before,
+                limit,
+                forward,
+                where_clause,
+                order_by,
+                include_total_count,
+                session_vars,
+            )
+            .await
+    }
 }

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
@@ -234,13 +234,11 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
             crate::runtime::AggregationSqlGenerator::new(self.ctx.adapter.database_type());
         let parameterized = sql_generator.generate_parameterized(&plan)?;
 
-        // 5. Execute with bind parameters (eliminates escape-based injection risk),
-        //    pinning session variables to the connection for current_setting() RLS (#329).
+        // 5. Execute with bind parameters (eliminates escape-based injection risk), pinning session
+        //    variables to the connection for current_setting() RLS (#329).
         let resolved_session_vars = self.resolve_session_vars(security_context);
-        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self
             .ctx
             .adapter
@@ -412,13 +410,11 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
         let sql = sql_generator.generate(&plan)?;
 
         // 4. Execute SQL — bind parameters via execute_parameterized_aggregate so WHERE clause
-        //    values are passed as prepared-statement parameters, not inlined.
-        //    Session variables are pinned to the connection for current_setting() RLS (#329).
+        //    values are passed as prepared-statement parameters, not inlined. Session variables are
+        //    pinned to the connection for current_setting() RLS (#329).
         let resolved_session_vars = self.resolve_session_vars(security_context);
-        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self
             .ctx
             .adapter

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
@@ -20,6 +20,23 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
         Self { ctx }
     }
 
+    /// Resolve configured session variables for `security_context` into owned
+    /// `(name, value)` pairs, for passing to the connection-affine
+    /// `*_with_session` adapter methods so `current_setting()`-backed RLS on
+    /// aggregate views is effective (#329).
+    fn resolve_session_vars(
+        &self,
+        security_context: Option<&SecurityContext>,
+    ) -> Vec<(String, String)> {
+        let sv = &self.ctx.schema.session_variables;
+        match security_context {
+            Some(sec) if !sv.variables.is_empty() || sv.inject_started_at => {
+                crate::runtime::executor::security::resolve_session_variables(sv, sec)
+            },
+            _ => Vec::new(),
+        }
+    }
+
     /// Execute an aggregate query dispatch.
     ///
     /// # Errors
@@ -217,11 +234,21 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
             crate::runtime::AggregationSqlGenerator::new(self.ctx.adapter.database_type());
         let parameterized = sql_generator.generate_parameterized(&plan)?;
 
-        // 5. Execute with bind parameters (eliminates escape-based injection risk)
+        // 5. Execute with bind parameters (eliminates escape-based injection risk),
+        //    pinning session variables to the connection for current_setting() RLS (#329).
+        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
         let rows = self
             .ctx
             .adapter
-            .execute_parameterized_aggregate(&parameterized.sql, &parameterized.params)
+            .execute_parameterized_aggregate_with_session(
+                &parameterized.sql,
+                &parameterized.params,
+                &session_pairs,
+            )
             .await?;
 
         // 6. Project results
@@ -284,7 +311,11 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
             extra_where.as_ref(),
         )?;
 
-        // Execute
+        // Execute.
+        // No session vars: the partial-period UNION branch does not thread a
+        // SecurityContext (callers above do), so there is nothing to resolve
+        // session variables from here. RLS for partial-period aggregates over
+        // current_setting()-backed views is a follow-up (#329).
         let rows = self
             .ctx
             .adapter
@@ -382,10 +413,20 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
 
         // 4. Execute SQL — bind parameters via execute_parameterized_aggregate so WHERE clause
         //    values are passed as prepared-statement parameters, not inlined.
+        //    Session variables are pinned to the connection for current_setting() RLS (#329).
+        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
         let rows = self
             .ctx
             .adapter
-            .execute_parameterized_aggregate(&sql.raw_sql, &sql.parameters)
+            .execute_parameterized_aggregate_with_session(
+                &sql.raw_sql,
+                &sql.parameters,
+                &session_pairs,
+            )
             .await?;
 
         // 5. Project results

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -255,10 +255,8 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
             _ => Vec::new(),
         }
     };
-    let session_pairs: Vec<(&str, &str)> = resolved_session_vars
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
+    let session_pairs: Vec<(&str, &str)> =
+        resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
     // 4. Call the database function (session variables pinned to its connection).
     let rows = ctx

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -237,26 +237,34 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
         }
     }
 
-    // 3b. Inject session variables (transaction-scoped set_config) when configured.
+    // 3b. Resolve session variables once and pass them to the adapter call so
+    //     they are applied on the same connection / transaction as the function
+    //     (fixes #329 — set_config(..., true) is transaction-local, so applying
+    //     it on a separate pooled connection left it invisible to the function).
     //
-    // Only called when there are variables to inject or inject_started_at is enabled,
-    // and only on the authenticated path (security context present). The no-op default
-    // on non-PostgreSQL adapters means this call is effectively free there.
-    {
+    // Only resolved when there are variables to inject or inject_started_at is
+    // enabled, and only on the authenticated path (security context present).
+    // The no-op default on non-PostgreSQL adapters means an empty slice here is
+    // effectively free there.
+    let resolved_session_vars = {
         let sv = &ctx.schema.session_variables;
-        if !sv.variables.is_empty() || sv.inject_started_at {
-            if let Some(sec_ctx) = security_ctx {
-                let vars =
-                    crate::runtime::executor::security::resolve_session_variables(sv, sec_ctx);
-                let pairs: Vec<(&str, &str)> =
-                    vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
-                ctx.adapter.set_session_variables(&pairs).await?;
-            }
+        match security_ctx {
+            Some(sec_ctx) if !sv.variables.is_empty() || sv.inject_started_at => {
+                crate::runtime::executor::security::resolve_session_variables(sv, sec_ctx)
+            },
+            _ => Vec::new(),
         }
-    }
+    };
+    let session_pairs: Vec<(&str, &str)> = resolved_session_vars
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
 
-    // 4. Call the database function
-    let rows = ctx.adapter.execute_function_call(sql_source, &args).await?;
+    // 4. Call the database function (session variables pinned to its connection).
+    let rows = ctx
+        .adapter
+        .execute_function_call_with_session(sql_source, &args, &session_pairs)
+        .await?;
 
     // 5. Expect at least one row
     let row = rows.into_iter().next().ok_or_else(|| FraiseQLError::Validation {

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -95,15 +95,18 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         // the connection-affine adapter call below, so PostgreSQL RLS policies
         // that read `current_setting()` (e.g. `app.tenant_id`) are effective.
         let resolved_session_vars = self.resolve_session_vars(Some(security_context));
-        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
         // Route relay queries to dedicated handler with security context.
         if query_match.query_def.relay {
             return self
-                .execute_relay_query(&query_match, variables, Some(security_context), &session_pairs)
+                .execute_relay_query(
+                    &query_match,
+                    variables,
+                    Some(security_context),
+                    &session_pairs,
+                )
                 .await;
         }
 
@@ -314,8 +317,8 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             None
         };
 
-        // 9. Execute query with combined WHERE clause filter, pinning session
-        //    variables to the read's connection (fixes #329 for RLS).
+        // 9. Execute query with combined WHERE clause filter, pinning session variables to the
+        //    read's connection (fixes #329 for RLS).
         let results = self
             .ctx
             .adapter
@@ -702,10 +705,8 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
 
         // Execute, pinning session variables to the read's connection (#329).
         let resolved_session_vars = self.resolve_session_vars(security_context);
-        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let results = self
             .ctx
             .adapter
@@ -829,13 +830,11 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             combined_where
         };
 
-        // 4. Execute COUNT query via adapter, pinning session variables to the
-        //    read's connection so RLS counts match the filtered rows (#329).
+        // 4. Execute COUNT query via adapter, pinning session variables to the read's connection so
+        //    RLS counts match the filtered rows (#329).
         let resolved_session_vars = self.resolve_session_vars(security_context);
-        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self
             .ctx
             .adapter

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -21,6 +21,30 @@ use crate::{
 };
 
 impl<A: DatabaseAdapter> QueryRunner<A> {
+    /// Resolve configured session variables for `security_context` into owned
+    /// `(name, value)` pairs.
+    ///
+    /// The caller borrows these into a `&[(&str, &str)]` slice for the
+    /// connection-affine `*_with_session` adapter methods, which apply them
+    /// transaction-locally on the same connection as the read (fixes #329 for
+    /// RLS policies backed by `current_setting()`).
+    ///
+    /// Returns an empty vec when there is no security context or no session
+    /// variables are configured; the adapter treats an empty slice as "no
+    /// session variables" with zero overhead.
+    fn resolve_session_vars(
+        &self,
+        security_context: Option<&SecurityContext>,
+    ) -> Vec<(String, String)> {
+        let sv = &self.ctx.schema.session_variables;
+        match security_context {
+            Some(sec) if !sv.variables.is_empty() || sv.inject_started_at => {
+                crate::runtime::executor::security::resolve_session_variables(sv, sec)
+            },
+            _ => Vec::new(),
+        }
+    }
+
     /// Execute a regular query with row-level security (RLS) filtering.
     ///
     /// This method:
@@ -66,30 +90,21 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             }
         }
 
-        // Inject session variables (transaction-scoped set_config) when configured.
-        //
-        // Must run before any DB execution (including the relay branch below) so that
-        // PostgreSQL-native Row Level Security policies that rely on `current_setting()`
-        // values (e.g. `app.tenant_id`) are effective for read queries, matching the
-        // behaviour already in place for mutations.
-        {
-            let sv = &self.ctx.schema.session_variables;
-            if !sv.variables.is_empty() || sv.inject_started_at {
-                let vars = crate::runtime::executor::security::resolve_session_variables(
-                    sv,
-                    security_context,
-                );
-                if !vars.is_empty() {
-                    let pairs: Vec<(&str, &str)> =
-                        vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
-                    self.ctx.adapter.set_session_variables(&pairs).await?;
-                }
-            }
-        }
+        // Resolve session variables once. They are applied transaction-locally
+        // on the same connection as the read (fixes #329) by passing them into
+        // the connection-affine adapter call below, so PostgreSQL RLS policies
+        // that read `current_setting()` (e.g. `app.tenant_id`) are effective.
+        let resolved_session_vars = self.resolve_session_vars(Some(security_context));
+        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
 
         // Route relay queries to dedicated handler with security context.
         if query_match.query_def.relay {
-            return self.execute_relay_query(&query_match, variables, Some(security_context)).await;
+            return self
+                .execute_relay_query(&query_match, variables, Some(security_context), &session_pairs)
+                .await;
         }
 
         // 0. Check response cache (skips all projection/RBAC/serialization work on hit)
@@ -299,18 +314,22 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             None
         };
 
-        // 9. Execute query with combined WHERE clause filter
+        // 9. Execute query with combined WHERE clause filter, pinning session
+        //    variables to the read's connection (fixes #329 for RLS).
         let results = self
             .ctx
             .adapter
-            .execute_with_projection_arc(&crate::db::ProjectionRequest {
-                view: sql_source,
-                projection: projection_hint.as_ref(),
-                where_clause: combined_where.as_ref(),
-                order_by: order_by_clauses.as_deref(),
-                limit,
-                offset,
-            })
+            .execute_with_projection_arc_with_session(
+                &crate::db::ProjectionRequest {
+                    view: sql_source,
+                    projection: projection_hint.as_ref(),
+                    where_clause: combined_where.as_ref(),
+                    order_by: order_by_clauses.as_deref(),
+                    limit,
+                    offset,
+                },
+                &session_pairs,
+            )
             .await?;
 
         // 10. Apply field-level RBAC filtering (reject / mask / allow)
@@ -441,8 +460,9 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         }
 
         // Route relay queries to dedicated handler.
+        // No session vars: unauthenticated entrypoint (no SecurityContext). See #329.
         if query_match.query_def.relay {
-            return self.execute_relay_query(&query_match, variables, None).await;
+            return self.execute_relay_query(&query_match, variables, None, &[]).await;
         }
 
         // 2. Create execution plan
@@ -544,6 +564,9 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             None
         };
 
+        // No session vars: this is the unauthenticated entrypoint (no
+        // SecurityContext), so there is nothing to resolve session variables
+        // from. See #329 / resolve_session_vars.
         let results = self
             .ctx
             .adapter
@@ -677,18 +700,26 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             }
         }
 
-        // Execute.
+        // Execute, pinning session variables to the read's connection (#329).
+        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
         let results = self
             .ctx
             .adapter
-            .execute_with_projection_arc(&crate::db::ProjectionRequest {
-                view: sql_source,
-                projection: None,
-                where_clause: composed_where.as_ref(),
-                order_by: order_by_clauses.as_deref(),
-                limit,
-                offset,
-            })
+            .execute_with_projection_arc_with_session(
+                &crate::db::ProjectionRequest {
+                    view: sql_source,
+                    projection: None,
+                    where_clause: composed_where.as_ref(),
+                    order_by: order_by_clauses.as_deref(),
+                    limit,
+                    offset,
+                },
+                &session_pairs,
+            )
             .await?;
 
         // Project results.
@@ -798,11 +829,24 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             combined_where
         };
 
-        // 4. Execute COUNT query via adapter
+        // 4. Execute COUNT query via adapter, pinning session variables to the
+        //    read's connection so RLS counts match the filtered rows (#329).
+        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let session_pairs: Vec<(&str, &str)> = resolved_session_vars
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
         let rows = self
             .ctx
             .adapter
-            .execute_where_query_arc(sql_source, combined_where.as_ref(), None, None, None)
+            .execute_where_query_arc_with_session(
+                sql_source,
+                combined_where.as_ref(),
+                None,
+                None,
+                None,
+                &session_pairs,
+            )
             .await?;
 
         // Return the row count

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_relay.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_relay.rs
@@ -52,6 +52,7 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         query_match: &crate::runtime::matcher::QueryMatch,
         variables: Option<&serde_json::Value>,
         security_context: Option<&SecurityContext>,
+        session_vars: &[(&str, &str)],
     ) -> Result<serde_json::Value> {
         use crate::{
             compiler::aggregation::OrderByClause,
@@ -272,8 +273,10 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         let had_after = after_pk.is_some();
         let had_before = before_pk.is_some();
 
+        // Pin session variables to the page/count queries' connection so
+        // RLS-protected relay pagination returns the correct tenant's rows (#329).
         let result = relay
-            .execute_relay_page(
+            .execute_relay_page_with_session(
                 sql_source,
                 cursor_column,
                 after_pk,
@@ -283,6 +286,7 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
                 combined_where.as_ref(),
                 order_by.as_deref(),
                 include_total_count,
+                session_vars,
             )
             .await?;
 
@@ -449,6 +453,10 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         };
 
         // 6. Execute the query (limit 1) with projection.
+        // No session vars: the Relay `node(id:)` lookup is a separate entrypoint
+        // that does not receive a SecurityContext, so session variables cannot be
+        // resolved here. Threading a SecurityContext through node resolution to
+        // enable current_setting()-backed RLS is a follow-up (#329).
         let rows = self
             .ctx
             .adapter

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
@@ -437,7 +437,8 @@ mod session_variables {
         schema::{SessionVariableMapping, SessionVariableSource, SessionVariablesConfig},
     };
 
-    /// Mock adapter that captures calls to `set_session_variables`.
+    /// Mock adapter that captures the session variables passed into the
+    /// connection-affine `*_with_session` read methods (#329).
     struct SessionVarCapturingAdapter {
         mock_results: Vec<JsonbValue>,
         captured:     std::sync::Mutex<Vec<(String, String)>>,
@@ -483,12 +484,32 @@ mod session_variables {
             Ok(self.mock_results.clone())
         }
 
-        async fn set_session_variables(&self, variables: &[(&str, &str)]) -> Result<()> {
+        async fn execute_with_projection_arc_with_session(
+            &self,
+            _request: &crate::db::ProjectionRequest<'_>,
+            session_vars: &[(&str, &str)],
+        ) -> Result<std::sync::Arc<Vec<JsonbValue>>> {
             let mut guard = self.captured.lock().unwrap();
-            for (k, v) in variables {
+            for (k, v) in session_vars {
                 guard.push(((*k).to_string(), (*v).to_string()));
             }
-            Ok(())
+            Ok(std::sync::Arc::new(self.mock_results.clone()))
+        }
+
+        async fn execute_where_query_arc_with_session(
+            &self,
+            _view: &str,
+            _where_clause: Option<&WhereClause>,
+            _limit: Option<u32>,
+            _offset: Option<u32>,
+            _order_by: Option<&[OrderByClause]>,
+            session_vars: &[(&str, &str)],
+        ) -> Result<std::sync::Arc<Vec<JsonbValue>>> {
+            let mut guard = self.captured.lock().unwrap();
+            for (k, v) in session_vars {
+                guard.push(((*k).to_string(), (*v).to_string()));
+            }
+            Ok(std::sync::Arc::new(self.mock_results.clone()))
         }
 
         async fn health_check(&self) -> Result<()> {
@@ -564,7 +585,8 @@ mod session_variables {
         }
     }
 
-    /// C-SV1: session variables are injected via `set_session_variables` before a read query.
+    /// C-SV1: session variables are passed into the connection-affine read
+    /// method when configured.
     #[tokio::test]
     async fn test_session_variables_injected_on_read_query() {
         let schema = schema_with_session_vars();
@@ -580,7 +602,7 @@ mod session_variables {
         let pairs = adapter.captured_pairs();
         assert!(
             !pairs.is_empty(),
-            "set_session_variables must be called before a read query when session_variables are \
+            "session variables must be passed into the read method when session_variables are \
              configured"
         );
         assert!(
@@ -589,7 +611,7 @@ mod session_variables {
         );
     }
 
-    /// C-SV2: no `set_session_variables` call when `session_variables` config is empty.
+    /// C-SV2: no session variables passed when `session_variables` config is empty.
     #[tokio::test]
     async fn test_no_session_variables_injected_when_config_empty() {
         let schema = test_schema(); // session_variables defaults to empty
@@ -604,7 +626,7 @@ mod session_variables {
 
         assert!(
             adapter.captured_pairs().is_empty(),
-            "set_session_variables must not be called when no session_variables are configured"
+            "no session variables must be passed when no session_variables are configured"
         );
     }
 }

--- a/crates/fraiseql-core/src/runtime/executor/support/relay.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/relay.rs
@@ -25,8 +25,8 @@ use crate::{
 pub(in crate::runtime::executor) trait RelayDispatch:
     Send + Sync
 {
-    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments; no natural grouping
-    fn execute_relay_page<'a>(
+    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments plus session vars; no natural grouping
+    fn execute_relay_page_with_session<'a>(
         &'a self,
         view: &'a str,
         cursor_column: &'a str,
@@ -37,6 +37,7 @@ pub(in crate::runtime::executor) trait RelayDispatch:
         where_clause: Option<&'a WhereClause>,
         order_by: Option<&'a [OrderByClause]>,
         include_total_count: bool,
+        session_vars: &'a [(&'a str, &'a str)],
     ) -> BoxFuture<'a, Result<RelayPageResult>>;
 }
 
@@ -45,8 +46,8 @@ pub(in crate::runtime::executor) struct RelayDispatchImpl<A: RelayDatabaseAdapte
 );
 
 impl<A: RelayDatabaseAdapter + Send + Sync + 'static> RelayDispatch for RelayDispatchImpl<A> {
-    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments; no natural grouping
-    fn execute_relay_page<'a>(
+    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments plus session vars; no natural grouping
+    fn execute_relay_page_with_session<'a>(
         &'a self,
         view: &'a str,
         cursor_column: &'a str,
@@ -57,8 +58,9 @@ impl<A: RelayDatabaseAdapter + Send + Sync + 'static> RelayDispatch for RelayDis
         where_clause: Option<&'a WhereClause>,
         order_by: Option<&'a [OrderByClause]>,
         include_total_count: bool,
+        session_vars: &'a [(&'a str, &'a str)],
     ) -> BoxFuture<'a, Result<RelayPageResult>> {
-        Box::pin(self.0.execute_relay_page(
+        Box::pin(self.0.execute_relay_page_with_session(
             view,
             cursor_column,
             after,
@@ -68,6 +70,7 @@ impl<A: RelayDatabaseAdapter + Send + Sync + 'static> RelayDispatch for RelayDis
             where_clause,
             order_by,
             include_total_count,
+            session_vars,
         ))
     }
 }

--- a/crates/fraiseql-core/tests/session_variables_integration.rs
+++ b/crates/fraiseql-core/tests/session_variables_integration.rs
@@ -1,71 +1,188 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 #![allow(missing_docs)]
 
-//! Integration test for #329 — session variables MUST be visible to the SQL
-//! function that the mutation runner calls.
+//! Integration tests for #329 — session variables MUST be visible to the SQL
+//! function / view that the executor's adapter call runs.
 //!
 //! ## The bug
 //!
-//! `PostgresAdapter::set_session_variables` acquires its own pooled connection
-//! and runs `SELECT set_config($1, $2, true)` per variable. `is_local = true`
+//! `PostgresAdapter::set_session_variables` acquired its own pooled connection
+//! and ran `SELECT set_config($1, $2, true)` per variable. `is_local = true`
 //! makes the setting transaction-scoped, but a bare `SELECT` is its own
-//! autocommit transaction — so the GUC is discarded the instant the statement
-//! returns. Even setting that aside, the subsequent `execute_function_call`
-//! acquires a *different* pooled connection, so the function never sees the
-//! value.
+//! autocommit transaction — so the GUC was discarded the instant the statement
+//! returned. Even setting that aside, the subsequent `execute_function_call` /
+//! read acquired a *different* pooled connection, so the operation never saw
+//! the value.
+//!
+//! The fix applies session variables transaction-locally on the *same*
+//! connection as the operation via the `*_with_session` adapter methods.
 //!
 //! These tests run against a real PostgreSQL container so the connection-pool
-//! and transaction-scope behaviour is exercised exactly as in production.
+//! and transaction-scope behaviour is exercised exactly as in production. Each
+//! test uses a unique object/GUC suffix so the shared container can run them in
+//! parallel without `CREATE OR REPLACE` racing on `pg_proc`/`pg_class`.
 
 mod common;
 
-use fraiseql_core::db::{DatabaseAdapter, postgres::PostgresAdapter};
+use fraiseql_core::db::{DatabaseAdapter, RelayDatabaseAdapter, postgres::PostgresAdapter};
 
-/// Install a function that echoes a transaction-local GUC back to the caller.
-/// Returns a fresh adapter (its own pool) connected to the shared container.
-async fn adapter_with_echo_fn() -> PostgresAdapter {
+/// Connect a fresh adapter (its own pool) to the shared container and install a
+/// function `fn_show_tenant_<key>()` that echoes the GUC `app.tenant_id_<key>`.
+async fn adapter_with_echo_fn(key: &str) -> PostgresAdapter {
     let container = common::testcontainer::get_test_container().await;
     let adapter = PostgresAdapter::new(&container.connection_string())
         .await
         .expect("connect adapter");
 
     adapter
-        .execute_raw_query(
-            "CREATE OR REPLACE FUNCTION fn_show_tenant_329() RETURNS text \
-             LANGUAGE sql AS $$ SELECT current_setting('app.tenant_id_329', true) $$;",
-        )
+        .execute_raw_query(&format!(
+            "CREATE OR REPLACE FUNCTION fn_show_tenant_{key}() RETURNS text \
+             LANGUAGE sql AS $$ SELECT current_setting('app.tenant_id_{key}', true) $$;"
+        ))
         .await
         .expect("create echo function");
 
     adapter
 }
 
-/// #329 — the value applied via session variables must be visible to the
-/// function body.
-///
-/// On v2.3.2 this fails with `None` ("<NULL>") because the GUC is applied on a
-/// different connection / transaction than the one that runs the function.
+/// Regression guard documenting *why* `set_session_variables` is deprecated: the
+/// legacy two-call pattern (apply, then call on a separate pooled connection /
+/// autocommit transaction) leaves the GUC invisible to the function — bug #329.
+/// If this ever returns the configured value, the two-call pattern has somehow
+/// become connection-affine and the deprecation note should be revisited.
 #[tokio::test]
-async fn session_variables_visible_inside_function() {
-    let adapter = adapter_with_echo_fn().await;
+#[allow(deprecated)] // Reason: deliberately exercises the deprecated two-call pattern to pin bug #329
+async fn legacy_set_session_variables_is_invisible_to_function() {
+    let adapter = adapter_with_echo_fn("legacy").await;
 
-    // The two-call pattern the executor uses today: apply the session
-    // variables, then call the function. This is exactly bug #329.
     adapter
-        .set_session_variables(&[("app.tenant_id_329", "tenant-abc")])
+        .set_session_variables(&[("app.tenant_id_legacy", "tenant-abc")])
         .await
         .unwrap();
     let rows = adapter
-        .execute_function_call("fn_show_tenant_329", &[])
+        .execute_function_call("fn_show_tenant_legacy", &[])
         .await
         .unwrap();
 
-    let value = rows[0].get("fn_show_tenant_329").and_then(|v| v.as_str());
+    let value = rows[0].get("fn_show_tenant_legacy").and_then(|v| v.as_str());
 
-    assert_eq!(
+    assert_ne!(
         value,
         Some("tenant-abc"),
-        "expected app.tenant_id_329 == \"tenant-abc\" inside fn_show_tenant_329, \
-         got {value:?} — this is bug #329 (GUC observed as NULL inside the function)"
+        "the legacy two-call set_session_variables pattern must NOT reach the \
+         function (bug #329); use execute_function_call_with_session instead"
     );
+}
+
+/// #329 — the connection-affine method applies the GUC on the same connection /
+/// transaction as the function call, so the function body sees it.
+#[tokio::test]
+async fn function_call_with_session_sees_set_config() {
+    let adapter = adapter_with_echo_fn("fncall").await;
+
+    let rows = adapter
+        .execute_function_call_with_session(
+            "fn_show_tenant_fncall",
+            &[],
+            &[("app.tenant_id_fncall", "tenant-abc")],
+        )
+        .await
+        .unwrap();
+
+    let value = rows[0].get("fn_show_tenant_fncall").and_then(|v| v.as_str());
+    assert_eq!(value, Some("tenant-abc"));
+}
+
+/// Set up an RLS-style table + view filtering on `current_setting`, returning
+/// `(id, data)` so it works for both plain reads and relay pagination.
+async fn setup_widget_view(key: &str) -> PostgresAdapter {
+    let container = common::testcontainer::get_test_container().await;
+    let adapter = PostgresAdapter::new(&container.connection_string())
+        .await
+        .expect("connect adapter");
+
+    // execute_raw_query uses the extended protocol (one statement per call).
+    for stmt in [
+        format!(
+            "CREATE TABLE IF NOT EXISTS tb_widget_{key} \
+             (id bigint primary key, tenant text not null)"
+        ),
+        format!("TRUNCATE tb_widget_{key}"),
+        format!("INSERT INTO tb_widget_{key} VALUES (1, 'tenant-a'), (2, 'tenant-b'), (3, 'tenant-a')"),
+        format!(
+            "CREATE OR REPLACE VIEW v_widget_{key} AS \
+             SELECT id, jsonb_build_object('id', id, 'tenant', tenant) AS data \
+             FROM tb_widget_{key} \
+             WHERE tenant = current_setting('app.tenant_id_{key}', true)"
+        ),
+    ] {
+        adapter.execute_raw_query(&stmt).await.unwrap();
+    }
+
+    adapter
+}
+
+/// Connection-affine read path: an RLS-style view filtering on
+/// `current_setting` returns only the matching tenant's rows.
+#[tokio::test]
+async fn where_query_with_session_applies_rls_setting() {
+    let adapter = setup_widget_view("where").await;
+
+    let rows = adapter
+        .execute_where_query_arc_with_session(
+            "v_widget_where",
+            None,
+            None,
+            None,
+            None,
+            &[("app.tenant_id_where", "tenant-a")],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.len(), 2, "RLS-style view should return only tenant-a's rows");
+    for row in rows.iter() {
+        let tenant = row.as_value().pointer("/tenant").and_then(|v| v.as_str());
+        assert_eq!(tenant, Some("tenant-a"));
+    }
+}
+
+/// Connection-affine relay path: cursor pagination over an RLS-style view sees
+/// the session variable, so only the matching tenant's rows (and an accurate
+/// `totalCount`) are returned.
+#[tokio::test]
+async fn relay_page_with_session_applies_rls_setting() {
+    let adapter = setup_widget_view("relay").await;
+
+    let page = adapter
+        .execute_relay_page_with_session(
+            "v_widget_relay",
+            "id",
+            None,
+            None,
+            10,
+            true,
+            None,
+            None,
+            true, // include_total_count
+            &[("app.tenant_id_relay", "tenant-a")],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(page.rows().len(), 2, "relay page should contain only tenant-a's rows");
+    assert_eq!(page.total_count(), Some(2), "totalCount must respect RLS via session vars");
+    for row in page.rows() {
+        let tenant = row.as_value().pointer("/tenant").and_then(|v| v.as_str());
+        assert_eq!(tenant, Some("tenant-a"));
+    }
+
+    // Sanity: without the session variable the view filters everything out.
+    let empty = adapter
+        .execute_relay_page_with_session(
+            "v_widget_relay", "id", None, None, 10, true, None, None, false, &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(empty.rows().len(), 0, "no session var => RLS predicate is NULL => no rows");
 }

--- a/crates/fraiseql-core/tests/session_variables_integration.rs
+++ b/crates/fraiseql-core/tests/session_variables_integration.rs
@@ -59,10 +59,7 @@ async fn legacy_set_session_variables_is_invisible_to_function() {
         .set_session_variables(&[("app.tenant_id_legacy", "tenant-abc")])
         .await
         .unwrap();
-    let rows = adapter
-        .execute_function_call("fn_show_tenant_legacy", &[])
-        .await
-        .unwrap();
+    let rows = adapter.execute_function_call("fn_show_tenant_legacy", &[]).await.unwrap();
 
     let value = rows[0].get("fn_show_tenant_legacy").and_then(|v| v.as_str());
 
@@ -108,7 +105,9 @@ async fn setup_widget_view(key: &str) -> PostgresAdapter {
              (id bigint primary key, tenant text not null)"
         ),
         format!("TRUNCATE tb_widget_{key}"),
-        format!("INSERT INTO tb_widget_{key} VALUES (1, 'tenant-a'), (2, 'tenant-b'), (3, 'tenant-a')"),
+        format!(
+            "INSERT INTO tb_widget_{key} VALUES (1, 'tenant-a'), (2, 'tenant-b'), (3, 'tenant-a')"
+        ),
         format!(
             "CREATE OR REPLACE VIEW v_widget_{key} AS \
              SELECT id, jsonb_build_object('id', id, 'tenant', tenant) AS data \
@@ -180,7 +179,16 @@ async fn relay_page_with_session_applies_rls_setting() {
     // Sanity: without the session variable the view filters everything out.
     let empty = adapter
         .execute_relay_page_with_session(
-            "v_widget_relay", "id", None, None, 10, true, None, None, false, &[],
+            "v_widget_relay",
+            "id",
+            None,
+            None,
+            10,
+            true,
+            None,
+            None,
+            false,
+            &[],
         )
         .await
         .unwrap();

--- a/crates/fraiseql-core/tests/session_variables_integration.rs
+++ b/crates/fraiseql-core/tests/session_variables_integration.rs
@@ -1,0 +1,71 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(missing_docs)]
+
+//! Integration test for #329 — session variables MUST be visible to the SQL
+//! function that the mutation runner calls.
+//!
+//! ## The bug
+//!
+//! `PostgresAdapter::set_session_variables` acquires its own pooled connection
+//! and runs `SELECT set_config($1, $2, true)` per variable. `is_local = true`
+//! makes the setting transaction-scoped, but a bare `SELECT` is its own
+//! autocommit transaction — so the GUC is discarded the instant the statement
+//! returns. Even setting that aside, the subsequent `execute_function_call`
+//! acquires a *different* pooled connection, so the function never sees the
+//! value.
+//!
+//! These tests run against a real PostgreSQL container so the connection-pool
+//! and transaction-scope behaviour is exercised exactly as in production.
+
+mod common;
+
+use fraiseql_core::db::{DatabaseAdapter, postgres::PostgresAdapter};
+
+/// Install a function that echoes a transaction-local GUC back to the caller.
+/// Returns a fresh adapter (its own pool) connected to the shared container.
+async fn adapter_with_echo_fn() -> PostgresAdapter {
+    let container = common::testcontainer::get_test_container().await;
+    let adapter = PostgresAdapter::new(&container.connection_string())
+        .await
+        .expect("connect adapter");
+
+    adapter
+        .execute_raw_query(
+            "CREATE OR REPLACE FUNCTION fn_show_tenant_329() RETURNS text \
+             LANGUAGE sql AS $$ SELECT current_setting('app.tenant_id_329', true) $$;",
+        )
+        .await
+        .expect("create echo function");
+
+    adapter
+}
+
+/// #329 — the value applied via session variables must be visible to the
+/// function body.
+///
+/// On v2.3.2 this fails with `None` ("<NULL>") because the GUC is applied on a
+/// different connection / transaction than the one that runs the function.
+#[tokio::test]
+async fn session_variables_visible_inside_function() {
+    let adapter = adapter_with_echo_fn().await;
+
+    // The two-call pattern the executor uses today: apply the session
+    // variables, then call the function. This is exactly bug #329.
+    adapter
+        .set_session_variables(&[("app.tenant_id_329", "tenant-abc")])
+        .await
+        .unwrap();
+    let rows = adapter
+        .execute_function_call("fn_show_tenant_329", &[])
+        .await
+        .unwrap();
+
+    let value = rows[0].get("fn_show_tenant_329").and_then(|v| v.as_str());
+
+    assert_eq!(
+        value,
+        Some("tenant-abc"),
+        "expected app.tenant_id_329 == \"tenant-abc\" inside fn_show_tenant_329, \
+         got {value:?} — this is bug #329 (GUC observed as NULL inside the function)"
+    );
+}

--- a/crates/fraiseql-db/src/postgres/adapter/database.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/database.rs
@@ -1,14 +1,19 @@
 //! `DatabaseAdapter` and `SupportsMutations` implementations for `PostgresAdapter`.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use bytes::BufMut as _;
 use fraiseql_error::{FraiseQLError, Result};
 use tokio_postgres::Row;
 
-use super::{PostgresAdapter, build_where_select_sql, build_where_select_sql_ordered};
+use super::{
+    PostgresAdapter, build_projection_select_sql, build_where_select_sql,
+    build_where_select_sql_ordered,
+};
 use crate::{
     identifier::quote_postgres_identifier,
-    traits::{DatabaseAdapter, SupportsMutations},
+    traits::{DatabaseAdapter, ProjectionRequest, SupportsMutations},
     types::{
         DatabaseType, JsonbValue, PoolMetrics, QueryParam,
         sql_hints::{OrderByClause, SqlProjectionHint},
@@ -158,6 +163,26 @@ fn row_to_map(row: &Row) -> std::collections::HashMap<String, serde_json::Value>
         map.insert(column_name, value);
     }
     map
+}
+
+/// Apply transaction-local session variables on an in-progress transaction.
+///
+/// Each `(name, value)` pair is set with `SELECT set_config($1, $2, true)`, so
+/// the values are scoped to `txn` and visible to every statement run on it
+/// (fixes #329). The caller is responsible for committing or rolling back.
+pub(super) async fn apply_session_vars(
+    txn: &tokio_postgres::Transaction<'_>,
+    session_vars: &[(&str, &str)],
+) -> Result<()> {
+    for (name, value) in session_vars {
+        txn.execute("SELECT set_config($1, $2, true)", &[name, value])
+            .await
+            .map_err(|e| FraiseQLError::Database {
+                message:   format!("set_config({name:?}) failed: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
+    }
+    Ok(())
 }
 
 // Reason: DatabaseAdapter is defined with #[async_trait]; all implementations must match
@@ -310,6 +335,38 @@ impl DatabaseAdapter for PostgresAdapter {
         Ok(results)
     }
 
+    async fn execute_parameterized_aggregate_with_session(
+        &self,
+        sql: &str,
+        params: &[serde_json::Value],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        if session_vars.is_empty() {
+            return self.execute_parameterized_aggregate(sql, params).await;
+        }
+
+        let typed: Vec<QueryParam> = params.iter().cloned().map(QueryParam::from).collect();
+        let param_refs = crate::types::as_sql_param_refs(&typed);
+
+        let mut client = self.acquire_connection_with_retry().await?;
+        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to start session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+        apply_session_vars(&txn, session_vars).await?;
+        let rows: Vec<Row> =
+            txn.query(sql, &param_refs).await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Parameterized aggregate query failed: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
+        txn.commit().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to commit session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+
+        Ok(rows.iter().map(row_to_map).collect())
+    }
+
     async fn execute_function_call(
         &self,
         function_name: &str,
@@ -400,21 +457,140 @@ impl DatabaseAdapter for PostgresAdapter {
         }
     }
 
-    async fn set_session_variables(&self, variables: &[(&str, &str)]) -> Result<()> {
-        if variables.is_empty() {
-            return Ok(());
+    // Note: `set_session_variables` is intentionally NOT overridden here. The
+    // trait default (a deprecated no-op) stands in; PostgreSQL session variables
+    // are applied connection-affinely by the `*_with_session` methods below
+    // (fixes #329).
+
+    async fn execute_function_call_with_session(
+        &self,
+        function_name: &str,
+        args: &[serde_json::Value],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        // Fast path: no session variables and no mutation timing => behave
+        // exactly like execute_function_call (no transaction overhead, and
+        // execute_function_call already opens its own txn when timing is on).
+        if session_vars.is_empty() && !self.mutation_timing_enabled {
+            return self.execute_function_call(function_name, args).await;
         }
-        let client = self.acquire_connection_with_retry().await?;
-        for (name, value) in variables {
-            client
-                .execute("SELECT set_config($1, $2, true)", &[name, value])
-                .await
-                .map_err(|e| FraiseQLError::Database {
-                    message:   format!("set_config({name:?}) failed: {e}"),
-                    sql_state: e.code().map(|c| c.code().to_string()),
-                })?;
+
+        let quoted_fn = quote_postgres_identifier(function_name);
+        let placeholders: Vec<String> = (1..=args.len()).map(|i| format!("${i}")).collect();
+        let sql = format!("SELECT * FROM {quoted_fn}({})", placeholders.join(", "));
+
+        // See execute_function_call for why FlexParam is required here.
+        let flex_args: Vec<FlexParam> = args
+            .iter()
+            .map(|v| match v {
+                serde_json::Value::Null => FlexParam::Null,
+                serde_json::Value::String(s) => FlexParam::Text(s.clone()),
+                _ => FlexParam::Text(v.to_string()),
+            })
+            .collect();
+        let params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = flex_args
+            .iter()
+            .map(|v| v as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+
+        let mut client = self.acquire_connection_with_retry().await?;
+        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to start session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+
+        // Apply session variables FIRST so the function body sees them.
+        apply_session_vars(&txn, session_vars).await?;
+
+        // If mutation timing is on, stamp the timing variable in the same txn.
+        if self.mutation_timing_enabled {
+            txn.execute(
+                "SELECT set_config($1, clock_timestamp()::text, true)",
+                &[&self.timing_variable_name],
+            )
+            .await
+            .map_err(|e| FraiseQLError::Database {
+                message:   format!("Failed to set mutation timing variable: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
         }
-        Ok(())
+
+        let rows: Vec<Row> = txn.query(sql.as_str(), params.as_slice()).await.map_err(|e| {
+            let detail = e.as_db_error().map_or("", |d| d.message());
+            FraiseQLError::Database {
+                message:   format!("Function call {function_name} failed: {e}: {detail}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            }
+        })?;
+
+        txn.commit().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to commit session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+
+        Ok(rows.iter().map(row_to_map).collect())
+    }
+
+    async fn execute_where_query_arc_with_session(
+        &self,
+        view: &str,
+        where_clause: Option<&WhereClause>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+        order_by: Option<&[OrderByClause]>,
+        session_vars: &[(&str, &str)],
+    ) -> Result<Arc<Vec<JsonbValue>>> {
+        if session_vars.is_empty() {
+            return self.execute_where_query_arc(view, where_clause, limit, offset, order_by).await;
+        }
+
+        let (sql, typed_params) =
+            build_where_select_sql_ordered(view, where_clause, limit, offset, order_by)?;
+        let param_refs = crate::types::as_sql_param_refs(&typed_params);
+
+        self.execute_raw_with_session(&sql, &param_refs, session_vars)
+            .await
+            .map(Arc::new)
+            .map_err(|e| enrich_undefined_column_error(e, view, where_clause))
+    }
+
+    async fn execute_with_projection_arc_with_session(
+        &self,
+        request: &ProjectionRequest<'_>,
+        session_vars: &[(&str, &str)],
+    ) -> Result<Arc<Vec<JsonbValue>>> {
+        if session_vars.is_empty() {
+            return self.execute_with_projection_arc(request).await;
+        }
+
+        // No projection => behave like a plain WHERE query, matching
+        // execute_with_projection_impl's fallback.
+        let Some(projection) = request.projection else {
+            return self
+                .execute_where_query_arc_with_session(
+                    request.view,
+                    request.where_clause,
+                    request.limit,
+                    request.offset,
+                    request.order_by,
+                    session_vars,
+                )
+                .await;
+        };
+
+        let (sql, typed_params) = build_projection_select_sql(
+            projection,
+            request.view,
+            request.where_clause,
+            request.limit,
+            request.offset,
+            request.order_by,
+        )?;
+        let param_refs = crate::types::as_sql_param_refs(&typed_params);
+
+        self.execute_raw_with_session(&sql, &param_refs, session_vars)
+            .await
+            .map(Arc::new)
     }
 
     async fn explain_query(

--- a/crates/fraiseql-db/src/postgres/adapter/database.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/database.rs
@@ -349,10 +349,11 @@ impl DatabaseAdapter for PostgresAdapter {
         let param_refs = crate::types::as_sql_param_refs(&typed);
 
         let mut client = self.acquire_connection_with_retry().await?;
-        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
-            message:   format!("Failed to start session-var transaction: {e}"),
-            sql_state: e.code().map(|c| c.code().to_string()),
-        })?;
+        let txn =
+            client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Failed to start session-var transaction: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
         apply_session_vars(&txn, session_vars).await?;
         let rows: Vec<Row> =
             txn.query(sql, &param_refs).await.map_err(|e| FraiseQLError::Database {
@@ -494,10 +495,11 @@ impl DatabaseAdapter for PostgresAdapter {
             .collect();
 
         let mut client = self.acquire_connection_with_retry().await?;
-        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
-            message:   format!("Failed to start session-var transaction: {e}"),
-            sql_state: e.code().map(|c| c.code().to_string()),
-        })?;
+        let txn =
+            client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Failed to start session-var transaction: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
 
         // Apply session variables FIRST so the function body sees them.
         apply_session_vars(&txn, session_vars).await?;

--- a/crates/fraiseql-db/src/postgres/adapter/mod.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/mod.rs
@@ -390,18 +390,18 @@ impl PostgresAdapter {
         session_vars: &[(&str, &str)],
     ) -> Result<Vec<JsonbValue>> {
         let mut client = self.acquire_connection_with_retry().await?;
-        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
-            message:   format!("Failed to start session-var transaction: {e}"),
-            sql_state: e.code().map(|c| c.code().to_string()),
-        })?;
+        let txn =
+            client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Failed to start session-var transaction: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
 
         database::apply_session_vars(&txn, session_vars).await?;
 
-        let rows: Vec<Row> =
-            txn.query(sql, params).await.map_err(|e| FraiseQLError::Database {
-                message:   format!("Query execution failed: {e}"),
-                sql_state: e.code().map(|c| c.code().to_string()),
-            })?;
+        let rows: Vec<Row> = txn.query(sql, params).await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Query execution failed: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
 
         txn.commit().await.map_err(|e| FraiseQLError::Database {
             message:   format!("Failed to commit session-var transaction: {e}"),

--- a/crates/fraiseql-db/src/postgres/adapter/mod.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/mod.rs
@@ -371,6 +371,52 @@ impl PostgresAdapter {
         Ok(results)
     }
 
+    /// Like [`execute_raw`](Self::execute_raw) but applies transaction-local
+    /// session variables on the same connection / transaction that runs the
+    /// query.
+    ///
+    /// `set_config(..., true)` and the `SELECT` share one transaction, so
+    /// PostgreSQL RLS policies backed by `current_setting()` see the configured
+    /// values (fixes #329).
+    ///
+    /// # Errors
+    ///
+    /// Returns `FraiseQLError::Database` on transaction, `set_config`, query, or
+    /// commit failure.
+    pub(super) async fn execute_raw_with_session(
+        &self,
+        sql: &str,
+        params: &[&(dyn tokio_postgres::types::ToSql + Sync)],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<JsonbValue>> {
+        let mut client = self.acquire_connection_with_retry().await?;
+        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to start session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+
+        database::apply_session_vars(&txn, session_vars).await?;
+
+        let rows: Vec<Row> =
+            txn.query(sql, params).await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Query execution failed: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
+
+        txn.commit().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to commit session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let data: serde_json::Value = row.get(0);
+                JsonbValue::new(data)
+            })
+            .collect())
+    }
+
     /// Acquire a connection from the pool with retry logic.
     ///
     /// - `PoolError::Timeout`: the pool was exhausted for the full configured wait period. This is
@@ -518,43 +564,8 @@ impl PostgresAdapter {
 
         let projection = projection.expect("projection is Some; None was returned above");
 
-        // Build SQL with projection
-        // The projection_template is expected to be the SELECT clause with projection SQL
-        // e.g., "jsonb_build_object('id', data->>'id', 'email', data->>'email')"
-        let mut sql = format!(
-            "SELECT {} FROM {}",
-            projection.projection_template,
-            quote_postgres_identifier(view)
-        );
-
-        // Add WHERE clause if present
-        let mut typed_params: Vec<QueryParam> = if let Some(clause) = where_clause {
-            let generator = PostgresWhereGenerator::new(PostgresDialect);
-            let (where_sql, where_params) = generator.generate(clause)?;
-            sql.push_str(" WHERE ");
-            sql.push_str(&where_sql);
-            where_params.into_iter().map(QueryParam::from).collect()
-        } else {
-            Vec::new()
-        };
-        let mut param_count = typed_params.len();
-
-        // ORDER BY must come before LIMIT/OFFSET in SQL.
-        append_order_by(&mut sql, order_by, DatabaseType::PostgreSQL)?;
-
-        // Append LIMIT/OFFSET as BigInt (PostgreSQL requires integer type).
-        // Reason (expect below): fmt::Write for String is infallible.
-        if let Some(lim) = limit {
-            param_count += 1;
-            write!(sql, " LIMIT ${param_count}").expect("write to String");
-            typed_params.push(QueryParam::BigInt(i64::from(lim)));
-        }
-
-        if let Some(off) = offset {
-            param_count += 1;
-            write!(sql, " OFFSET ${param_count}").expect("write to String");
-            typed_params.push(QueryParam::BigInt(i64::from(off)));
-        }
+        let (sql, typed_params) =
+            build_projection_select_sql(projection, view, where_clause, limit, offset, order_by)?;
 
         tracing::debug!("SQL with projection = {}", sql);
         tracing::debug!("typed_params = {:?}", typed_params);
@@ -654,6 +665,66 @@ pub(super) fn build_where_select_sql_ordered(
     }
 
     // Add OFFSET as BigInt (PostgreSQL requires integer type for OFFSET)
+    if let Some(off) = offset {
+        param_count += 1;
+        write!(sql, " OFFSET ${param_count}").expect("write to String");
+        typed_params.push(QueryParam::BigInt(i64::from(off)));
+    }
+
+    Ok((sql, typed_params))
+}
+
+/// Build a parameterized projection `SELECT` SQL string.
+///
+/// Mirrors the SQL produced inline by [`PostgresAdapter::execute_with_projection_impl`],
+/// extracted so the connection-affine `*_with_session` path can reuse it
+/// without acquiring its own connection.
+///
+/// # Returns
+///
+/// `(sql, typed_params)` — the SQL string and the bound parameter values.
+///
+/// # Errors
+///
+/// Returns `FraiseQLError` if WHERE clause generation fails.
+pub(super) fn build_projection_select_sql(
+    projection: &SqlProjectionHint,
+    view: &str,
+    where_clause: Option<&WhereClause>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+    order_by: Option<&[OrderByClause]>,
+) -> Result<(String, Vec<QueryParam>)> {
+    // The projection_template is the SELECT clause with projection SQL,
+    // e.g. "jsonb_build_object('id', data->>'id', 'email', data->>'email')".
+    let mut sql = format!(
+        "SELECT {} FROM {}",
+        projection.projection_template,
+        quote_postgres_identifier(view)
+    );
+
+    let mut typed_params: Vec<QueryParam> = if let Some(clause) = where_clause {
+        let generator = PostgresWhereGenerator::new(PostgresDialect);
+        let (where_sql, where_params) = generator.generate(clause)?;
+        sql.push_str(" WHERE ");
+        sql.push_str(&where_sql);
+        where_params.into_iter().map(QueryParam::from).collect()
+    } else {
+        Vec::new()
+    };
+    let mut param_count = typed_params.len();
+
+    // ORDER BY must come before LIMIT/OFFSET in SQL.
+    append_order_by(&mut sql, order_by, DatabaseType::PostgreSQL)?;
+
+    // Append LIMIT/OFFSET as BigInt (PostgreSQL requires integer type).
+    // Reason (expect below): fmt::Write for String is infallible.
+    if let Some(lim) = limit {
+        param_count += 1;
+        write!(sql, " LIMIT ${param_count}").expect("write to String");
+        typed_params.push(QueryParam::BigInt(i64::from(lim)));
+    }
+
     if let Some(off) = offset {
         param_count += 1;
         write!(sql, " OFFSET ${param_count}").expect("write to String");

--- a/crates/fraiseql-db/src/postgres/adapter/relay.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/relay.rs
@@ -107,10 +107,11 @@ impl RelayDatabaseAdapter for PostgresAdapter {
         // Apply set_config and run BOTH the page and count queries inside one
         // transaction on one connection so RLS sees the session variables.
         let mut client = self.acquire_connection_with_retry().await?;
-        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
-            message:   format!("Failed to start relay session-var transaction: {e}"),
-            sql_state: e.code().map(|c| c.code().to_string()),
-        })?;
+        let txn =
+            client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Failed to start relay session-var transaction: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
         super::database::apply_session_vars(&txn, session_vars).await?;
         let result = self
             .run_relay_page(

--- a/crates/fraiseql-db/src/postgres/adapter/relay.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/relay.rs
@@ -57,6 +57,104 @@ impl RelayDatabaseAdapter for PostgresAdapter {
         order_by: Option<&[OrderByClause]>,
         include_total_count: bool,
     ) -> Result<RelayPageResult> {
+        let client = self.acquire_connection_with_retry().await?;
+        self.run_relay_page(
+            &**client,
+            view,
+            cursor_column,
+            after,
+            before,
+            limit,
+            forward,
+            where_clause,
+            order_by,
+            include_total_count,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments plus session vars; no natural grouping
+    async fn execute_relay_page_with_session(
+        &self,
+        view: &str,
+        cursor_column: &str,
+        after: Option<CursorValue>,
+        before: Option<CursorValue>,
+        limit: u32,
+        forward: bool,
+        where_clause: Option<&WhereClause>,
+        order_by: Option<&[OrderByClause]>,
+        include_total_count: bool,
+        session_vars: &[(&str, &str)],
+    ) -> Result<RelayPageResult> {
+        // Fast path: no session vars => identical to execute_relay_page.
+        if session_vars.is_empty() {
+            return self
+                .execute_relay_page(
+                    view,
+                    cursor_column,
+                    after,
+                    before,
+                    limit,
+                    forward,
+                    where_clause,
+                    order_by,
+                    include_total_count,
+                )
+                .await;
+        }
+
+        // Apply set_config and run BOTH the page and count queries inside one
+        // transaction on one connection so RLS sees the session variables.
+        let mut client = self.acquire_connection_with_retry().await?;
+        let txn = client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to start relay session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+        super::database::apply_session_vars(&txn, session_vars).await?;
+        let result = self
+            .run_relay_page(
+                &*txn,
+                view,
+                cursor_column,
+                after,
+                before,
+                limit,
+                forward,
+                where_clause,
+                order_by,
+                include_total_count,
+            )
+            .await?;
+        txn.commit().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to commit relay session-var transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+        Ok(result)
+    }
+}
+
+impl PostgresAdapter {
+    /// Build and run the relay page (and optional total-count) queries against
+    /// an arbitrary client — a pooled connection for the plain path, or a
+    /// transaction for the connection-affine `*_with_session` path.
+    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments; no natural grouping
+    async fn run_relay_page<C>(
+        &self,
+        client: &C,
+        view: &str,
+        cursor_column: &str,
+        after: Option<CursorValue>,
+        before: Option<CursorValue>,
+        limit: u32,
+        forward: bool,
+        where_clause: Option<&WhereClause>,
+        order_by: Option<&[OrderByClause]>,
+        include_total_count: bool,
+    ) -> Result<RelayPageResult>
+    where
+        C: tokio_postgres::GenericClient + Sync,
+    {
         let quoted_view = quote_postgres_identifier(view);
         let quoted_col = quote_postgres_identifier(cursor_column);
 
@@ -173,9 +271,7 @@ impl RelayDatabaseAdapter for PostgresAdapter {
         }
         page_typed_params.push(QueryParam::BigInt(i64::from(limit)));
 
-        let client = self.acquire_connection_with_retry().await?;
-
-        // ── Execute page query ─────────────────────────────────────────────────
+        // ── Execute page query (on the caller-provided client / transaction) ────
         let page_param_refs = crate::types::as_sql_param_refs(&page_typed_params);
 
         let page_rows = client.query(&page_sql, &page_param_refs).await.map_err(|e| {

--- a/crates/fraiseql-db/src/traits.rs
+++ b/crates/fraiseql-db/src/traits.rs
@@ -601,6 +601,27 @@ pub trait DatabaseAdapter: Send + Sync {
         params: &[serde_json::Value],
     ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>>;
 
+    /// Connection-affine variant of [`execute_parameterized_aggregate`].
+    ///
+    /// Applies `session_vars` transaction-locally on the same connection that
+    /// runs the aggregate, so aggregate views backed by `current_setting()` RLS
+    /// observe the configured values (fixes #329 for the aggregate path). See
+    /// [`execute_function_call_with_session`](Self::execute_function_call_with_session)
+    /// for the non-PostgreSQL default behaviour.
+    ///
+    /// # Errors
+    ///
+    /// Same errors as [`execute_parameterized_aggregate`]; additionally returns
+    /// `FraiseQLError::Database` if `set_config` fails.
+    async fn execute_parameterized_aggregate_with_session(
+        &self,
+        sql: &str,
+        params: &[serde_json::Value],
+        _session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        self.execute_parameterized_aggregate(sql, params).await
+    }
+
     /// Execute a database function call and return all columns as rows.
     ///
     /// Builds `SELECT * FROM {function_name}($1, $2, ...)` with one positional placeholder per
@@ -802,31 +823,109 @@ pub trait DatabaseAdapter: Send + Sync {
         MutationStrategy::FunctionCall
     }
 
-    /// Set transaction-scoped session variables before query/mutation execution.
+    /// **Deprecated**: use [`execute_function_call_with_session`](Self::execute_function_call_with_session),
+    /// [`execute_where_query_arc_with_session`](Self::execute_where_query_arc_with_session),
+    /// or [`execute_with_projection_arc_with_session`](Self::execute_with_projection_arc_with_session)
+    /// instead.
     ///
-    /// Called at the start of each mutation request when `SessionVariablesConfig`
-    /// is populated.  Each `(name, value)` pair is applied via
-    /// `SELECT set_config($1, $2, true)` (transaction-local, auto-reset on
-    /// commit/rollback).
+    /// This method applies `set_config(..., true)` on a connection that is then
+    /// returned to the pool. The setting is transaction-local, so it is
+    /// discarded when the `SELECT set_config` statement's implicit transaction
+    /// commits — and even setting that aside, the subsequent operation may
+    /// acquire a *different* pooled connection, making the GUC invisible to it
+    /// (bug #329). It is retained for one release for source compatibility and
+    /// is **no longer called by the executor**.
     ///
-    /// SQL functions and views can then read these settings via
-    /// `current_setting('app.tenant_id', true)`.
-    ///
-    /// # Arguments
-    ///
-    /// * `variables` - Slice of `(setting_name, value)` pairs to inject. Names must be safe
-    ///   PostgreSQL setting names (e.g. `"app.tenant_id"`).
-    ///
-    /// # Default
-    ///
-    /// No-op.  Only `PostgresAdapter` overrides this with `set_config()` calls.
-    /// MySQL, SQLite, and SQL Server adapters inherit the no-op default.
+    /// Will be removed in 2.4.
     ///
     /// # Errors
     ///
-    /// Returns `FraiseQLError::Database` if the underlying `set_config()` call fails.
+    /// The default implementation is a no-op and never errors.
+    #[deprecated(
+        since = "2.3.3",
+        note = "session variables are now applied on the same connection as the operation; use the *_with_session adapter methods"
+    )]
     async fn set_session_variables(&self, _variables: &[(&str, &str)]) -> Result<()> {
         Ok(())
+    }
+
+    /// Execute a database function call after pinning session variables on the
+    /// **same connection** within the **same transaction** as the call.
+    ///
+    /// This is the connection-affine variant of [`execute_function_call`].
+    /// Unlike the legacy two-call pattern (`set_session_variables` followed by
+    /// `execute_function_call`), the `set_config(..., true)` calls and the
+    /// `SELECT * FROM fn(...)` call share one pooled connection inside one
+    /// transaction, so transaction-local GUCs are visible to the function body
+    /// (fixes #329).
+    ///
+    /// Adapters that do not support session variables (MySQL, SQLite, SQL
+    /// Server, mocks) inherit the default implementation, which silently drops
+    /// `session_vars` and delegates to [`execute_function_call`] — safe,
+    /// because their `set_session_variables` is also a no-op.
+    ///
+    /// # Arguments
+    ///
+    /// * `function_name` - Fully-qualified function name
+    /// * `args` - Positional JSON arguments passed as `$1, $2, …`
+    /// * `session_vars` - `(setting_name, value)` pairs applied with
+    ///   `SELECT set_config(name, value, true)` before the function call. Pass
+    ///   `&[]` when no session variables are configured.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`execute_function_call`]; additionally returns
+    /// `FraiseQLError::Database` if `set_config` fails on any pair.
+    async fn execute_function_call_with_session(
+        &self,
+        function_name: &str,
+        args: &[serde_json::Value],
+        _session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        // Default: ignore session_vars and delegate. Safe for non-PostgreSQL
+        // adapters because their `set_session_variables` is also a no-op.
+        self.execute_function_call(function_name, args).await
+    }
+
+    /// Connection-affine variant of [`execute_where_query_arc`].
+    ///
+    /// Applies `session_vars` transaction-locally on the same connection that
+    /// runs the read, so PostgreSQL Row-Level-Security policies backed by
+    /// `current_setting()` see the configured values (fixes #329). See
+    /// [`execute_function_call_with_session`] for the rationale and the
+    /// non-PostgreSQL default behaviour.
+    ///
+    /// # Errors
+    ///
+    /// Same errors as [`execute_where_query_arc`]; additionally returns
+    /// `FraiseQLError::Database` if `set_config` fails on any pair.
+    async fn execute_where_query_arc_with_session(
+        &self,
+        view: &str,
+        where_clause: Option<&WhereClause>,
+        limit: Option<u32>,
+        offset: Option<u32>,
+        order_by: Option<&[OrderByClause]>,
+        _session_vars: &[(&str, &str)],
+    ) -> Result<Arc<Vec<JsonbValue>>> {
+        self.execute_where_query_arc(view, where_clause, limit, offset, order_by)
+            .await
+    }
+
+    /// Connection-affine variant of [`execute_with_projection_arc`].
+    ///
+    /// See [`execute_where_query_arc_with_session`] for the rationale.
+    ///
+    /// # Errors
+    ///
+    /// Same errors as [`execute_with_projection_arc`]; additionally returns
+    /// `FraiseQLError::Database` if `set_config` fails on any pair.
+    async fn execute_with_projection_arc_with_session(
+        &self,
+        request: &ProjectionRequest<'_>,
+        _session_vars: &[(&str, &str)],
+    ) -> Result<Arc<Vec<JsonbValue>>> {
+        self.execute_with_projection_arc(request).await
     }
 
     /// Execute a direct SQL mutation (INSERT/UPDATE/DELETE) and return the

--- a/crates/fraiseql-db/src/traits.rs
+++ b/crates/fraiseql-db/src/traits.rs
@@ -823,7 +823,8 @@ pub trait DatabaseAdapter: Send + Sync {
         MutationStrategy::FunctionCall
     }
 
-    /// **Deprecated**: use [`execute_function_call_with_session`](Self::execute_function_call_with_session),
+    /// **Deprecated**: use
+    /// [`execute_function_call_with_session`](Self::execute_function_call_with_session),
     /// [`execute_where_query_arc_with_session`](Self::execute_where_query_arc_with_session),
     /// or [`execute_with_projection_arc_with_session`](Self::execute_with_projection_arc_with_session)
     /// instead.
@@ -868,9 +869,9 @@ pub trait DatabaseAdapter: Send + Sync {
     ///
     /// * `function_name` - Fully-qualified function name
     /// * `args` - Positional JSON arguments passed as `$1, $2, …`
-    /// * `session_vars` - `(setting_name, value)` pairs applied with
-    ///   `SELECT set_config(name, value, true)` before the function call. Pass
-    ///   `&[]` when no session variables are configured.
+    /// * `session_vars` - `(setting_name, value)` pairs applied with `SELECT set_config(name,
+    ///   value, true)` before the function call. Pass `&[]` when no session variables are
+    ///   configured.
     ///
     /// # Errors
     ///
@@ -908,8 +909,7 @@ pub trait DatabaseAdapter: Send + Sync {
         order_by: Option<&[OrderByClause]>,
         _session_vars: &[(&str, &str)],
     ) -> Result<Arc<Vec<JsonbValue>>> {
-        self.execute_where_query_arc(view, where_clause, limit, offset, order_by)
-            .await
+        self.execute_where_query_arc(view, where_clause, limit, offset, order_by).await
     }
 
     /// Connection-affine variant of [`execute_with_projection_arc`].

--- a/crates/fraiseql-db/src/traits/relay.rs
+++ b/crates/fraiseql-db/src/traits/relay.rs
@@ -55,4 +55,45 @@ pub trait RelayDatabaseAdapter: DatabaseAdapter {
         order_by: Option<&'a [OrderByClause]>,
         include_total_count: bool,
     ) -> impl Future<Output = Result<RelayPageResult>> + Send + 'a;
+
+    /// Connection-affine variant of [`execute_relay_page`](Self::execute_relay_page).
+    ///
+    /// Applies `session_vars` transaction-locally on the same connection that
+    /// runs the page (and total-count) queries, so RLS-protected relay
+    /// pagination over views reading `current_setting()` returns the correct
+    /// tenant's rows (fixes #329 for the cursor-pagination path).
+    ///
+    /// Adapters that do not support session variables inherit the default,
+    /// which drops `session_vars` and delegates to `execute_relay_page`.
+    ///
+    /// # Errors
+    ///
+    /// Same errors as [`execute_relay_page`](Self::execute_relay_page);
+    /// additionally returns `FraiseQLError::Database` if `set_config` fails.
+    #[allow(clippy::too_many_arguments)] // Reason: relay pagination requires all cursor/filter/sort/count arguments plus session vars; no natural grouping
+    fn execute_relay_page_with_session<'a>(
+        &'a self,
+        view: &'a str,
+        cursor_column: &'a str,
+        after: Option<CursorValue>,
+        before: Option<CursorValue>,
+        limit: u32,
+        forward: bool,
+        where_clause: Option<&'a WhereClause>,
+        order_by: Option<&'a [OrderByClause]>,
+        include_total_count: bool,
+        _session_vars: &'a [(&'a str, &'a str)],
+    ) -> impl Future<Output = Result<RelayPageResult>> + Send + 'a {
+        self.execute_relay_page(
+            view,
+            cursor_column,
+            after,
+            before,
+            limit,
+            forward,
+            where_clause,
+            order_by,
+            include_total_count,
+        )
+    }
 }

--- a/crates/fraiseql-server/src/routes/grpc/handler.rs
+++ b/crates/fraiseql-server/src/routes/grpc/handler.rs
@@ -419,6 +419,11 @@ pub async fn execute_grpc_mutation<A: DatabaseAdapter>(
         "Executing gRPC mutation"
     );
 
+    // No session vars: the gRPC mutation path does not yet thread the schema's
+    // session-variable config or a SecurityContext, so current_setting()-backed
+    // RLS / functions are not configured here. Wiring this through gRPC auth is a
+    // follow-up (#329); the GraphQL mutation path uses
+    // execute_function_call_with_session.
     let rows = adapter.execute_function_call(function_name, &args).await?;
 
     // The Trinity pattern returns a single row with status/entity_id columns.


### PR DESCRIPTION
## What

Pins session variables to the **operation's own connection** so `set_config(...)` is visible to the mutation SQL function (and to RLS-protected views, relay-paginated lists, and aggregates) executed in the same logical operation.

Before this change, `current_setting('app.x', true)` inside a mutation function / RLS policy always returned `NULL`: `PostgresAdapter::set_session_variables` ran `SELECT set_config(..., true)` on a *separate* pooled connection in its own autocommit transaction, so the (transaction-local) setting never reached the connection that ran the function. This adds `*_with_session` adapter methods that set the session variables on the same connection as the operation and deprecates the old split path.

This is the extraction of the three `#329` commits from the combined local `fix/329` stack onto current `dev`, for the v2.4.0 wide-scope release. It is on the critical path (the change-log / Change-Spine executor-outbox work depends on this connection affinity).

## Commits

- `test(db): failing integration test for session-variable connection split (#329)` — RED
- `fix(db): pin session variables to the operation's connection (#329)` — GREEN
- `docs(changelog): document session-variable connection-affinity fix (#329)`

## Tests

`crates/fraiseql-core/tests/session_variables_integration.rs` — **4/4 passing** against a real PostgreSQL testcontainer:

- `legacy_set_session_variables_is_invisible_to_function` — proves the original bug (legacy path → setting invisible to the function).
- `function_call_with_session_sees_set_config` — proves the fix (`*_with_session` → function sees `set_config`).
- `where_query_with_session_applies_rls_setting` — RLS setting applied on a WHERE query.
- `relay_page_with_session_applies_rls_setting` — RLS setting applied on a relay page.

## Verification

- `cargo check -p fraiseql-db -p fraiseql-core` ✅
- `cargo clippy -p fraiseql-db -p fraiseql-core --all-targets -- -D warnings` ✅
- Integration suite ✅ (above)

## ⚠️ HOLD — do not merge yet

Hold until **#395 (webhook log redaction, B6)** lands on `dev`, so the `CHANGELOG.md [Unreleased]` conflict-resolution ordering stays predictable across the v2.4.0 release assembly. The only conflict in this extraction was an additive `CHANGELOG.md` merge (kept dev's `### Security` / `### Breaking changes` + this branch's `### Fixed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
