### PR TITLE
feat(cli): add mutation→function drift check to `doctor --against-db` (#384)

### DIFF
--- a/crates/fraiseql-cli/src/cli.rs
+++ b/crates/fraiseql-cli/src/cli.rs
@@ -646,9 +646,11 @@ EXAMPLES:
 
         /// Run the live-database passes against this PostgreSQL database: the
         /// change-log contract drift check (compares core.tb_entity_change_log
-        /// against the shipped contract — #380) and the PL/pgSQL
-        /// body-resolution pass (reports internal calls that no longer resolve
-        /// — #409).
+        /// against the shipped contract — #380), the PL/pgSQL body-resolution
+        /// pass (reports internal calls that no longer resolve — #409), and the
+        /// mutation→function contract drift check (every declared mutation has a
+        /// matching backing function with a mutation_response-shaped return —
+        /// #384).
         ///
         /// The body-resolution pass requires the `plpgsql_check` extension and
         /// skips with a hint when it is unavailable.

--- a/crates/fraiseql-cli/src/commands/doctor.rs
+++ b/crates/fraiseql-cli/src/commands/doctor.rs
@@ -7,14 +7,18 @@
 
 use std::{net::TcpStream, path::Path, time::Duration};
 
+use fraiseql_core::schema::CompiledSchema;
 use fraiseql_observers::migrations::ENTITY_CHANGE_LOG_CONTRACT;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     config::toml_schema::TomlSchema,
-    schema::pg_catalog::{
-        CaptureFnSecurity, ChangeLogRlsStatus, LiveColumn, PgCatalog, PlpgsqlCheckOutcome,
-        PublicGrant,
+    schema::{
+        mutation_contract::{ContractReport, Severity, validate_mutation_contract},
+        pg_catalog::{
+            CaptureFnSecurity, ChangeLogRlsStatus, LiveColumn, PgCatalog, PlpgsqlCheckOutcome,
+            PublicGrant,
+        },
     },
 };
 
@@ -481,13 +485,14 @@ pub fn run_checks(
 /// Returns `true` if all checks passed (exit 0), `false` if any check failed
 /// (exit 1). Warnings do not trigger an exit-1.
 /// Execute the doctor command including the optional `--against-db` live-DB
-/// passes: the change-log contract drift check (#380) and the PL/pgSQL
-/// body-resolution pass (#409).
+/// passes: the change-log contract drift check (#380), the PL/pgSQL
+/// body-resolution pass (#409), and the mutation→function contract drift check
+/// (#384).
 ///
 /// Runs the standard checks, then — when `against_db` is set — appends the
-/// change-log contract drift report and the internal-call resolution results
-/// for `schemas`. Returns `true` if all checks passed (exit 0), `false` if any
-/// failed (exit 1).
+/// change-log contract/RLS/grant/capture reports, the internal-call resolution
+/// results for `schemas`, and the mutation→function contract drift report.
+/// Returns `true` if all checks passed (exit 0), `false` if any failed (exit 1).
 pub async fn run_with_db_checks(
     config: &Path,
     schema: &Path,
@@ -503,6 +508,7 @@ pub async fn run_with_db_checks(
         checks.extend(changelog_public_grants_checks(url).await);
         checks.extend(capture_fn_security_checks(url).await);
         checks.extend(body_resolution_checks(url, schemas).await);
+        checks.extend(mutation_contract_checks(url, schema).await);
     }
 
     if json {
@@ -559,6 +565,99 @@ async fn body_resolution_checks(db_url: &str, schemas: &[String]) -> Vec<DoctorC
                 )
             })
             .collect(),
+    }
+}
+
+const MUTATION_CONTRACT_NAME: &str = "Mutation→function contract";
+
+/// Convert a mutation-contract [`ContractReport`] into doctor checks (#384).
+///
+/// A clean report (no violations) yields a single `Pass` summarising how many
+/// DB-backed mutations resolved. Otherwise each violation becomes its own
+/// `Fail`/`Warn` naming the mutation and its `sql_source`, so a declared
+/// mutation with a missing or mismatched backing function — the most common
+/// "failed to prepare" root cause — is surfaced at check time, not first call.
+///
+/// Pure (no I/O) so it is unit-tested without a database.
+pub(crate) fn mutation_contract_drift(report: &ContractReport) -> Vec<DoctorCheck> {
+    if report.mutations.is_empty() {
+        return vec![DoctorCheck::pass(
+            MUTATION_CONTRACT_NAME,
+            format!(
+                "all {} DB-backed mutation(s) resolve to a matching function ({} skipped)",
+                report.checked, report.skipped
+            ),
+        )];
+    }
+    report
+        .mutations
+        .iter()
+        .flat_map(|m| {
+            m.violations.iter().map(move |v| {
+                let detail = format!("{} (sql_source: {}): {v}", m.mutation, m.sql_source);
+                match v.severity() {
+                    Severity::Error => DoctorCheck::fail(
+                        MUTATION_CONTRACT_NAME,
+                        detail,
+                        "Declared mutation does not match its backing function — create or fix \
+                         the function, or correct the schema",
+                    ),
+                    Severity::Warn => DoctorCheck::warn(
+                        MUTATION_CONTRACT_NAME,
+                        detail,
+                        "The backing function differs from the declaration (non-fatal)",
+                    ),
+                }
+            })
+        })
+        .collect()
+}
+
+/// Run the mutation→function contract drift check against a live database (#384).
+///
+/// Loads the compiled schema, then for every DB-backed mutation verifies its
+/// `sql_source` resolves to exactly one function whose argument arity/shape and
+/// `mutation_response` return columns match what the runtime will send and
+/// decode — the same static check as `fraiseql validate --against-db`, surfaced
+/// in `doctor` so it is the single drift report.
+///
+/// Never panics: a schema-load, connection, or catalog failure becomes a single
+/// check rather than aborting the doctor run.
+async fn mutation_contract_checks(db_url: &str, schema_path: &Path) -> Vec<DoctorCheck> {
+    let schema = match std::fs::read_to_string(schema_path)
+        .map_err(|e| format!("cannot read schema: {e}"))
+        .and_then(|c| {
+            serde_json::from_str::<CompiledSchema>(&c)
+                .map_err(|e| format!("schema parse error: {e}"))
+        }) {
+        Ok(s) => s,
+        Err(detail) => {
+            return vec![DoctorCheck::warn(
+                MUTATION_CONTRACT_NAME,
+                format!("skipped — {detail}"),
+                "Run `fraiseql compile` to produce a valid schema.compiled.json",
+            )];
+        },
+    };
+
+    let catalog = match PgCatalog::connect(db_url) {
+        Ok(c) => c,
+        Err(e) => {
+            return vec![DoctorCheck::fail(
+                MUTATION_CONTRACT_NAME,
+                format!("cannot connect: {e}"),
+                "Pass a reachable postgres:// URL to --against-db",
+            )];
+        },
+    };
+
+    match validate_mutation_contract(&schema, &catalog).await {
+        Ok(report) => mutation_contract_drift(&report),
+        Err(e) => vec![DoctorCheck::fail(
+            MUTATION_CONTRACT_NAME,
+            format!("contract check failed: {e}"),
+            "Ensure the connecting role can read pg_catalog for the function schema",
+        )],
     }
 }
 

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -1505,6 +1505,45 @@ mod doctor_tests {
         assert_eq!(warn.status, CheckStatus::Warn);
         assert!(warn.detail.contains("non-contract"));
     }
