### PR TITLE
fix(core): route failed mutations onto the declared error type, not the success arm (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Failed mutations now resolve onto the declared error type, not the success arm
+  (#465).** When a `mutation_response` reported failure (`succeeded = false`), the
+  GraphQL projection resolved the result type *only* via `find_union(return_type)`.
+  If that found no `is_error` member — e.g. the mutation returns the bare success
+  entity with sibling error types declared (the shipped `04-error-type` pattern), or
+  any schema where the result union is not the mutation's compiled return type — the
+  error arm fell through to emitting `__typename = <success/return type>` and
+  projected no error fields. A client selecting `... on MutationError { … }` then
+  received nothing on that arm and `__typename` named the entity. The error arm now
+  mirrors the success arm: it resolves the concrete error type from the response's
+  `entity_type` column (the declared error type the function stamps, e.g.
+  `DuplicateEmailError`) when it names an `is_error` type, falling back to the return
+  union's `is_error` member otherwise. This both fixes the mis-routing and, for unions
+  with several error members, projects the *specific* error the function reported
+  rather than the first one in the union. Success-path projection is unchanged.
 - **Root `{ __typename }` resolves to the operation type name (#450).** A top-level
   `{ __typename }` — the canonical zero-cost GraphQL health probe — was rejected with
   `Query '__typename' not found in schema` because the query classifier only

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -971,6 +971,7 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
             error_class,
             message,
             http_status,
+            entity_type,
             metadata,
         } => {
             let status = error_class.as_str();
@@ -999,13 +1000,28 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
                 .or_insert_with(|| serde_json::Value::String(status.to_string()));
             let source = serde_json::Value::Object(source_map);
 
-            // Find the matching error type from the return union.
-            let error_type = ctx.schema.find_union(&mutation_return_type).and_then(|u| {
-                u.member_types.iter().find_map(|t| {
-                    let td = ctx.schema.find_type(t)?;
-                    if td.is_error { Some(td) } else { None }
-                })
-            });
+            // Resolve the concrete error type to project — symmetric with the
+            // success arm's typename resolution (#465). The function stamps the
+            // declared error type it produced onto `entity_type`, so prefer it when
+            // it names a known `is_error` type: this routes onto the *specific*
+            // error member (e.g. `DuplicateEmailError` vs `ValidationError`) and,
+            // crucially, surfaces the declared error type even when the mutation's
+            // return type is the bare success entity rather than a union (the
+            // `Entity`-return + declared-error-types pattern, where `find_union`
+            // finds nothing and the result previously leaked the success typename).
+            // Fall back to the return union's first `is_error` member otherwise.
+            let error_type = entity_type
+                .as_deref()
+                .and_then(|name| ctx.schema.find_type(name))
+                .filter(|td| td.is_error)
+                .or_else(|| {
+                    ctx.schema.find_union(&mutation_return_type).and_then(|u| {
+                        u.member_types.iter().find_map(|t| {
+                            let td = ctx.schema.find_type(t)?;
+                            if td.is_error { Some(td) } else { None }
+                        })
+                    })
+                });
 
             // Project the error source through the same canonical projector when the
             // schema declares a matching error type. Otherwise emit just __typename

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
@@ -479,8 +479,19 @@ mod mutation {
 
     /// Mock adapter that returns a failed `mutation_response` row (an error
     /// outcome with no entity), driving the executor down the mutation-error
-    /// fallback path.
-    struct MutationErrorMockAdapter;
+    /// path. `entity_type` is the optional concrete error type a real failure
+    /// branch stamps on the response (e.g. `"DuplicateEmailError"`); `None`
+    /// leaves the column absent, exercising the union-fallback resolution (#465).
+    struct MutationErrorMockAdapter {
+        entity_type: Option<&'static str>,
+    }
+
+    impl MutationErrorMockAdapter {
+        /// A failure row with no `entity_type` stamped (the union-fallback case).
+        const fn bare() -> Self {
+            Self { entity_type: None }
+        }
+    }
 
     #[async_trait]
     impl DatabaseAdapter for MutationErrorMockAdapter {
@@ -496,6 +507,9 @@ mod mutation {
             row.insert("error_class".to_string(), json!("conflict"));
             row.insert("message".to_string(), json!("already exists"));
             row.insert("http_status".to_string(), json!(409));
+            if let Some(et) = self.entity_type {
+                row.insert("entity_type".to_string(), json!(et));
+            }
             Ok(vec![row])
         }
 
@@ -572,7 +586,7 @@ mod mutation {
             ..MutationDefinition::new("createUser", "User")
         });
 
-        let adapter = Arc::new(MutationErrorMockAdapter);
+        let adapter = Arc::new(MutationErrorMockAdapter::bare());
         let executor = Executor::new(schema, adapter);
 
         // `__typename` is selected ONLY inside an inline fragment, never at the
@@ -621,7 +635,7 @@ mod mutation {
             ..MutationDefinition::new("createUser", "CreateUserResult")
         });
 
-        let adapter = Arc::new(MutationErrorMockAdapter);
+        let adapter = Arc::new(MutationErrorMockAdapter::bare());
         let executor = Executor::new(schema, adapter);
 
         let result = executor
@@ -650,6 +664,174 @@ mod mutation {
             Some("conflict"),
             "error_class must be surfaced as errorClass"
         );
+    }
+
+    /// #465: when the mutation's return type is the bare success entity (no result
+    /// union) and the schema declares an `is_error` type, a genuine failure must
+    /// project that declared error type — driven by the response's `entity_type` —
+    /// not leak the success entity's typename onto the result. Before the fix the
+    /// error arm consulted only `find_union(return_type)`, found nothing, and fell
+    /// back to emitting `__typename = <success entity>` with no error fields.
+    #[tokio::test]
+    async fn test_mutation_failure_projects_declared_error_type_from_entity_type() {
+        use crate::schema::{FieldDefinition, FieldType, MutationDefinition, TypeDefinition};
+
+        let mut schema = CompiledSchema::new();
+        // The success entity carries its own legacy `status` field (e.g. an order
+        // status) — the field the bug surfaced in place of the error.
+        let mut user = TypeDefinition::new("CreateUserSuccess", "v_user");
+        user.fields = vec![
+            FieldDefinition::new("id", FieldType::String),
+            FieldDefinition::new("status", FieldType::String),
+        ];
+        schema.types.push(user);
+        schema.types.push(TypeDefinition {
+            is_error: true,
+            fields: vec![
+                FieldDefinition::new("message", FieldType::String),
+                FieldDefinition::new("errorClass", FieldType::String),
+            ],
+            ..TypeDefinition::new("DuplicateEmailError", "")
+        });
+        schema.mutations.push(MutationDefinition {
+            sql_source: Some("fn_create_user".to_string()),
+            // Bare success entity as the return type — no synthesized result union.
+            ..MutationDefinition::new("createUser", "CreateUserSuccess")
+        });
+
+        let adapter = Arc::new(MutationErrorMockAdapter {
+            entity_type: Some("DuplicateEmailError"),
+        });
+        let executor = Executor::new(schema, adapter);
+
+        let result = executor
+            .execute(
+                "mutation { createUser { __typename ... on CreateUserSuccess { id } \
+                 ... on DuplicateEmailError { errorClass message } } }",
+                None,
+            )
+            .await
+            .unwrap();
+        let data = result.get("data").and_then(|d| d.get("createUser")).unwrap();
+
+        assert_eq!(
+            data.get("__typename").and_then(|v| v.as_str()),
+            Some("DuplicateEmailError"),
+            "a failed mutation must resolve to the declared error type, not the success entity"
+        );
+        assert_eq!(
+            data.get("errorClass").and_then(|v| v.as_str()),
+            Some("conflict"),
+            "the error arm must project the declared error type's fields"
+        );
+        assert_eq!(data.get("message").and_then(|v| v.as_str()), Some("already exists"),);
+        // The success entity arm must contribute nothing on a failure.
+        assert!(data.get("id").is_none(), "success-arm field 'id' must be absent on failure");
+    }
+
+    /// #465 (specificity): with a result union carrying *several* `is_error`
+    /// members, the response's `entity_type` selects the exact one the function
+    /// reported — not merely the first error member in the union. This both fixes
+    /// the mis-routing and sharpens multi-error unions.
+    #[tokio::test]
+    async fn test_mutation_failure_selects_specific_union_error_member() {
+        use crate::schema::{
+            FieldDefinition, FieldType, MutationDefinition, TypeDefinition, UnionDefinition,
+        };
+
+        let mut schema = CompiledSchema::new();
+        schema.types.push(TypeDefinition::new("User", "v_user"));
+        // First error member — the one the OLD `find_union` resolution would pick.
+        schema.types.push(TypeDefinition {
+            is_error: true,
+            fields: vec![FieldDefinition::new("message", FieldType::String)],
+            ..TypeDefinition::new("ValidationError", "")
+        });
+        // Second error member — the one the function actually produced.
+        schema.types.push(TypeDefinition {
+            is_error: true,
+            fields: vec![FieldDefinition::new("message", FieldType::String)],
+            ..TypeDefinition::new("DuplicateEmailError", "")
+        });
+        schema.unions.push(UnionDefinition::new("CreateUserResult").with_members(vec![
+            "User".to_string(),
+            "ValidationError".to_string(),
+            "DuplicateEmailError".to_string(),
+        ]));
+        schema.mutations.push(MutationDefinition {
+            sql_source: Some("fn_create_user".to_string()),
+            ..MutationDefinition::new("createUser", "CreateUserResult")
+        });
+
+        let adapter = Arc::new(MutationErrorMockAdapter {
+            entity_type: Some("DuplicateEmailError"),
+        });
+        let executor = Executor::new(schema, adapter);
+
+        let result = executor
+            .execute(
+                "mutation { createUser { __typename ... on ValidationError { message } \
+                 ... on DuplicateEmailError { message } } }",
+                None,
+            )
+            .await
+            .unwrap();
+        let data = result.get("data").and_then(|d| d.get("createUser")).unwrap();
+
+        assert_eq!(
+            data.get("__typename").and_then(|v| v.as_str()),
+            Some("DuplicateEmailError"),
+            "entity_type must select the specific error member, not the first is_error member"
+        );
+    }
+
+    /// #465 (fallback): when the function does *not* stamp `entity_type`, the error
+    /// arm still resolves the union's `is_error` member, preserving the original
+    /// auto-error-union behaviour.
+    #[tokio::test]
+    async fn test_mutation_failure_falls_back_to_union_error_member_without_entity_type() {
+        use crate::schema::{
+            FieldDefinition, FieldType, MutationDefinition, TypeDefinition, UnionDefinition,
+        };
+
+        let mut schema = CompiledSchema::new();
+        schema.types.push(TypeDefinition::new("User", "v_user"));
+        schema.types.push(TypeDefinition {
+            is_error: true,
+            fields: vec![
+                FieldDefinition::new("status", FieldType::String),
+                FieldDefinition::new("errorClass", FieldType::String),
+            ],
+            ..TypeDefinition::new("MutationError", "")
+        });
+        schema.unions.push(
+            UnionDefinition::new("CreateUserResult")
+                .with_members(vec!["User".to_string(), "MutationError".to_string()]),
+        );
+        schema.mutations.push(MutationDefinition {
+            sql_source: Some("fn_create_user".to_string()),
+            ..MutationDefinition::new("createUser", "CreateUserResult")
+        });
+
+        // MutationErrorMockAdapter returns a failure row WITHOUT entity_type.
+        let adapter = Arc::new(MutationErrorMockAdapter::bare());
+        let executor = Executor::new(schema, adapter);
+
+        let result = executor
+            .execute(
+                "mutation { createUser { __typename ... on MutationError { errorClass } } }",
+                None,
+            )
+            .await
+            .unwrap();
+        let data = result.get("data").and_then(|d| d.get("createUser")).unwrap();
+
+        assert_eq!(
+            data.get("__typename").and_then(|v| v.as_str()),
+            Some("MutationError"),
+            "without entity_type the union's is_error member must still be resolved"
+        );
+        assert_eq!(data.get("errorClass").and_then(|v| v.as_str()), Some("conflict"));
     }
 
     // ── Three-state field semantics (issue #221) ───────────────────────────

--- a/crates/fraiseql-core/src/runtime/mutation_result.rs
+++ b/crates/fraiseql-core/src/runtime/mutation_result.rs
@@ -50,6 +50,12 @@ pub enum MutationOutcome {
         message:     String,
         /// Suggested HTTP status code, when the composite supplied one.
         http_status: Option<i16>,
+        /// Concrete GraphQL type name for the failure (from the `entity_type`
+        /// column). On the error path a function stamps the declared error type it
+        /// produced (e.g. `"DuplicateEmailError"`), letting the executor route the
+        /// result onto the right `is_error` union member — symmetric with the
+        /// success arm's use of `entity_type` (#465).
+        entity_type: Option<String>,
         /// Structured metadata JSONB containing error-type field values.
         metadata:    JsonValue,
     },
@@ -179,6 +185,7 @@ fn to_outcome(row: MutationResponse) -> Result<MutationOutcome> {
             error_class: class,
             message:     row.message.unwrap_or_default(),
             http_status: row.http_status,
+            entity_type: row.entity_type,
             metadata:    row.error_detail,
         })
     }

