### PR TITLE
fix(core): read a NULL mutation_response.updated_fields as an empty list (#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   union's `is_error` member otherwise. This both fixes the mis-routing and, for unions
   with several error members, projects the *specific* error the function reported
   rather than the first one in the union. Success-path projection is unchanged.
+- **A SQL-`NULL` `updated_fields` no longer breaks mutation parsing (#473).** A failed
+  mutation's function commonly leaves `mutation_response.updated_fields` (a `TEXT[]`)
+  unset, which `row_to_map` renders as JSON `null`. The parser's `#[serde(default)]`
+  only fills an *absent* key, so an explicit null reached `Vec<String>`'s deserializer
+  and failed with `invalid type: null, expected a sequence` — turning the failed
+  mutation into an opaque parse error before the typed error arm was reached. A null
+  `updated_fields` column is now read as the empty list, matching the absent-key
+  behaviour. No function-side `updated_fields := ARRAY[]::text[]` boilerplate required.
 - **Root `{ __typename }` resolves to the operation type name (#450).** A top-level
   `{ __typename }` — the canonical zero-cost GraphQL health probe — was rejected with
   `Query '__typename' not found in schema` because the query classifier only

--- a/crates/fraiseql-core/src/runtime/mutation_result.rs
+++ b/crates/fraiseql-core/src/runtime/mutation_result.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
@@ -93,8 +93,10 @@ pub struct MutationResponse {
     /// Full entity payload. Populated even for noops.
     #[serde(default)]
     pub entity:         JsonValue,
-    /// GraphQL field names that changed. Empty on noop.
-    #[serde(default)]
+    /// GraphQL field names that changed. Empty on noop. A SQL-`NULL` column
+    /// (rendered by `row_to_map` as JSON `null`) is read as the empty list — see
+    /// `null_as_empty_string_vec`.
+    #[serde(default, deserialize_with = "null_as_empty_string_vec")]
     pub updated_fields: Vec<String>,
     /// Cascade operations (see the graphql-cascade specification).
     #[serde(default)]
@@ -105,6 +107,21 @@ pub struct MutationResponse {
     /// Observability only (trace IDs, timings, audit extras).
     #[serde(default)]
     pub metadata:       JsonValue,
+}
+
+/// Deserialize a possibly-`null` `TEXT[]` column as an empty `Vec`.
+///
+/// A failed mutation's function commonly leaves `updated_fields` unset (SQL NULL),
+/// which `row_to_map` renders as JSON `null`. Serde's `#[serde(default)]` only fills
+/// an *absent* key, so an explicit null still reaches `Vec<String>`'s deserializer
+/// and fails with `invalid type: null, expected a sequence` — turning every such
+/// failure into an opaque parse error before the typed error arm is reached (#473).
+/// Treating null as the empty list matches the absent-key behaviour.
+fn null_as_empty_string_vec<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<Vec<String>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// Parse a `mutation_response` row into a [`MutationOutcome`].

--- a/crates/fraiseql-core/src/runtime/tests.rs
+++ b/crates/fraiseql-core/src/runtime/tests.rs
@@ -2215,6 +2215,44 @@ mod mutation_result_tests {
         assert!(parsed.entity_id.is_none());
     }
 
+    /// A `mutation_response` row whose `updated_fields` column is SQL NULL — the
+    /// natural state for a failure branch that never assigns it, rendered by
+    /// `row_to_map` as JSON `null` — must parse as an empty list, not fail with
+    /// "invalid type: null, expected a sequence". `#[serde(default)]` only covers an
+    /// *absent* key; an explicit null still routes to `Vec<String>`'s deserializer,
+    /// which rejects it — so a real failed mutation surfaced as an opaque parse error
+    /// instead of the typed error arm (#473).
+    #[test]
+    fn null_updated_fields_parses_as_empty() {
+        // Failure path: a function that doesn't assign updated_fields leaves it NULL.
+        let outcome = Row::new(false, false)
+            .with("error_class", json!("not_found"))
+            .with("message", json!("absent"))
+            .with("updated_fields", JsonValue::Null)
+            .parse()
+            .expect("null updated_fields must not fail to deserialize on the error path");
+        assert!(
+            matches!(outcome, MutationOutcome::Error { .. }),
+            "a failed row with null updated_fields must still route to the error outcome"
+        );
+
+        // Success path: an explicit-null updated_fields surfaces as an empty list.
+        let outcome = Row::new(true, true)
+            .with("entity", json!({"id": "x"}))
+            .with("updated_fields", JsonValue::Null)
+            .parse()
+            .expect("null updated_fields must not fail to deserialize on the success path");
+        match outcome {
+            MutationOutcome::Success { updated_fields, .. } => {
+                assert!(
+                    updated_fields.is_empty(),
+                    "null updated_fields must surface as an empty list"
+                );
+            },
+            MutationOutcome::Error { .. } => panic!("expected Success"),
+        }
+    }
+
     // ── Semantics table ────────────────────────────────────────────────────
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -292,13 +292,6 @@ name = "hyper"
 reason = "hyper 0.14 required by aws-sdk via aws-smithy-runtime; pulls in h2 0.3, http 0.2, http-body 0.4"
 version = "=0.14.32"
 
-# windows ecosystem: multiple windows-sys major versions coexist transitively
-# (0.48 via older crates, 0.52 via the migration wave, 0.53 via notify 8 →
-# windows-sys 0.60). Each root pulls its own windows-targets + per-arch
-# windows_* leaf crates. Skip-tree the older roots so the whole subtree (targets
-# + all seven leaf crates) is exempt in one entry each, leaving windows-sys
-# 0.61 (which has no windows-targets dep) as the canonical version.
-
 [[bans.skip-tree]]
 name = "rustls"
 reason = "rustls 0.21 required by aws-sdk-s3 via hyper-rustls 0.24; EOL but no upstream fix"
@@ -313,6 +306,7 @@ version = "=0.11.1"
 name = "wasmtime"
 reason = "wasmtime v44 pulls in older debug utilities (addr2line, gimli, object, etc.) via backtrace/dhat; upgrade tracked for 2026-12-01"
 version = "=44.0.3"
+
 [[bans.skip-tree]]
 name = "windows-sys"
 reason = "windows-sys 0.48 → windows-targets 0.48.5 → windows_* 0.48.5 leaf crates"


### PR DESCRIPTION
## Summary

Fixes #473. A failed mutation's PL/pgSQL function commonly leaves `updated_fields` (a `TEXT[]`) unset, so it is SQL NULL — and `row_to_map` renders it as JSON `null`. The parser's `#[serde(default)]` only fills an **absent** key, so an explicit null still routed to `Vec<String>`'s deserializer and failed with `invalid type: null, expected a sequence`. The whole row then failed to parse, so a genuine failed mutation surfaced as an opaque validation error instead of the typed error arm.

Distinct from #228 (that was `row_to_map` nulling a non-null `TEXT[]` at the *decode* layer; this is serde rejecting an explicit null at the *parse* layer).

## Fix

`MutationResponse.updated_fields` gains a `null_as_empty_string_vec` deserializer that reads a null (or absent) column as the empty list. Field type stays `Vec<String>` — no public API change.

## Changes

- `crates/fraiseql-core/src/runtime/mutation_result.rs` — `deserialize_with` helper on `updated_fields`.
- `crates/fraiseql-core/src/runtime/tests.rs` — `null_updated_fields_parses_as_empty` (error + success paths). Proven RED before the fix.
- CHANGELOG: Unreleased / Fixed.

## Verification

- ✅ `cargo test -p fraiseql-core` (lib 2563 pass; new test RED before the fix)
- ✅ clippy `-D warnings`, rustdoc `-D warnings`, fmt, all preflight shell gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)