### PR TITLE
fix: root { __typename } resolution (#450) + PostgreSQL prepare-error diagnostic (#451)

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -116,6 +116,26 @@ jobs:
           fi
           echo "GraphQL query smoke OK."
 
+      - name: Smoke the root __typename health probe (#450)
+        run: |
+          set -eu
+          # `{ __typename }` is the canonical zero-cost "is this a reachable GraphQL
+          # endpoint" probe used by many clients/test harnesses. It must resolve to
+          # the root operation type name ("Query") — #450 regressed this to a
+          # "Query '__typename' not found in schema" validation error.
+          status=$(curl -s -o /tmp/typename.json -w '%{http_code}' \
+            -X POST http://127.0.0.1:8815/graphql \
+            -H 'Content-Type: application/json' \
+            -d '{"query":"{ __typename }"}')
+          echo "HTTP $status"; cat /tmp/typename.json; echo
+          test "$status" = "200" || { echo "::error::/graphql __typename returned HTTP $status (expected 200)" >&2; exit 1; }
+          grep -q '"__typename"[[:space:]]*:[[:space:]]*"Query"' /tmp/typename.json \
+            || { echo "::error::/graphql { __typename } did not resolve to \"Query\"" >&2; exit 1; }
+          if grep -q '"errors"' /tmp/typename.json; then
+            echo "::error::/graphql { __typename } response contained errors" >&2; exit 1
+          fi
+          echo "Root __typename probe smoke OK."
+
       - name: Stop server
         if: always()
         run: kill "$(cat /tmp/fraiseql-server.pid 2>/dev/null)" 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Root `{ __typename }` resolves to the operation type name (#450).** A top-level
+  `{ __typename }` — the canonical zero-cost GraphQL health probe — was rejected with
+  `Query '__typename' not found in schema` because the query classifier only
+  special-cased `__schema`/`__type`. Per the GraphQL spec, `__typename` is a
+  meta-field available at every selection set; at the root it resolves to the
+  operation's root type name (`Query`/`Mutation`/`Subscription`). It now resolves with
+  no database round-trip — including when aliased (`{ ping: __typename }`), mixed with
+  real fields (`{ __typename users { id } }`, either order), repeated
+  (`{ a: __typename b: __typename }`), on a `mutation`, and under `@skip`/`@include`.
+  (Fragment-wrapped root `__typename` is not yet special-cased.)
+- **PostgreSQL statement-prepare failures surface the real diagnostic (#451).** A
+  failed prepare previously surfaced the opaque `Failed to prepare statement: db error`,
+  dropping the PostgreSQL diagnostic (e.g. `function "foo" does not exist`,
+  SQLSTATE 42883) that names the offending object — making server↔database contract
+  drift undiagnosable from logs. The diagnostic is now extracted into the message (the
+  SQL state was already populated); client-facing error sanitization is unchanged.
+
 ## [2.9.0] - 2026-06-22
 
 ### Security

--- a/crates/fraiseql-core/src/runtime/executor/execution.rs
+++ b/crates/fraiseql-core/src/runtime/executor/execution.rs
@@ -209,13 +209,33 @@ impl<A: DatabaseAdapter> Executor<A> {
                     .await
             },
             QueryType::TypeName {
-                response_key,
+                selection,
                 operation_type,
             } => {
                 // Root `__typename` meta-field: resolve to the operation's root
                 // type name with no DB round-trip (spec §"Type Name Introspection").
-                let ty = root_type_name(&operation_type);
-                Ok(serde_json::json!({ "data": { response_key: ty } }))
+                // Honour `@skip`/`@include` on the field — a skipped meta-field is
+                // omitted from `data`, exactly like any other skipped field.
+                let vars: std::collections::HashMap<String, serde_json::Value> = match variables {
+                    Some(serde_json::Value::Object(map)) => {
+                        map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+                    },
+                    _ => std::collections::HashMap::new(),
+                };
+                let included =
+                    crate::graphql::DirectiveEvaluator::evaluate_directives(&selection, &vars)
+                        .map_err(|e| FraiseQLError::Validation {
+                            message: e.to_string(),
+                            path:    Some("directives".to_string()),
+                        })?;
+                let mut data = serde_json::Map::new();
+                if included {
+                    data.insert(
+                        selection.response_key().to_string(),
+                        serde_json::Value::String(root_type_name(&operation_type).to_string()),
+                    );
+                }
+                Ok(serde_json::json!({ "data": data }))
             },
         }
     }

--- a/crates/fraiseql-core/src/runtime/executor/execution.rs
+++ b/crates/fraiseql-core/src/runtime/executor/execution.rs
@@ -3,7 +3,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use super::{Executor, QueryType, pipeline, support};
+use super::{Executor, QueryType, pipeline, root_type_name, support};
 use crate::{
     db::traits::DatabaseAdapter,
     error::{FraiseQLError, Result},
@@ -207,6 +207,15 @@ impl<A: DatabaseAdapter> Executor<A> {
                 self.query_runner()
                     .execute_node_query(query, variables, &selections, security_context)
                     .await
+            },
+            QueryType::TypeName {
+                response_key,
+                operation_type,
+            } => {
+                // Root `__typename` meta-field: resolve to the operation's root
+                // type name with no DB round-trip (spec §"Type Name Introspection").
+                let ty = root_type_name(&operation_type);
+                Ok(serde_json::json!({ "data": { response_key: ty } }))
             },
         }
     }

--- a/crates/fraiseql-core/src/runtime/executor/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/mod.rs
@@ -237,11 +237,18 @@ enum QueryType {
     /// Root `__typename` meta-field — a single-root selection consisting solely
     /// of `__typename` (optionally aliased). Resolves to the operation's root
     /// type name (`Query` / `Mutation` / `Subscription`) without a DB round-trip.
-    /// Mixed roots (`{ __typename users { id } }`) are not classified here; they
-    /// fall through to `Regular` and are resolved in the multi-root pipeline.
+    ///
+    /// Carries the root [`FieldSelection`](crate::graphql::FieldSelection) so the
+    /// executor can honour the response key (alias) and evaluate `@skip` /
+    /// `@include` directives against the request variables.
+    ///
+    /// Scope: mixed roots (`{ __typename users { id } }`) are not classified
+    /// here — they fall through to `Regular` and are resolved by the multi-root
+    /// pipeline. Fragment-wrapped root `__typename` (`{ ...F }` or
+    /// `{ ... on Query { __typename } }`) is likewise not special-cased.
     TypeName {
-        /// Response key (alias if provided, otherwise `__typename`).
-        response_key:   String,
+        /// The root `__typename` selection (alias + `@skip`/`@include` directives).
+        selection:      Box<crate::graphql::FieldSelection>,
         /// Operation type string from the parsed query (`query` / `mutation` /
         /// `subscription`), used to resolve the root type name.
         operation_type: String,

--- a/crates/fraiseql-core/src/runtime/executor/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/mod.rs
@@ -233,6 +233,33 @@ enum QueryType {
     NodeQuery {
         selections: Vec<crate::graphql::FieldSelection>,
     },
+
+    /// Root `__typename` meta-field — a single-root selection consisting solely
+    /// of `__typename` (optionally aliased). Resolves to the operation's root
+    /// type name (`Query` / `Mutation` / `Subscription`) without a DB round-trip.
+    /// Mixed roots (`{ __typename users { id } }`) are not classified here; they
+    /// fall through to `Regular` and are resolved in the multi-root pipeline.
+    TypeName {
+        /// Response key (alias if provided, otherwise `__typename`).
+        response_key:   String,
+        /// Operation type string from the parsed query (`query` / `mutation` /
+        /// `subscription`), used to resolve the root type name.
+        operation_type: String,
+    },
+}
+
+/// Resolve a GraphQL operation type string to its root type name.
+///
+/// Matches the hardcoded root type names emitted by the introspection schema
+/// builder (`Query` / `Mutation` / `Subscription`), so a root `__typename`
+/// resolves to the same name as `__schema { queryType { name } }`. Defaults to
+/// `Query` for unknown operation strings.
+pub(in crate::runtime::executor) fn root_type_name(operation_type: &str) -> &'static str {
+    match operation_type {
+        "mutation" => "Mutation",
+        "subscription" => "Subscription",
+        _ => "Query",
+    }
 }
 
 /// Null out masked fields in a projected JSON result.

--- a/crates/fraiseql-core/src/runtime/executor/support/authz.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/authz.rs
@@ -39,7 +39,9 @@ pub(in crate::runtime::executor) fn collect_authz_ops(
         QueryType::IntrospectionSchema => vec![(OperationKind::Query, "__schema".to_string())],
         QueryType::IntrospectionType(_) => vec![(OperationKind::Query, "__type".to_string())],
         QueryType::NodeQuery { .. } => vec![(OperationKind::Query, "node".to_string())],
-        // Mutations are gated at `execute_mutation_impl` (see fn-level docs).
-        QueryType::Mutation { .. } => Vec::new(),
+        // Both yield an empty op-list:
+        // - `Mutation` is gated downstream at `execute_mutation_impl` (see fn-level docs).
+        // - `TypeName` (`__typename`) is a GraphQL spec meta-field, always allowed.
+        QueryType::Mutation { .. } | QueryType::TypeName { .. } => Vec::new(),
     }
 }

--- a/crates/fraiseql-core/src/runtime/executor/support/classify.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/classify.rs
@@ -74,6 +74,25 @@ impl<A: DatabaseAdapter> Executor<A> {
             return Ok((QueryType::IntrospectionType(type_name.unwrap_or_default()), None));
         }
 
+        // Root `__typename` meta-field (GraphQL spec §"Type Name Introspection"):
+        // a single-root selection consisting solely of `__typename` (optionally
+        // aliased) resolves to the operation's root type name without a DB
+        // round-trip. Placed before the mutation branch so `mutation { __typename }`
+        // and `subscription { __typename }` resolve correctly instead of being
+        // routed as a (missing) mutation field. The `len() == 1` guard is
+        // load-bearing: mixed roots like `{ __typename users { id } }` fall through
+        // to `Regular` and are resolved by the multi-root pipeline.
+        if root_field == "__typename" && parsed.selections.len() == 1 {
+            let response_key = parsed.selections[0].response_key().to_string();
+            return Ok((
+                QueryType::TypeName {
+                    response_key,
+                    operation_type: parsed.operation_type.clone(),
+                },
+                None,
+            ));
+        }
+
         // Federation (Apollo Federation v1/v2 entry-points).
         if root_field == "_service" || root_field == "_entities" {
             return Ok((QueryType::Federation(root_field.clone()), None));

--- a/crates/fraiseql-core/src/runtime/executor/support/classify.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/classify.rs
@@ -83,10 +83,9 @@ impl<A: DatabaseAdapter> Executor<A> {
         // load-bearing: mixed roots like `{ __typename users { id } }` fall through
         // to `Regular` and are resolved by the multi-root pipeline.
         if root_field == "__typename" && parsed.selections.len() == 1 {
-            let response_key = parsed.selections[0].response_key().to_string();
             return Ok((
                 QueryType::TypeName {
-                    response_key,
+                    selection:      Box::new(parsed.selections[0].clone()),
                     operation_type: parsed.operation_type.clone(),
                 },
                 None,

--- a/crates/fraiseql-core/src/runtime/executor/support/pipeline.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/pipeline.rs
@@ -15,7 +15,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::super::Executor;
+use super::super::{Executor, root_type_name};
 use crate::{
     db::traits::DatabaseAdapter,
     error::Result,
@@ -187,24 +187,35 @@ impl<A: DatabaseAdapter> Executor<A> {
     ) -> Result<PipelineResult> {
         MULTI_ROOT_QUERIES_TOTAL.fetch_add(1, Ordering::Relaxed);
 
-        // Pre-compute synthetic single-root query strings (owned — avoids borrow
-        // lifetime entanglement between iterations and the final zip).
-        let field_queries: Vec<(String, String)> = parsed
+        // Root `__typename` resolves to the operation's root type name with no DB
+        // round-trip (GraphQL spec §"Type Name Introspection"). It is a meta-field
+        // available at every selection set, including the root; dispatching it as a
+        // regular sub-query would fail `find_query`. We resolve it locally and only
+        // dispatch the genuine data-bearing roots.
+        let root_type = root_type_name(&parsed.operation_type);
+
+        // Synthetic single-root query strings for every data-bearing selection,
+        // tagged with their original index so results can be reassembled in request
+        // order. `__typename` roots are skipped here and resolved below. (Owned —
+        // avoids borrow lifetime entanglement between iterations and the final zip.)
+        let dispatched: Vec<(usize, String, String)> = parsed
             .selections
             .iter()
-            .map(|f| (f.response_key().to_string(), field_selection_to_query(f)))
+            .enumerate()
+            .filter(|(_, f)| f.name != "__typename")
+            .map(|(i, f)| (i, f.response_key().to_string(), field_selection_to_query(f)))
             .collect();
 
         // Pre-create one QueryRunner per sub-query (each is a cheap Arc::clone).
         // Storing them in a Vec ensures they live long enough for the futures to borrow from.
-        let runners: Vec<_> = field_queries.iter().map(|_| self.query_runner()).collect();
+        let runners: Vec<_> = dispatched.iter().map(|_| self.query_runner()).collect();
 
         // Build futures — each borrows from its corresponding runner in `runners`.
         // Both `runners` and `futs` are owned by this function scope, so the borrows are valid.
         let futs: Vec<_> = runners
             .iter()
-            .zip(field_queries.iter())
-            .map(|(runner, (_, query))| {
+            .zip(dispatched.iter())
+            .map(|(runner, (_, _, query))| {
                 runner.execute_regular_query_maybe_security(
                     query.as_str(),
                     variables,
@@ -216,18 +227,30 @@ impl<A: DatabaseAdapter> Executor<A> {
         // Drive all futures concurrently (single-threaded cooperative multitasking).
         let results = futures::future::try_join_all(futs).await?;
 
-        // Extract the per-field `data` from each `{"data":{"field":[...]}}` Value response.
-        let fields = results
+        // Extract the per-field `data` from each `{"data":{"field":[...]}}` response,
+        // keyed by the original selection index.
+        let mut dispatched_data: std::collections::HashMap<usize, serde_json::Value> = results
             .into_iter()
-            .zip(field_queries.iter())
-            .map(|(response, (field_name, _))| {
-                let data = response["data"][field_name.as_str()].clone();
-                Ok(RootFieldResult {
-                    field_name: field_name.clone(),
-                    data,
-                })
+            .zip(dispatched.iter())
+            .map(|(response, (index, key, _))| (*index, response["data"][key.as_str()].clone()))
+            .collect();
+
+        // Reassemble in request order: `__typename` roots resolve locally; every
+        // other root pulls its dispatched data by index.
+        let fields = parsed
+            .selections
+            .iter()
+            .enumerate()
+            .map(|(index, f)| {
+                let field_name = f.response_key().to_string();
+                let data = if f.name == "__typename" {
+                    serde_json::Value::String(root_type.to_string())
+                } else {
+                    dispatched_data.remove(&index).unwrap_or(serde_json::Value::Null)
+                };
+                RootFieldResult { field_name, data }
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect();
 
         Ok(PipelineResult {
             fields,

--- a/crates/fraiseql-core/src/runtime/executor/support/pipeline.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/pipeline.rs
@@ -192,6 +192,12 @@ impl<A: DatabaseAdapter> Executor<A> {
         // available at every selection set, including the root; dispatching it as a
         // regular sub-query would fail `find_query`. We resolve it locally and only
         // dispatch the genuine data-bearing roots.
+        //
+        // NOTE: `@skip`/`@include` on a root field are not honoured on the
+        // multi-root path — `field_selection_to_query` drops directives when it
+        // re-serializes every root (a pre-existing limitation for all multi-root
+        // fields, not specific to `__typename`). The single-root `TypeName` path
+        // does honour them.
         let root_type = root_type_name(&parsed.operation_type);
 
         // Synthetic single-root query strings for every data-bearing selection,

--- a/crates/fraiseql-core/src/runtime/executor/support/planning.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/planning.rs
@@ -117,6 +117,13 @@ impl<A: DatabaseAdapter> Executor<A> {
                 views_accessed: Vec::new(),
                 query_type:     "introspection".to_string(),
             }),
+            QueryType::TypeName { .. } => Ok(ExplainPlan {
+                sql:            String::new(),
+                parameters:     Vec::new(),
+                estimated_cost: 0,
+                views_accessed: Vec::new(),
+                query_type:     "typename".to_string(),
+            }),
             QueryType::Federation(_) => Ok(ExplainPlan {
                 sql:            String::new(),
                 parameters:     Vec::new(),

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -154,6 +154,42 @@ mod typename {
         let result = executor.execute("{ ping: __typename }", None).await.unwrap();
         assert_eq!(result, serde_json::json!({ "data": { "ping": "Query" } }));
     }
+
+    #[tokio::test]
+    async fn test_root_typename_mixed_with_regular_field() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(mock_user_results()));
+        let executor = Executor::new(schema, adapter);
+
+        // Mixed root: `__typename` resolves locally while `users` is dispatched.
+        let result = executor.execute("{ __typename users { id } }", None).await.unwrap();
+        assert_eq!(result["data"]["__typename"], "Query");
+        assert!(result["data"]["users"].is_array());
+        assert!(result["data"]["users"][0].get("id").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_root_typename_mixed_trailing() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(mock_user_results()));
+        let executor = Executor::new(schema, adapter);
+
+        // Order-independent: `__typename` after the real field must still resolve.
+        let result = executor.execute("{ users { id } __typename }", None).await.unwrap();
+        assert_eq!(result["data"]["__typename"], "Query");
+        assert!(result["data"]["users"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_root_typename_multiple_aliased() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // Several aliased `__typename` roots, no DB round-trip at all.
+        let result = executor.execute("{ a: __typename b: __typename }", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({ "data": { "a": "Query", "b": "Query" } }));
+    }
 }
 
 // ── mod classify: query type detection ───────────────────────────────────

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -190,6 +190,53 @@ mod typename {
         let result = executor.execute("{ a: __typename b: __typename }", None).await.unwrap();
         assert_eq!(result, serde_json::json!({ "data": { "a": "Query", "b": "Query" } }));
     }
+
+    #[tokio::test]
+    async fn test_root_typename_skipped_directive() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // `@skip(if: true)` omits the meta-field, exactly like any other field.
+        let result = executor.execute("{ __typename @skip(if: true) }", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({ "data": {} }));
+    }
+
+    #[tokio::test]
+    async fn test_root_typename_excluded_directive() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        let result = executor.execute("{ __typename @include(if: false) }", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({ "data": {} }));
+    }
+
+    #[tokio::test]
+    async fn test_root_typename_kept_directive() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // `@skip(if: false)` keeps the field — resolves to "Query".
+        let result = executor.execute("{ __typename @skip(if: false) }", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({ "data": { "__typename": "Query" } }));
+    }
+
+    #[tokio::test]
+    async fn test_root_typename_skip_via_variable() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // Directive condition driven by a request variable.
+        let vars = serde_json::json!({ "drop": true });
+        let result = executor
+            .execute("query($drop: Boolean!) { __typename @skip(if: $drop) }", Some(&vars))
+            .await
+            .unwrap();
+        assert_eq!(result, serde_json::json!({ "data": {} }));
+    }
 }
 
 // ── mod classify: query type detection ───────────────────────────────────
@@ -227,13 +274,16 @@ mod classify {
         let executor = Executor::new(schema, adapter);
 
         let query = r"{ __typename }";
-        assert_eq!(
-            executor.classify_query(query).unwrap(),
+        match executor.classify_query(query).unwrap() {
             QueryType::TypeName {
-                response_key:   "__typename".to_string(),
-                operation_type: "query".to_string(),
+                selection,
+                operation_type,
+            } => {
+                assert_eq!(selection.response_key(), "__typename");
+                assert_eq!(operation_type, "query");
             },
-        );
+            other => panic!("expected TypeName, got {other:?}"),
+        }
     }
 
     #[test]
@@ -244,13 +294,16 @@ mod classify {
 
         // The response key is the alias when one is provided.
         let query = r"{ ping: __typename }";
-        assert_eq!(
-            executor.classify_query(query).unwrap(),
+        match executor.classify_query(query).unwrap() {
             QueryType::TypeName {
-                response_key:   "ping".to_string(),
-                operation_type: "query".to_string(),
+                selection,
+                operation_type,
+            } => {
+                assert_eq!(selection.response_key(), "ping");
+                assert_eq!(operation_type, "query");
             },
-        );
+            other => panic!("expected TypeName, got {other:?}"),
+        }
     }
 
     #[test]
@@ -262,13 +315,16 @@ mod classify {
         // `mutation { __typename }` resolves to the Mutation root type — the
         // classifier branch must precede the mutation branch.
         let query = r"mutation { __typename }";
-        assert_eq!(
-            executor.classify_query(query).unwrap(),
+        match executor.classify_query(query).unwrap() {
             QueryType::TypeName {
-                response_key:   "__typename".to_string(),
-                operation_type: "mutation".to_string(),
+                selection,
+                operation_type,
+            } => {
+                assert_eq!(selection.response_key(), "__typename");
+                assert_eq!(operation_type, "mutation");
             },
-        );
+            other => panic!("expected TypeName, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -129,6 +129,33 @@ mod introspection {
     }
 }
 
+// ── mod typename: root __typename meta-field (#450) ───────────────────────
+
+mod typename {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_root_typename_resolves_to_query() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // The canonical zero-cost health probe: `{ __typename }` → "Query".
+        let result = executor.execute("{ __typename }", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({ "data": { "__typename": "Query" } }));
+    }
+
+    #[tokio::test]
+    async fn test_root_typename_aliased() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        let result = executor.execute("{ ping: __typename }", None).await.unwrap();
+        assert_eq!(result, serde_json::json!({ "data": { "ping": "Query" } }));
+    }
+}
+
 // ── mod classify: query type detection ───────────────────────────────────
 
 mod classify {
@@ -155,6 +182,69 @@ mod classify {
             executor.classify_query(query).unwrap(),
             QueryType::IntrospectionType("User".to_string()),
         );
+    }
+
+    #[test]
+    fn test_detect_root_typename() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        let query = r"{ __typename }";
+        assert_eq!(
+            executor.classify_query(query).unwrap(),
+            QueryType::TypeName {
+                response_key:   "__typename".to_string(),
+                operation_type: "query".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_detect_root_typename_aliased() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // The response key is the alias when one is provided.
+        let query = r"{ ping: __typename }";
+        assert_eq!(
+            executor.classify_query(query).unwrap(),
+            QueryType::TypeName {
+                response_key:   "ping".to_string(),
+                operation_type: "query".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_detect_root_typename_on_mutation() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // `mutation { __typename }` resolves to the Mutation root type — the
+        // classifier branch must precede the mutation branch.
+        let query = r"mutation { __typename }";
+        assert_eq!(
+            executor.classify_query(query).unwrap(),
+            QueryType::TypeName {
+                response_key:   "__typename".to_string(),
+                operation_type: "mutation".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_classify_typename_prefix_is_regular() {
+        let schema = test_schema();
+        let adapter = Arc::new(MockAdapter::new(vec![]));
+        let executor = Executor::new(schema, adapter);
+
+        // A field whose name merely begins with "__typename" must NOT be treated
+        // as the meta-field — exact match only (mirrors the node substring guard).
+        let query = r"{ __typenameExtra }";
+        assert_eq!(executor.classify_query(query).unwrap(), QueryType::Regular);
     }
 
     #[test]

--- a/crates/fraiseql-db/src/postgres/adapter/database.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/database.rs
@@ -375,11 +375,13 @@ async fn prepare_cached_stmt(
     sql: &str,
 ) -> Result<tokio_postgres::Statement> {
     client.prepare_cached(sql).await.map_err(|e| {
-        // Extract the underlying PostgreSQL diagnostic (SQLSTATE message, e.g.
-        // `function "foo" does not exist`) the same way the function-call path
-        // does — the top-level `Display` renders only as the opaque `db error`,
-        // dropping the one detail that names the offending object (#451). Fall
-        // back to `Display` so the message is never empty.
+        // Surface the underlying PostgreSQL diagnostic (SQLSTATE message, e.g.
+        // `function "foo" does not exist`). The top-level `Display` renders only
+        // as the opaque `db error`, dropping the one detail that names the
+        // offending object (#451). The function-call path extracts the same
+        // `as_db_error()` detail; here we put it *in place of* the useless
+        // `db error` (rather than alongside it), falling back to `Display` so the
+        // message is never empty.
         let detail = e.as_db_error().map_or_else(|| e.to_string(), |d| d.message().to_string());
         FraiseQLError::Database {
             message:   format!("Failed to prepare statement: {detail}"),

--- a/crates/fraiseql-db/src/postgres/adapter/database.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/database.rs
@@ -374,9 +374,17 @@ async fn prepare_cached_stmt(
     client: &deadpool_postgres::Client,
     sql: &str,
 ) -> Result<tokio_postgres::Statement> {
-    client.prepare_cached(sql).await.map_err(|e| FraiseQLError::Database {
-        message:   format!("Failed to prepare statement: {e}"),
-        sql_state: e.code().map(|c| c.code().to_string()),
+    client.prepare_cached(sql).await.map_err(|e| {
+        // Extract the underlying PostgreSQL diagnostic (SQLSTATE message, e.g.
+        // `function "foo" does not exist`) the same way the function-call path
+        // does — the top-level `Display` renders only as the opaque `db error`,
+        // dropping the one detail that names the offending object (#451). Fall
+        // back to `Display` so the message is never empty.
+        let detail = e.as_db_error().map_or_else(|| e.to_string(), |d| d.message().to_string());
+        FraiseQLError::Database {
+            message:   format!("Failed to prepare statement: {detail}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        }
     })
 }
 

--- a/crates/fraiseql-db/tests/prepare_error_diagnostic.rs
+++ b/crates/fraiseql-db/tests/prepare_error_diagnostic.rs
@@ -1,0 +1,57 @@
+#![cfg(feature = "postgres")]
+#![allow(clippy::unwrap_used, clippy::print_stderr, clippy::panic)] // Reason: test code, panics are acceptable
+
+//! Regression proof for #451: a statement-prepare failure must surface the real
+//! PostgreSQL diagnostic, not the opaque `db error`.
+//!
+//! `prepare_cached_stmt` is the single prepare-error mapping site on the
+//! function-call path. Calling a function that does not exist makes PostgreSQL
+//! fail the *prepare* (Parse) with SQLSTATE `42883` ("function ... does not
+//! exist"). Before the fix the surfaced message was
+//! `Failed to prepare statement: db error` — the `e.as_db_error()` detail was
+//! discarded. This test asserts the human-readable diagnostic now rides through.
+//!
+//! Runs against the harness-provided PostgreSQL (Dagger-bound in CI via the
+//! `integrationPostgres` leg, or a local spawn with the `local-testcontainers`
+//! feature). It touches no shared tables, so it is isolation-safe.
+
+use fraiseql_db::{DatabaseAdapter, PostgresAdapter};
+use fraiseql_error::FraiseQLError;
+
+#[tokio::test]
+async fn prepare_failure_surfaces_postgres_diagnostic() {
+    let svc = fraiseql_test_support::postgres()
+        .await
+        .expect("DATABASE_URL must be set (or enable fraiseql-test-support/local-testcontainers)");
+    let adapter = PostgresAdapter::new(svc.url()).await.expect("build adapter");
+
+    // A function that cannot exist — the prepare of `SELECT * FROM fn()` fails at
+    // Parse time with SQLSTATE 42883 before any execution happens.
+    let missing_fn = "fraiseql_test_nonexistent_fn_42883";
+    let err = adapter
+        .execute_function_call(missing_fn, &[])
+        .await
+        .expect_err("calling a non-existent function must fail");
+
+    match err {
+        FraiseQLError::Database { message, sql_state } => {
+            // The real PostgreSQL diagnostic must be present...
+            assert!(
+                message.contains("does not exist"),
+                "expected the PostgreSQL diagnostic in the message, got: {message:?}"
+            );
+            assert!(
+                message.contains(missing_fn),
+                "expected the offending function name in the message, got: {message:?}"
+            );
+            // ...and the opaque top-level Display must no longer be the detail.
+            assert!(
+                !message.ends_with("db error"),
+                "message still ends with the opaque `db error`: {message:?}"
+            );
+            // SQLSTATE was already populated; assert it pins the function-not-found code.
+            assert_eq!(sql_state.as_deref(), Some("42883"), "expected SQLSTATE 42883");
+        },
+        other => panic!("expected FraiseQLError::Database, got: {other:?}"),
+    }
+}

--- a/crates/fraiseql-server/tests/typename_e2e_test.rs
+++ b/crates/fraiseql-server/tests/typename_e2e_test.rs
@@ -1,0 +1,73 @@
+//! End-to-end proof for #450: a root `{ __typename }` query resolves to the
+//! operation's root type name through the full HTTP → parse → classify →
+//! execute → serialize pipeline.
+//!
+//! The router is built over an EMPTY schema (no queries) backed by a
+//! `FailingAdapter` that errors on any database call. If `{ __typename }` still
+//! resolves to `"Query"`, it proves the meta-field is handled without a schema
+//! lookup or a DB round-trip — before the fix it was rejected with
+//! "Query '__typename' not found in schema". No auth layer is mounted, so this
+//! also confirms the probe works unauthenticated (it is not gated behind
+//! introspection-auth).
+
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(missing_docs)] // Reason: test code
+
+use std::sync::Arc;
+
+use axum::{Router, body::Body, routing::post};
+use fraiseql_core::{runtime::Executor, schema::CompiledSchema};
+use fraiseql_server::routes::graphql::{AppState, graphql_handler};
+use fraiseql_test_utils::failing_adapter::FailingAdapter;
+use http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+/// `/graphql` over an empty schema + a `FailingAdapter` (errors on any DB call).
+fn typename_router() -> Router {
+    let schema = CompiledSchema::new();
+    let adapter = Arc::new(FailingAdapter::new());
+    let state = AppState::new(Arc::new(Executor::new(schema, adapter)));
+    Router::new()
+        .route("/graphql", post(graphql_handler::<FailingAdapter>))
+        .with_state(state)
+}
+
+async fn post_graphql(router: Router, body: Value) -> (StatusCode, Value) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/graphql")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn root_typename_probe_resolves_to_query() {
+    let (status, body) =
+        post_graphql(typename_router(), json!({ "query": "{ __typename }" })).await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["data"]["__typename"], "Query", "body: {body}");
+    // A validation error would have produced `data: null` + an errors array.
+    assert!(body.get("errors").is_none(), "unexpected errors: {body}");
+}
+
+#[tokio::test]
+async fn root_typename_probe_supports_alias() {
+    let (status, body) =
+        post_graphql(typename_router(), json!({ "query": "{ ping: __typename }" })).await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["data"]["ping"], "Query", "body: {body}");
+    assert!(body.get("errors").is_none(), "unexpected errors: {body}");
+}

--- a/docs/architecture/change-log-contract.md
+++ b/docs/architecture/change-log-contract.md
@@ -195,9 +195,8 @@ portable, fully-parameterized INSERT for non-PostgreSQL dialects is
 [`fraiseql_db::changelog::CHANGELOG_PORTABLE_INSERT_COLUMNS`].
 
 For these rows **`duration_ms` and `started_at` are legitimately `NULL`** —
-there is no FraiseQL request context to measure. This is expected, not drift;
-
-# 392's `null-rate` subcommand exists to measure exactly this population
+there is no FraiseQL request context to measure. This is expected, not
+drift; #392's `null-rate` subcommand exists to measure exactly this population.
 
 ---
 

--- a/docs/architecture/change-log-contract.md
+++ b/docs/architecture/change-log-contract.md
@@ -196,7 +196,8 @@ portable, fully-parameterized INSERT for non-PostgreSQL dialects is
 
 For these rows **`duration_ms` and `started_at` are legitimately `NULL`** —
 there is no FraiseQL request context to measure. This is expected, not drift;
-# 392's `null-rate` subcommand exists to measure exactly this population.
+
+# 392's `null-rate` subcommand exists to measure exactly this population
 
 ---
 

--- a/docs/auth/local-password.md
+++ b/docs/auth/local-password.md
@@ -37,9 +37,8 @@ parameters upgrade automatically on the next successful login (see *Rehash* belo
 
 ## Schema
 
-One table in the `core` schema, created idempotently by `init()` (which also ensures the
-
-# 411 identity tables it FK-references)
+One table in the `core` schema, created idempotently by `init()` (which also ensures
+the #411 identity tables it FK-references):
 
 | Table | Purpose |
 | --- | --- |

--- a/docs/auth/local-password.md
+++ b/docs/auth/local-password.md
@@ -38,7 +38,8 @@ parameters upgrade automatically on the next successful login (see *Rehash* belo
 ## Schema
 
 One table in the `core` schema, created idempotently by `init()` (which also ensures the
-# 411 identity tables it FK-references):
+
+# 411 identity tables it FK-references)
 
 | Table | Purpose |
 | --- | --- |


### PR DESCRIPTION
Fixes #450 and #451.

## #450 — root `{ __typename }` rejected with "Query '__typename' not found in schema"

The query classifier only special-cased `__schema`/`__type`, so `__typename` fell through to the regular matcher and failed `find_query`. Per the GraphQL spec, `__typename` is a meta-field available at every selection set; at the root it resolves to the operation's root type name. `{ __typename }` is the canonical zero-cost "is this a reachable GraphQL endpoint" probe, so rejecting it makes those probes report the endpoint as broken.

**Fix** — a new `QueryType::TypeName` classification resolved with **no DB round-trip**, covering:
- pure (`{ __typename }`) and aliased (`{ ping: __typename }`)
- mixed roots, either order (`{ __typename users { id } }`, `{ users { id } __typename }`) — resolved locally in the multi-root pipeline
- repeated (`{ a: __typename b: __typename }`)
- `mutation { __typename }` → `"Mutation"` (classified before the mutation branch)
- `@skip` / `@include` on the meta-field (evaluated via the same `DirectiveEvaluator` the regular path uses)

The resolved name (`Query`/`Mutation`/`Subscription`) is derived from the operation type and matches the introspection builder's `__schema { queryType { name } }`.

Scope: fragment-wrapped root `__typename` (`{ ...F }`, `{ ... on Query { __typename } }`) is **not** special-cased (falls through unchanged); root-field directives are not honored on the multi-root path (pre-existing limitation of selection re-serialization). Both documented in code.

## #451 — statement-prepare failures surfaced opaque "db error"

`prepare_cached_stmt` formatted only the top-level `Display` (`db error`), dropping `e.as_db_error()` — the diagnostic that names the offending object (e.g. `function "foo" does not exist`, SQLSTATE 42883). This made server↔database contract drift undiagnosable from logs, even though the SQL state was already populated.

**Fix** — extract the diagnostic into the message (the function-call path in the same file already did this). Client-facing sanitization is unchanged.

## Why it wasn't caught pre-release
- #450: classify tests covered `__schema`/`__type` but never `__typename`; nested `__typename` tests gave false confidence; no test issued the `{ __typename }` GraphQL probe (health checks hit REST `/health`).
- #451: the prepare error-mapping was never asserted; it only fires against a real DB with contract drift, and nothing guarded its consistency with the function-call path.

## Regression gates added
- `release-smoke.yml` now POSTs `{ __typename }` to the booted server and asserts `"__typename":"Query"`.
- `crates/fraiseql-server/tests/typename_e2e_test.rs` drives `{ __typename }` through the real handler over an empty schema + `FailingAdapter` (proves no schema lookup / no DB call; unauthenticated).
- `crates/fraiseql-db/tests/prepare_error_diagnostic.rs` drives a real prepare failure (SQLSTATE 42883) and asserts the diagnostic + function name surface — runs on the `integrationPostgres` leg via the existing `--test '*'` glob.

## Verification
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps` — clean
- `cargo +nightly fmt --check` — clean
- lint ratchets (unwrap/expect/async-trait 188/188/tests-layout) + 5 shell gates — pass
- 2554 core lib tests + server e2e (2) + db prepare test (1, fresh PG) — pass
- No public-API, schema-format, or Cargo-feature change; no new `#[async_trait]`.

An external senior-engineer review (evergreen + GraphQL-spec / reference-implementation comparison against async-graphql/juniper) returned **fix-then-ship**; its one gating finding (`@skip`/`@include` on root `__typename`) is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)