### PR TITLE
style(server): nightly-fmt the #466/#469 cluster code (preflight fix)

### DIFF
--- a/crates/fraiseql-server/src/main.rs
+++ b/crates/fraiseql-server/src/main.rs
@@ -416,9 +416,11 @@ fn warn_files_not_wired(config: &ServerConfig) {
 #[cfg(not(feature = "observers"))]
 fn warn_observers_feature_missing(config_path: Option<&str>) {
     let Some(path) = config_path else { return };
-    let Ok(contents) = std::fs::read_to_string(path) else { return };
-    let has_observers = toml::from_str::<toml::Table>(&contents)
-        .is_ok_and(|table| table.contains_key("observers"));
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let has_observers =
+        toml::from_str::<toml::Table>(&contents).is_ok_and(|table| table.contains_key("observers"));
     if has_observers {
         tracing::warn!(
             path,

--- a/crates/fraiseql-server/src/observers/handlers.rs
+++ b/crates/fraiseql-server/src/observers/handlers.rs
@@ -27,7 +27,7 @@ pub struct ObserverState {
     /// self-consistent without a manual `POST /api/observers/runtime/reload`
     /// (#466). `None` when the admin API is mounted without a running
     /// background runtime (e.g. a control-plane-only deployment, or tests).
-    pub runtime: Option<std::sync::Arc<tokio::sync::RwLock<super::ObserverRuntime>>>,
+    pub runtime:    Option<std::sync::Arc<tokio::sync::RwLock<super::ObserverRuntime>>>,
 }
 
 /// Refresh the in-process matcher after a successful observer write so the admin
@@ -43,10 +43,7 @@ async fn refresh_runtime_after_write(state: &ObserverState) {
     };
     match runtime.read().await.reload_observers().await {
         Ok(count) => {
-            tracing::debug!(
-                observer_count = count,
-                "Observer matcher reloaded after admin write"
-            );
+            tracing::debug!(observer_count = count, "Observer matcher reloaded after admin write");
         },
         Err(e) => {
             tracing::warn!(

--- a/crates/fraiseql-server/src/observers/tests.rs
+++ b/crates/fraiseql-server/src/observers/tests.rs
@@ -425,7 +425,7 @@ mod router_construction {
     async fn observer_routes_constructs() {
         let state = ObserverState {
             repository: ObserverRepository::new(lazy_pool()),
-            runtime: None,
+            runtime:    None,
         };
         let _ = observer_routes(state);
     }

--- a/crates/fraiseql-server/src/server/routing/observers.rs
+++ b/crates/fraiseql-server/src/server/routing/observers.rs
@@ -68,7 +68,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             // Inject the runtime so admin CRUD writes refresh the in-process
             // matcher without a manual `…/runtime/reload` (#466). `None` when no
             // background runtime is mounted (control-plane-only deployments).
-            runtime: self.observer_runtime.clone(),
+            runtime:    self.observer_runtime.clone(),
         };
 
         let changelog_state = ChangelogState { pool: db_pool };

--- a/crates/fraiseql-server/tests/observer_runtime_integration_test.rs
+++ b/crates/fraiseql-server/tests/observer_runtime_integration_test.rs
@@ -1483,14 +1483,16 @@ async fn test_admin_create_reloads_matcher() {
         .execute(&pool)
         .await
         .expect("clean logs");
-    sqlx::query("DELETE FROM tb_observer").execute(&pool).await.expect("clean observers");
+    sqlx::query("DELETE FROM tb_observer")
+        .execute(&pool)
+        .await
+        .expect("clean observers");
 
     // Runtime carrying the in-process matcher. Not started: matcher reload is
     // independent of the background poller, so this exercises only the reload
     // path the handler now triggers.
-    let runtime = Arc::new(RwLock::new(ObserverRuntime::new(ObserverRuntimeConfig::new(
-        pool.clone(),
-    ))));
+    let runtime =
+        Arc::new(RwLock::new(ObserverRuntime::new(ObserverRuntimeConfig::new(pool.clone()))));
 
     // Baseline matcher: zero observers in the (cleaned) table.
     let baseline = runtime.read().await.reload_observers().await.expect("baseline reload");
@@ -1498,7 +1500,7 @@ async fn test_admin_create_reloads_matcher() {
 
     let state = ObserverState {
         repository: ObserverRepository::new(pool.clone()),
-        runtime: Some(Arc::clone(&runtime)),
+        runtime:    Some(Arc::clone(&runtime)),
     };
 
     let entity_type = format!("Order_{test_id}");


### PR DESCRIPTION
Post-merge fix-forward. PRs #476 (#469) and #477 (#466) only ran pre-commit.ci (stable rustfmt), not the project's `cargo +nightly fmt --check`, so the cumulative dev `preflight` leg went red on nightly-rustfmt diffs in `main.rs`, `observers/handlers.rs`, `observers/tests.rs`, `server/routing/observers.rs`, and `observer_runtime_integration_test.rs`. Reformat with nightly rustfmt; no behavior change.

## Verification
- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy -p {fraiseql-server,fraiseql-observers,fraiseql-cli} --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc -p {fraiseql-server,fraiseql-observers,fraiseql-cli} --all-features --no-deps`
- ✅ all 12 preflight shell gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)