### PR TITLE
fix(#456): recase camelCase mutation input keys to snake_case for compiled Input-type args

### DIFF
--- a/crates/fraiseql-cli/src/commands/compile.rs
+++ b/crates/fraiseql-cli/src/commands/compile.rs
@@ -6,7 +6,8 @@ use std::{fs, path::Path, process::Command};
 
 use anyhow::{Context, Result};
 use fraiseql_core::schema::{
-    CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema, FieldType, NamingConvention, canonicalize_json,
+    CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema, FieldType, InputStyle, MutationOperation,
+    NamingConvention, canonicalize_json,
 };
 use tracing::{info, warn};
 
@@ -382,6 +383,10 @@ pub async fn compile_to_schema(
 
     // 5d. Warn when mutations have wide invalidation fan-out (HOT update pressure).
     warn_wide_cascade_mutations(&schema);
+
+    // 5e. Warn when a `preserve` schema would silently forward camelCase input keys
+    // to snake_case SQL functions on the single-JSONB mutation path (#456).
+    warn_jsonb_preserve_mismatch(&schema);
 
     Ok((schema, report))
 }
@@ -809,6 +814,80 @@ fn warn_wide_cascade_mutations(schema: &CompiledSchema) {
             total,
             targets.join(", "),
             alter_stmts.join("  "),
+        );
+    }
+}
+
+/// Detect single-JSONB mutations that would silently forward `camelCase` input
+/// keys to a `snake_case` SQL function under `naming_convention = "preserve"`.
+///
+/// Returns `(mutation_name, camelCase_field_names)` for every mutation that, on a
+/// `Preserve` schema, takes one declared `input` Input type through the
+/// single-JSONB path (`input_style = "jsonb"` or an `Update`) and whose Input
+/// type has `camelCase`-looking field name(s). Under `Preserve` the runtime
+/// forwards the payload verbatim — no `snake_case` recasing — so a function
+/// reading `payload->>'snake_field'` sees NULL for every multi-word field (#456).
+///
+/// Pure (no I/O) so it can be unit-tested; [`warn_jsonb_preserve_mismatch`] is the
+/// thin logging wrapper.
+pub(crate) fn jsonb_preserve_mismatches(schema: &CompiledSchema) -> Vec<(String, Vec<String>)> {
+    if schema.naming_convention != NamingConvention::Preserve {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    for mutation in &schema.mutations {
+        // The single-JSONB path: an explicit `input_style = jsonb` or an Update,
+        // both of which forward the whole `input` object as one JSONB arg.
+        let single_jsonb = matches!(mutation.input_style, InputStyle::Jsonb)
+            || matches!(mutation.operation, MutationOperation::Update { .. });
+        if !single_jsonb {
+            continue;
+        }
+        // The single-`input`-object pattern: exactly one arg named "input" whose
+        // type is a declared input type (mirrors the runtime's detection). The
+        // compiler emits input-type references as `FieldType::Object`, never
+        // `FieldType::Input`, so recognise an `Object` naming a registered input
+        // type too — otherwise this warning is blind to every real compiled schema
+        // (#456).
+        let input_type_name = match mutation.arguments.as_slice() {
+            [arg] if arg.name == "input" => match &arg.arg_type {
+                FieldType::Input(name) => name.as_str(),
+                FieldType::Object(name) if schema.find_input_type(name).is_some() => name.as_str(),
+                _ => continue,
+            },
+            _ => continue,
+        };
+        let Some(input_type) = schema.find_input_type(input_type_name) else {
+            continue;
+        };
+        // A field name with any uppercase letter is camelCase-looking — under
+        // Preserve it reaches the function verbatim and won't match a snake key.
+        let camel_fields: Vec<String> = input_type
+            .fields
+            .iter()
+            .filter(|f| f.name.chars().any(|c| c.is_ascii_uppercase()))
+            .map(|f| f.name.clone())
+            .collect();
+        if !camel_fields.is_empty() {
+            out.push((mutation.name.clone(), camel_fields));
+        }
+    }
+    out
+}
+
+/// Warn for every [`jsonb_preserve_mismatches`] hit — the silent #456
+/// misconfiguration where a `preserve` schema forwards camelCase input keys to a
+/// snake_case SQL function on the single-JSONB path.
+fn warn_jsonb_preserve_mismatch(schema: &CompiledSchema) {
+    for (mutation, fields) in jsonb_preserve_mismatches(schema) {
+        warn!(
+            "mutation '{mutation}' forwards its input as a single JSONB payload but the schema \
+             uses naming_convention = \"preserve\", and its input type has camelCase field(s) \
+             [{}]. Under 'preserve' the runtime forwards input keys verbatim (no snake_case \
+             recasing), so a SQL function reading payload->>'snake_field' will receive these \
+             camelCase keys and see NULL. Set naming_convention = \"camelCase\" (the default for \
+             new schemas) if the function expects snake_case keys, or rename the fields. (#456)",
+            fields.join(", "),
         );
     }
 }

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -81,7 +81,9 @@ mod compile_tests {
     use fraiseql_core::{
         schema::{
             ArgumentDefinition, AutoParams, CompiledSchema, CursorType, FieldDefinition,
-            FieldDenyPolicy, FieldType, MutationDefinition, QueryDefinition, TypeDefinition,
+            FieldDenyPolicy, FieldType, InputFieldDefinition, InputObjectDefinition, InputStyle,
+            MutationDefinition, MutationOperation, NamingConvention, QueryDefinition,
+            TypeDefinition,
         },
         validation::CustomTypeRegistry,
     };
@@ -89,7 +91,8 @@ mod compile_tests {
 
     use super::super::compile::{
         WIDE_FANOUT_THRESHOLD, emit_ddl_to_dir, field_type_to_pg,
-        infer_native_columns_from_arg_types, to_snake_case, wide_cascade_mutations,
+        infer_native_columns_from_arg_types, jsonb_preserve_mismatches, to_snake_case,
+        wide_cascade_mutations,
     };
 
     fn mutation_with_fanout(
@@ -162,6 +165,139 @@ mod compile_tests {
     fn test_wide_cascade_no_mutations_no_warnings() {
         let schema = CompiledSchema::default();
         assert!(wide_cascade_mutations(&schema, WIDE_FANOUT_THRESHOLD).is_empty());
+    }
+
+    // ── jsonb_preserve_mismatches (#456 compile-time warning) ────────────
+
+    /// Build a schema with one single-`input` mutation over a declared Input type.
+    fn schema_with_input_mutation(
+        naming: NamingConvention,
+        input_style: InputStyle,
+        operation: MutationOperation,
+        input_field_names: &[&str],
+    ) -> CompiledSchema {
+        let mut schema = CompiledSchema {
+            naming_convention: naming,
+            ..Default::default()
+        };
+        schema.input_types.push(InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      input_field_names
+                .iter()
+                .map(|n| InputFieldDefinition::new(*n, "String"))
+                .collect(),
+            description: None,
+            metadata:    None,
+        });
+        let mut m = MutationDefinition::new("createOrder", "Order");
+        m.input_style = input_style;
+        m.operation = operation;
+        m.arguments = vec![ArgumentDefinition {
+            name:          "input".to_string(),
+            arg_type:      FieldType::Input("CreateOrderInput".to_string()),
+            nullable:      false,
+            default_value: None,
+            description:   None,
+            deprecation:   None,
+        }];
+        schema.mutations.push(m);
+        schema
+    }
+
+    /// Same as [`schema_with_input_mutation`] but the input arg uses the real
+    /// compiled shape — `FieldType::Object(name)` naming a registered input type,
+    /// which is what the converter actually emits (never `FieldType::Input`).
+    fn schema_with_object_input_mutation(
+        naming: NamingConvention,
+        input_style: InputStyle,
+        operation: MutationOperation,
+        input_field_names: &[&str],
+    ) -> CompiledSchema {
+        let mut schema =
+            schema_with_input_mutation(naming, input_style, operation, input_field_names);
+        schema.mutations[0].arguments[0].arg_type =
+            FieldType::Object("CreateOrderInput".to_string());
+        schema
+    }
+
+    #[test]
+    fn jsonb_preserve_flags_object_typed_input_arg() {
+        // The real compiled shape (Object naming an input type) must be detected —
+        // not just the synthetic FieldType::Input form (#456).
+        let schema = schema_with_object_input_mutation(
+            NamingConvention::Preserve,
+            InputStyle::Jsonb,
+            MutationOperation::Insert { table: "t".into() },
+            &["shippingAddress"],
+        );
+        let hits = jsonb_preserve_mismatches(&schema);
+        assert_eq!(hits.len(), 1, "Object-typed input arg must be detected");
+        assert_eq!(hits[0].1, vec!["shippingAddress"]);
+    }
+
+    #[test]
+    fn jsonb_preserve_flags_camelcase_fields_under_preserve() {
+        let schema = schema_with_input_mutation(
+            NamingConvention::Preserve,
+            InputStyle::Jsonb,
+            MutationOperation::Insert { table: "t".into() },
+            &["shippingAddress", "customerNote"],
+        );
+        let hits = jsonb_preserve_mismatches(&schema);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, "createOrder");
+        assert_eq!(hits[0].1, vec!["shippingAddress", "customerNote"]);
+    }
+
+    #[test]
+    fn jsonb_preserve_flags_update_operation_too() {
+        // An Update always uses the single-JSONB path even without input_style=jsonb.
+        let schema = schema_with_input_mutation(
+            NamingConvention::Preserve,
+            InputStyle::Flatten,
+            MutationOperation::Update { table: "t".into() },
+            &["fullName"],
+        );
+        let hits = jsonb_preserve_mismatches(&schema);
+        assert_eq!(hits.len(), 1, "Update is single-JSONB and must be flagged");
+        assert_eq!(hits[0].1, vec!["fullName"]);
+    }
+
+    #[test]
+    fn jsonb_preserve_silent_when_naming_is_camel_case() {
+        // Under camelCase the runtime recases input keys, so no mismatch.
+        let schema = schema_with_input_mutation(
+            NamingConvention::CamelCase,
+            InputStyle::Jsonb,
+            MutationOperation::Insert { table: "t".into() },
+            &["shippingAddress"],
+        );
+        assert!(jsonb_preserve_mismatches(&schema).is_empty());
+    }
+
+    #[test]
+    fn jsonb_preserve_silent_for_snake_case_fields() {
+        // Snake_case fields under preserve reach the function correctly — no warning.
+        let schema = schema_with_input_mutation(
+            NamingConvention::Preserve,
+            InputStyle::Jsonb,
+            MutationOperation::Insert { table: "t".into() },
+            &["shipping_address", "customer_note"],
+        );
+        assert!(jsonb_preserve_mismatches(&schema).is_empty());
+    }
+
+    #[test]
+    fn jsonb_preserve_silent_for_flatten_insert() {
+        // A flatten Insert maps fields to positional args (casing implicit), so the
+        // single-JSONB hazard does not apply.
+        let schema = schema_with_input_mutation(
+            NamingConvention::Preserve,
+            InputStyle::Flatten,
+            MutationOperation::Insert { table: "t".into() },
+            &["shippingAddress"],
+        );
+        assert!(jsonb_preserve_mismatches(&schema).is_empty());
     }
 
     #[test]

--- a/crates/fraiseql-cli/src/config/toml_schema/mod.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/mod.rs
@@ -55,6 +55,15 @@ use super::{
     runtime::{DatabaseRuntimeConfig, ServerRuntimeConfig},
 };
 
+/// Default `naming_convention` for the TomlSchema compile path: `CamelCase`,
+/// matching the JSON-schema compile path (#456). Note: the derived
+/// [`Default`] for [`TomlSchema`] still yields the enum default (`Preserve`) for
+/// this field; only deserialization (the real compile path, via
+/// [`TomlSchema::parse_toml`]) applies this `camelCase` default.
+fn default_naming_convention() -> NamingConvention {
+    NamingConvention::CamelCase
+}
+
 /// Complete TOML schema configuration
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -167,9 +176,14 @@ pub struct TomlSchema {
 
     /// Naming convention for GraphQL operation names.
     ///
-    /// `"preserve"` (default) keeps names as authored (snake_case from Python SDKs).
-    /// `"camelCase"` converts operation names to standard GraphQL camelCase.
-    #[serde(default)]
+    /// Defaults to `"camelCase"` — the standard GraphQL surface (`snake_case` in
+    /// the database, `camelCase` exposed to clients, with single-JSONB input-key
+    /// recasing) — matching the JSON-schema (`fraiseql-cli compile schema.json`)
+    /// compile path. This avoids the silent footgun where a TomlSchema-authored
+    /// schema defaulted to `Preserve` and forwarded camelCase input keys verbatim
+    /// to `snake_case` SQL functions (#456). Set `"preserve"` to keep names exactly
+    /// as authored (`snake_case`).
+    #[serde(default = "default_naming_convention")]
     pub naming_convention: NamingConvention,
 
     /// CRUD function naming config for automatic `sql_source` resolution.

--- a/crates/fraiseql-cli/src/schema/converter/mod.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mod.rs
@@ -263,11 +263,55 @@ impl SchemaConverter {
             mutation_error_union::synthesize_mutation_error_unions(&mut compiled);
         }
 
+        // IR honesty (#456): `parse_field_type` has no `Input` variant, so an
+        // argument referencing a declared input type was resolved to
+        // `FieldType::Object`. Rewrite those argument types to `FieldType::Input`
+        // now that every input type is registered (after relay / rich-filter /
+        // changelog / error-union injection) so the IR honestly represents the
+        // GraphQL input position — which also makes introspection report the correct
+        // `INPUT_OBJECT` kind for those args. The runtime already accepts both
+        // shapes, so this is purely representational.
+        Self::promote_input_type_args(&mut compiled);
+
         // Validate the compiled schema
         Self::validate(&compiled)?;
 
         info!("Schema conversion successful");
         Ok(compiled)
+    }
+
+    /// Rewrite mutation/query argument types of the form `Object(name)` (and lists
+    /// thereof) to `Input(name)` when `name` is a registered input type, so the IR
+    /// honestly represents input-position references (#456). Input type names are
+    /// disjoint from output type names per the GraphQL spec, so the lookup is exact
+    /// — an output-object argument is never misclassified.
+    fn promote_input_type_args(schema: &mut CompiledSchema) {
+        fn promote(ft: &mut FieldType, input_names: &HashSet<String>) {
+            match ft {
+                FieldType::Object(name) if input_names.contains(name) => {
+                    *ft = FieldType::Input(name.clone());
+                },
+                FieldType::List(inner) => promote(inner, input_names),
+                _ => {},
+            }
+        }
+
+        let input_names: HashSet<String> =
+            schema.input_types.iter().map(|i| i.name.clone()).collect();
+        if input_names.is_empty() {
+            return;
+        }
+
+        for mutation in &mut schema.mutations {
+            for arg in &mut mutation.arguments {
+                promote(&mut arg.arg_type, &input_names);
+            }
+        }
+        for query in &mut schema.queries {
+            for arg in &mut query.arguments {
+                promote(&mut arg.arg_type, &input_names);
+            }
+        }
     }
 
     #[allow(clippy::cognitive_complexity)] // Reason: comprehensive schema validation with many field-level checks

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -1572,6 +1572,64 @@ fn test_convert_field_requires_scope() {
     assert_eq!(employee_type.fields[3].requires_scope, Some("admin".to_string()));
 }
 
+// ── promote_input_type_args (#456 Option 2: IR honesty) ──────────────────────
+
+#[test]
+fn promote_input_type_args_rewrites_object_to_input() {
+    use fraiseql_core::schema::{
+        ArgumentDefinition, CompiledSchema, FieldType, InputObjectDefinition, MutationDefinition,
+    };
+
+    let arg = |arg_type| ArgumentDefinition {
+        name: "input".to_string(),
+        arg_type,
+        nullable: false,
+        default_value: None,
+        description: None,
+        deprecation: None,
+    };
+
+    let mut schema = CompiledSchema {
+        input_types: vec![InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      vec![],
+            description: None,
+            metadata:    None,
+        }],
+        ..Default::default()
+    };
+    // (1) arg naming an input type → Input
+    let mut m1 = MutationDefinition::new("createOrder", "Order");
+    m1.arguments = vec![arg(FieldType::Object("CreateOrderInput".to_string()))];
+    // (2) arg naming an OUTPUT object type → stays Object
+    let mut m2 = MutationDefinition::new("touchOrder", "Order");
+    m2.arguments = vec![arg(FieldType::Object("Order".to_string()))];
+    // (3) list of an input type → inner promoted to Input
+    let mut m3 = MutationDefinition::new("bulkCreate", "Order");
+    m3.arguments = vec![arg(FieldType::List(Box::new(FieldType::Object(
+        "CreateOrderInput".to_string(),
+    ))))];
+    schema.mutations = vec![m1, m2, m3];
+
+    SchemaConverter::promote_input_type_args(&mut schema);
+
+    assert_eq!(
+        schema.mutations[0].arguments[0].arg_type,
+        FieldType::Input("CreateOrderInput".to_string()),
+        "an Object naming a registered input type must become Input"
+    );
+    assert_eq!(
+        schema.mutations[1].arguments[0].arg_type,
+        FieldType::Object("Order".to_string()),
+        "an Object naming an output type must stay Object"
+    );
+    assert_eq!(
+        schema.mutations[2].arguments[0].arg_type,
+        FieldType::List(Box::new(FieldType::Input("CreateOrderInput".to_string()))),
+        "a list of an input type must promote its element to Input"
+    );
+}
+
 // ── tenancy converter tests ─────────────────────────────────────────────────
 
 mod tenancy_tests {

--- a/crates/fraiseql-cli/tests/query_defaults_test.rs
+++ b/crates/fraiseql-cli/tests/query_defaults_test.rs
@@ -458,10 +458,30 @@ database_target = "postgresql"
 }
 
 #[test]
-fn test_parse_naming_convention_default_is_preserve() {
+fn test_parse_naming_convention_default_is_camel_case() {
+    use fraiseql_cli::config::TomlSchema;
+
+    // #456: the TomlSchema compile path defaults to camelCase (matching the
+    // JSON-schema path), so a schema that omits `naming_convention` gets the
+    // standard GraphQL surface with input-key recasing — not the old `preserve`
+    // default that silently forwarded camelCase keys to snake_case SQL functions.
+    let toml = r#"
+[schema]
+name = "myapp"
+version = "1.0.0"
+database_target = "postgresql"
+"#;
+    let schema = TomlSchema::parse_toml(toml).expect("Failed to parse");
+    assert_eq!(schema.naming_convention, NamingConvention::CamelCase);
+}
+
+#[test]
+fn test_parse_naming_convention_explicit_preserve_honored() {
     use fraiseql_cli::config::TomlSchema;
 
     let toml = r#"
+naming_convention = "preserve"
+
 [schema]
 name = "myapp"
 version = "1.0.0"

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -130,24 +130,31 @@ impl<A: DatabaseAdapter + SupportsMutations> MutationRunner<A> {
 }
 
 /// Re-case a mutation input payload's keys from the GraphQL surface naming
-/// convention to the schema's canonical (stored) field names, recursing into
-/// nested input objects and arrays of input objects.
+/// convention to canonical `snake_case`, recursing into nested input objects and
+/// arrays of input objects.
 ///
-/// The compiled schema stores field names in their canonical (typically
-/// `snake_case`) form; with [`NamingConvention::CamelCase`] the GraphQL surface
-/// presents them as `camelCase`, so a client sends `camelCase` keys. The Insert
-/// path maps those to positional SQL args by name (casing handled implicitly),
-/// but the Update path forwards the whole object as one JSONB arg — so without
-/// this the SQL function receives surface-cased keys it cannot read (#400).
+/// The compiled schema stores field names in their GraphQL *surface* form: SDKs
+/// pre-case them (the Python SDK camelCases at `registry.py:233`; the
+/// `TypeScript` SDK stores whatever the author wrote, idiomatically
+/// `camelCase`), and the
+/// introspection layer renders them verbatim. With
+/// [`NamingConvention::CamelCase`] a client therefore sends `camelCase` keys. The
+/// Insert path maps those to positional SQL args by name (casing handled
+/// implicitly), but the Update / `input_style = jsonb` path forwards the whole
+/// object as one JSONB arg — so without this the SQL function receives
+/// surface-cased keys it cannot read (#400, #456).
 ///
-/// Driven by the input type's per-field map (not a lossy `camel→snake` regex)
-/// when one is available, so intentional names / acronyms in the canonical field
-/// names are preserved, and keys that match no field are left untouched.
+/// The input type's per-field map is used to *match* the incoming surface key and
+/// to drive recursion into nested input types; every emitted canonical key is
+/// then normalised with the engine's acronym-aware
+/// [`to_snake_case`](crate::utils::to_snake_case) so writes round-trip exactly as
+/// reads do (`s3Key → s3_key`, `dns1Id → dns_1_id`) — the same transform the
+/// fallback below uses, regardless of which SDK authored the schema (#456).
 ///
 /// When no per-field map is available — `input_type_name` is `None` (a raw `JSON`
 /// input arg) or names a type absent from the compiled schema — it falls back to
-/// the canonical acronym-aware key transform ([`recase_jsonb_keys_to_snake`]) so a
-/// single-JSONB payload still reaches the function as `snake_case` (#400). A
+/// the same key transform ([`recase_jsonb_keys_to_snake`]) so a single-JSONB
+/// payload still reaches the function as `snake_case` (#400). A
 /// [`NamingConvention::Preserve`] schema is always left untouched.
 fn recase_input_payload(
     value: serde_json::Value,
@@ -169,9 +176,18 @@ fn recase_input_payload(
             let mut out = serde_json::Map::with_capacity(map.len());
             for (key, val) in map {
                 // Match the incoming surface key against each field's surface name,
-                // then map back to the exact canonical name.
+                // then emit the canonical key in `snake_case`. The stored field
+                // name is the GraphQL *surface* name (SDKs pre-case it — e.g. the
+                // Python SDK camelCases at `registry.py:233`), so it cannot be
+                // forwarded verbatim; normalising with the engine's acronym-aware
+                // `to_snake_case` — the same transform the raw-`JSON` fallback and
+                // the read path use — is what reaches the function as `snake_case`
+                // regardless of which SDK authored the schema (#456 / #400).
                 let field = input_type.fields.iter().find(|f| schema.display_name(&f.name) == key);
-                let canonical = field.map_or(key, |f| f.name.clone());
+                let canonical = field.map_or_else(
+                    || crate::utils::to_snake_case(&key),
+                    |f| crate::utils::to_snake_case(&f.name),
+                );
                 let recased = match field {
                     Some(f) => recase_input_field_value(val, &f.field_type, schema),
                     None => val,
@@ -498,10 +514,10 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
             //
             // Look up each field by its GraphQL surface name (`display_name`):
             // under `NamingConvention::CamelCase` the client sends camelCase keys
-            // while `input_type.fields` hold canonical (snake_case) names. Using
-            // the surface key both makes the required check correct and fixes the
-            // latent value-passing miss on the camelCase Insert path (previously
-            // only the Update path recased — see `recase_input_payload`).
+            // and `field.name` is itself the surface name (`display_name` is then a
+            // no-op), so matching on it makes the required check correct and finds
+            // the value to forward. The canonical column name handed to DirectSql is
+            // re-derived as `snake_case` below — see `recase_input_payload` (#456).
             let mut missing_input_fields: Vec<&str> = Vec::new();
             for field in &input_type.fields {
                 let key = ctx.schema.display_name(&field.name);
@@ -514,7 +530,11 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
                 // — recase its keys so the SQL function can read them (#400).
                 let raw = value.cloned().unwrap_or(serde_json::Value::Null);
                 args.push(recase_input_field_value(raw, &field.field_type, &ctx.schema));
-                direct_columns.push(field.name.clone());
+                // DirectSql (SQLite) builds its INSERT/DELETE column list from this:
+                // the column is `snake_case` in the table, while `field.name` is the
+                // GraphQL surface name (camelCase under `CamelCase`), so normalise it
+                // the same way the JSONB path normalises its keys (#456).
+                direct_columns.push(crate::utils::to_snake_case(&field.name));
             }
             if !missing_input_fields.is_empty() {
                 return Err(FraiseQLError::Validation {

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -432,22 +432,38 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
     // `(input jsonb, …)`); it drives the field-level flatten/recase path below.
     let single_input_arg =
         mutation_def.arguments.len() == 1 && mutation_def.arguments[0].name == "input";
+    // The compiler emits an input-type reference as `FieldType::Object(name)`, never
+    // `FieldType::Input` (the converter's `parse_field_type` has no `Input` variant),
+    // so an `Object` whose name resolves to a registered input type IS a structured
+    // input arg. Without recognising it here the arg matches neither the
+    // single-JSONB nor the flatten branch and falls through to the verbatim
+    // standard-arg path — forwarding camelCase keys to the SQL function with no
+    // recasing, regardless of `naming_convention` (#456). The `find_input_type`
+    // guard is exact: only names registered as input types match, so output-object
+    // args are never misclassified.
     let input_type_name = if single_input_arg {
         match &mutation_def.arguments[0].arg_type {
             crate::schema::FieldType::Input(name) => Some(name.as_str()),
+            crate::schema::FieldType::Object(name)
+                if ctx.schema.find_input_type(name).is_some() =>
+            {
+                Some(name.as_str())
+            },
             _ => None,
         }
     } else {
         None
     };
-    // A single `input` arg shaped as a JSON payload — a structured Input type or a
-    // raw `JSON` scalar — as opposed to a plain scalar (`input: String`), which is
-    // a positional arg, not a JSONB blob.
+    // A single `input` arg shaped as a JSON payload — a structured Input type
+    // (`FieldType::Input`, or the `Object` the compiler actually emits for one) or a
+    // raw `JSON` scalar — as opposed to a plain scalar (`input: String`), which is a
+    // positional arg, not a JSONB blob.
     let input_arg_is_structured = single_input_arg
-        && matches!(
-            &mutation_def.arguments[0].arg_type,
-            crate::schema::FieldType::Input(_) | crate::schema::FieldType::Json
-        );
+        && match &mutation_def.arguments[0].arg_type {
+            crate::schema::FieldType::Input(_) | crate::schema::FieldType::Json => true,
+            crate::schema::FieldType::Object(name) => ctx.schema.find_input_type(name).is_some(),
+            _ => false,
+        };
 
     // Update mutations pass the entire input object as a single JSONB arg, which
     // preserves all three field states that typed positional args cannot express:

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
@@ -1519,6 +1519,87 @@ mod mutation {
         );
     }
 
+    /// Server-path guard for the #456 follow-up: the GraphQL handler calls
+    /// `execute_with_security` for authenticated requests (handler.rs:649) — a
+    /// different dispatch entry than `execute`. A jsonb mutation driven through it
+    /// must recase `camelCase` input to `snake_case` identically, so the
+    /// authenticated path cannot silently diverge from the anonymous one.
+    #[tokio::test]
+    async fn jsonb_mutation_recases_through_execute_with_security() {
+        use chrono::Utc;
+
+        use crate::{
+            schema::{
+                FieldType, InputFieldDefinition, InputObjectDefinition, InputStyle,
+                MutationDefinition, MutationOperation, NamingConvention,
+            },
+            security::SecurityContext,
+        };
+        let mut schema = CompiledSchema::new();
+        schema.naming_convention = NamingConvention::CamelCase;
+        schema.input_types.push(InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      vec![InputFieldDefinition::new("shippingAddress", "String!")],
+            description: None,
+            metadata:    None,
+        });
+        schema.mutations.push(MutationDefinition {
+            name: "createOrder".to_string(),
+            return_type: "Order".to_string(),
+            sql_source: Some("app.create_order".to_string()),
+            operation: MutationOperation::Insert {
+                table: "app.create_order".to_string(),
+            },
+            input_style: InputStyle::Jsonb,
+            arguments: vec![crate::schema::ArgumentDefinition {
+                name:          "input".to_string(),
+                arg_type:      FieldType::Input("CreateOrderInput".to_string()),
+                nullable:      false,
+                default_value: None,
+                description:   None,
+                deprecation:   None,
+            }],
+            ..MutationDefinition::new("createOrder", "Order")
+        });
+        schema.build_indexes();
+
+        let adapter = Arc::new(CapturingFunctionCallAdapter::new());
+        let adapter_ref = Arc::clone(&adapter);
+        let executor = Executor::new(schema, adapter);
+
+        let sec_ctx = SecurityContext {
+            user_id:          "u".into(),
+            roles:            vec![],
+            tenant_id:        None,
+            scopes:           vec![],
+            attributes:       std::collections::HashMap::default(),
+            request_id:       "req-1".to_string(),
+            ip_address:       None,
+            expires_at:       Utc::now() + chrono::Duration::hours(1),
+            authenticated_at: Utc::now(),
+            issuer:           None,
+            audience:         None,
+            email:            None,
+            display_name:     None,
+        };
+
+        let doc = r#"mutation { createOrder(input: { shippingAddress: "1 Main St" }) { id } }"#;
+        executor.execute_with_security(doc, None, &sec_ctx).await.unwrap();
+
+        let captured = adapter_ref.args();
+        assert_eq!(captured.len(), 1, "jsonb path passes one JSONB arg, got {captured:?}");
+        assert_eq!(
+            captured[0]["shipping_address"], "1 Main St",
+            "authenticated dispatch must recase camelCase input to snake_case: {:?}",
+            captured[0]
+        );
+        assert!(
+            captured[0].get("shippingAddress").is_none(),
+            "verbatim camelCase key must not survive: {:?}",
+            captured[0]
+        );
+    }
+
     // ── changelog_pre_image threading (opt-in pre-image) ──────────────────
     //
     // The per-mutation `changelog_pre_image` flag rides on the `ChangeLogWrite`

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
@@ -1432,6 +1432,134 @@ mod mutation {
         );
     }
 
+    /// #456 ROOT CAUSE: the compiler emits an input-type mutation argument as
+    /// `FieldType::Object(name)` — never `FieldType::Input` — so a *real compiled*
+    /// schema's `input` arg is `Object("CreateOrderInput")`. The runtime must
+    /// recognise an `Object` naming a registered input type as a structured input
+    /// (via `find_input_type`), or it skips both the single-JSONB and flatten
+    /// branches and forwards the payload verbatim — camelCase keys to the SQL
+    /// function, no recasing, regardless of `naming_convention`. This mirrors the
+    /// beta-tester's `createEmailTemplate` (Object arg + `input_style=jsonb` +
+    /// camelCase surface); before the fix it forwarded camelCase verbatim.
+    #[tokio::test]
+    async fn jsonb_object_typed_input_arg_recased_to_snake() {
+        use crate::schema::{
+            FieldType, InputFieldDefinition, InputObjectDefinition, InputStyle, MutationDefinition,
+            MutationOperation, NamingConvention,
+        };
+        let mut schema = CompiledSchema::new();
+        schema.naming_convention = NamingConvention::CamelCase;
+        schema.input_types.push(InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      vec![
+                InputFieldDefinition::new("shippingAddress", "String!"),
+                InputFieldDefinition::new("customerNote", "String!"),
+            ],
+            description: None,
+            metadata:    None,
+        });
+        schema.mutations.push(MutationDefinition {
+            name: "createOrder".to_string(),
+            return_type: "Order".to_string(),
+            sql_source: Some("app.create_order".to_string()),
+            operation: MutationOperation::Insert {
+                table: "app.create_order".to_string(),
+            },
+            input_style: InputStyle::Jsonb,
+            arguments: vec![crate::schema::ArgumentDefinition {
+                name:          "input".to_string(),
+                // The real compiled shape: Object naming a registered input type
+                // (NOT FieldType::Input, which the compiler never emits).
+                arg_type:      FieldType::Object("CreateOrderInput".to_string()),
+                nullable:      false,
+                default_value: None,
+                description:   None,
+                deprecation:   None,
+            }],
+            ..MutationDefinition::new("createOrder", "Order")
+        });
+
+        let adapter = Arc::new(CapturingFunctionCallAdapter::new());
+        let adapter_ref = Arc::clone(&adapter);
+        let executor = Executor::new(schema, adapter);
+
+        let vars = serde_json::json!({
+            "input": { "shippingAddress": "1 Main St", "customerNote": "gift" }
+        });
+        executor.execute_mutation("createOrder", Some(&vars), &[]).await.unwrap();
+
+        let captured = adapter_ref.args();
+        assert_eq!(captured.len(), 1, "jsonb path passes one JSONB arg, got {captured:?}");
+        assert_eq!(
+            captured[0]["shipping_address"], "1 Main St",
+            "Object-typed input arg must be recognised and recased to snake_case: {:?}",
+            captured[0]
+        );
+        assert_eq!(captured[0]["customer_note"], "gift");
+        assert!(
+            captured[0].get("shippingAddress").is_none(),
+            "verbatim camelCase key must not survive: {:?}",
+            captured[0]
+        );
+    }
+
+    /// The flatten path (Insert without `input_style=jsonb`) must likewise
+    /// recognise an `Object`-typed input arg and flatten its camelCase fields to
+    /// positional args with `snake_case` column names — not fall through to verbatim
+    /// forwarding (#456).
+    #[tokio::test]
+    async fn flatten_object_typed_input_arg_recognised_and_flattened() {
+        use crate::schema::{
+            FieldType, InputFieldDefinition, InputObjectDefinition, InputStyle, MutationDefinition,
+            MutationOperation, NamingConvention,
+        };
+        let mut schema = CompiledSchema::new();
+        schema.naming_convention = NamingConvention::CamelCase;
+        schema.input_types.push(InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      vec![
+                InputFieldDefinition::new("id", "ID!"),
+                InputFieldDefinition::new("fullName", "String!"),
+            ],
+            description: None,
+            metadata:    None,
+        });
+        schema.mutations.push(MutationDefinition {
+            name: "createOrder".to_string(),
+            return_type: "Order".to_string(),
+            sql_source: Some("app.create_order".to_string()),
+            operation: MutationOperation::Insert {
+                table: "app.create_order".to_string(),
+            },
+            input_style: InputStyle::Flatten,
+            arguments: vec![crate::schema::ArgumentDefinition {
+                name:          "input".to_string(),
+                arg_type:      FieldType::Object("CreateOrderInput".to_string()),
+                nullable:      false,
+                default_value: None,
+                description:   None,
+                deprecation:   None,
+            }],
+            ..MutationDefinition::new("createOrder", "Order")
+        });
+
+        let adapter = Arc::new(CapturingFunctionCallAdapter::new());
+        let adapter_ref = Arc::clone(&adapter);
+        let executor = Executor::new(schema, adapter);
+
+        let vars = serde_json::json!({ "input": { "id": "u1", "fullName": "Alice" } });
+        executor.execute_mutation("createOrder", Some(&vars), &[]).await.unwrap();
+
+        let captured = adapter_ref.args();
+        assert_eq!(
+            captured.len(),
+            2,
+            "Object-typed input arg must flatten to positional args, got {captured:?}"
+        );
+        assert_eq!(captured[0], "u1");
+        assert_eq!(captured[1], "Alice");
+    }
+
     /// End-to-end guard for the #456 follow-up: a camelCase schema serialized to
     /// JSON and re-loaded via `CompiledSchema::from_json` (the server's real load
     /// path) must keep `naming_convention = CamelCase`, and an **inline-literal**

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
@@ -1363,6 +1363,162 @@ mod mutation {
         assert_eq!(adapter_ref.modification_type().as_deref(), Some("INSERT"));
     }
 
+    /// #456 regression: a declared Input type whose field names are stored
+    /// **already camelCased** — exactly what the Python SDK emits (it
+    /// pre-camelCases field names, `registry.py:233`) — must still reach the SQL
+    /// function as `snake_case` on the single-JSONB path. Before the fix the
+    /// field-driven recase mapped the surface key back to the *stored* camelCase
+    /// name (a no-op), so a function reading `p_input->>'shipping_address'` saw
+    /// NULL. The recase now normalises every canonical key with the engine's
+    /// acronym-aware `to_snake_case`, matching the raw-`JSON` fallback path.
+    #[tokio::test]
+    async fn jsonb_input_style_camelcase_input_fields_recased_to_snake() {
+        use crate::schema::{
+            FieldType, InputFieldDefinition, InputObjectDefinition, InputStyle, MutationDefinition,
+            MutationOperation, NamingConvention,
+        };
+        let mut schema = CompiledSchema::new();
+        schema.naming_convention = NamingConvention::CamelCase;
+        // Field names stored already-camelCased, mirroring real SDK output.
+        schema.input_types.push(InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      vec![
+                InputFieldDefinition::new("shippingAddress", "String!"),
+                InputFieldDefinition::new("customerNote", "String!"),
+            ],
+            description: None,
+            metadata:    None,
+        });
+        schema.mutations.push(MutationDefinition {
+            name: "create_order".to_string(),
+            return_type: "Order".to_string(),
+            sql_source: Some("create_order".to_string()),
+            operation: MutationOperation::Insert {
+                table: "create_order".to_string(),
+            },
+            input_style: InputStyle::Jsonb,
+            arguments: vec![crate::schema::ArgumentDefinition {
+                name:          "input".to_string(),
+                arg_type:      FieldType::Input("CreateOrderInput".to_string()),
+                nullable:      false,
+                default_value: None,
+                description:   None,
+                deprecation:   None,
+            }],
+            ..MutationDefinition::new("create_order", "Order")
+        });
+
+        let adapter = Arc::new(CapturingFunctionCallAdapter::new());
+        let adapter_ref = Arc::clone(&adapter);
+        let executor = Executor::new(schema, adapter);
+
+        let vars = serde_json::json!({
+            "input": { "shippingAddress": "1 Main St", "customerNote": "gift" }
+        });
+        executor.execute_mutation("create_order", Some(&vars), &[]).await.unwrap();
+
+        let captured = adapter_ref.args();
+        assert_eq!(captured.len(), 1, "jsonb path passes one JSONB arg, got {captured:?}");
+        assert_eq!(
+            captured[0]["shipping_address"], "1 Main St",
+            "camelCase-stored input field must reach the function as snake_case: {:?}",
+            captured[0]
+        );
+        assert_eq!(captured[0]["customer_note"], "gift");
+        assert!(
+            captured[0].get("shippingAddress").is_none(),
+            "verbatim camelCase key must not survive to the SQL function: {:?}",
+            captured[0]
+        );
+    }
+
+    /// End-to-end guard for the #456 follow-up: a camelCase schema serialized to
+    /// JSON and re-loaded via `CompiledSchema::from_json` (the server's real load
+    /// path) must keep `naming_convention = CamelCase`, and an **inline-literal**
+    /// `input_style="jsonb"` mutation driven through `Executor::execute` (the real
+    /// GraphQL request path, not the typed API) must reach the SQL function as
+    /// `snake_case`. The follow-up report suspected the convention was dropped to
+    /// `Preserve` somewhere between load and the runner; this reproduces that whole
+    /// pipeline in one test so any such regression fails here.
+    #[tokio::test]
+    async fn jsonb_inline_literal_recases_after_from_json_roundtrip() {
+        use crate::schema::{
+            FieldType, InputFieldDefinition, InputObjectDefinition, InputStyle, MutationDefinition,
+            MutationOperation, NamingConvention,
+        };
+        let mut schema = CompiledSchema::new();
+        schema.naming_convention = NamingConvention::CamelCase;
+        schema.input_types.push(InputObjectDefinition {
+            name:        "CreateOrderInput".to_string(),
+            fields:      vec![
+                InputFieldDefinition::new("shippingAddress", "String!"),
+                InputFieldDefinition::new("customerNote", "String!"),
+            ],
+            description: None,
+            metadata:    None,
+        });
+        schema.mutations.push(MutationDefinition {
+            name: "createOrder".to_string(),
+            return_type: "Order".to_string(),
+            sql_source: Some("app.create_order".to_string()),
+            operation: MutationOperation::Insert {
+                table: "app.create_order".to_string(),
+            },
+            input_style: InputStyle::Jsonb,
+            arguments: vec![crate::schema::ArgumentDefinition {
+                name:          "input".to_string(),
+                arg_type:      FieldType::Input("CreateOrderInput".to_string()),
+                nullable:      false,
+                default_value: None,
+                description:   None,
+                deprecation:   None,
+            }],
+            ..MutationDefinition::new("createOrder", "Order")
+        });
+
+        // Round-trip through the real load path: serialize **with a
+        // `_content_hash`** so `from_json` takes the same canonicalize → reserialize
+        // → deserialize branch the CLI-produced server file does (not the
+        // hash-absent shortcut), then re-parse exactly as `CompiledSchemaLoader`
+        // does on the server.
+        let mut value: serde_json::Value =
+            serde_json::from_str(&schema.to_json().unwrap()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("_content_hash".to_string(), serde_json::Value::String(schema.content_hash()));
+        let json = serde_json::to_string(&value).unwrap();
+        let loaded = CompiledSchema::from_json(&json, false).unwrap();
+        assert_eq!(
+            loaded.naming_convention,
+            NamingConvention::CamelCase,
+            "naming_convention must survive the serialize/from_json round-trip"
+        );
+
+        let adapter = Arc::new(CapturingFunctionCallAdapter::new());
+        let adapter_ref = Arc::clone(&adapter);
+        let executor = Executor::new(loaded, adapter);
+
+        // Inline-literal argument (no `$variable`) — the report's exact repro and
+        // the standard GraphQL surface.
+        let doc = r#"mutation { createOrder(input: { shippingAddress: "1 Main St", customerNote: "x" }) { id } }"#;
+        executor.execute(doc, None).await.unwrap();
+
+        let captured = adapter_ref.args();
+        assert_eq!(captured.len(), 1, "jsonb path passes one JSONB arg, got {captured:?}");
+        assert_eq!(
+            captured[0]["shipping_address"], "1 Main St",
+            "inline-literal camelCase input must reach the function as snake_case: {:?}",
+            captured[0]
+        );
+        assert_eq!(captured[0]["customer_note"], "x");
+        assert!(
+            captured[0].get("shippingAddress").is_none(),
+            "verbatim camelCase key must not survive to the SQL function: {:?}",
+            captured[0]
+        );
+    }
+
     // ── changelog_pre_image threading (opt-in pre-image) ──────────────────
     //
     // The per-mutation `changelog_pre_image` flag rides on the `ChangeLogWrite`

--- a/crates/fraiseql-server/src/routes/grpc/handler.rs
+++ b/crates/fraiseql-server/src/routes/grpc/handler.rs
@@ -211,6 +211,30 @@ pub(crate) fn proto_value_to_json(value: &Value) -> serde_json::Value {
     }
 }
 
+/// Recursively recase every object key of a gRPC mutation arg to canonical
+/// `snake_case` with the engine's acronym-aware
+/// [`to_snake_case`](fraiseql_core::utils::to_snake_case), recursing into nested
+/// objects and arrays; scalar values are returned untouched.
+///
+/// Applied to each arg in [`execute_grpc_mutation`] only under
+/// [`NamingConvention::CamelCase`](fraiseql_core::schema::NamingConvention), so a
+/// nested `input` message reaches the SQL function as `snake_case` (#456). Shares
+/// `to_snake_case` with the read path, so writes round-trip exactly as reads
+/// (`s3Key` → `s3_key`, `dns1Id` → `dns_1_id`).
+pub(crate) fn recase_keys_to_snake(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => serde_json::Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (fraiseql_core::utils::to_snake_case(&k), recase_keys_to_snake(v)))
+                .collect(),
+        ),
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(recase_keys_to_snake).collect())
+        },
+        other => other,
+    }
+}
+
 /// Encode bytes as base64 for JSON serialization.
 fn base64_encode(bytes: &prost::bytes::Bytes) -> String {
     use base64::Engine;
@@ -404,13 +428,30 @@ pub async fn execute_grpc_mutation<A: DatabaseAdapter>(
     adapter: &A,
     function_name: &str,
     request_msg: &DynamicMessage,
+    recase_input_keys: bool,
 ) -> Result<MutationResult, FraiseQLError> {
     // Extract arguments from the request message as JSON values.
+    //
+    // Object-valued args (a nested `input` message under the single-JSONB
+    // convention) serialize with the protobuf JSON name — `camelCase` for a
+    // `camelCase` GraphQL surface — so under `NamingConvention::CamelCase` their
+    // keys must be reversed to canonical `snake_case` before reaching a SQL
+    // function that reads `payload->>'snake_field'`, exactly as the GraphQL and
+    // REST mutation paths do via `recase_input_payload` (#456). Scalars carry no
+    // keys, so recasing is a no-op for them; `to_snake_case` is idempotent on
+    // already-`snake_case` keys.
     let args: Vec<serde_json::Value> = request_msg
         .descriptor()
         .fields()
         .filter(|f| request_msg.has_field(f))
-        .map(|f| proto_value_to_json(request_msg.get_field(&f).as_ref()))
+        .map(|f| {
+            let value = proto_value_to_json(request_msg.get_field(&f).as_ref());
+            if recase_input_keys {
+                recase_keys_to_snake(value)
+            } else {
+                value
+            }
+        })
         .collect();
 
     debug!(

--- a/crates/fraiseql-server/src/routes/grpc/mod.rs
+++ b/crates/fraiseql-server/src/routes/grpc/mod.rs
@@ -317,10 +317,16 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> DynamicGrpcService<A> {
                 );
             },
             handler::RpcKind::Mutation { function_name } => {
+                // Under a camelCase GraphQL surface, reverse object-valued arg keys
+                // to canonical snake_case before the SQL call — same contract as the
+                // GraphQL/REST mutation paths (#456).
+                let recase_input_keys = self.schema.naming_convention
+                    == fraiseql_core::schema::NamingConvention::CamelCase;
                 let result = match handler::execute_grpc_mutation(
                     self.adapter.as_ref(),
                     function_name,
                     &request_msg,
+                    recase_input_keys,
                 )
                 .await
                 {

--- a/crates/fraiseql-server/src/routes/grpc/tests.rs
+++ b/crates/fraiseql-server/src/routes/grpc/tests.rs
@@ -13,7 +13,7 @@ use prost_reflect::Value;
 use super::handler::{
     column_specs_from_type, column_value_to_proto, encode_response, encode_row,
     field_type_to_column_type, grpc_method_to_mutation_name, grpc_method_to_query_name,
-    proto_value_to_json,
+    proto_value_to_json, recase_keys_to_snake,
 };
 
 // ── field_type_to_column_type ────────────────────────────────────────
@@ -361,4 +361,53 @@ fn column_specs_from_type_filters_non_scalars() {
     let specs = column_specs_from_type(&type_def);
     let names: Vec<&str> = specs.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(names, vec!["id", "name", "age"]);
+}
+
+// ── recase_keys_to_snake (#456: gRPC single-JSONB arg recasing) ──────────
+
+#[test]
+fn recase_keys_to_snake_recases_nested_object_keys() {
+    use serde_json::json;
+    // A nested `input` message serializes with camelCase JSON names; its keys
+    // must reach the SQL function as snake_case.
+    let input = json!({ "shippingAddress": "1 Main St", "customerNote": "gift" });
+    let recased = recase_keys_to_snake(input);
+    assert_eq!(recased, json!({ "shipping_address": "1 Main St", "customer_note": "gift" }));
+}
+
+#[test]
+fn recase_keys_to_snake_recurses_into_nested_objects_and_arrays() {
+    use serde_json::json;
+    let input = json!({
+        "billingAddress": { "postalCode": "75001", "lineItems": [ { "skuId": "x" } ] }
+    });
+    let recased = recase_keys_to_snake(input);
+    assert_eq!(
+        recased,
+        json!({
+            "billing_address": { "postal_code": "75001", "line_items": [ { "sku_id": "x" } ] }
+        })
+    );
+}
+
+#[test]
+fn recase_keys_to_snake_is_acronym_and_digit_aware() {
+    use serde_json::json;
+    // Same `to_snake_case` the read path uses → writes round-trip as reads.
+    let input = json!({ "s3Key": "k", "dns1Id": "d" });
+    let recased = recase_keys_to_snake(input);
+    assert_eq!(recased, json!({ "s3_key": "k", "dns_1_id": "d" }));
+}
+
+#[test]
+fn recase_keys_to_snake_leaves_scalars_and_snake_keys_untouched() {
+    use serde_json::json;
+    // Scalars carry no keys; already-snake keys are idempotent — so a flattened
+    // positional scalar arg or a Preserve-authored object is unchanged.
+    assert_eq!(recase_keys_to_snake(json!("u1")), json!("u1"));
+    assert_eq!(recase_keys_to_snake(json!(42)), json!(42));
+    assert_eq!(
+        recase_keys_to_snake(json!({ "already_snake": 1 })),
+        json!({ "already_snake": 1 })
+    );
 }


### PR DESCRIPTION
Fixes #456.

## Root cause
The compiler emits an input-type mutation argument as `FieldType::Object(name)` — `FieldType::Input` is never constructed in the compile pipeline (`parse_field_type` maps every custom type name to `Object`). The runtime's single-JSONB recase / flatten detection keyed exclusively on `FieldType::Input`, so a real compiled `input` arg matched neither branch and fell through to the standard-arg path, forwarding the payload **verbatim** (camelCase keys) to the SQL function — regardless of `naming_convention`. A function reading `p_input->>'snake_field'` therefore saw NULL for every multi-word field.

Verified on a real ~140-mutation schema: 113/113 single-`input` args were `Object(<registered input type>)`, zero were `Input`.

## Fixes (5 commits)
1. `fix(core)` recase declared Input-type keys to snake_case on the single-JSONB path (acronym-aware `to_snake_case`, matches the read path).
2. `fix(server)` recase gRPC mutation input keys + guard the authenticated dispatch path.
3. **`fix(core)` recognize `Object`-typed input args by name** (`find_input_type`) so compiled mutations route through recase/flatten — the load-bearing fix; works on already-deployed schemas with no recompile.
4. `feat(cli)` default TomlSchema `naming_convention` to camelCase (matching the JSON path) + compile-time warning for `preserve` + single-JSONB + camelCase input fields.
5. `refactor(cli)` emit `FieldType::Input` for input-type args (IR honesty; also fixes a latent introspection `INPUT_OBJECT` kind). The runtime accepts both shapes.

#3 is necessary and sufficient for existing deployments; #5 is the clean representation going forward.

## Verification
- `cargo +nightly fmt --check`, `clippy --all-targets --all-features -D warnings` clean (core, server, cli)
- `cargo test -p fraiseql-core --lib` (2559 passed), `-p fraiseql-server --features grpc` (gRPC tests), `-p fraiseql-cli` (43 binaries) — all green
- Real-file check: 113/113 Object input args now recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)