### PR TITLE
fix(observers): reload in-process matcher on admin CRUD writes (#466)

### DIFF
--- a/crates/fraiseql-server/src/observers/handlers.rs
+++ b/crates/fraiseql-server/src/observers/handlers.rs
@@ -20,6 +20,43 @@ use crate::extractors::OptionalSecurityContext;
 pub struct ObserverState {
     /// Repository used by all observer HTTP handlers.
     pub repository: ObserverRepository,
+    /// Optional handle to the in-process observer runtime.
+    ///
+    /// When present, a successful create/update/delete/enable/disable write
+    /// refreshes the runtime's `EventMatcher` so the admin API is
+    /// self-consistent without a manual `POST /api/observers/runtime/reload`
+    /// (#466). `None` when the admin API is mounted without a running
+    /// background runtime (e.g. a control-plane-only deployment, or tests).
+    pub runtime: Option<std::sync::Arc<tokio::sync::RwLock<super::ObserverRuntime>>>,
+}
+
+/// Refresh the in-process matcher after a successful observer write so the admin
+/// API is self-consistent without a manual `…/runtime/reload` call (#466).
+///
+/// Best-effort: the write is already committed to `tb_observer`, so a reload
+/// failure is logged rather than failing the request (which would invite a
+/// duplicate write). The persisted change still goes live on the next
+/// reload/poll/restart, and the manual reload endpoint remains as a retry.
+async fn refresh_runtime_after_write(state: &ObserverState) {
+    let Some(runtime) = state.runtime.as_ref() else {
+        return;
+    };
+    match runtime.read().await.reload_observers().await {
+        Ok(count) => {
+            tracing::debug!(
+                observer_count = count,
+                "Observer matcher reloaded after admin write"
+            );
+        },
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Observer write persisted but the in-process matcher reload failed; the change \
+                 will go live on the next reload/poll/restart. Retry with \
+                 POST /api/observers/runtime/reload."
+            );
+        },
+    }
 }
 
 /// List observers with optional filters.
