### PR TITLE
fix(server): add #468 audit columns to observer test schema (tb_observer_log)

### DIFF
--- a/crates/fraiseql-server/tests/observer_test_helpers.rs
+++ b/crates/fraiseql-server/tests/observer_test_helpers.rs
@@ -143,6 +143,13 @@ pub async fn setup_observer_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
             error_message TEXT,
             attempt_number INTEGER NOT NULL DEFAULT 1,
             max_attempts INTEGER NOT NULL DEFAULT 3,
+            -- #468 per-action audit columns written by write_observer_log. These
+            -- mirror migrations/06_create_observer_management.sql; the inline test
+            -- schema had drifted and lacked them, so the writer INSERT failed with
+            -- a missing-column error on response_status_code.
+            request_payload JSONB,
+            response_payload JSONB,
+            response_status_code INTEGER,
             trace_id VARCHAR(64),
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )


### PR DESCRIPTION
## Problem

The post-merge dev CI `integration (observers)` leg failed for `b6ee37e94`: **all four** `observer_runtime_integration_test` cases (including #468's `test_observer_log_populates_audit_columns`) failed against real PG with:

```
column "response_status_code" of relation "tb_observer_log" does not exist
```

Root cause: the integration tests' **inline** `tb_observer_log` schema (`observer_test_helpers.rs::setup_observer_schema`) had drifted from `migrations/06_create_observer_management.sql`. It was missing `request_payload`, `response_payload`, and `response_status_code` — the per-action audit columns that #468's `write_observer_log` (`runtime.rs:1180`) INSERTs on every observer-log write. Since the observer runtime writes a log per processed event, every runtime test failed. The #468 PR (#480) was only compile-checked locally (no local PG), so the test-schema gap shipped.

Production **migration 06 already defines these columns**, so the feature is correct in production — this is purely a test-harness fix.

## Fix

Add the three missing columns to the inline test schema, matching migration 06 and the writer's INSERT column list.

## Verification

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo test -p fraiseql-server --features observers-nats --test observer_runtime_integration_test --no-run`
- ✅ `cargo clippy -p fraiseql-server --features observers-nats --tests -- -D warnings`
- ✅ preflight shell gates (lint-tests-layout / lint-unwrap / lint-async-trait / check-route-syntax)
- Real-PG execution validated post-merge on the `observers-nats` integration leg.

Note: the underlying issue is an inline test schema duplicating (and drifting from) the real migration. Converging the test harness onto migration 06 would prevent recurrence — left as a follow-up to keep this fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)