### PR TITLE
fix(observers): populate tb_observer_log request/response audit columns (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Observer execution log now populates its request/response audit columns (#468).**
+  `tb_observer_log` declares `action_index`, `action_type`, `response_status_code`,
+  `response_payload`, and `request_payload`, but the runtime log writer left them
+  `NULL` — it recorded only status/duration — so a webhook delivery-log / audit UI
+  built on the schema could not show response codes or bodies. The per-action result
+  (HTTP status, action type/index, outcome) is now threaded from the
+  `fraiseql-observers` executor back to the writer via a new
+  `ExecutionSummary.action_details` / `ActionExecutionDetail` contract and written to
+  the log. `action_type`, `action_index`, `response_status_code`, and the
+  `response_payload` outcome summary are non-sensitive and always populated;
+  `request_payload` (the triggering event data, which can carry PII) is gated behind
+  the new `[observers.runtime].log_payloads` flag (default off) and truncated to a
+  marker past 64 KiB. Part of the #471 "declared but unwired" cluster.
 - **PostgreSQL `ENUM` columns no longer decode to null in `row_to_map` (#472).** An
   enum-typed column (notably `app.mutation_response.error_class`, the
   `app.mutation_error_class` enum) fell through the `row_to_map` decode ladder to

--- a/crates/fraiseql-observers/src/cached_executor/mod.rs
+++ b/crates/fraiseql-observers/src/cached_executor/mod.rs
@@ -175,6 +175,9 @@ impl<E: ActionExecutor + Send + Sync, C: CacheBackend + Send + Sync> ActionExecu
                     success:     cached_result.success,
                     message:     cached_result.message,
                     duration_ms: cached_result.duration_ms,
+                    // A cache hit carries no fresh transport round-trip, so there
+                    // is no HTTP status to surface (#468).
+                    status_code: None,
                 });
             },
             Ok(None) => {

--- a/crates/fraiseql-observers/src/cached_executor/tests.rs
+++ b/crates/fraiseql-observers/src/cached_executor/tests.rs
@@ -38,6 +38,7 @@ impl ActionExecutor for TestExecutor {
             success:     true,
             message:     "Test success".to_string(),
             duration_ms: 10.0,
+            status_code: None,
         })
     }
 }

--- a/crates/fraiseql-observers/src/concurrent/mod.rs
+++ b/crates/fraiseql-observers/src/concurrent/mod.rs
@@ -120,12 +120,14 @@ impl<E: ActionExecutor + Clone + Send + Sync + 'static> ConcurrentActionExecutor
                         success: false,
                         message: format!("Execution error: {err}"),
                         duration_ms,
+                        status_code: None,
                     },
                     Err(_) => ActionResult {
                         action_type: format!("{action:?}"),
                         success: false,
                         message: "Action timeout".to_string(),
                         duration_ms,
+                        status_code: None,
                     },
                 }
             });

--- a/crates/fraiseql-observers/src/concurrent/tests.rs
+++ b/crates/fraiseql-observers/src/concurrent/tests.rs
@@ -31,6 +31,7 @@ mod concurrent_tests {
                 success:     true,
                 message:     "Test success".to_string(),
                 duration_ms: 10.0,
+                status_code: None,
             })
         }
     }
@@ -128,6 +129,7 @@ mod concurrent_tests {
                 success: true,
                 message: "Completed after delay".to_string(),
                 duration_ms,
+                status_code: None,
             })
         }
     }

--- a/crates/fraiseql-observers/src/deduped_executor/mod.rs
+++ b/crates/fraiseql-observers/src/deduped_executor/mod.rs
@@ -322,6 +322,8 @@ impl<D: DeduplicationStore> DedupedObserverExecutor<D> {
                 tenant_rejected:    false,
                 cache_hits:         0,
                 cache_misses:       0,
+                // A deduplicated event runs no actions (#468).
+                action_details:     Vec::new(),
             });
         }
 

--- a/crates/fraiseql-observers/src/executor/cache.rs
+++ b/crates/fraiseql-observers/src/executor/cache.rs
@@ -48,6 +48,9 @@ impl ObserverExecutor {
                     success:     cached.success,
                     message:     cached.message,
                     duration_ms: cached.duration_ms,
+                    // A cache hit carries no fresh transport round-trip, so there
+                    // is no HTTP status to surface (#468).
+                    status_code: None,
                 });
             }
         }

--- a/crates/fraiseql-observers/src/executor/dispatch.rs
+++ b/crates/fraiseql-observers/src/executor/dispatch.rs
@@ -169,6 +169,7 @@ impl ActionDispatcher for DefaultActionDispatcher {
                             success:     true,
                             message:     format!("HTTP {}", response.status_code),
                             duration_ms: response.duration_ms,
+                            status_code: Some(response.status_code),
                         }),
                         Err(e) => Err(e),
                     }
@@ -194,6 +195,7 @@ impl ActionDispatcher for DefaultActionDispatcher {
                             success:     true,
                             message:     format!("HTTP {}", response.status_code),
                             duration_ms: response.duration_ms,
+                            status_code: Some(response.status_code),
                         }),
                         Err(e) => Err(e),
                     }
@@ -227,6 +229,7 @@ impl ActionDispatcher for DefaultActionDispatcher {
                                 .message_id
                                 .unwrap_or_else(|| "queued".to_string()),
                             duration_ms: response.duration_ms,
+                            status_code: None,
                         }),
                         Err(e) => Err(e),
                     }
@@ -294,6 +297,7 @@ impl DefaultActionDispatcher {
             success: true,
             message: format!("invalidated {removed} key(s)"),
             duration_ms,
+            status_code: None,
         })
     }
 

--- a/crates/fraiseql-observers/src/executor/mod.rs
+++ b/crates/fraiseql-observers/src/executor/mod.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, atomic::AtomicUsize};
 
 pub(crate) use dispatch::ActionDispatcher;
 use dispatch::DefaultActionDispatcher;
