### PR TITLE
fix(ci): skip-tree windows-sys subtrees to unbreak cargo-deny bans

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -142,25 +142,9 @@ name = "rand_core"
 reason = "transitive via rand 0.9"
 version = "=0.9.5"
 
-[[bans.skip]]
-name = "windows-sys"
-reason = "transitive via older windows ecosystem crates"
-version = "=0.48.0"
-
-[[bans.skip]]
-name = "windows-sys"
-reason = "transitive via windows ecosystem migration"
-version = "=0.52.0"
-
-[[bans.skip]]
-name = "windows-targets"
-reason = "transitive via windows-sys 0.48"
-version = "=0.48.5"
-
-[[bans.skip]]
-name = "windows-targets"
-reason = "transitive via windows-sys 0.52"
-version = "=0.52.6"
+# windows-sys: the older roots and their entire windows-targets + windows_* leaf
+# subtrees are skip-tree'd below (one entry per root), so individual skips for
+# windows-sys / windows-targets / the per-arch leaf crates are unnecessary.
 
 [[bans.skip]]
 name = "wasi"
@@ -326,6 +310,27 @@ version = "=0.11.1"
 name = "wasmtime"
 reason = "wasmtime v44 pulls in older debug utilities (addr2line, gimli, object, etc.) via backtrace/dhat; upgrade tracked for 2026-12-01"
 version = "=44.0.3"
+
+# windows ecosystem: multiple windows-sys major versions coexist transitively
+# (0.48 via older crates, 0.52 via the migration wave, 0.53 via notify 8 →
+# windows-sys 0.60). Each root pulls its own windows-targets + per-arch
+# windows_* leaf crates. Skip-tree the older roots so the whole subtree (targets
+# + all seven leaf crates) is exempt in one entry each, leaving windows-sys
+# 0.61 (which has no windows-targets dep) as the canonical version.
+[[bans.skip-tree]]
+name = "windows-sys"
+reason = "windows-sys 0.48 → windows-targets 0.48.5 → windows_* 0.48.5 leaf crates"
+version = "=0.48.0"
+
+[[bans.skip-tree]]
+name = "windows-sys"
+reason = "windows-sys 0.52 → windows-targets 0.52.6 → windows_* 0.52.6 leaf crates"
+version = "=0.52.0"
+
+[[bans.skip-tree]]
+name = "windows-sys"
+reason = "windows-sys 0.60 (via notify 8) → windows-targets 0.53.5 → windows_* 0.53.1 leaf crates"
+version = "=0.60.2"
 
 # Non-wasmtime duplicates from ecosystem migrations
 [graph]


### PR DESCRIPTION
## Problem

The `notify` 7→8 bump (dev `9e1ce0c2a`) pulled in `windows-sys` 0.60.2 → `windows-targets` 0.53.5 → the per-arch `windows_*` 0.53.1 leaf crates. Each `windows_*` leaf crate now has **three** coexisting versions (0.48.5 / 0.52.6 / 0.53.1).

The existing `[[bans.skip]]` entries only exempted `windows-sys` and `windows-targets` at the two older versions — **not** the per-arch leaf crates — so `cargo deny check bans` fails with `found 2 duplicate entries` for all seven `windows_*` crates. The Dagger `security` leg runs `cargo-deny check` **without `--locked`**, so the failure is deterministic (the rerun reproduced it identically; the failure also reproduces locally against the dev lockfile).

## Fix

Replace the four version-pinned windows `[[bans.skip]]` entries with three `[[bans.skip-tree]]` entries on the older `windows-sys` roots (`0.48.0`, `0.52.0`, `0.60.2`). Each prunes its whole subtree — `windows-targets` plus all seven per-arch leaf crates — in a single entry, leaving `windows-sys` `0.61.2` (which has no `windows-targets` dependency) as the canonical version. This mirrors the existing skip-tree handling of hyper/rustls/p256/wasmtime.

## Verification

✅ `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok` (locally, against the dev lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)