+
+    // ── mutation→function contract drift check (#384) ────────────────────────
+    use crate::schema::mutation_contract::{ContractReport, ContractViolation, MutationReport};
+
+    #[test]
+    fn mutation_contract_clean_report_is_single_pass() {
+        let report = ContractReport {
+            checked:   3,
+            skipped:   1,
+            mutations: vec![],
+        };
+        let checks = mutation_contract_drift(&report);
+        assert_eq!(checks.len(), 1, "a clean report yields exactly one check");
+        assert_eq!(checks[0].status, CheckStatus::Pass);
+        assert!(checks[0].detail.contains("DB-backed mutation"));
+    }
+
+    #[test]
+    fn mutation_contract_missing_function_is_fatal() {
+        // The "literal root cause" of the migration in #384/#471: a declared
+        // mutation with no backing function. The drift check must flag it fatal.
+        let report = ContractReport {
+            checked:   1,
+            skipped:   0,
+            mutations: vec![MutationReport {
+                mutation:   "createWidget".to_string(),
+                sql_source: "fn_create_widget".to_string(),
+                violations: vec![ContractViolation::MissingFunction],
+            }],
+        };
+        let checks = mutation_contract_drift(&report);
+        let fail = checks
+            .iter()
+            .find(|c| c.status == CheckStatus::Fail)
+            .expect("a missing backing function is fatal");
+        assert!(fail.detail.contains("createWidget"));
+        assert!(fail.detail.contains("fn_create_widget"));
+        assert!(fail.hint.is_some());
+    }
 }
 
 mod explain_tests {


### PR DESCRIPTION
Addresses the highest-leverage slice of #384 (and rec #2 of the AX umbrella #471).

## Why

`fraiseql doctor --against-db` is the natural single "is my schema in sync with storage?" report. But the most-requested drift check — **does every declared mutation actually have a callable backing function with a `mutation_response`-shaped return?** — lived only in `fraiseql validate --against-db`. A declared mutation with no (or a mismatched) backing function is the *"literal root cause"* of the migration described in the #384 comment and #471: discovered only as a runtime "failed to prepare", never at check time.

This surfaces that same static check in `doctor`, so the live-DB pass is the one command that reports change-log/RLS/grant/capture drift, PL/pgSQL body resolution, **and** mutation→function contract drift.

## What

- New `mutation_contract_checks(db_url, schema)` in `doctor` reuses the existing `validate_mutation_contract` engine (identical to `validate --against-db`) plus a **pure, unit-tested** `mutation_contract_drift(report) -> Vec<DoctorCheck>` converter:
  - clean report → one `Pass` ("all N DB-backed mutations resolve to a matching function, M skipped");
  - each violation → a `Fail`/`Warn` naming the mutation + `sql_source` (missing function, arity/ambiguity, payload-not-jsonb, inject-name & response-column mismatches);
  - schema-load / connect / catalog failures degrade to a single check — never a panic or aborted run.
- Wired into `run_with_db_checks`; `--against-db` help updated.

## Scope note

The **type↔view** JSONB-key drift check (the other half of #384) already ships in `fraiseql compile --database` (the L3 sampler in `database_validator.rs`). It's necessarily *advisory* given FraiseQL's JSONB `data` model — type fields are keys built by the view's `SELECT`, not columns in the DDL — so it samples rows rather than reading a declared schema. Folding that into `doctor` as a third drift category is a clean follow-up; this PR delivers the highest-leverage, fully-static check first. The remaining #384 "input↔table" idea is largely covered by the arity check here (an extra input arg is an arity mismatch).

## Verification
- ✅ `cargo clippy -p fraiseql-cli --all-targets -- -D warnings`
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc -p fraiseql-cli --all-features`
- ✅ `doctor_tests::mutation_contract_*` (clean-pass + missing-function-fatal) pass
- ✅ `make lint-tests-layout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)