-pub use summary::ExecutionSummary;
+pub use summary::{ActionExecutionDetail, ExecutionSummary};
 use tracing::{debug, error};
 
 #[cfg(feature = "caching")]
@@ -333,14 +333,17 @@ impl ObserverExecutor {
                 }
             }
 
-            // Execute actions for this observer
-            for action in &observer.actions {
+            // Execute actions for this observer. The index identifies the
+            // action within this observer's list so the per-action detail can
+            // be attributed in a durable execution log (#468).
+            for (action_index, action) in observer.actions.iter().enumerate() {
                 self.execute_action_with_retry(
                     action,
                     event,
                     &observer.retry,
                     &observer.on_failure,
                     &mut summary,
+                    action_index,
                 )
                 .await;
             }

--- a/crates/fraiseql-observers/src/executor/retry.rs
+++ b/crates/fraiseql-observers/src/executor/retry.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
-use super::{ExecutionSummary, ObserverExecutor};
+use super::{ActionExecutionDetail, ExecutionSummary, ObserverExecutor};
 use crate::{
     config::{ActionConfig, BackoffStrategy, FailurePolicy, RetryConfig},
     error::{ObserverError, Result},
@@ -14,7 +14,12 @@ use crate::{
 };
 
 impl ObserverExecutor {
-    /// Execute a single action with retry logic
+    /// Execute a single action with retry logic.
+    ///
+    /// `action_index` is the action's position within its observer's action
+    /// list; it is recorded on the [`ActionExecutionDetail`] pushed onto
+    /// `summary.action_details` so embedders can attribute a durable execution
+    /// log entry to the right action (#468).
     #[allow(clippy::cognitive_complexity)] // Reason: retry loop with backoff, jitter, and per-attempt logging — inherently sequential
     pub(crate) async fn execute_action_with_retry(
         &self,
@@ -23,6 +28,7 @@ impl ObserverExecutor {
         retry_config: &RetryConfig,
         failure_policy: &FailurePolicy,
         summary: &mut ExecutionSummary,
+        action_index: usize,
     ) {
         let mut attempt = 0;
 
@@ -44,6 +50,15 @@ impl ObserverExecutor {
 
                     summary.successful_actions += 1;
                     summary.total_duration_ms += result.duration_ms;
+                    summary.action_details.push(ActionExecutionDetail {
+                        action_index,
+                        action_type: result.action_type,
+                        success: true,
+                        status_code: result.status_code,
+                        message: result.message,
+                        error_message: None,
+                        duration_ms: result.duration_ms,
+                    });
                     return;
                 },
                 Err(e) => {
@@ -54,6 +69,7 @@ impl ObserverExecutor {
                         warn!("Permanent error in action {}: {}", action.action_type(), e);
                         self.handle_action_failure(action, event, &e, failure_policy, summary)
                             .await;
+                        Self::record_failure_detail(summary, action, action_index, &e);
                         return;
                     }
 
@@ -62,6 +78,7 @@ impl ObserverExecutor {
                         error!("Action {} failed after {} attempts", action.action_type(), attempt);
                         self.handle_action_failure(action, event, &e, failure_policy, summary)
                             .await;
+                        Self::record_failure_detail(summary, action, action_index, &e);
                         return;
                     }
 
@@ -79,6 +96,29 @@ impl ObserverExecutor {
                 },
             }
         }
+    }
+
+    /// Record an [`ActionExecutionDetail`] for an action that failed after its
+    /// retries were exhausted or hit a permanent error (#468).
+    ///
+    /// Failures carry no transport status code (the error variants do not
+    /// surface one); the error string is preserved in both `message` and
+    /// `error_message` so the embedder can populate `error_message` in the log.
+    fn record_failure_detail(
+        summary: &mut ExecutionSummary,
+        action: &ActionConfig,
+        action_index: usize,
+        error: &ObserverError,
+    ) {
+        summary.action_details.push(ActionExecutionDetail {
+            action_index,
+            action_type: action.action_type().to_string(),
+            success: false,
+            status_code: None,
+            message: error.to_string(),
+            error_message: Some(error.to_string()),
+            duration_ms: 0.0,
+        });
     }
 
     /// Calculate backoff delay based on attempt number and strategy

--- a/crates/fraiseql-observers/src/executor/summary.rs
+++ b/crates/fraiseql-observers/src/executor/summary.rs
@@ -8,6 +8,33 @@
 /// logged at ERROR level via the standard logging path in `mod.rs`).
 pub(super) const MAX_ERROR_STRINGS: usize = 100;
 
+/// Per-action execution detail captured during event processing.
+///
+/// One entry is produced per action that ran (succeeded or failed), in
+/// dispatch order. Embedders use these to populate a durable execution log
+/// (`tb_observer_log`) with the action type, transport status code, and
+/// response summary that the aggregate counters in [`ExecutionSummary`] would
+/// otherwise discard (#468). It deliberately carries no request payload: the
+/// triggering event is already available to the embedder, and payload capture
+/// is a privacy-gated decision made at the persistence boundary.
+#[derive(Debug, Clone)]
+pub struct ActionExecutionDetail {
+    /// Index of the action within its observer's action list.
+    pub action_index:  usize,
+    /// Action type that ran (`"webhook"`, `"slack"`, `"email"`, `"cache"`).
+    pub action_type:   String,
+    /// Whether the action ultimately succeeded.
+    pub success:       bool,
+    /// Transport status code for HTTP-backed actions, if any.
+    pub status_code:   Option<u16>,
+    /// Short outcome message (e.g. `"HTTP 200"` or a queued message id).
+    pub message:       String,
+    /// Failure detail when the action did not succeed.
+    pub error_message: Option<String>,
+    /// Wall-clock duration of the (final) attempt in milliseconds.
+    pub duration_ms:   f64,
+}
+
 /// Summary of event processing results
 #[derive(Debug, Clone, Default)]
 pub struct ExecutionSummary {
@@ -31,6 +58,12 @@ pub struct ExecutionSummary {
     pub cache_hits:         usize,
     /// Number of cache misses during action execution
     pub cache_misses:       usize,
+    /// Per-action execution details, in dispatch order (#468).
+    ///
+    /// Populated by [`process_event`](super::ObserverExecutor::process_event)
+    /// so embedders can record per-action audit columns (status code, action
+    /// type, response summary). Empty for skipped/deduplicated/rejected events.
+    pub action_details:     Vec<ActionExecutionDetail>,
 }
 
 impl ExecutionSummary {

--- a/crates/fraiseql-observers/src/executor/tests.rs
+++ b/crates/fraiseql-observers/src/executor/tests.rs
@@ -114,6 +114,7 @@ fn test_execution_summary_success() {
         tenant_rejected:    false,
         cache_hits:         0,
         cache_misses:       0,
+        action_details:     Vec::new(),
     };
 
     assert!(summary.is_success());
@@ -133,6 +134,7 @@ fn test_execution_summary_failure() {
         tenant_rejected:    false,
         cache_hits:         0,
         cache_misses:       0,
+        action_details:     Vec::new(),
     };
 
     assert!(!summary.is_success());
@@ -387,7 +389,7 @@ async fn test_retry_happy_path_succeeds_first_attempt() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &failure_policy, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &failure_policy, &mut summary, 0)
         .await;
 
     assert_eq!(summary.successful_actions, 1, "expected 1 success");
@@ -410,7 +412,7 @@ async fn test_retry_total_duration_accumulated_on_success() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary, 0)
         .await;
 
     assert!((summary.total_duration_ms - 42.0).abs() < f64::EPSILON);
@@ -449,6 +451,7 @@ async fn test_retry_transient_then_success() {
                         success: true,
                         message: "ok".to_string(),
                         duration_ms: 1.0,
+                        status_code: None,
                     })
                 }
             })
