### PR TITLE
chore(deps): bump notify 7 -> 8 to drop unmaintained instant (RUSTSEC-2024-0384)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5042,11 +5042,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -5080,15 +5080,6 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -5892,12 +5883,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "notify"
-version = "7.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5906,16 +5896,16 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-types"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "instant",
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/crates/fraiseql-cli/Cargo.toml
+++ b/crates/fraiseql-cli/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = {workspace = true}
 # Serialization
 indexmap = {workspace = true}
 # File watching (for serve command)
-notify = "7.0"
+notify = "8"
 regex = {workspace = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"


### PR DESCRIPTION
Genuinely removes one of the cargo-audit informational warnings by dropping the unmaintained `instant` crate.

## Change
- `fraiseql-cli`: `notify "7" → "8"`. notify 8 moved to `notify-types 2.x`, which dropped `instant` (RUSTSEC-2024-0384, unmaintained) in favour of `web-time`. `instant` is now gone from the dependency tree entirely.

## Verification
- `cargo check -p fraiseql-cli` passes (no API breakage from notify 7→8; `fraiseql watch` compiles).
- Full `fraiseql-cli` test suite passes (43 binaries, 0 failures).
- `cargo audit`: **6 → 5** informational warnings.

## The remaining 5 warnings are intentionally left visible
adler, bincode, paste (unmaintained) and lru, rand (unsound) are pinned by major upstream deps (deno_core, clickhouse, aws-sdk-s3, tiberius) with no feasible upgrade, and all sit behind optional features / build-deps. Per `.cargo/audit.toml` (`informational_warnings = ["unmaintained","unsound"]`), the project deliberately surfaces these as warnings rather than ignoring them — so they're left tracked and visible, not suppressed. They are non-gating (the `security` gate passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)