### PR TITLE
feat(server): dispatch after:mutation function triggers after commit (#460)

### DIFF
--- a/crates/fraiseql-functions/src/observer/mod.rs
+++ b/crates/fraiseql-functions/src/observer/mod.rs
@@ -128,6 +128,46 @@ impl FunctionObserver {
     ) -> Vec<crate::triggers::mutation::AfterMutationTrigger> {
         registry.after_mutation_triggers.find(&event.entity, event.event_kind)
     }
+
+    /// Execute a WASM module with a full I/O-capable host context.
+    ///
+    /// Unlike [`invoke`](Self::invoke) — which snapshots the host into a
+    /// sync-only `HostContextSnapshot` and so returns `Unsupported` for async
+    /// I/O — this routes to
+    /// [`WasmRuntime::invoke_with_context`](crate::runtime::wasm::WasmRuntime::invoke_with_context),
+    /// giving the guest live HTTP / query / storage access through `host`. The
+    /// after:mutation dispatcher uses this so side-effecting functions (webhooks,
+    /// external provisioning) can reach the network.
+    ///
+    /// Only the WASM runtime is supported on this path; an event whose module
+    /// targets another runtime returns `Unsupported`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if no WASM runtime is registered, the registered runtime is
+    /// not a [`WasmRuntime`](crate::runtime::wasm::WasmRuntime), or guest
+    /// execution fails.
+    #[cfg(feature = "runtime-wasm")]
+    pub async fn invoke_with_context(
+        &self,
+        module: &FunctionModule,
+        event: EventPayload,
+        host: Arc<dyn crate::runtime::wasm::host_bridge::DynHostContext>,
+        limits: ResourceLimits,
+    ) -> Result<FunctionResult> {
+        let runtime_box = self.runtimes.get(&RuntimeType::Wasm).ok_or_else(|| {
+            fraiseql_error::FraiseQLError::Unsupported {
+                message: "No WASM runtime registered for after:mutation dispatch".to_string(),
+            }
+        })?;
+        let runtime =
+            runtime_box.downcast_ref::<crate::runtime::wasm::WasmRuntime>().ok_or_else(|| {
+                fraiseql_error::FraiseQLError::Unsupported {
+                    message: "Invalid WASM runtime".to_string(),
+                }
+            })?;
+        runtime.invoke_with_context(module, event, host, limits).await
+    }
 }
 
 impl Default for FunctionObserver {

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -172,6 +172,16 @@ grpc = ["dep:tonic", "dep:prost", "dep:prost-reflect", "dep:http-body", "dep:htt
 federation = ["fraiseql-core/federation", "dep:fraiseql-federation"]
 # Edge functions HTTP endpoint (POST /functions/v1/{name})
 functions = []
+# After-mutation function-trigger dispatch with a full I/O-capable host context
+# (outbound HTTP with an SSRF allowlist, secrets). Pulls in the WASM runtime and
+# the live host context, which are opt-in (#460), so the stock binary stays lean.
+# Enable this to actually run `after:mutation` functions after a committed
+# mutation; without it the dispatch step is compiled out.
+functions-runtime = [
+    "functions",
+    "fraiseql-functions/runtime-wasm",
+    "fraiseql-functions/host-live",
+]
 # auth is included by default because auth middleware is wired into the core request pipeline.
 # secrets and webhooks are opt-in: add them to your dependency features when needed.
 default = ["auth", "cli"]

--- a/crates/fraiseql-server/src/routes/after_mutation.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation.rs
@@ -1,0 +1,365 @@
+//! After-mutation function-trigger dispatch (#460).
+//!
+//! When a GraphQL or REST mutation commits, the server looks up any matching
+//! `after:mutation` function triggers and dispatches each as a fire-and-forget
+//! task. Failures are logged; they never affect the mutation response.
+//!
+//! The work is split in two:
+//!
+//! - `plan_after_mutation_dispatch` — pure, always-compiled, and unit-tested. It
+//!   maps a completed mutation to `(entity, event_kind)`, finds matching
+//!   triggers, resolves their modules, and builds the event payloads. It has no
+//!   side effects and needs no function runtime.
+//! - `spawn_after_mutation` — gated behind `functions-runtime`. It runs each plan
+//!   on a live, I/O-capable host context (`LiveHostContext`) via
+//!   `FunctionObserver::invoke_with_context`, so side-effecting functions
+//!   (webhooks, external provisioning) can reach the network.
+//!
+//! A stock server binary compiles only the planner; the runtime + live host
+//! context are opt-in (see the crate's `functions-runtime` feature).
+
+use fraiseql_core::schema::{CompiledSchema, MutationOperation};
+use fraiseql_functions::{EntityEvent, EventKind, EventPayload, FunctionModule};
+
+use crate::subsystems::BeforeMutationHooks;
+
+/// A single resolved after:mutation invocation: the module to run and the event
+/// payload to run it with.
+pub struct AfterMutationDispatch {
+    /// The function module to execute.
+    pub module:  FunctionModule,
+    /// The event payload (`after:mutation:<fn>` with `{event_kind, old, new}`).
+    pub payload: EventPayload,
+}
+
+/// Map a mutation's SQL operation to the after:mutation [`EventKind`] it emits.
+///
+/// `Custom` mutations have no insert/update/delete semantics, so they produce no
+/// after:mutation event and return `None`.
+pub const fn event_kind_for(operation: &MutationOperation) -> Option<EventKind> {
+    match operation {
+        MutationOperation::Insert { .. } => Some(EventKind::Insert),
+        MutationOperation::Update { .. } => Some(EventKind::Update),
+        MutationOperation::Delete { .. } => Some(EventKind::Delete),
+        // Custom (and any future non-DML variant) emits no entity event.
+        _ => None,
+    }
+}
+
+/// Plan the after:mutation dispatch for a committed mutation.
+///
+/// Resolves the mutation definition (→ entity type + DML verb), builds the
+/// [`EntityEvent`] from the response, finds matching `after:mutation` triggers,
+/// and pairs each with its function module. Returns an empty vector when the
+/// operation is not a state-changing mutation, the mutation is unknown, or no
+/// trigger matches — all of which are the common, allocation-cheap fast path.
+///
+/// `response_data` is the full GraphQL execution result (`{"data": {...}}`); the
+/// affected entity is read from `data.<mutation_name>`.
+pub fn plan_after_mutation_dispatch(
+    hooks: &BeforeMutationHooks,
+    schema: &CompiledSchema,
+    mutation_name: &str,
+    response_data: &serde_json::Value,
+) -> Vec<AfterMutationDispatch> {
+    let Some(definition) = schema.find_mutation(mutation_name) else {
+        return Vec::new();
+    };
+    let Some(event_kind) = event_kind_for(&definition.operation) else {
+        return Vec::new();
+    };
+
+    // The affected entity is flattened under `data.<mutation_name>` in the
+    // GraphQL response. A null result (e.g. a no-op delete) carries no entity.
+    let entity_value = response_data
+        .get("data")
+        .and_then(|data| data.get(mutation_name))
+        .filter(|value| !value.is_null())
+        .cloned();
+
+    // A delete reports the removed row as the *old* state; insert/update report
+    // the resulting row as the *new* state. The complementary pre-image is not
+    // available on this path, so it stays `None`.
+    let (old, new) = match event_kind {
+        EventKind::Delete => (entity_value, None),
+        _ => (None, entity_value),
+    };
+
+    let event = EntityEvent {
+        entity: definition.return_type.clone(),
+        event_kind,
+        old,
+        new,
+        timestamp: chrono::Utc::now(),
+    };
+
+    hooks
+        .observer
+        .find_after_mutation_triggers(&hooks.trigger_registry, &event)
+        .into_iter()
+        .filter_map(|trigger| {
+            // A trigger whose module never loaded is silently skipped: dispatch
+            // is best-effort and must not block the response.
+            let module = hooks.module_registry.get(&trigger.function_name)?.clone();
+            let payload = trigger.build_payload(&event);
+            Some(AfterMutationDispatch { module, payload })
+        })
+        .collect()
+}
+
+/// Spawn each planned after:mutation invocation as a fire-and-forget task.
+///
+/// Each task runs its module on a [`LiveHostContext`] so the function can perform
+/// outbound I/O (HTTP, with the SSRF allowlist from
+/// `FRAISEQL_FUNCTIONS_ALLOWED_DOMAINS`). Errors are logged, never propagated —
+/// the mutation response has already been sent.
+///
+/// [`LiveHostContext`]: fraiseql_functions::host::live::LiveHostContext
+#[cfg(feature = "functions-runtime")]
+pub fn spawn_after_mutation(hooks: &BeforeMutationHooks, plans: Vec<AfterMutationDispatch>) {
+    let config = host_context_config();
+    let limits = fraiseql_functions::ResourceLimits::default();
+
+    for plan in plans {
+        let observer = std::sync::Arc::clone(&hooks.observer);
+        let config = config.clone();
+        let limits = limits.clone();
+        tokio::spawn(async move {
+            let function_name = plan.module.name.clone();
+            let host: std::sync::Arc<
+                dyn fraiseql_functions::runtime::wasm::host_bridge::DynHostContext,
+            > = std::sync::Arc::new(fraiseql_functions::host::live::LiveHostContext::new(
+                plan.payload.clone(),
+                config,
+            ));
+            match observer.invoke_with_context(&plan.module, plan.payload, host, limits).await {
+                Ok(_) => {
+                    tracing::debug!(function = %function_name, "after:mutation function dispatched");
+                },
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        function = %function_name,
+                        "after:mutation function failed",
+                    );
+                },
+            }
+        });
+    }
+}
+
+/// Build the host-context config for after:mutation functions.
+///
+/// Outbound HTTP is deny-by-default; the SSRF allowlist is sourced from the
+/// comma-separated `FRAISEQL_FUNCTIONS_ALLOWED_DOMAINS` environment variable so
+/// production can grant outbound access without recompiling the schema.
+#[cfg(feature = "functions-runtime")]
+fn host_context_config() -> fraiseql_functions::host::live::HostContextConfig {
+    let mut config = fraiseql_functions::host::live::HostContextConfig::default();
+    if let Ok(domains) = std::env::var("FRAISEQL_FUNCTIONS_ALLOWED_DOMAINS") {
+        config.allowed_domains = domains
+            .split(',')
+            .map(str::trim)
+            .filter(|domain| !domain.is_empty())
+            .map(String::from)
+            .collect();
+    }
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use fraiseql_core::schema::{CompiledSchema, MutationDefinition, MutationOperation};
+    use fraiseql_functions::{
+        FunctionDefinition, FunctionModule, FunctionObserver, RuntimeType, TriggerRegistry,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    fn module(name: &str) -> FunctionModule {
+        FunctionModule {
+            name:        name.to_string(),
+            source_hash: "test".to_string(),
+            bytecode:    bytes::Bytes::new(),
+            runtime:     RuntimeType::Wasm,
+        }
+    }
+
+    fn hooks(triggers: &[(&str, &str)], modules: &[&str]) -> BeforeMutationHooks {
+        let definitions: Vec<FunctionDefinition> = triggers
+            .iter()
+            .map(|(name, trigger)| FunctionDefinition {
+                name:       (*name).to_string(),
+                trigger:    (*trigger).to_string(),
+                runtime:    RuntimeType::Wasm,
+                timeout_ms: None,
+            })
+            .collect();
+        let trigger_registry =
+            TriggerRegistry::load_from_definitions(&definitions).expect("valid trigger definitions");
+        let module_registry: HashMap<String, FunctionModule> =
+            modules.iter().map(|name| ((*name).to_string(), module(name))).collect();
+        BeforeMutationHooks {
+            trigger_registry,
+            module_registry,
+            observer: Arc::new(FunctionObserver::new()),
+        }
+    }
+
+    fn schema_with(name: &str, return_type: &str, operation: MutationOperation) -> CompiledSchema {
+        let mut definition = MutationDefinition::new(name, return_type);
+        definition.operation = operation;
+        let mut schema = CompiledSchema::default();
+        schema.mutations.push(definition);
+        schema
+    }
+
+    fn insert(table: &str) -> MutationOperation {
+        MutationOperation::Insert {
+            table: table.to_string(),
+        }
+    }
+
+    #[test]
+    fn event_kind_maps_dml_verbs_and_skips_custom() {
+        assert_eq!(event_kind_for(&insert("t")), Some(EventKind::Insert));
+        assert_eq!(
+            event_kind_for(&MutationOperation::Update {
+                table: "t".to_string(),
+            }),
+            Some(EventKind::Update)
+        );
+        assert_eq!(
+            event_kind_for(&MutationOperation::Delete {
+                table: "t".to_string(),
+            }),
+            Some(EventKind::Delete)
+        );
+        assert_eq!(event_kind_for(&MutationOperation::Custom), None);
+    }
+
+    #[test]
+    fn plans_dispatch_for_matching_insert_trigger() {
+        let hooks = hooks(&[("onUserCreated", "after:mutation:User:insert")], &["onUserCreated"]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createUser": { "id": "u1", "name": "Ada" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createUser", &response);
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].module.name, "onUserCreated");
+        // The payload carries the new entity under `data.new`.
+        let data = &plans[0].payload.data;
+        assert_eq!(data["event_kind"], "insert");
+        assert_eq!(data["new"]["name"], "Ada");
+        assert!(data["old"].is_null());
+    }
+
+    #[test]
+    fn delete_reports_entity_as_old_not_new() {
+        let hooks = hooks(&[("onUserDeleted", "after:mutation:User:delete")], &["onUserDeleted"]);
+        let schema = schema_with(
+            "deleteUser",
+            "User",
+            MutationOperation::Delete {
+                table: "tb_user".to_string(),
+            },
+        );
+        let response = json!({ "data": { "deleteUser": { "id": "u1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "deleteUser", &response);
+
+        assert_eq!(plans.len(), 1);
+        let data = &plans[0].payload.data;
+        assert_eq!(data["event_kind"], "delete");
+        assert_eq!(data["old"]["id"], "u1");
+        assert!(data["new"].is_null());
+    }
+
+    #[test]
+    fn custom_mutation_emits_no_dispatch() {
+        // A trigger keyed on the entity exists, but a Custom op has no event kind.
+        let hooks = hooks(&[("onAnything", "after:mutation:Report")], &["onAnything"]);
+        let schema = schema_with("generateReport", "Report", MutationOperation::Custom);
+        let response = json!({ "data": { "generateReport": { "id": "r1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "generateReport", &response);
+
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn unknown_mutation_emits_no_dispatch() {
+        let hooks = hooks(&[("onUserCreated", "after:mutation:User:insert")], &["onUserCreated"]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createPost": { "id": "p1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createPost", &response);
+
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn non_matching_entity_emits_no_dispatch() {
+        // Trigger is for Post, but the mutation returns User.
+        let hooks = hooks(&[("onPostCreated", "after:mutation:Post:insert")], &["onPostCreated"]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createUser": { "id": "u1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createUser", &response);
+
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn wrong_event_kind_filter_emits_no_dispatch() {
+        // Trigger only fires on update; the mutation is an insert.
+        let hooks = hooks(&[("onUserUpdated", "after:mutation:User:update")], &["onUserUpdated"]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createUser": { "id": "u1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createUser", &response);
+
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn all_kinds_trigger_matches_insert() {
+        // No operation filter → matches every event kind for the entity.
+        let hooks = hooks(&[("onUserChange", "after:mutation:User")], &["onUserChange"]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createUser": { "id": "u1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createUser", &response);
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].module.name, "onUserChange");
+    }
+
+    #[test]
+    fn trigger_without_loaded_module_is_skipped() {
+        // Trigger is registered but its module never loaded → dropped, not panicked.
+        let hooks = hooks(&[("ghost", "after:mutation:User:insert")], &[]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createUser": { "id": "u1" } } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createUser", &response);
+
+        assert!(plans.is_empty());
+    }
+
+    #[test]
+    fn null_entity_yields_empty_new_but_still_dispatches() {
+        let hooks = hooks(&[("onUserCreated", "after:mutation:User:insert")], &["onUserCreated"]);
+        let schema = schema_with("createUser", "User", insert("tb_user"));
+        let response = json!({ "data": { "createUser": null } });
+
+        let plans = plan_after_mutation_dispatch(&hooks, &schema, "createUser", &response);
+
+        assert_eq!(plans.len(), 1);
+        assert!(plans[0].payload.data["new"].is_null());
+    }
+}

--- a/crates/fraiseql-server/src/routes/graphql/handler.rs
+++ b/crates/fraiseql-server/src/routes/graphql/handler.rs
@@ -757,6 +757,27 @@ async fn execute_graphql_request<A: DatabaseAdapter + Clone + Send + Sync + 'sta
         }
     }
 
+    // After-mutation function triggers (#460): once the mutation has committed,
+    // fire-and-forget any matching `after:mutation` functions on a live,
+    // I/O-capable host context. Gated on `functions-runtime` (the WASM runtime +
+    // live host are opt-in); a single `HashMap::get` of zero overhead when no
+    // hooks are registered. Errors are logged inside the spawned tasks and never
+    // affect the response that was already produced above.
+    #[cfg(feature = "functions-runtime")]
+    if let Some(ref hooks) = state.before_mutation_hooks {
+        if let Some(mutation_name) = detect_mutation_name(&query) {
+            let plans = crate::routes::after_mutation::plan_after_mutation_dispatch(
+                hooks,
+                executor.schema(),
+                &mutation_name,
+                &response_json,
+            );
+            if !plans.is_empty() {
+                crate::routes::after_mutation::spawn_after_mutation(hooks, plans);
+            }
+        }
+    }
+
     Ok(GraphQLResponse {
         body: response_json,
     })

--- a/crates/fraiseql-server/src/routes/mod.rs
+++ b/crates/fraiseql-server/src/routes/mod.rs
@@ -1,5 +1,10 @@
 //! HTTP routes.
 
+// After-mutation function-trigger dispatch (#460). The planner is always
+// compiled (and unit-tested); the I/O-capable spawn path is gated behind
+// `functions-runtime`, so the items are dead in a default build.
+#[cfg_attr(not(feature = "functions-runtime"), allow(dead_code))]
+pub(crate) mod after_mutation;
 pub mod api;
 #[cfg(feature = "auth")]
 pub mod auth;

--- a/crates/fraiseql-server/src/routes/rest/handler/mod.rs
+++ b/crates/fraiseql-server/src/routes/rest/handler/mod.rs
@@ -46,6 +46,10 @@ pub struct RestHandler<'a, A: DatabaseAdapter> {
     pub(super) config:            &'a RestConfig,
     pub(super) route_table:       &'a RestRouteTable,
     pub(super) idempotency_store: Option<&'a Arc<dyn IdempotencyStore>>,
+    /// After-mutation function-trigger hooks (#460). Read only by the gated
+    /// after:mutation dispatch; unused in a build without `functions-runtime`.
+    #[cfg_attr(not(feature = "functions-runtime"), allow(dead_code))]
+    pub(super) function_hooks:    Option<&'a Arc<crate::subsystems::BeforeMutationHooks>>,
 }
 
 impl<'a, A: DatabaseAdapter> RestHandler<'a, A> {
@@ -63,7 +67,21 @@ impl<'a, A: DatabaseAdapter> RestHandler<'a, A> {
             config,
             route_table,
             idempotency_store: None,
+            function_hooks: None,
         }
+    }
+
+    /// Attach after-mutation function-trigger hooks for `after:mutation` dispatch.
+    ///
+    /// When set (and built with `functions-runtime`), a committed mutation
+    /// fire-and-forget-dispatches any matching `after:mutation` functions.
+    #[must_use]
+    pub const fn with_function_hooks(
+        mut self,
+        hooks: Option<&'a Arc<crate::subsystems::BeforeMutationHooks>>,
+    ) -> Self {
+        self.function_hooks = hooks;
+        self
     }
 
     /// Access the underlying executor.

--- a/crates/fraiseql-server/src/routes/rest/handler/mutation.rs
+++ b/crates/fraiseql-server/src/routes/rest/handler/mutation.rs
@@ -33,6 +33,33 @@ impl<'a, A: DatabaseAdapter> RestHandler<'a, A> {
 }
 
 impl<A: DatabaseAdapter + SupportsMutations> RestHandler<'_, A> {
+    /// Fire-and-forget dispatch of `after:mutation` function triggers for a
+    /// committed REST mutation (#460).
+    ///
+    /// `result` is the executor result (`{"data": {...}}`). Matching triggers
+    /// run on a live, I/O-capable host context; errors are logged inside the
+    /// spawned tasks and never affect the response. This is a no-op in a build
+    /// without `functions-runtime`.
+    #[cfg(feature = "functions-runtime")]
+    fn dispatch_after_mutation(&self, mutation_name: &str, result: &serde_json::Value) {
+        if let Some(hooks) = self.function_hooks {
+            let plans = crate::routes::after_mutation::plan_after_mutation_dispatch(
+                hooks,
+                self.schema,
+                mutation_name,
+                result,
+            );
+            if !plans.is_empty() {
+                crate::routes::after_mutation::spawn_after_mutation(hooks, plans);
+            }
+        }
+    }
+
+    /// No-op after:mutation dispatch when the function runtime is not compiled in.
+    #[cfg(not(feature = "functions-runtime"))]
+    #[allow(clippy::unused_self)] // Reason: mirrors the gated signature
+    const fn dispatch_after_mutation(&self, _mutation_name: &str, _result: &serde_json::Value) {}
+
     /// Handle a POST request (create mutation, bulk insert, or custom action).
     ///
     /// Array body on a collection route triggers bulk insert mode.
@@ -135,6 +162,10 @@ impl<A: DatabaseAdapter + SupportsMutations> RestHandler<'_, A> {
         let result =
             execute_mutation(self.executor, effective_mutation, vars_ref, security_context).await?;
 
+        // After-mutation triggers (#460): dispatch on the declared mutation name
+        // (not the upsert override) so the entity type and DML verb resolve.
+        self.dispatch_after_mutation(mutation_name, &result);
+
         let mut response_headers = HeaderMap::new();
         set_request_id(headers, &mut response_headers);
 
@@ -231,6 +262,9 @@ impl<A: DatabaseAdapter + SupportsMutations> RestHandler<'_, A> {
         let result =
             execute_mutation(self.executor, mutation_name, vars_ref, security_context).await?;
 
+        // After-mutation triggers (#460): fire-and-forget once the update commits.
+        self.dispatch_after_mutation(mutation_name, &result);
+
         let mut response_headers = HeaderMap::new();
         set_request_id(headers, &mut response_headers);
 
@@ -305,6 +339,9 @@ impl<A: DatabaseAdapter + SupportsMutations> RestHandler<'_, A> {
                 let result =
                     execute_mutation(self.executor, mutation_name, vars_ref, security_context)
                         .await?;
+
+                // After-mutation triggers (#460): fire-and-forget once the patch commits.
+                self.dispatch_after_mutation(mutation_name, &result);
 
                 let mut response_headers = HeaderMap::new();
                 set_request_id(headers, &mut response_headers);
@@ -387,6 +424,9 @@ impl<A: DatabaseAdapter + SupportsMutations> RestHandler<'_, A> {
                 let result =
                     execute_mutation(self.executor, mutation_name, vars_ref, security_context)
                         .await?;
+
+                // After-mutation triggers (#460): fire-and-forget once the delete commits.
+                self.dispatch_after_mutation(mutation_name, &result);
 
                 let prefer = PreferHeader::from_headers(headers);
                 let mut response_headers = HeaderMap::new();

--- a/crates/fraiseql-server/src/routes/rest/router/mod.rs
+++ b/crates/fraiseql-server/src/routes/rest/router/mod.rs
@@ -102,6 +102,7 @@ where
         route_table: route_table.clone(),
         idempotency_store,
         error_sanitizer: Arc::clone(&state.error_sanitizer),
+        function_hooks: state.before_mutation_hooks.clone(),
         #[cfg(feature = "observers")]
         event_transport: None,
         #[cfg(feature = "export-xlsx")]
@@ -336,6 +337,10 @@ struct RestState<A: DatabaseAdapter> {
     /// Error sanitizer (from `compiled.security.error_sanitization`). Strips raw DB/SQL
     /// detail from 5xx response bodies before they reach the client (H7).
     error_sanitizer:   Arc<crate::config::error_sanitization::ErrorSanitizer>,
+    /// After-mutation function-trigger hooks (#460), forwarded to the mutation
+    /// handlers so a committed REST mutation can dispatch `after:mutation`
+    /// functions. `None` when the functions subsystem is absent.
+    function_hooks:    Option<Arc<crate::subsystems::BeforeMutationHooks>>,
     /// Optional event transport for SSE streaming (requires `observers` feature).
     #[cfg(feature = "observers")]
     event_transport:   Option<Arc<dyn fraiseql_observers::transport::EventTransport>>,
@@ -526,7 +531,8 @@ where
     let schema = rest.executor.schema();
     let config = schema.rest_config.as_ref().expect("REST config must exist: handler is only reached via a matched REST route, which requires rest_config to be present in the schema");
     let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table)
-        .with_idempotency_store(&rest.idempotency_store);
+        .with_idempotency_store(&rest.idempotency_store)
+        .with_function_hooks(rest.function_hooks.as_ref());
 
     let result = handler
         .handle_post(&relative_path, &body_value, &parts.headers, security_ctx.as_ref())
@@ -554,7 +560,8 @@ where
 
     let schema = rest.executor.schema();
     let config = schema.rest_config.as_ref().expect("REST config must exist: handler is only reached via a matched REST route, which requires rest_config to be present in the schema");
-    let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table);
+    let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table)
+        .with_function_hooks(rest.function_hooks.as_ref());
 
     let result = handler
         .handle_put(&relative_path, &body_value, &parts.headers, security_ctx.as_ref())
@@ -586,7 +593,8 @@ where
 
     let schema = rest.executor.schema();
     let config = schema.rest_config.as_ref().expect("REST config must exist: handler is only reached via a matched REST route, which requires rest_config to be present in the schema");
-    let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table);
+    let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table)
+        .with_function_hooks(rest.function_hooks.as_ref());
 
     let result = handler
         .handle_patch(
@@ -619,7 +627,8 @@ where
 
     let schema = rest.executor.schema();
     let config = schema.rest_config.as_ref().expect("REST config must exist: handler is only reached via a matched REST route, which requires rest_config to be present in the schema");
-    let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table);
+    let handler = RestHandler::new(&rest.executor, schema, config, &rest.route_table)
+        .with_function_hooks(rest.function_hooks.as_ref());
 
     let result = handler
         .handle_delete(&relative_path, &query_refs, &parts.headers, security_ctx.as_ref())


### PR DESCRIPTION
Fixes #460.

## Problem

`after:mutation` function triggers were parsed, registered, and surfaced in the `TriggerRegistry`, but the server **never dispatched them** — a repo-wide grep found zero call sites for `find_after_mutation_triggers` in `crates/fraiseql-server/src/`. A registered `after:mutation:<entity>:<op>` function (e.g. a fire-and-forget webhook / external provisioning call) silently never ran. `before:mutation` already runs inline on the request hot path; this brings `after:mutation` to parity.

## Changes

- **`fraiseql-functions`**: add `FunctionObserver::invoke_with_context` (gated on `runtime-wasm`) routing to `WasmRuntime::invoke_with_context`, so an after:mutation function runs on a full I/O-capable `LiveHostContext` instead of the sync-only snapshot that `invoke()` uses.
- **`fraiseql-server`**: new always-compiled `routes::after_mutation` module:
  - `plan_after_mutation_dispatch` (pure, unit-tested) maps a committed mutation to `(entity, event_kind)` via its `MutationDefinition` (`return_type` + `operation`), reads the affected entity from `data.<mutation>`, finds matching triggers, and pairs each with its module + event payload.
  - `spawn_after_mutation` (gated on `functions-runtime`) runs each plan as a fire-and-forget task on a `LiveHostContext`, logging errors — never blocking or failing the response.
- Wire the dispatch into the **GraphQL** mutation path (after commit, before the response returns) and all four single-resource **REST** mutation handlers (POST/PUT/PATCH/DELETE) via a `RestHandler::with_function_hooks` builder mirroring `with_idempotency_store`.
- New **`functions-runtime`** feature forwards `fraiseql-functions/runtime-wasm` + `host-live`. Off by default so the stock binary stays lean (the function runtime is opt-in, per the issue); the dispatch step compiles out without it, while the planner stays compiled + tested. Outbound HTTP uses the SSRF allowlist from `FRAISEQL_FUNCTIONS_ALLOWED_DOMAINS` (deny-by-default).

Delete reports the removed row as `old`; insert/update report the resulting row as `new`. Custom (non-DML) mutations emit no event.

## Not in scope (follow-ups)

- Bulk / collection-level REST mutations and gRPC mutations.
- Populating the function-hooks bundle from the compiled schema at startup — a **pre-existing** gap that gates `before:mutation` too (the bundle is only assembled in tests today). This PR fills the handler-level dispatch gap the issue describes; the bootstrap wiring is orthogonal.
- A surfaced compiled-schema `allowed_domains` (this slice sources it from the env var).

## Verification

- ✅ `cargo +nightly fmt`
- ✅ `cargo clippy -p fraiseql-server --all-targets --all-features -- -D warnings`
- ✅ `cargo clippy -p fraiseql-functions --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- ✅ `cargo test -p fraiseql-server` — default 1139; `rest,functions-runtime` 1508
- ✅ `cargo test -p fraiseql-functions` — 126 (incl. 10 new planner tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)