@@ -467,7 +470,7 @@ async fn test_retry_transient_then_success() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary, 0)
         .await;
 
     assert_eq!(summary.successful_actions, 1);
@@ -495,7 +498,7 @@ async fn test_retry_permanent_error_no_retry() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary, 0)
         .await;
 
     // Called exactly once — no retry for permanent errors
@@ -525,7 +528,7 @@ async fn test_retry_exhausted_after_max_attempts() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary, 0)
         .await;
 
     // Should have been called max_attempts times (3) then failed
@@ -555,7 +558,7 @@ async fn test_retry_single_attempt_max_no_retry() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &FailurePolicy::Log, &mut summary, 0)
         .await;
 
     assert_eq!(dispatcher.call_count(), 1);
@@ -590,6 +593,7 @@ async fn test_retry_two_transient_then_success() {
                         success:     true,
                         message:     "ok".to_string(),
                         duration_ms: 1.0,
+                        status_code: None,
                     })
                 }
             })
@@ -610,6 +614,7 @@ async fn test_retry_two_transient_then_success() {
             &make_retry(5, 0),
             &FailurePolicy::Log,
             &mut summary,
+            0,
         )
         .await;
 
@@ -1275,6 +1280,7 @@ async fn test_mock_dispatcher_call_log_records_action_type() {
                 &make_retry(1, 0),
                 &FailurePolicy::Log,
                 &mut s,
+                0,
             )
             .await;
     }
@@ -1300,6 +1306,7 @@ async fn test_execution_summary_is_success_with_mock() {
             &make_retry(1, 0),
             &FailurePolicy::Log,
             &mut summary,
+            0,
         )
         .await;
 
@@ -1329,6 +1336,7 @@ async fn test_execution_summary_not_success_on_failure() {
             &make_retry(1, 0),
             &FailurePolicy::Log,
             &mut summary,
+            0,
         )
         .await;
 
@@ -1520,6 +1528,7 @@ async fn test_action_timeout_fires_when_dispatcher_is_slow() {
                     success: true,
                     message: "slow ok".to_string(),
                     duration_ms: 200.0,
+                    status_code: None,
                 })
             })
         }
@@ -1821,7 +1830,7 @@ async fn email_action_reports_failure_not_silent_success() {
     let mut summary = ExecutionSummary::new();
 
     executor
-        .execute_action_with_retry(&action, &event, &retry, &failure_policy, &mut summary)
+        .execute_action_with_retry(&action, &event, &retry, &failure_policy, &mut summary, 0)
         .await;
 
     assert_eq!(summary.successful_actions, 0, "a non-sending email must NOT count as success");

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -112,7 +112,7 @@ pub use dedup::{DeduplicationStats, DeduplicationStore};
 pub use elasticsearch_sink::{ElasticsearchSink, ElasticsearchSinkConfig};
 pub use error::{ObserverError, ObserverErrorCode, Result};
 pub use event::{EntityEvent, EventKind, FieldChanges};
-pub use executor::{ExecutionSummary, ObserverExecutor};
+pub use executor::{ActionExecutionDetail, ExecutionSummary, ObserverExecutor};
 #[cfg(feature = "queue")]
 pub use job_queue::dlq::{DeadLetterQueueManager, DlqStats};
 #[cfg(feature = "queue")]

--- a/crates/fraiseql-observers/src/queue/tests.rs
+++ b/crates/fraiseql-observers/src/queue/tests.rs
@@ -298,6 +298,7 @@ mod redis_tests {
                 success:     true,
                 message:     "Email sent".to_string(),
                 duration_ms: 100.0,
+                status_code: None,
             },
             attempts:      1,
             duration_ms:   100.0,

--- a/crates/fraiseql-observers/src/queued_executor.rs
+++ b/crates/fraiseql-observers/src/queued_executor.rs
@@ -222,6 +222,9 @@ impl QueuedExecutionSummary {
             tenant_rejected:    false,
             cache_hits:         0,
             cache_misses:       0,
+            // Queued execution defers dispatch, so no per-action detail is
+            // available at queue time (#468).
+            action_details:     Vec::new(),
         }
     }
 }

