### PR TITLE
chore(deps): joint upgrade sha1 0.11 + sha2 0.11 + hmac 0.13 + pbkdf2 0.13 (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the RustCrypto hashing stack jointly (#300): `sha1 0.10 → 0.11`,
+  `sha2 0.10 → 0.11`, `hmac 0.12 → 0.13`, and `pbkdf2 0.12 → 0.13` (the latter
+  forced by the wire SCRAM PRF). These all ride `digest 0.11` / `crypto-common
+  0.2` and cannot be mixed with the `digest 0.10` generation, so they move in
+  lockstep. Call sites were updated to the new API: `KeyInit` is now imported
+  for `Hmac::new_from_slice`, and digest outputs are hex-encoded via
+  `hex::encode` (the new `hybrid-array` `Output` no longer implements
+  `LowerHex`). No public API changed. The `cargo deny` skip for the transitive
+  `sha1 0.10.6` (pinned by `sqlx-mysql`) was re-added.
+
 ### Security
 
 - **`POST /auth/revoke` and `POST /auth/revoke-all` are now authenticated** (#358, FW-21 class). In v2.3.x and earlier, both routes were mounted with no auth middleware, so any unauthenticated client could revoke any harvested JWT (by `jti`) or wipe every active session for any user (by `sub`). The handlers used `jsonwebtoken::dangerous::insecure_decode` to extract the `jti` from a body-supplied token without any proof-of-possession, so the attack required nothing beyond a network path to the server. Affected anyone running `[security.token_revocation] enabled = true`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -973,7 +973,7 @@ dependencies = [
  "http-body 0.4.6",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tracing",
 ]
@@ -1229,7 +1229,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -3335,7 +3335,7 @@ dependencies = [
  "dashmap",
  "fraiseql-error",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 1.4.0",
  "jsonwebtoken",
  "parking_lot",
@@ -3345,8 +3345,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx",
  "subtle",
  "temp-env",
@@ -3389,7 +3389,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "temp-env",
  "tempfile",
@@ -3428,7 +3428,7 @@ dependencies = [
  "futures",
  "graphql-parser",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "hostname",
  "indexmap 2.14.0",
  "insta",
@@ -3448,7 +3448,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "subtle",
  "temp-env",
@@ -3554,10 +3554,11 @@ dependencies = [
  "fraiseql-error",
  "fraiseql-observers",
  "fraiseql-storage",
+ "hex",
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlparser",
  "sqlx",
  "testcontainers",
@@ -3598,7 +3599,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "tabwriter",
  "temp-env",
@@ -3676,7 +3677,7 @@ dependencies = [
  "futures",
  "graphql-parser",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3704,8 +3705,8 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx",
  "subtle",
  "temp-env",
@@ -3749,7 +3750,7 @@ dependencies = [
  "criterion",
  "fraiseql-error",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "image",
  "jsonwebtoken",
  "kamadak-exif",
@@ -3757,7 +3758,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "tempfile",
  "testcontainers",
@@ -3793,14 +3794,14 @@ dependencies = [
  "fraiseql-error",
  "futures",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "p256 0.13.2",
  "rand 0.9.4",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx",
  "subtle",
  "thiserror 2.0.18",
@@ -3818,7 +3819,7 @@ dependencies = [
  "bytes",
  "criterion",
  "futures",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "metrics 0.22.4",
  "pbkdf2",
  "proptest",
@@ -3829,7 +3830,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "socket2 0.6.3",
  "subtle",
  "testcontainers",
@@ -6132,12 +6133,12 @@ checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
+ "digest 0.11.2",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -7967,6 +7968,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8351,7 +8363,7 @@ dependencies = [
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -9194,7 +9206,7 @@ dependencies = [
  "constant_time_eq",
  "hmac 0.12.1",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "url",
  "urlencoding",
@@ -9389,7 +9401,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls 0.23.40",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -9406,7 +9418,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.3.0"}
 futures = "0.3"
 graphql-parser = "0.4"
 hex = "0.4"
-hmac = "0.12"
+hmac = "0.13"
 hyper = {version = "1.0"}
 indexmap = {version = "2", features = ["serde"]}
 itertools = "0.14"
@@ -107,7 +107,7 @@ rusqlite = {version = "0.32", features = ["bundled"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 # Crypto
-sha2 = "0.10"
+sha2 = "0.11"
 # SQL toolkit (MySQL feature gated behind per-crate optional flags)
 sqlx = {version = "0.8", features = ["runtime-tokio", "json"]}
 # Testing utilities

--- a/crates/fraiseql-auth/Cargo.toml
+++ b/crates/fraiseql-auth/Cargo.toml
@@ -10,7 +10,7 @@ chrono = {workspace = true}
 dashmap = {workspace = true}
 fraiseql-error = {workspace = true}
 hex = "0.4"
-hmac = {version = "0.12", features = ["std"]}
+hmac = "0.13"
 http = "1"
 jsonwebtoken = {version = "10", features = ["rust_crypto"]}
 parking_lot = {workspace = true}
@@ -20,8 +20,8 @@ redis = {workspace = true, optional = true}
 reqwest = {workspace = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = "0.11"
+sha2 = "0.11"
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio", "uuid", "chrono"]}
 subtle = "2.5"
 totp-rs = {version = "5", features = ["gen_secret", "otpauth"]}

--- a/crates/fraiseql-auth/src/audit/chain.rs
+++ b/crates/fraiseql-auth/src/audit/chain.rs
@@ -24,7 +24,7 @@
 //! chain_seed_env = "AUDIT_CHAIN_SEED"  # 32-byte hex-encoded value
 //! ```
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;

--- a/crates/fraiseql-auth/src/session.rs
+++ b/crates/fraiseql-auth/src/session.rs
@@ -179,7 +179,7 @@ pub fn unix_now() -> Result<u64> {
 pub fn hash_token(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 /// Generate a cryptographically secure refresh token.

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -2682,7 +2682,7 @@ mod validate_documents_tests {
         let path = dir.path().join("manifest.json");
 
         let query = "{ users { id } }";
-        let hash = format!("{:x}", Sha256::digest(query.as_bytes()));
+        let hash = hex::encode(Sha256::digest(query.as_bytes()));
         let manifest = serde_json::json!({
             "version": 1,
             "documents": {

--- a/crates/fraiseql-cli/src/commands/validate_documents.rs
+++ b/crates/fraiseql-cli/src/commands/validate_documents.rs
@@ -89,7 +89,7 @@ pub fn run(manifest_path: &str, formatter: &OutputFormatter) -> Result<bool> {
         }
 
         // Compute SHA-256 of the query body and compare
-        let computed = format!("{:x}", Sha256::digest(body.as_bytes()));
+        let computed = hex::encode(Sha256::digest(body.as_bytes()));
         if computed == hash_hex {
             results.push(EntryResult {
                 key:   key.clone(),

--- a/crates/fraiseql-cli/tests/validate_documents_command_tests.rs
+++ b/crates/fraiseql-cli/tests/validate_documents_command_tests.rs
@@ -30,7 +30,7 @@ fn write_manifest(dir: &tempfile::TempDir, content: &serde_json::Value) -> Strin
 
 /// Compute the `sha256:` prefixed key for a query body.
 fn sha256_key(query: &str) -> String {
-    let hash = format!("{:x}", Sha256::digest(query.as_bytes()));
+    let hash = hex::encode(Sha256::digest(query.as_bytes()));
     format!("sha256:{hash}")
 }
 
@@ -158,7 +158,7 @@ fn validate_documents_partial_mismatch_exits_nonzero() {
 fn validate_documents_hash_without_prefix_is_accepted() {
     let dir = tempfile::tempdir().unwrap();
     let query = "query GetOrders { orders { id status } }";
-    let hash = format!("{:x}", Sha256::digest(query.as_bytes()));
+    let hash = hex::encode(Sha256::digest(query.as_bytes()));
     // Key without `sha256:` prefix
     let manifest = serde_json::json!({
         "version": 1,

--- a/crates/fraiseql-core/src/runtime/subscription/webhook.rs
+++ b/crates/fraiseql-core/src/runtime/subscription/webhook.rs
@@ -176,7 +176,7 @@ impl WebhookAdapter {
 
     /// Compute HMAC-SHA256 signature for payload.
     fn compute_signature(&self, payload: &str) -> Option<String> {
-        use hmac::{Hmac, Mac};
+        use hmac::{Hmac, KeyInit, Mac};
         use sha2::Sha256;
 
         let secret = self.config.secret.as_ref()?;

--- a/crates/fraiseql-core/src/security/audit.rs
+++ b/crates/fraiseql-core/src/security/audit.rs
@@ -121,7 +121,7 @@ impl AuditEntry {
             hasher.update(prev.as_bytes());
         }
 
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     }
 
     /// Verify integrity of this entry against its stored hash

--- a/crates/fraiseql-functions/Cargo.toml
+++ b/crates/fraiseql-functions/Cargo.toml
@@ -27,6 +27,7 @@ tracing.workspace = true
 tokio.workspace = true
 trait-variant = "0.1"
 chrono = {workspace = true}
+hex.workspace = true
 sha2.workspace = true
 sqlparser = {version = "0.62", optional = true}
 reqwest = {workspace = true, optional = true}

--- a/crates/fraiseql-functions/src/types.rs
+++ b/crates/fraiseql-functions/src/types.rs
@@ -42,7 +42,7 @@ pub struct FunctionModule {
 impl FunctionModule {
     /// Create a new WASM module from compiled bytecode.
     pub fn from_bytecode(name: String, bytecode: bytes::Bytes) -> Self {
-        let source_hash = format!("{:x}", sha2::Sha256::digest(&bytecode));
+        let source_hash = hex::encode(sha2::Sha256::digest(&bytecode));
         Self {
             name,
             source_hash,
@@ -55,7 +55,7 @@ impl FunctionModule {
     #[must_use]
     pub fn from_source(name: String, source: String, runtime: RuntimeType) -> Self {
         let bytecode = bytes::Bytes::from(source);
-        let source_hash = format!("{:x}", sha2::Sha256::digest(&bytecode));
+        let source_hash = hex::encode(sha2::Sha256::digest(&bytecode));
         Self {
             name,
             source_hash,

--- a/crates/fraiseql-observers/Cargo.toml
+++ b/crates/fraiseql-observers/Cargo.toml
@@ -22,7 +22,7 @@ redis = {workspace = true, optional = true}
 reqwest = {workspace = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha2 = "0.10"
+sha2 = "0.11"
 # sqlx with multiple database backends (features enabled conditionally)
 sqlx = {version = "0.8", features = ["runtime-tokio", "uuid", "chrono"]}
 tabwriter = {version = "1.4", optional = true}

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -67,7 +67,7 @@ futures = "0.3"
 graphql-parser = {workspace = true}
 hex = "0.4"
 # Webhook signature verification
-hmac = "0.12"
+hmac = "0.13"
 http = "1"
 http-body = { version = "1.0.1", optional = true }
 http-body-util = { version = "0.1.3", optional = true }
@@ -103,8 +103,8 @@ rust-embed = {version = "8", features = ["interpolate-folder-path"]}
 # Serialization
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = "0.11"
+sha2 = "0.11"
 # Database
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio", "uuid", "chrono"]}
 # Constant-time comparison (timing attack prevention)

--- a/crates/fraiseql-server/src/routes/functions/mod.rs
+++ b/crates/fraiseql-server/src/routes/functions/mod.rs
@@ -79,7 +79,7 @@ pub async fn invoke_function_handler(
     // Convert the stored record into an executable module.
     let module = FunctionModule {
         name:        record.name.clone(),
-        source_hash: format!("{:x}", sha2::Sha256::digest(&record.bytecode)),
+        source_hash: hex::encode(sha2::Sha256::digest(&record.bytecode)),
         bytecode:    record.bytecode,
         runtime:     record.runtime,
     };

--- a/crates/fraiseql-server/src/storage/azure.rs
+++ b/crates/fraiseql-server/src/storage/azure.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
 use fraiseql_error::FileError;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::{StorageBackend, StorageResult, validate_key};

--- a/crates/fraiseql-storage/Cargo.toml
+++ b/crates/fraiseql-storage/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1", features = ["fs", "io-util", "rt"] }
 axum = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 thiserror = "1"
 tracing = "0.1"

--- a/crates/fraiseql-storage/src/backend/azure.rs
+++ b/crates/fraiseql-storage/src/backend/azure.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
 use fraiseql_error::{FileError, FraiseQLError, Result};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::validate_key;

--- a/crates/fraiseql-storage/src/transforms/cache.rs
+++ b/crates/fraiseql-storage/src/transforms/cache.rs
@@ -98,7 +98,7 @@ impl TransformCache {
         // Compute source data hash for cache validation
         let mut hasher = Sha256::new();
         hasher.update(source_data);
-        let source_hash = format!("{:x}", hasher.finalize());
+        let source_hash = hex::encode(hasher.finalize());
 
         // Try to get from cache
         if let Ok(cached_data) = self.backend.download(&cache_key).await {

--- a/crates/fraiseql-webhooks/Cargo.toml
+++ b/crates/fraiseql-webhooks/Cargo.toml
@@ -4,12 +4,12 @@ ed25519-dalek = {version = "2", features = ["std"]}
 fraiseql-error = {workspace = true}
 futures = "0.3"
 hex = "0.4"
-hmac = "0.12"
+hmac = "0.13"
 p256 = {version = "0.13", features = ["ecdsa", "pem"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-sha1 = "0.10"
-sha2 = "0.10"
+sha1 = "0.11"
+sha2 = "0.11"
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio"]}
 subtle = "2.5"
 thiserror = "2.0"

--- a/crates/fraiseql-webhooks/src/signature/generic.rs
+++ b/crates/fraiseql-webhooks/src/signature/generic.rs
@@ -1,6 +1,6 @@
 //! Generic HMAC signature verifiers.
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha1::Sha1;
 use sha2::Sha256;
 

--- a/crates/fraiseql-webhooks/src/signature/github.rs
+++ b/crates/fraiseql-webhooks/src/signature/github.rs
@@ -3,7 +3,7 @@
 //! Format: `sha256=<hex>`
 //! Algorithm: HMAC-SHA256
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/github/tests.rs
+++ b/crates/fraiseql-webhooks/src/signature/github/tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::*;

--- a/crates/fraiseql-webhooks/src/signature/lemonsqueezy.rs
+++ b/crates/fraiseql-webhooks/src/signature/lemonsqueezy.rs
@@ -3,7 +3,7 @@
 //! Format: Base64 encoded HMAC-SHA256
 
 use base64::{Engine as _, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/paddle.rs
+++ b/crates/fraiseql-webhooks/src/signature/paddle.rs
@@ -5,7 +5,7 @@
 //!
 //! See: <https://developer.paddle.com/webhooks/signature-verification>
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/paddle/tests.rs
+++ b/crates/fraiseql-webhooks/src/signature/paddle/tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::*;

--- a/crates/fraiseql-webhooks/src/signature/postmark.rs
+++ b/crates/fraiseql-webhooks/src/signature/postmark.rs
@@ -3,7 +3,7 @@
 //! Format: Base64 encoded HMAC-SHA256
 
 use base64::{Engine as _, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/shopify.rs
+++ b/crates/fraiseql-webhooks/src/signature/shopify.rs
@@ -3,7 +3,7 @@
 //! Format: Base64 encoded HMAC-SHA256
 
 use base64::{Engine as _, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/shopify/tests.rs
+++ b/crates/fraiseql-webhooks/src/signature/shopify/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
 use base64::{Engine as _, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::*;

--- a/crates/fraiseql-webhooks/src/signature/slack.rs
+++ b/crates/fraiseql-webhooks/src/signature/slack.rs
@@ -5,7 +5,7 @@
 //!
 //! Timestamps older than 5 minutes are rejected to prevent replay attacks.
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/slack/tests.rs
+++ b/crates/fraiseql-webhooks/src/signature/slack/tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::*;

--- a/crates/fraiseql-webhooks/src/signature/stripe.rs
+++ b/crates/fraiseql-webhooks/src/signature/stripe.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/stripe/tests.rs
+++ b/crates/fraiseql-webhooks/src/signature/stripe/tests.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 use super::*;

--- a/crates/fraiseql-webhooks/src/signature/twilio.rs
+++ b/crates/fraiseql-webhooks/src/signature/twilio.rs
@@ -10,7 +10,7 @@
 //! See: <https://www.twilio.com/docs/usage/webhooks/webhooks-security>
 
 use base64::{Engine as _, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha1::Sha1;
 
 use crate::{

--- a/crates/fraiseql-webhooks/src/signature/twilio/tests.rs
+++ b/crates/fraiseql-webhooks/src/signature/twilio/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
 use base64::{Engine as _, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha1::Sha1;
 
 use super::*;

--- a/crates/fraiseql-webhooks/tests/sendgrid_replay_test.rs
+++ b/crates/fraiseql-webhooks/tests/sendgrid_replay_test.rs
@@ -83,7 +83,7 @@ fn valid_ecdsa_p256_signature_over_timestamp_and_payload_verifies() {
 /// a forged HMAC signature does NOT pass the ECDSA verifier.
 #[test]
 fn hmac_sha256_forged_signature_is_rejected_by_ecdsa_verifier() {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
 
     let (_signing_key, pem_public_key) = generate_p256_key();

--- a/crates/fraiseql-webhooks/tests/slack_replay_test.rs
+++ b/crates/fraiseql-webhooks/tests/slack_replay_test.rs
@@ -14,7 +14,7 @@
 use fraiseql_webhooks::{
     SignatureError, signature::slack::SlackVerifier, traits::SignatureVerifier as _,
 };
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
 const SIGNING_SECRET: &str = "8f742231b10e8888abcd99yyyzzz85a5";

--- a/crates/fraiseql-webhooks/tests/twilio_replay_test.rs
+++ b/crates/fraiseql-webhooks/tests/twilio_replay_test.rs
@@ -14,7 +14,7 @@
 
 use base64::{Engine as _, engine::general_purpose};
 use fraiseql_webhooks::{signature::twilio::TwilioVerifier, traits::SignatureVerifier as _};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha1::Sha1;
 
 // ---------------------------------------------------------------------------

--- a/crates/fraiseql-wire/Cargo.toml
+++ b/crates/fraiseql-wire/Cargo.toml
@@ -22,10 +22,10 @@ base64 = "0.22"  # Base64 encoding/decoding
 # Bytes manipulation
 bytes = "1"
 futures = "0.3"
-hmac = "0.12"  # HMAC-SHA256
+hmac = "0.13"  # HMAC-SHA256
 # Metrics for observability
 metrics = "0.22"  # Metrics collection framework
-pbkdf2 = "0.12"  # Key derivation for SCRAM
+pbkdf2 = "0.13"  # Key derivation for SCRAM
 rand = "0.9"  # Random nonce generation
 # TLS support
 rustls = {version = "0.23", features = ["ring"]}
@@ -36,7 +36,7 @@ rustls-pki-types = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 # Cryptography for SCRAM authentication
-sha2 = "0.10"  # HMAC-SHA256 for SCRAM
+sha2 = "0.11"  # HMAC-SHA256 for SCRAM
 socket2 = {version = "0.6", features = ["all"]}
 subtle = "2"  # Constant-time comparison for SCRAM
 # Error handling

--- a/crates/fraiseql-wire/src/auth/scram/mod.rs
+++ b/crates/fraiseql-wire/src/auth/scram/mod.rs
@@ -4,7 +4,7 @@
 //! as defined in RFC 5802 for PostgreSQL authentication (Postgres 10+).
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use pbkdf2::pbkdf2;
 use rand::Rng;
 use sha2::{Digest, Sha256};

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,11 @@ multiple-versions = "deny"
 wildcards = "allow"
 
 [[bans.skip]]
+name = "sha1"
+reason = "transitive via sqlx-mysql (pinned to sha1 0.10.x); workspace direct on sha1 0.11 (#300)"
+version = "=0.10.6"
+
+[[bans.skip]]
 name = "aws-smithy-http"
 reason = "aws-sdk-s3 transitively depends on two smithy-http versions"
 version = "=0.62.6"


### PR DESCRIPTION
Closes #300.

## Summary

Cherry-pick of \`3ce0844ca\` from the original \`fix/329-session-vars-connection-affinity\` bundle. Realigns the RustCrypto hashing stack on the \`digest 0.11\` / \`crypto-common 0.2\` generation. The issue named only \`sha1\` + \`hmac\`, but a spike proved the digest major bump couples the whole family: \`sha2\` and \`pbkdf2\` (the wire SCRAM PRF) cannot stay on digest 0.10 alongside an \`hmac 0.13\` / \`sha1 0.11\` workspace, or trait bounds (\`FixedOutput\` / \`KeyInit\`) no longer resolve.

This is functionally equivalent to PR #324 (which we closed during the v2.4.0 stack prep) — same 41-file diff plus the CHANGELOG entry. Cherry-picked here so the work lands cleanly on the current \`dev\` (post-B1–B6 + #328).

## Changes

- **Manifests:** \`sha1 0.10→0.11\`, \`sha2 0.10→0.11\`, \`hmac 0.12→0.13\`, \`pbkdf2 0.12→0.13\` across workspace + per-crate pins (auth, webhooks, wire, server, storage, observers); dropped the removed \`std\` feature from auth's hmac; added \`hex\` to fraiseql-functions for the formatting fix.
- **API:** imported \`KeyInit\` for \`Hmac::new_from_slice\` in 23 files (the method moved off the \`Mac\` trait); replaced \`format!(\"{:x}\", <digest>)\` with \`hex::encode(...)\` at 8 sites — digest's \`Output\` is now \`hybrid-array::Array\`, which (unlike \`generic-array\`) has no \`LowerHex\`. Integer-hash \`{:x}\` sites (fnv1a, simple_hash) left untouched.
- **deny.toml:** re-added the \`sha1 =0.10.6\` ban skip (transitive via sqlx-mysql) that #298 removed when it reverted the standalone bump.
- **CHANGELOG:** documented under \`[Unreleased]\` → \`### Changed\`.

## Verification

- [x] \`cargo check --workspace --all-targets\` → clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` → clean
- [x] \`cargo deny check\` → advisories/bans/licenses/sources ok
- [x] CHANGELOG conflict (against B1–B6 \`[Unreleased]\` content) resolved by adding a clean \`### Changed\` block

## Why a cherry-pick

The original \`fix/329-session-vars-connection-affinity\` branch bundled 8 items into one 21-commit branch. PR #324 (your earlier evoludigit-authored standalone PR) was the same fix but stale vs current dev. Per the v2.4.0 release plan, each item ships as its own focused PR off current dev. #324 was closed in favour of this bundled commit; this PR is the bundled commit, extracted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)