@@ -127,6 +164,7 @@ pub async fn create_observer(
 
     match state.repository.create(&request, customer_org, created_by).await {
         Ok(observer) => {
+            refresh_runtime_after_write(&state).await;
             (StatusCode::CREATED, Json(observer.with_redacted_secrets())).into_response()
         },
         Err(e) => {
@@ -170,6 +208,7 @@ pub async fn update_observer(
 
     match state.repository.update(id, &request, customer_org, updated_by).await {
         Ok(Some(observer)) => {
+            refresh_runtime_after_write(&state).await;
             (StatusCode::OK, Json(observer.with_redacted_secrets())).into_response()
         },
         Ok(None) => (
@@ -199,7 +238,10 @@ pub async fn delete_observer(
     let customer_org: Option<i64> = None;
 
     match state.repository.delete(id, customer_org).await {
-        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(true) => {
+            refresh_runtime_after_write(&state).await;
+            StatusCode::NO_CONTENT.into_response()
+        },
         Ok(false) => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "Observer not found" })),
@@ -292,6 +334,7 @@ pub async fn enable_observer(
 
     match state.repository.update(id, &request, customer_org, updated_by).await {
         Ok(Some(observer)) => {
+            refresh_runtime_after_write(&state).await;
             (StatusCode::OK, Json(observer.with_redacted_secrets())).into_response()
         },
         Ok(None) => (
@@ -328,6 +371,7 @@ pub async fn disable_observer(
 
     match state.repository.update(id, &request, customer_org, updated_by).await {
         Ok(Some(observer)) => {
+            refresh_runtime_after_write(&state).await;
             (StatusCode::OK, Json(observer.with_redacted_secrets())).into_response()
         },
         Ok(None) => (

--- a/crates/fraiseql-server/src/observers/tests.rs
+++ b/crates/fraiseql-server/src/observers/tests.rs
@@ -405,6 +405,7 @@ mod router_construction {
     async fn observer_routes_constructs() {
         let state = ObserverState {
             repository: ObserverRepository::new(lazy_pool()),
+            runtime: None,
         };
         let _ = observer_routes(state);
     }

--- a/crates/fraiseql-server/src/server/routing/observers.rs
+++ b/crates/fraiseql-server/src/server/routing/observers.rs
@@ -65,6 +65,10 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
 
         let observer_state = ObserverState {
             repository: ObserverRepository::new(db_pool.clone()),
+            // Inject the runtime so admin CRUD writes refresh the in-process
+            // matcher without a manual `…/runtime/reload` (#466). `None` when no
+            // background runtime is mounted (control-plane-only deployments).
+            runtime: self.observer_runtime.clone(),
         };
 
         let changelog_state = ChangelogState { pool: db_pool };

--- a/crates/fraiseql-server/tests/observer_runtime_integration_test.rs
+++ b/crates/fraiseql-server/tests/observer_runtime_integration_test.rs
@@ -1330,3 +1330,76 @@ async fn test_listener_direct() {
         },
     }
 }
+
+/// Test: a successful admin CRUD write refreshes the in-process matcher (#466).
+///
+/// Before this fix the `/api/observers` create/update/delete/enable/disable
+/// handlers persisted to `tb_observer` but did NOT reload the runtime's
+/// `EventMatcher`, so an admin write silently had no effect until a separate
+/// `POST /api/observers/runtime/reload`. This drives the real `create_observer`
+/// handler with the runtime injected and asserts the matcher reflects the new
+/// observer with **no** manual reload.
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn test_admin_create_reloads_matcher() {
+    use std::sync::Arc;
+
+    use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+    use fraiseql_server::{
+        extractors::OptionalSecurityContext,
+        observers::{
+            CreateObserverRequest, ObserverRepository, ObserverState, handlers::create_observer,
+        },
+    };
+    use tokio::sync::RwLock;
+
+    init_test_tracing();
+
+    let test_id = Uuid::new_v4().to_string();
+    let pool = create_test_pool().await;
+    setup_observer_schema(&pool).await.expect("Failed to setup schema");
+
+    // Start from a clean table (order matters due to foreign keys).
+    sqlx::query("DELETE FROM tb_observer_log")
+        .execute(&pool)
+        .await
+        .expect("clean logs");
+    sqlx::query("DELETE FROM tb_observer").execute(&pool).await.expect("clean observers");
+
+    // Runtime carrying the in-process matcher. Not started: matcher reload is
+    // independent of the background poller, so this exercises only the reload
+    // path the handler now triggers.
+    let runtime = Arc::new(RwLock::new(ObserverRuntime::new(ObserverRuntimeConfig::new(
+        pool.clone(),
+    ))));
+
+    // Baseline matcher: zero observers in the (cleaned) table.
+    let baseline = runtime.read().await.reload_observers().await.expect("baseline reload");
+    assert_eq!(baseline, 0, "no observers should be live before the create");
+
+    let state = ObserverState {
+        repository: ObserverRepository::new(pool.clone()),
+        runtime: Some(Arc::clone(&runtime)),
+    };
+
+    let entity_type = format!("Order_{test_id}");
+    let request: CreateObserverRequest = serde_json::from_value(serde_json::json!({
+        "name": format!("reload-on-create-{test_id}"),
+        "entity_type": entity_type,
+        "event_type": "INSERT",
+        // URL is never dispatched in this test — only the matcher reload matters.
+        "actions": [{ "type": "webhook", "url": "http://127.0.0.1:9/never-called" }],
+    }))
+    .expect("valid create request");
+
+    let response = create_observer(State(state), OptionalSecurityContext(None), Json(request))
+        .await
+        .into_response();
+    assert_eq!(response.status(), StatusCode::CREATED, "create should succeed");
+
+    // The matcher must now reflect the new observer WITHOUT a manual reload.
+    let live = runtime.read().await.health().observer_count;
+    assert_eq!(live, 1, "create handler should have refreshed the in-process matcher (#466)");
+
+    cleanup_test_data(&pool, &test_id).await.expect("Failed to cleanup");
+}


### PR DESCRIPTION
Closes #466.

## Problem

The `/api/observers` admin API persisted create/update/delete/enable/disable writes to `tb_observer` but never refreshed the in-process `EventMatcher`. A change only took effect after a separate `POST /api/observers/runtime/reload`, a listener restart, or a periodic poll — so a UI- or automation-driven observer-CRUD flow had to remember the follow-up reload, and otherwise the edit was a silent no-op. (One instance of the "silent failure" theme in the AX umbrella #471.)

`ObserverRuntime::reload_observers()` already performs an atomic `ArcSwap` swap of the matcher; it just wasn't invoked on write.

## Fix

- `ObserverState` gains an optional `runtime: Option<Arc<RwLock<ObserverRuntime>>>` handle, injected from `Server::observer_runtime` at route-mount time (`None` for control-plane-only deployments / tests).
- New `refresh_runtime_after_write()` is called from the success arm of create/update/delete/enable/disable. The read paths (list/get) are untouched.

### Failure semantics
Best-effort by design: the write is already committed to `tb_observer`, so a reload failure is **logged** (the persisted change still goes live on the next reload/poll/restart, and the manual reload endpoint remains as a retry) rather than failing the request — which would invite a duplicate write. A `LISTEN/NOTIFY`-debounced variant (suggested in the issue) could layer on later for high-write deployments; this fix makes the common path self-consistent.

## Test

`test_admin_create_reloads_matcher` drives the real `create_observer` handler with the runtime injected and asserts the matcher reflects the new observer with **no** manual reload. It rides the existing observers integration leg (`--test observer_runtime_integration_test ... --ignored --test-threads=1`, serial — consistent with the existing `test_hot_reload_observers`), so no Dagger change is needed.

## Verification
- ✅ `cargo clippy -p fraiseql-server --features observers --all-targets -- -D warnings`
- ✅ `cargo clippy -p fraiseql-server --all-targets -- -D warnings` (observers OFF — module gated, unaffected)
- ✅ `cargo test --features observers-nats --test observer_runtime_integration_test --no-run`
- ✅ router-construction smoke test passes
- ✅ `make lint-tests-layout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)