--- a/crates/fraiseql-observers/src/testing.rs
+++ b/crates/fraiseql-observers/src/testing.rs
@@ -57,6 +57,7 @@ pub mod mocks {
                 success: true,
                 message: "mock success".to_string(),
                 duration_ms,
+                status_code: None,
             };
             self.responses.lock().unwrap().insert(action_type.to_string(), Ok(result));
         }
@@ -102,6 +103,7 @@ pub mod mocks {
                         success:     true,
                         message:     "mock default ok".to_string(),
                         duration_ms: 1.0,
+                        status_code: None,
                     }),
                 }
             })
@@ -213,6 +215,7 @@ pub mod mocks {
                 success: true,
                 message: "Mock execution".to_string(),
                 duration_ms: 10.0,
+                status_code: None,
             })
         }
     }

--- a/crates/fraiseql-observers/src/tests.rs
+++ b/crates/fraiseql-observers/src/tests.rs
@@ -1579,6 +1579,7 @@ mod traits_tests {
             success:     true,
             message:     "Email sent".to_string(),
             duration_ms: 125.5,
+            status_code: None,
         };
 
         assert_eq!(result.action_type, "email");

--- a/crates/fraiseql-observers/src/traits.rs
+++ b/crates/fraiseql-observers/src/traits.rs
@@ -51,10 +51,17 @@ pub struct ActionResult {
     pub message:     String,
     /// Execution time in milliseconds
     pub duration_ms: f64,
+    /// Transport status code for HTTP-backed actions (webhook/slack), if any.
+    ///
+    /// `Some(code)` for actions that complete an HTTP round-trip; `None` for
+    /// actions with no HTTP status (email/cache) or for results served from a
+    /// cache. Surfaced so embedders can record `response_status_code` in an
+    /// execution log (#468).
+    pub status_code: Option<u16>,
 }
 
 impl ActionResult {
-    /// Creates a new `ActionResult`.
+    /// Creates a new `ActionResult` with no transport status code.
     #[must_use]
     pub const fn new(
         action_type: String,
@@ -67,6 +74,7 @@ impl ActionResult {
             success,
             message,
             duration_ms,
+            status_code: None,
         }
     }
 }

