### PR TITLE
fix(db): decode PostgreSQL ENUM columns in row_to_map (mutation_response.error_class) (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PostgreSQL `ENUM` columns no longer decode to null in `row_to_map` (#472).** An
+  enum-typed column (notably `app.mutation_response.error_class`, the
+  `app.mutation_error_class` enum) fell through the `row_to_map` decode ladder to
+  `Null` because `String`'s `FromSql` rejects a custom enum OID. On a *failed*
+  mutation this dropped `error_class` to absent, and the parser then rejected the
+  whole row with `succeeded=false requires error_class` — so the typed error arm was
+  never reached and the failure surfaced as an opaque validation error. `row_to_map`
+  now decodes any enum to its text label (a small `FromSql` wrapper keyed on
+  `Kind::Enum`), generalising to every enum-typed column. Same class of latent
+  null-drop as the earlier `SMALLINT`/`http_status` and `TEXT[]`/`updated_fields`
+  (#228) fixes.
 - **Failed mutations now resolve onto the declared error type, not the success arm
   (#465).** When a `mutation_response` reported failure (`succeeded = false`), the
   GraphQL projection resolved the result type *only* via `find_union(return_type)`.

--- a/crates/fraiseql-db/src/postgres/adapter/database.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/database.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::BufMut as _;
 use fraiseql_error::{FraiseQLError, Result};
-use tokio_postgres::Row;
+use tokio_postgres::{
+    Row,
+    types::{FromSql, Kind, Type},
+};
 
 use super::{
     PostgresAdapter, build_projection_select_sql, build_where_select_sql,
@@ -137,6 +140,27 @@ fn enrich_undefined_column_error(
     }
 }
 
+/// Decodes any PostgreSQL `ENUM` value as its text label.
+///
+/// `String`'s `FromSql` accepts only the text family (TEXT/VARCHAR/BPCHAR/NAME), not
+/// a custom enum OID, so an enum column otherwise falls through [`row_to_map`]'s
+/// decode ladder to `Null`. An enum's binary wire representation *is* its label as
+/// UTF-8 text, so this reads it directly (#472).
+struct PgEnumLabel(String);
+
+impl<'a> FromSql<'a> for PgEnumLabel {
+    fn from_sql(
+        _ty: &Type,
+        raw: &'a [u8],
+    ) -> std::result::Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(Self(std::str::from_utf8(raw)?.to_owned()))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(ty.kind(), Kind::Enum(_))
+    }
+}
+
 /// Convert a single `tokio_postgres::Row` into a `HashMap<String, serde_json::Value>`.
 ///
 /// Tries each PostgreSQL type in priority order; falls back to `Null` for
@@ -191,6 +215,16 @@ fn row_to_map(row: &Row) -> std::collections::HashMap<String, serde_json::Value>
             // expecting a sequence fails. Must precede the jsonb branch (a jsonb
             // column never deserializes as Vec<String>, so ordering is safe).
             serde_json::json!(v)
+        } else if let Ok(v) = row.try_get::<_, PgEnumLabel>(idx) {
+            // ENUM columns (e.g. `app.mutation_response.error_class`, the
+            // `app.mutation_error_class` enum) render as their text label. Without
+            // this branch a non-null enum fell through to `Null` (`String: FromSql`
+            // rejects a custom enum OID), which dropped `error_class` to absent on a
+            // failed mutation — and the parser then rejected the row with
+            // "succeeded=false requires error_class", so the typed error arm was
+            // never reached (#472). `PgEnumLabel` accepts only `Kind::Enum`, so this
+            // never shadows another branch regardless of position.
+            serde_json::json!(v.0)
         } else if let Ok(v) = row.try_get::<_, serde_json::Value>(idx) {
             v
         } else {

--- a/crates/fraiseql-db/src/postgres/adapter/integration_tests.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/integration_tests.rs
@@ -869,6 +869,34 @@ async fn row_to_map_renders_smallint() {
     assert_eq!(row["http_status"], json!(404), "SMALLINT/int2 must not be null");
 }
 
+// A PostgreSQL `ENUM` column must decode to its text label, not null. The headline
+// symptom: `app.mutation_response.error_class` is the `app.mutation_error_class`
+// ENUM, so a failed mutation's `error_class` fell through `row_to_map`'s type ladder
+// (`String: FromSql` rejects a custom enum OID) to `Null`, and the parser then
+// rejected the whole row with "succeeded=false requires error_class" — the typed
+// error arm was never reached (#472).
+#[tokio::test]
+async fn row_to_map_renders_enum() {
+    let adapter = create_test_adapter().await;
+    adapter
+        .execute_raw_query(
+            "DO $$ BEGIN CREATE TYPE row_to_map_enum_t AS ENUM ('not_found', 'conflict'); \
+             EXCEPTION WHEN duplicate_object THEN NULL; END $$;",
+        )
+        .await
+        .expect("create enum type failed");
+    let rows = adapter
+        .execute_raw_query("SELECT 'not_found'::row_to_map_enum_t AS c_enum")
+        .await
+        .expect("query failed");
+
+    assert_eq!(
+        rows[0]["c_enum"],
+        json!("not_found"),
+        "ENUM column must decode to its text label, not null"
+    );
+}
+
 // Cross-type conformance: one table of (SQL expression → expected JSON), so the
 // next time a type drifts back to a silent null a shared test fails. Each column
 // is a literal cast, keeping the fixture seed-independent.

--- a/deny.toml
+++ b/deny.toml
@@ -292,13 +292,6 @@ name = "hyper"
 reason = "hyper 0.14 required by aws-sdk via aws-smithy-runtime; pulls in h2 0.3, http 0.2, http-body 0.4"
 version = "=0.14.32"
 
-# windows ecosystem: multiple windows-sys major versions coexist transitively
-# (0.48 via older crates, 0.52 via the migration wave, 0.53 via notify 8 →
-# windows-sys 0.60). Each root pulls its own windows-targets + per-arch
-# windows_* leaf crates. Skip-tree the older roots so the whole subtree (targets
-# + all seven leaf crates) is exempt in one entry each, leaving windows-sys
-# 0.61 (which has no windows-targets dep) as the canonical version.
-
 [[bans.skip-tree]]
 name = "rustls"
 reason = "rustls 0.21 required by aws-sdk-s3 via hyper-rustls 0.24; EOL but no upstream fix"
@@ -313,6 +306,7 @@ version = "=0.11.1"
 name = "wasmtime"
 reason = "wasmtime v44 pulls in older debug utilities (addr2line, gimli, object, etc.) via backtrace/dhat; upgrade tracked for 2026-12-01"
 version = "=44.0.3"
+
 [[bans.skip-tree]]
 name = "windows-sys"
 reason = "windows-sys 0.48 → windows-targets 0.48.5 → windows_* 0.48.5 leaf crates"


### PR DESCRIPTION
## Summary

Fixes #472. A PostgreSQL **ENUM** column fell through `row_to_map`'s decode ladder to `Null` because `String`'s `FromSql` rejects a custom enum OID. The headline victim is `app.mutation_response.error_class` (the `app.mutation_error_class` enum): on a **failed** mutation the value nulled here, the parser then rejected the row with `succeeded=false requires error_class`, and the typed error arm was never reached — the failure surfaced as an opaque validation error (with a `row_to_map` warn logged).

This stayed latent because the canonical contract only nulls when `error_class` is the enum, and the real-DB parity test exercises only the success path (where `error_class` is NULL). With `error_class` declared as TEXT the same path works. Same class as the earlier SMALLINT/`http_status` and TEXT[]/`updated_fields` (#228) fixes.

## Fix

`row_to_map` gains a `PgEnumLabel` `FromSql` wrapper that accepts only `Kind::Enum` and reads the enum's UTF-8 wire label, plus a decode branch before the jsonb catch-all. Generalises to **every** enum-typed column.

## Changes

- `crates/fraiseql-db/src/postgres/adapter/database.rs` — `PgEnumLabel` wrapper + enum branch in `row_to_map`.
- `crates/fraiseql-db/src/postgres/adapter/integration_tests.rs` — `row_to_map_renders_enum` (real-PG: enum value → text label, not null). Proven RED before the fix.
- CHANGELOG: Unreleased / Fixed.

## Verification

- ✅ `row_to_map` integration tests pass against real PostgreSQL (enum decodes to its label; RED before the fix)
- ✅ clippy `-D warnings`, rustdoc `-D warnings`, fmt, all preflight shell gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)