### PR TITLE
fix(observers): accept null webhook headers in actions round-trip (#466)

### DIFF
--- a/crates/fraiseql-observers/src/config/runtime.rs
+++ b/crates/fraiseql-observers/src/config/runtime.rs
@@ -257,6 +257,21 @@ pub enum FailurePolicy {
 // Action Configuration
 // ============================================================================
 
+/// Deserialize a value, mapping an explicit JSON `null` to `T::default()`.
+///
+/// `#[serde(default)]` only fills in an *absent* field; a present `null` is still
+/// handed to the field's deserializer and fails for non-`Option` types. Pairing
+/// `default` with this `deserialize_with` makes both an absent key and an
+/// explicit `null` resolve to the default — needed for the `actions` JSONB
+/// round-trip where the writer emits `"headers": null` (#466).
+fn null_as_default<'de, D, T>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 /// Action configuration (tagged union)
 ///
 /// Marked `#[non_exhaustive]` so that new action types (e.g., `Kafka`, `Pubsub`)
@@ -273,7 +288,15 @@ pub enum ActionConfig {
         /// Environment variable containing the URL
         url_env:            Option<String>,
         /// Optional HTTP headers
-        #[serde(default)]
+        ///
+        /// `deserialize_with` treats an explicit JSON `null` the same as an
+        /// absent key (an empty map). `#[serde(default)]` alone only covers an
+        /// absent key; the admin-API writer (`fraiseql-server`'s `ActionConfig`)
+        /// serializes `None` headers as `null`, and existing `tb_observer.actions`
+        /// rows may already hold `"headers": null`, so reload must accept it
+        /// rather than fail the whole observer with `invalid type: null, expected
+        /// a map` (#466 round-trip).
+        #[serde(default, deserialize_with = "null_as_default")]
         headers:            HashMap<String, String>,
         /// Template for request body
         #[serde(default)]

--- a/crates/fraiseql-server/src/observers/mod.rs
+++ b/crates/fraiseql-server/src/observers/mod.rs
@@ -261,7 +261,13 @@ pub enum ActionConfig {
         #[serde(default = "default_method")]
         method:             String,
         /// Optional custom request headers.
-        #[serde(default)]
+        ///
+        /// `skip_serializing_if` keeps a `None` out of the persisted `actions`
+        /// JSONB (matching `signing_secret` below) so it is stored as an absent
+        /// key rather than `"headers": null` — the runtime's `ActionConfig`
+        /// reads headers as a non-optional map and rejects an explicit `null`
+        /// (#466 round-trip).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         headers:            Option<std::collections::HashMap<String, String>>,
         /// Optional Handlebars body template.
         #[serde(default)]


### PR DESCRIPTION
## Problem

#477's `test_admin_create_reloads_matcher` (the #466 acceptance test) failed against real Postgres on the `integration (observers)` leg — it only ran pre-commit.ci before, never PG. An observer created via the admin API stored `actions` as `{"type":"webhook", ..., "headers":null}`, and `reload_observers()` then failed the whole observer with `invalid type: null, expected a map`, so the reload-on-write matcher refresh saw **0** observers instead of 1.

Two diverging `ActionConfig::Webhook` types back the same `tb_observer.actions` JSONB:
- server API struct: `headers: Option<HashMap>` with `#[serde(default)]` (no skip) → serialized `None` as `"headers": null`
- runtime struct: `headers: HashMap` with `#[serde(default)]` → accepts an *absent* key but **not** an explicit `null`

`signing_secret`/`signing_secret_env` already use `skip_serializing_if`; `headers` was simply missed.

## Fix (both ends)

- **runtime reader**: `deserialize_with = null_as_default` maps an explicit `null` → empty map. This also **repairs existing** `tb_observer.actions` rows that already hold `"headers": null`.
- **server writer**: add `skip_serializing_if = "Option::is_none"` to `headers` (matching its own `signing_secret`) so new rows store an absent key, not `null`.

## Verification (against local PostgreSQL)

- ✅ `test_admin_create_reloads_matcher ... ok`
- ✅ `observer_runtime_integration_test` suite: **16 passed, 0 failed** (with `DATABASE_URL` + `FRAISEQL_OBSERVERS_ALLOW_INSECURE=true`, mirroring the CI observers leg)
- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy -p {fraiseql-observers,fraiseql-server} --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc -p {fraiseql-observers,fraiseql-server} --all-features --no-deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)