--- a/crates/fraiseql-server/src/observers/runtime.rs
+++ b/crates/fraiseql-server/src/observers/runtime.rs
@@ -18,9 +18,9 @@ use std::{
 use arc_swap::ArcSwap;
 use fraiseql_core::runtime::subscription::ChangeSpineEnvelope;
 use fraiseql_observers::{
-    ActionConfig as ObserverActionConfig, ChangeLogListener, ChangeLogListenerConfig,
-    EntityEvent as ObserverEntityEvent, EventMatcher, FailurePolicy, InMemoryTransport,
-    ObserverDefinition, ObserverExecutor, RetryConfig as ObserverRetryConfig,
+    ActionConfig as ObserverActionConfig, ActionExecutionDetail, ChangeLogListener,
+    ChangeLogListenerConfig, EntityEvent as ObserverEntityEvent, EventMatcher, FailurePolicy,
+    InMemoryTransport, ObserverDefinition, ObserverExecutor, RetryConfig as ObserverRetryConfig,
     config::{EmailSmtpConfig, TransportConfig, TransportKind},
     transport::{EventFilter, EventTransport},
 };
@@ -133,6 +133,17 @@ pub struct ObserverRuntimeConfig {
     /// `None` leaves the email action without a backend (it fails loud, #349);
     /// `Some(_)` builds a real `lettre` SMTP sender when the executor is created.
     pub email: Option<EmailSmtpConfig>,
+
+    /// Whether to persist the triggering event payload into the
+    /// `tb_observer_log.request_payload` column (#468).
+    ///
+    /// Default `false`: the non-sensitive audit columns (`action_type`,
+    /// `action_index`, `response_status_code`, `response_payload` summary) are
+    /// always written, but the request payload — which can carry PII from the
+    /// entity row — is only stored when an operator opts in via
+    /// `[observers.runtime].log_payloads`. Large payloads are truncated to a
+    /// marker regardless.
+    pub log_payloads: bool,
 }
 
 impl ObserverRuntimeConfig {
@@ -149,6 +160,7 @@ impl ObserverRuntimeConfig {
             max_dlq_size: None,
             transport: TransportConfig::default(),
             email: None,
+            log_payloads: false,
         }
     }
 
@@ -191,6 +203,14 @@ impl ObserverRuntimeConfig {
     #[must_use]
     pub fn with_email(mut self, email: Option<EmailSmtpConfig>) -> Self {
         self.email = email;
+        self
+    }
+
+    /// Enable persisting the triggering event payload into
+    /// `tb_observer_log.request_payload` (#468). Off by default.
+    #[must_use]
+    pub const fn with_log_payloads(mut self, log_payloads: bool) -> Self {
+        self.log_payloads = log_payloads;
         self
     }
 }
@@ -445,6 +465,7 @@ impl ObserverRuntime {
         let last_checkpoint = self.last_checkpoint.clone();
         let poll_interval = Duration::from_millis(self.config.poll_interval_ms);
         let pool = self.config.pool.clone();
+        let log_payloads = self.config.log_payloads;
 
         // Clone Arc references for hot reload
         let matcher_ref = Arc::clone(&self.matcher);
@@ -549,6 +570,7 @@ impl ObserverRuntime {
                                         bridge_sender.as_ref(),
                                         &events_processed,
                                         &errors,
+                                        log_payloads,
                                     )
                                     .await;
                                 }
@@ -716,6 +738,7 @@ impl ObserverRuntime {
         let events_processed = self.events_processed.clone();
         let errors = self.errors.clone();
         let pool = self.config.pool.clone();
+        let log_payloads = self.config.log_payloads;
         let matcher_ref = Arc::clone(&self.matcher);
         let executor_ref = Arc::clone(&self.executor);
         let entity_type_index_ref = Arc::clone(&self.entity_type_index);
@@ -763,6 +786,7 @@ impl ObserverRuntime {
                                     bridge_sender.as_ref(),
                                     &events_processed,
                                     &errors,
+                                    log_payloads,
                                 )
                                 .await;
                             },
@@ -944,8 +968,11 @@ async fn process_entity_event(
     bridge_sender: Option<&mpsc::Sender<BridgeEntityEvent>>,
     events_processed: &std::sync::atomic::AtomicU64,
     errors: &std::sync::atomic::AtomicU64,
+    log_payloads: bool,
 ) {
     // Find matching observers using the current (possibly reloaded) matcher.
+    // Used only as a fallback duration source for the audit log (#468) — the
+    // executor performs its own matching internally for dispatch.
     let matching_observers = matcher.find_matches(event);
 
     // Process event using the current (possibly reloaded) executor.
@@ -972,14 +999,27 @@ async fn process_entity_event(
                 } else {
                     "error"
                 };
-                let duration_ms = if matching_observers.is_empty() {
-                    0
+                // Pick the per-action detail that best represents this row's
+                // outcome (#468): for a success row the first action that
+                // succeeded, for an error row the first that failed. In the
+                // common single-action observer case this is exact; the
+                // aggregate-per-observer model (one row per matched observer) is
+                // unchanged. `None` only when the executor produced no detail.
+                let representative = if status == "success" {
+                    summary.action_details.iter().find(|d| d.success)
+                } else {
+                    summary.action_details.iter().find(|d| !d.success)
+                }
+                .or_else(|| summary.action_details.first());
+
+                // Fallback duration (the pre-#468 average over matched observers)
+                // used only when no per-action detail is available.
+                let fallback_duration_ms = if matching_observers.is_empty() {
+                    None
                 } else {
                     #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-                    // Reason: observer count is small; average duration fits in i32
-                    {
-                        (summary.total_duration_ms / matching_observers.len() as f64) as i32
-                    }
+                    // Reason: observer count is small; average duration fits in i32.
+                    Some((summary.total_duration_ms / matching_observers.len() as f64) as i32)
                 };
 
                 // Write a log entry for each matched observer. A failed audit-log
@@ -988,30 +1028,17 @@ async fn process_entity_event(
                 // `warn!` (mirroring the EventBridge forward-failure handling below)
                 // so the dropped audit row is observable.
                 for observer_id in observer_ids {
-                    if let Err(e) = sqlx::query(
-                        // entity_id is bound as text (Uuid::to_string) and cast
-                        // to the column's uuid type — sqlx will not implicitly
-                        // coerce text to uuid on INSERT.
-                        "INSERT INTO tb_observer_log
-                         (fk_observer, event_id, entity_type, entity_id, event_type, status, duration_ms, attempt_number, max_attempts)
-                         VALUES ($1, $2, $3, $4::uuid, $5, $6, $7, 1, 3)",
+                    write_observer_log(
+                        pool,
+                        observer_id,
+                        event,
+                        status,
+                        representative,
+                        fallback_duration_ms,
+                        None,
+                        log_payloads,
                     )
-                    .bind(observer_id)
-                    .bind(event.id)
-                    .bind(&event.entity_type)
-                    .bind(event.entity_id.to_string())
-                    .bind(event.event_type.as_str())
-                    .bind(status)
-                    .bind(duration_ms)
-                    .execute(pool)
-                    .await
-                    {
-                        warn!(
-                            "Failed to write observer success log (observer {observer_id}, \
-                             event {}): {e}",
-                            event.id
-                        );
-                    }
+                    .await;
                 }
             }
 
@@ -1050,41 +1077,132 @@ async fn process_entity_event(
             errors.fetch_add(1, Ordering::Relaxed);
             error!("Failed to process event {}: {}", event.id, e);
 
-            // Write error logs for matched observers.
+            // Write error logs for matched observers. This is an event-level
+            // failure (e.g. condition-parser error), so there is no per-action
+            // detail to attribute — only the error message is recorded.
             let event_type_str = event.event_type.as_str().to_uppercase();
             let observer_ids_err = entity_type_index
                 .load()
                 .get(&(event.entity_type.clone(), event_type_str))
                 .cloned();
             if let Some(observer_ids) = observer_ids_err {
+                let error_message = e.to_string();
                 for observer_id in observer_ids {
-                    if let Err(log_err) = sqlx::query(
-                        // entity_id cast to uuid as in the success path above.
-                        "INSERT INTO tb_observer_log
-                         (fk_observer, event_id, entity_type, entity_id, event_type, status, error_message, attempt_number, max_attempts)
-                         VALUES ($1, $2, $3, $4::uuid, $5, 'error', $6, 1, 3)",
+                    write_observer_log(
+                        pool,
+                        observer_id,
+                        event,
+                        "error",
+                        None,
+                        None,
+                        Some(&error_message),
+                        log_payloads,
                     )
-                    .bind(observer_id)
-                    .bind(event.id)
-                    .bind(&event.entity_type)
-                    .bind(event.entity_id.to_string())
-                    .bind(event.event_type.as_str())
-                    .bind(e.to_string())
-                    .execute(pool)
-                    .await
-                    {
-                        // Don't let a failed error-log write be swallowed too
-                        // (M-observer-log-swallow). The event error is already counted
-                        // and logged above; this surfaces the lost audit row.
-                        warn!(
-                            "Failed to write observer error log (observer {observer_id}, \
-                             event {}): {log_err}",
-                            event.id
-                        );
-                    }
+                    .await;
                 }
             }
         },
+    }
+}
+
+/// Maximum serialized size (bytes) of an event payload persisted into a JSONB
+/// audit column. A larger payload is replaced with a small marker so a single
+/// oversized event cannot bloat `tb_observer_log` (#468).
+const MAX_LOG_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Clamp an event payload for persistence into `tb_observer_log.request_payload`.
+///
+/// Returns the value unchanged when its serialized form is within
+/// [`MAX_LOG_PAYLOAD_BYTES`]; otherwise returns a marker object recording the
+/// original size so the stored audit row stays bounded.
+fn truncate_log_payload(data: &serde_json::Value) -> serde_json::Value {
+    let size = serde_json::to_vec(data).map_or(0, |v| v.len());
+    if size > MAX_LOG_PAYLOAD_BYTES {
+        serde_json::json!({
+            "_truncated": true,
+            "_original_size_bytes": size,
+        })
+    } else {
+        data.clone()
+    }
+}
+
+/// Write a single `tb_observer_log` row, populating the per-action audit columns
+/// from `detail` when available (#468).
+///
+/// `action_type`, `action_index`, `response_status_code`, and the
+/// `response_payload` outcome summary are non-sensitive and always written when
+/// a per-action detail is present. `request_payload` carries the triggering
+/// event data — potentially PII — so it is only persisted when `log_payloads`
+/// is set, and is truncated to a marker past [`MAX_LOG_PAYLOAD_BYTES`].
+///
+/// A failed write is surfaced via `warn!` rather than swallowed
+/// (M-observer-log-swallow): the event itself already processed, so a dropped
+/// audit row is non-fatal but must remain observable.
+#[allow(clippy::too_many_arguments)]
+// Reason: a single INSERT site threading the event, the per-action detail, and
+// the privacy toggle so both success and error paths share one column contract.
+async fn write_observer_log(
+    pool: &PgPool,
+    observer_id: i64,
+    event: &ObserverEntityEvent,
+    status: &str,
+    detail: Option<&ActionExecutionDetail>,
+    fallback_duration_ms: Option<i32>,
+    fallback_error: Option<&str>,
+    log_payloads: bool,
+) {
+    let action_index = detail.map(|d| i32::try_from(d.action_index).unwrap_or(i32::MAX));
+    let action_type = detail.map(|d| d.action_type.clone());
+    let status_code = detail.and_then(|d| d.status_code).map(i32::from);
+    let duration_ms = detail
+        .map(|d| {
+            #[allow(clippy::cast_possible_truncation)]
+            // Reason: action durations are small; milliseconds fit in i32.
+            {
+                d.duration_ms as i32
+            }
+        })
+        .or(fallback_duration_ms);
+    // Non-sensitive outcome summary (message + success flag); always recorded.
+    let response_payload =
+        detail.map(|d| serde_json::json!({ "message": d.message, "success": d.success }));
+    // Request payload may carry PII → opt-in only, and truncated when large.
+    let request_payload = log_payloads.then(|| truncate_log_payload(&event.data));
+    // Prefer an explicit event-level error, else the action's own error.
+    let error_message = fallback_error
+        .map(ToString::to_string)
+        .or_else(|| detail.and_then(|d| d.error_message.clone()));
+
+    if let Err(e) = sqlx::query(
+        // entity_id is bound as text (Uuid::to_string) and cast to the column's
+        // uuid type — sqlx will not implicitly coerce text to uuid on INSERT.
+        "INSERT INTO tb_observer_log
+         (fk_observer, event_id, entity_type, entity_id, event_type, status,
+          action_index, action_type, response_status_code, response_payload,
+          request_payload, duration_ms, error_message, attempt_number, max_attempts)
+         VALUES ($1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, 1, 3)",
+    )
+    .bind(observer_id)
+    .bind(event.id)
+    .bind(&event.entity_type)
+    .bind(event.entity_id.to_string())
+    .bind(event.event_type.as_str())
+    .bind(status)
+    .bind(action_index)
+    .bind(action_type)
+    .bind(status_code)
+    .bind(response_payload)
+    .bind(request_payload)
+    .bind(duration_ms)
+    .bind(error_message)
+    .execute(pool)
+    .await
+    {
+        warn!(
+            "Failed to write observer {status} log (observer {observer_id}, event {}): {e}",
+            event.id
+        );
     }
 }
 

--- a/crates/fraiseql-server/src/observers/runtime/tests.rs
+++ b/crates/fraiseql-server/src/observers/runtime/tests.rs
@@ -255,3 +255,32 @@ mod nats_unrunnable_gate {
         );
     }
 }
+
+/// `truncate_log_payload` (#468): small payloads pass through, oversized ones
+/// become a bounded marker.
+mod log_payload_truncation {
+    use super::super::{MAX_LOG_PAYLOAD_BYTES, truncate_log_payload};
+
+    #[test]
+    fn small_payload_is_passed_through_unchanged() {
+        let data = serde_json::json!({"id": "abc", "status": "new"});
+        assert_eq!(truncate_log_payload(&data), data);
+    }
+
+    #[test]
+    fn oversized_payload_is_replaced_with_a_size_marker() {
+        // A string value comfortably larger than the cap.
+        let big = "x".repeat(MAX_LOG_PAYLOAD_BYTES + 1_024);
+        let data = serde_json::json!({ "blob": big });
+
+        let out = truncate_log_payload(&data);
+        assert_eq!(out["_truncated"], serde_json::Value::Bool(true));
+        let recorded = out["_original_size_bytes"].as_u64().unwrap();
+        assert!(
+            recorded > u64::try_from(MAX_LOG_PAYLOAD_BYTES).unwrap(),
+            "marker must record the original (oversized) byte length"
+        );
+        // The original (large) content must not be persisted verbatim.
+        assert!(out.get("blob").is_none());
+    }
+}

--- a/crates/fraiseql-server/src/server/extensions.rs
+++ b/crates/fraiseql-server/src/server/extensions.rs
@@ -451,7 +451,8 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             .with_channel_capacity(observer_config.runtime.channel_capacity)
             .with_max_dlq_size(observer_config.runtime.max_dlq_size)
             .with_transport(transport)
-            .with_email(observer_config.runtime.email.clone());
+            .with_email(observer_config.runtime.email.clone())
+            .with_log_payloads(observer_config.runtime.log_payloads);
 
         let runtime = ObserverRuntime::new(runtime_config);
         Ok(Some(Arc::new(RwLock::new(runtime))))

--- a/crates/fraiseql-server/src/server_config/observers.rs
+++ b/crates/fraiseql-server/src/server_config/observers.rs
@@ -183,6 +183,17 @@ pub struct ObserverRuntimeSettings {
     /// in `fraiseql.toml` to tune independently of the main pool.
     #[serde(default)]
     pub pool: ObserverPoolConfig,
+
+    /// Persist the triggering event payload into the
+    /// `tb_observer_log.request_payload` column (default: `false`).
+    ///
+    /// The non-sensitive audit columns (`action_type`, `action_index`,
+    /// `response_status_code`, and the `response_payload` outcome summary) are
+    /// always written. The request payload can carry PII from the entity row, so
+    /// it is only recorded when an operator opts in here; oversized payloads are
+    /// truncated to a marker regardless (#468).
+    #[serde(default)]
+    pub log_payloads: bool,
 }
 
 #[cfg(feature = "observers")]
@@ -198,6 +209,7 @@ impl Default for ObserverRuntimeSettings {
             transport:            TransportConfig::default(),
             email:                None,
             pool:                 ObserverPoolConfig::default(),
+            log_payloads:         false,
         }
     }
 }