--- a/crates/fraiseql-core/src/runtime/tests.rs
+++ b/crates/fraiseql-core/src/runtime/tests.rs
@@ -2269,6 +2269,7 @@ mod mutation_result_tests {
                 message,
                 http_status,
                 metadata,
+                ..
             } => {
                 assert_eq!(error_class, MutationErrorClass::Conflict);
                 assert_eq!(message, "duplicate");

--- a/deny.toml
+++ b/deny.toml
@@ -142,10 +142,6 @@ name = "rand_core"
 reason = "transitive via rand 0.9"
 version = "=0.9.5"
 
-# windows-sys: the older roots and their entire windows-targets + windows_* leaf
-# subtrees are skip-tree'd below (one entry per root), so individual skips for
-# windows-sys / windows-targets / the per-arch leaf crates are unnecessary.
-
 [[bans.skip]]
 name = "wasi"
 reason = "transitive via getrandom 0.2"
@@ -296,6 +292,13 @@ name = "hyper"
 reason = "hyper 0.14 required by aws-sdk via aws-smithy-runtime; pulls in h2 0.3, http 0.2, http-body 0.4"
 version = "=0.14.32"
 
+# windows ecosystem: multiple windows-sys major versions coexist transitively
+# (0.48 via older crates, 0.52 via the migration wave, 0.53 via notify 8 →
+# windows-sys 0.60). Each root pulls its own windows-targets + per-arch
+# windows_* leaf crates. Skip-tree the older roots so the whole subtree (targets
+# + all seven leaf crates) is exempt in one entry each, leaving windows-sys
+# 0.61 (which has no windows-targets dep) as the canonical version.
+
 [[bans.skip-tree]]
 name = "rustls"
 reason = "rustls 0.21 required by aws-sdk-s3 via hyper-rustls 0.24; EOL but no upstream fix"
@@ -310,13 +313,6 @@ version = "=0.11.1"
 name = "wasmtime"
 reason = "wasmtime v44 pulls in older debug utilities (addr2line, gimli, object, etc.) via backtrace/dhat; upgrade tracked for 2026-12-01"
 version = "=44.0.3"
-
-# windows ecosystem: multiple windows-sys major versions coexist transitively
-# (0.48 via older crates, 0.52 via the migration wave, 0.53 via notify 8 →
-# windows-sys 0.60). Each root pulls its own windows-targets + per-arch
-# windows_* leaf crates. Skip-tree the older roots so the whole subtree (targets
-# + all seven leaf crates) is exempt in one entry each, leaving windows-sys
-# 0.61 (which has no windows-targets dep) as the canonical version.
 [[bans.skip-tree]]
 name = "windows-sys"
 reason = "windows-sys 0.48 → windows-targets 0.48.5 → windows_* 0.48.5 leaf crates"


### PR DESCRIPTION
## Summary

Fixes #465. A failed `mutation_response` (`succeeded = false`) was projected onto the **entity/success** union arm instead of the declared **error** type: `__typename` resolved to the success entity (carrying its legacy `status` field) and a client selecting `... on MutationError { … }` got nothing on that arm.

## Root cause

The error arm resolved the result type **only** via `find_union(return_type)`. When that yielded no `is_error` member it fell through to emitting `__typename = <success/return type>` and projected no error fields. This happens whenever the result union is not the mutation's compiled return type — including the shipped `04-error-type` pattern (mutation returns the bare success entity; sibling error types declared; no union). The `mutation_response.entity_type` the function stamps with the concrete error type was dropped on the error branch and never consulted.

I reproduced this end-to-end against a real PostgreSQL: a `succeeded=false` row with `return_type` = the entity resolved to `{ "__typename": "Thing", "status": "not_found" }` — exactly the reported symptom.

## Fix

The error arm now mirrors the **success arm**'s typename resolution: resolve the concrete error type from the response's `entity_type` when it names a declared `is_error` type, falling back to the return union's `is_error` member otherwise. This both fixes the mis-routing and, for unions with several error members, projects the **specific** error the function reported rather than the first union member. Success-path projection is unchanged.

## Changes

- `MutationOutcome::Error` carries `entity_type` (threaded from the row in `to_outcome`).
- `execute_mutation_impl` error arm: `entity_type`-first error-type resolution, union fallback.
- Three regression tests (bare-entity + declared-error routing; specific-member selection in a multi-error union; union-fallback when no `entity_type`). All three are proven to fail under the prior behaviour.
- CHANGELOG: Unreleased / Fixed.

## Adjacent findings (not in this PR)

While reproducing against the canonical `app.mutation_response` contract I hit two **separate** real-DB bugs that make a failed mutation surface as an opaque error rather than the error arm — worth their own issues:
1. `error_class` declared as the `app.mutation_error_class` **ENUM** is nulled by `row_to_map` (tokio-postgres `String: FromSql` rejects enum OIDs) → "succeeded=false requires error_class". Same class as the sibling SMALLINT/`http_status` fix.
2. A failure row leaving `updated_fields` **NULL** fails deserialization ("invalid type: null, expected a sequence"), since serde `default` only covers absent keys, not explicit null.

## Verification

- ✅ `cargo test -p fraiseql-core` (lib 2562 pass; mutation runner 64 pass)
- ✅ Real-PostgreSQL repro now resolves to the error arm
- ✅ New tests proven to fail under the prior behaviour
- ✅ clippy `-D warnings`, rustdoc `-D warnings`, fmt, preflight shell gates (lint-unwrap's pre-existing `fraiseql-auth` flag is unrelated — this branch doesn't touch that crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)