--- a/crates/fraiseql-server/tests/observer_runtime_integration_test.rs
+++ b/crates/fraiseql-server/tests/observer_runtime_integration_test.rs
@@ -195,6 +195,125 @@ async fn test_runtime_start_stop_lifecycle() {
     cleanup_test_data(&pool, &test_id).await.expect("Failed to cleanup");
 }
 
+/// Test (#468): the observer execution log populates the per-action audit
+/// columns after a delivery.
+///
+/// Before #468 the runtime wrote only status/duration and left `action_index`,
+/// `action_type`, `response_status_code`, `response_payload`, and
+/// `request_payload` NULL — so a delivery-log / audit UI could not show the
+/// response code or body. This asserts they are populated after a successful
+/// webhook dispatch. `log_payloads` is enabled so the (privacy-gated) request
+/// payload is persisted too.
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn test_observer_log_populates_audit_columns() {
+    init_test_tracing();
+
+    let test_id = Uuid::new_v4().to_string();
+    let pool = create_test_pool().await;
+    setup_observer_schema(&pool).await.expect("Failed to setup schema");
+
+    // Clean up old test data (order matters due to foreign keys)
+    sqlx::query("DELETE FROM tb_observer_log")
+        .execute(&pool)
+        .await
+        .expect("Failed to clean observer logs");
+    sqlx::query("DELETE FROM tb_observer")
+        .execute(&pool)
+        .await
+        .expect("Failed to clean observers");
+    sqlx::query("DELETE FROM core.tb_entity_change_log")
+        .execute(&pool)
+        .await
+        .expect("Failed to clean change log");
+
+    // Mock webhook returns 200 with a JSON body.
+    let mock_server = MockWebhookServer::start().await;
+    mock_server.mock_success().await;
+
+    let entity_type = format!("AuditOrder_{}", test_id);
+    let _observer_id = create_test_observer(
+        &pool,
+        &format!("test-audit-{}", test_id),
+        Some(&entity_type),
+        Some("INSERT"),
+        None,
+        &mock_server.webhook_url(),
+    )
+    .await
+    .expect("Failed to create observer");
+
+    // Enable log_payloads so request_payload is persisted (default is off).
+    let config = ObserverRuntimeConfig::new(pool.clone())
+        .with_poll_interval(50)
+        .with_log_payloads(true);
+    let mut runtime = ObserverRuntime::new(config);
+    runtime.start().await.expect("Failed to start runtime");
+
+    let order_id = Uuid::new_v4();
+    let _ = insert_change_log_entry(
+        &pool,
+        "INSERT",
+        &entity_type,
+        &order_id.to_string(),
+        serde_json::json!({"id": order_id.to_string(), "status": "new"}),
+        None,
+    )
+    .await
+    .expect("Failed to insert change log entry");
+
+    wait_for_webhook(&mock_server, 1, Duration::from_secs(15)).await;
+
+    // The audit row is written after dispatch; poll until it appears.
+    let mut audit = None;
+    for _ in 0..50 {
+        if let Some(a) = get_observer_log_audit(&pool, &order_id.to_string())
+            .await
+            .expect("Failed to query observer log audit columns")
+        {
+            audit = Some(a);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let audit = audit.expect("Expected an observer_log row for the processed event");
+
+    assert_eq!(audit.status, "success", "delivery should be logged as success");
+    assert_eq!(
+        audit.action_type.as_deref(),
+        Some("webhook"),
+        "action_type must be populated (#468)"
+    );
+    assert_eq!(audit.action_index, Some(0), "action_index must be populated (#468)");
+    assert_eq!(
+        audit.response_status_code,
+        Some(200),
+        "response_status_code must record the HTTP status (#468)"
+    );
+    assert!(
+        audit.response_payload.is_some(),
+        "response_payload summary must be populated (#468)"
+    );
+    assert!(
+        audit.duration_ms.is_some_and(|d| d >= 0),
+        "duration_ms must be recorded from the action detail"
+    );
+
+    // request_payload is gated on log_payloads (enabled here) and is the
+    // triggering event's after-image.
+    let request_payload = audit
+        .request_payload
+        .expect("request_payload must be stored when log_payloads=true");
+    assert_eq!(
+        request_payload["id"].as_str(),
+        Some(order_id.to_string().as_str()),
+        "request_payload must contain the triggering event data"
+    );
+
+    runtime.stop().await.expect("Failed to stop runtime");
+    cleanup_test_data(&pool, &test_id).await.expect("Failed to cleanup");
+}
+
 /// Test 2: Checkpoint Recovery After Runtime Restart
 ///
 /// Verifies that the observer runtime:

--- a/crates/fraiseql-server/tests/observer_test_helpers.rs
+++ b/crates/fraiseql-server/tests/observer_test_helpers.rs
@@ -484,6 +484,66 @@ pub async fn get_observer_log_count(pool: &PgPool, status: &str) -> Result<i64, 
     Ok(count.0)
 }
 
+/// Per-action audit columns of a `tb_observer_log` row (#468).
+#[derive(Debug, Clone)]
+pub struct ObserverLogAudit {
+    pub status:               String,
+    pub action_index:         Option<i32>,
+    pub action_type:          Option<String>,
+    pub response_status_code: Option<i32>,
+    pub response_payload:     Option<serde_json::Value>,
+    pub request_payload:      Option<serde_json::Value>,
+    pub duration_ms:          Option<i32>,
+}
+
+/// Fetch the per-action audit columns for the most recent log row of an entity (#468).
+pub async fn get_observer_log_audit(
+    pool: &PgPool,
+    entity_id: &str,
+) -> Result<Option<ObserverLogAudit>, sqlx::Error> {
+    let row: Option<(
+        String,
+        Option<i32>,
+        Option<String>,
+        Option<i32>,
+        Option<serde_json::Value>,
+        Option<serde_json::Value>,
+        Option<i32>,
+    )> = sqlx::query_as(
+        r"
+        SELECT status, action_index, action_type, response_status_code,
+               response_payload, request_payload, duration_ms
+        FROM tb_observer_log
+        WHERE entity_id = $1::uuid
+        ORDER BY created_at DESC
+        LIMIT 1
+        ",
+    )
+    .bind(entity_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(
+        |(
+            status,
+            action_index,
+            action_type,
+            response_status_code,
+            response_payload,
+            request_payload,
+            duration_ms,
+        )| ObserverLogAudit {
+            status,
+            action_index,
+            action_type,
+            response_status_code,
+            response_payload,
+            request_payload,
+            duration_ms,
+        },
+    ))
+}
+
 /// Get all observer logs for an entity
 pub async fn get_observer_logs_for_entity(
     pool: &PgPool,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -238,6 +238,11 @@ enabled = true
 [observers.runtime]
 channel_capacity = 1000
 max_dlq_size = 10000   # prevent unbounded memory growth on persistent failures
+# Persist the triggering event payload into tb_observer_log.request_payload (#468).
+# Off by default: the non-sensitive audit columns (action_type, action_index,
+# response_status_code, response_payload summary) are always written, but the
+# request payload may carry PII so it is opt-in (oversized payloads are truncated).
+log_payloads = false
 
 # Optional: event transport (#350). Defaults to PostgreSQL LISTEN/NOTIFY.
 # "nats" requires a binary built with `--features observers-nats`; a NATS


### PR DESCRIPTION
## Summary

Closes #468 (part of the #471 "declared but unwired" cluster).

`tb_observer_log` (migration `06_create_observer_management.sql`) declares
`action_index`, `action_type`, `request_payload`, `response_payload`, and
`response_status_code`, but the runtime log writer left them `NULL` — it recorded
only status/duration. A webhook delivery-log / audit UI built on the schema
therefore could not show response codes or bodies.

The root blocker was a crate-boundary one: the executor returned only an aggregated
`ExecutionSummary` (counts/durations), so the per-action status code / outcome /
action index produced inside `fraiseql-observers` were discarded before the
server's `INSERT`. This threads a per-action detail struct from the executor back
to the writer.

## What changed

**`fraiseql-observers`**
- `ActionResult` gains `status_code: Option<u16>` — set from the HTTP response for
  webhook/slack; `None` for email/cache and cache hits.
- New `ActionExecutionDetail` + `ExecutionSummary.action_details` (one entry per
  action, in dispatch order). `process_event`/`execute_action_with_retry` populate
  it on both success and failure. `process_event`'s signature is unchanged, so the
  57 existing call sites are untouched.

**`fraiseql-server`**
- The observer-runtime log writer now writes the per-action columns through a single
  `write_observer_log` helper shared by the success and error paths.
- Always populated (non-sensitive): `action_type`, `action_index`,
  `response_status_code`, and a `response_payload` outcome summary
  (`{message, success}`).
- `request_payload` (the triggering event data, potentially PII) is gated behind the
  new `[observers.runtime].log_payloads` flag (**default off**) and truncated to a
  marker past 64 KiB.
- New `ObserverRuntimeConfig::with_log_payloads` + `ObserverRuntimeSettings.log_payloads`,
  wired through `init_observer_runtime`.

### Granularity / scope note
The writer keeps the existing **one row per matched observer** model and stamps it
with the representative action's detail (first succeeding action for a success row,
first failing for an error row). In the common single-action observer case this is
exact. Perfect per-(observer, action) attribution would require threading the DB
observer identity through the matcher (which discards it) — out of scope here; this
is a strict improvement over the previous all-`NULL` rows and no worse than the
pre-existing aggregate-per-observer status.

## Testing
- Unit tests for `truncate_log_payload` (gate-compliant `runtime/tests.rs`).
- `#[ignore]` PG integration test `test_observer_log_populates_audit_columns` in
  `observer_runtime_integration_test.rs` asserts the columns are populated after a
  delivery (with `log_payloads` on to exercise `request_payload`). Rides the existing
  Dagger leg `cargo test -p fraiseql-server --features observers-nats --test
  observer_runtime_integration_test -- --ignored --test-threads=1`.

## Verification
- ✅ `cargo check --workspace --all-features`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` (observers + server)
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- ✅ `make lint-tests-layout` / `make lint-routes`
- ✅ `cargo +nightly fmt --check`
- ✅ observers lib tests (669 `--all-features`), server observers tests
- ✅ integration test compiles (`--features observers-nats --no-run`); runs on the CI PG leg (no local PG here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)