### PR TITLE
fix(core): recase camelCase query filters to snake_case JSONB keys (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Multi-word camelCase query filters no longer silently return `[]` (#486).** On the
+  query path, an explicit filter argument (`orders(organizationId: "x")`) built its
+  JSONB predicate from the raw camelCase name — `data->>'organizationId'` — which never
+  matches the stored `organization_id` key, so the filter silently dropped to an empty
+  result instead of erroring. The JSONB key is now `snake_case`d with the same
+  acronym-aware caser the WHERE-input and mutation-input paths use
+  (`crate::utils::to_snake_case`), so `organizationId` → `organization_id`,
+  `dns1Id` → `dns_1_id`. This closes the class across every arg-shaped filter surface:
+  explicit args + inject params (`query_params`), aggregate `where` and `groupBy`
+  fallback dimensions, window `where`, and the EXPLAIN diagnostics
+  (`build_where_from_variables` / display SQL). For `groupBy`, only the JSONB extraction
+  *path* is recased — the result *alias* keeps the camel surface name so the GraphQL
+  response key is unchanged (the #418/#410 rule). The query-side analog of the merged
+  #456 mutation-input fix; a six-surface parity test fences the class against future
+  filter surfaces that forget to recase.
 - **Observer execution log now populates its request/response audit columns (#468).**
   `tb_observer_log` declares `action_index`, `action_type`, `response_status_code`,
   `response_payload`, and `request_payload`, but the runtime log writer left them

--- a/crates/fraiseql-core/src/runtime/aggregate_parser.rs
+++ b/crates/fraiseql-core/src/runtime/aggregate_parser.rs
@@ -204,7 +204,12 @@ impl AggregateQueryParser {
                     }
                 } else {
                     WhereClause::Field {
-                        path: vec![field.to_string()],
+                        // Recase the JSONB key so a camelCase aggregate filter
+                        // (`organizationId_eq`) builds `data->>'organization_id'`
+                        // rather than a never-matching `organizationId` key (#486).
+                        // Only the non-native branch recases — the native lookup
+                        // above stays on the surface name (mirror `query_params`).
+                        path: vec![crate::utils::to_snake_case(field)],
                         operator,
                         value: value.clone(),
                     }
@@ -291,7 +296,13 @@ impl AggregateQueryParser {
                         // allowlist (which is skipped when `dimensions.paths` is empty).
                         validate_dimension_key(key)?;
                         selections.push(GroupBySelection::Dimension {
-                            path:  key.clone(),
+                            // The `path` is the JSONB extraction key → recase to
+                            // snake_case so a camelCase dimension (`machineStatus`)
+                            // groups by `data->>'machine_status'` (#486). The `alias`
+                            // is the result/response column name, consumed verbatim by
+                            // `AggregationProjector`, so it keeps the camel surface name
+                            // (the #418/#410 "output key is the alias" rule).
+                            path:  crate::utils::to_snake_case(key),
                             alias: key.clone(),
                         });
                     }
@@ -754,7 +765,7 @@ fn validate_dimension_key(key: &str) -> Result<()> {
 
 #[cfg(test)]
 mod alias_injection_tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::panic)]
     use std::collections::HashMap;
 
     use super::*;
@@ -813,5 +824,26 @@ mod alias_injection_tests {
         let req = AggregateQueryParser::parse(&query, &empty_metadata(), &HashMap::new())
             .expect("plain groupBy key must parse");
         assert_eq!(req.group_by.len(), 1);
+    }
+
+    #[test]
+    fn camel_group_by_dimension_recases_path_but_keeps_alias() {
+        // #486: a camelCase groupBy dimension must extract the snake_case JSONB key
+        // (`data->>'machine_status'`) so grouping actually buckets rows, while the
+        // alias stays the camel surface name because `AggregationProjector` uses it
+        // verbatim as the GraphQL response key (#418/#410 "output key is the alias").
+        let query = serde_json::json!({
+            "table": "tf_sales",
+            "groupBy": { "machineStatus": true }
+        });
+        let req = AggregateQueryParser::parse(&query, &empty_metadata(), &HashMap::new())
+            .expect("camel groupBy key must parse");
+        match req.group_by.as_slice() {
+            [GroupBySelection::Dimension { path, alias }] => {
+                assert_eq!(path, "machine_status", "path is the snake JSONB key");
+                assert_eq!(alias, "machineStatus", "alias is the camel response key");
+            },
+            other => panic!("expected a single Dimension, got {other:?}"),
+        }
     }
 }

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_params.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_params.rs
@@ -29,7 +29,10 @@ pub fn inject_param_where_clause(
         }
     } else {
         WhereClause::Field {
-            path: vec![col.to_string()],
+            // Recase the JSONB key to snake_case so the predicate matches the stored
+            // key (parity with the WHERE-input / mutation-input paths, #486/#456).
+            // Idempotent for the common snake-from-config case.
+            path: vec![crate::utils::to_snake_case(col)],
             operator: WhereOperator::Eq,
             value,
         }
@@ -82,6 +85,11 @@ pub fn compute_projection_reduction(projected_field_count: usize) -> u32 {
 /// `WhereClause::NativeField` is emitted (enabling B-tree index lookup via
 /// `WHERE col = $N::type`).  Otherwise a `WhereClause::Field` is emitted
 /// (JSONB extraction: `WHERE data->>'col' = $N`).
+///
+/// The JSONB key is `snake_case`d with [`crate::utils::to_snake_case`] — the same
+/// caser the WHERE-input and mutation-input paths use — so a camelCase argument
+/// (`organizationId`) resolves to the stored key (`organization_id`) rather than a
+/// never-matching `organizationId` key (#486, mirrors the #456 mutation fix).
 pub fn combine_explicit_arg_where(
     existing: Option<WhereClause>,
     defined_args: &[crate::schema::ArgumentDefinition],
@@ -102,7 +110,12 @@ pub fn combine_explicit_arg_where(
                     }
                 } else {
                     WhereClause::Field {
-                        path:     vec![arg.name.clone()],
+                        // Recase the camelCase GraphQL arg name to the snake_case JSONB
+                        // key so `orders(organizationId: "x")` builds
+                        // `data->>'organization_id'` (matches) instead of
+                        // `data->>'organizationId'` (always NULL → silent `[]`).
+                        // Same caser as the WHERE-input path (#486, mirrors #456).
+                        path:     vec![crate::utils::to_snake_case(&arg.name)],
                         operator: WhereOperator::Eq,
                         value:    value.clone(),
                     }

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_params_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_params_tests.rs
@@ -31,3 +31,146 @@ fn enforce_max_page_size_rejects_value_over_max() {
         other => panic!("expected Validation error, got {other:?}"),
     }
 }
+
+// ── #486: query-path camelCase → snake_case recasing ─────────────────────────
+
+use std::collections::HashMap;
+
+use crate::schema::{ArgumentDefinition, FieldType};
+
+/// Build a one-argument explicit-arg WHERE clause and return the emitted JSONB path.
+fn explicit_arg_path(arg_name: &str) -> Vec<String> {
+    let args = [ArgumentDefinition::new(arg_name, FieldType::String)];
+    let mut provided = HashMap::new();
+    provided.insert(arg_name.to_string(), serde_json::json!("x"));
+    let native = HashMap::new();
+    let clause = combine_explicit_arg_where(None, &args, &provided, &native)
+        .expect("single explicit arg yields a clause");
+    match clause {
+        WhereClause::Field { path, .. } => path,
+        other => panic!("expected WhereClause::Field, got {other:?}"),
+    }
+}
+
+#[test]
+fn explicit_arg_multiword_camel_is_recased_to_snake() {
+    // Multi-word camelCase args MUST become snake_case JSONB keys so the filter
+    // matches the stored `data->>'organization_id'` instead of always-NULL
+    // `data->>'organizationId'` (#486 silent-empty). Mirrors the #456 mutation fix.
+    assert_eq!(explicit_arg_path("organizationId"), vec!["organization_id".to_string()]);
+    assert_eq!(explicit_arg_path("machineStatus"), vec!["machine_status".to_string()]);
+    // Acronym/digit parity with the canonical caser (`dns1Id` → `dns_1_id`).
+    assert_eq!(explicit_arg_path("dns1Id"), vec!["dns_1_id".to_string()]);
+}
+
+#[test]
+fn explicit_arg_single_word_is_unchanged() {
+    // Single-token args must not be mangled by over-eager recasing.
+    assert_eq!(explicit_arg_path("status"), vec!["status".to_string()]);
+    assert_eq!(explicit_arg_path("url"), vec!["url".to_string()]);
+}
+
+#[test]
+fn inject_param_recasing_is_idempotent_on_snake() {
+    // Inject params arrive snake_case from config; recasing must be a no-op so the
+    // class is closed once without disturbing the common case.
+    let native = HashMap::new();
+    let clause = inject_param_where_clause("tenant_id", serde_json::json!("t"), &native);
+    match clause {
+        WhereClause::Field { path, .. } => assert_eq!(path, vec!["tenant_id".to_string()]),
+        other => panic!("expected WhereClause::Field, got {other:?}"),
+    }
+}
+
+/// Extract the single JSONB field path from a `WhereClause`, unwrapping a
+/// one-element `And`. Panics on any other shape.
+fn single_field_path(clause: &WhereClause) -> Vec<String> {
+    match clause {
+        WhereClause::Field { path, .. } => path.clone(),
+        WhereClause::And(inner) if inner.len() == 1 => single_field_path(&inner[0]),
+        other => panic!("expected a single Field clause, got {other:?}"),
+    }
+}
+
+/// **Six-surface parity canary (#486).** For one multi-word camel name, every
+/// arg-shaped filter surface must resolve to the *identical* snake column. A
+/// future filter surface that forgets to recase breaks this test.
+///
+/// Five surfaces are exercised here (all reachable from this module); the sixth,
+/// `explain` (`build_where_from_variables` / `build_display_sql`), is a private
+/// EXPLAIN-only path verified by its own sibling test in
+/// `executor/support/explain.rs` — see `explain_recases_*`.
+#[test]
+fn camel_filter_recasing_is_identical_across_surfaces() {
+    // `organizationId` → `organization_id` must hold on every arg-shaped surface.
+    const SNAKE: &str = "organization_id";
+
+    // 1. Explicit query argument.
+    assert_eq!(
+        explicit_arg_path("organizationId"),
+        vec![SNAKE.to_string()],
+        "explicit-arg surface"
+    );
+
+    // 2. WHERE-input object (the already-correct reference path).
+    let where_input = WhereClause::from_graphql_json(&serde_json::json!({
+        "organizationId": { "eq": "x" }
+    }))
+    .expect("where-input parses");
+    assert_eq!(single_field_path(&where_input), vec![SNAKE.to_string()], "where-input surface");
+
+    // 3 & 4. Aggregate `where` and `groupBy` fallback dimension.
+    let metadata = empty_fact_metadata();
+    let native = HashMap::new();
+    let agg = crate::runtime::AggregateQueryParser::parse(
+        &serde_json::json!({
+            "table": "tf_x",
+            "where": { "organizationId_eq": "x" },
+            "groupBy": { "organizationId": true },
+        }),
+        &metadata,
+        &native,
+    )
+    .expect("aggregate query parses");
+    let agg_where = agg.where_clause.expect("aggregate where present");
+    assert_eq!(
+        single_field_path(&agg_where),
+        vec![SNAKE.to_string()],
+        "aggregate-where surface"
+    );
+    let dim = agg.group_by.iter().find_map(|g| match g {
+        crate::compiler::aggregation::GroupBySelection::Dimension { path, alias } => {
+            Some((path.clone(), alias.clone()))
+        },
+        _ => None,
+    });
+    let (dim_path, dim_alias) = dim.expect("groupBy dimension present");
+    assert_eq!(dim_path, SNAKE, "aggregate-groupBy path surface");
+    // The alias is the GraphQL response key (consumed verbatim by
+    // AggregationProjector), so it keeps the camel surface name (#418/#410 rule).
+    assert_eq!(dim_alias, "organizationId", "aggregate-groupBy alias keeps the surface name");
+
+    // 5. Window `where`.
+    let win = crate::runtime::WindowQueryParser::parse(
+        &serde_json::json!({
+            "table": "tf_x",
+            "where": { "organizationId_eq": "x" },
+        }),
+        &metadata,
+    )
+    .expect("window query parses");
+    let win_where = win.where_clause.expect("window where present");
+    assert_eq!(single_field_path(&win_where), vec![SNAKE.to_string()], "window-where surface");
+}
+
+/// Minimal fact-table metadata with an empty dimension allowlist, so the
+/// `groupBy` fallback dimension (priority 5) is the live path.
+fn empty_fact_metadata() -> crate::compiler::fact_table::FactTableMetadata {
+    serde_json::from_value(serde_json::json!({
+        "table_name": "tf_x",
+        "measures": [],
+        "dimensions": { "name": "dimensions", "paths": [] },
+        "denormalized_filters": []
+    }))
+    .expect("valid empty fact-table metadata")
+}

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
@@ -1180,3 +1180,85 @@ mod node_authz {
         }
     }
 }
+
+// ── mod explicit_arg_recasing: #486 end-to-end (GraphQL arg → WHERE) ──────────
+//
+// Mirrors the #456 mutation-input e2e (`CapturingFunctionCallAdapter`): drive a
+// real GraphQL query through the executor and capture the WHERE clause the
+// adapter receives, proving a camelCase explicit argument resolves to the
+// snake_case JSONB column the stored data actually uses.
+mod explicit_arg_recasing {
+    use super::*;
+    use crate::schema::ArgumentDefinition;
+
+    /// Build a list query `orders(<arg>: String)` over `v_orders`.
+    fn orders_schema_with_arg(arg_name: &str) -> CompiledSchema {
+        let mut schema = CompiledSchema::new();
+        schema.queries.push(QueryDefinition {
+            name:                "orders".to_string(),
+            return_type:         "Order".to_string(),
+            returns_list:        true,
+            nullable:            false,
+            arguments:           vec![ArgumentDefinition::new(arg_name, FieldType::String)],
+            sql_source:          Some("v_orders".to_string()),
+            description:         None,
+            auto_params:         AutoParams::default(),
+            deprecation:         None,
+            jsonb_column:        "data".to_string(),
+            relay:               false,
+            relay_cursor_column: None,
+            relay_cursor_type:   CursorType::default(),
+            inject_params:       IndexMap::default(),
+            cache_ttl_seconds:   None,
+            additional_views:    vec![],
+            requires_role:       None,
+            rest_path:           None,
+            rest_method:         None,
+            native_columns:      HashMap::new(),
+        });
+        schema
+    }
+
+    /// Extract the single `Field` clause, unwrapping a one-element `And`.
+    fn single_field(clause: WhereClause) -> (Vec<String>, serde_json::Value) {
+        match clause {
+            WhereClause::Field { path, value, .. } => (path, value),
+            WhereClause::And(mut inner) if inner.len() == 1 => single_field(inner.remove(0)),
+            other => panic!("expected a single Field clause, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn multiword_camel_arg_filters_on_snake_column() {
+        let schema = orders_schema_with_arg("organizationId");
+        let adapter = Arc::new(CapturingMockAdapter::new(mock_user_results()));
+        let executor = Executor::new(schema, adapter.clone());
+
+        executor
+            .execute("{ orders(organizationId: \"abc\") { id } }", None)
+            .await
+            .unwrap();
+
+        let (path, value) =
+            single_field(adapter.captured_where().expect("explicit arg reaches the DB"));
+        assert_eq!(
+            path,
+            vec!["organization_id".to_string()],
+            "must filter data->>'organization_id'"
+        );
+        assert_eq!(value, serde_json::json!("abc"));
+    }
+
+    #[tokio::test]
+    async fn single_word_arg_is_unchanged() {
+        let schema = orders_schema_with_arg("status");
+        let adapter = Arc::new(CapturingMockAdapter::new(mock_user_results()));
+        let executor = Executor::new(schema, adapter.clone());
+
+        executor.execute("{ orders(status: \"open\") { id } }", None).await.unwrap();
+
+        let (path, _) =
+            single_field(adapter.captured_where().expect("explicit arg reaches the DB"));
+        assert_eq!(path, vec!["status".to_string()]);
+    }
+}

--- a/crates/fraiseql-core/src/runtime/executor/support/explain.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/explain.rs
@@ -114,7 +114,10 @@ fn build_where_from_variables(variables: Option<&serde_json::Value>) -> Option<W
     let mut conditions: Vec<WhereClause> = map
         .iter()
         .map(|(k, v)| WhereClause::Field {
-            path:     vec![k.clone()],
+            // Recase the variable name to the snake_case JSONB key so the EXPLAIN'd
+            // SQL filters the same column the real query path does (#486). Without
+            // this, EXPLAIN runs against a never-matching `data->>'camelKey'`.
+            path:     vec![crate::utils::to_snake_case(k)],
             operator: WhereOperator::Eq,
             value:    v.clone(),
         })
@@ -150,7 +153,10 @@ pub fn build_display_sql(
             let conditions: Vec<String> = map
                 .keys()
                 .enumerate()
-                .map(|(i, k)| format!("data->>'{}' = ${}", k, i + 1))
+                // Recase the key so the displayed SQL matches the snake_case column
+                // the executed EXPLAIN actually filters on (#486 — keep the human-
+                // readable echo consistent with `build_where_from_variables`).
+                .map(|(i, k)| format!("data->>'{}' = ${}", crate::utils::to_snake_case(k), i + 1))
                 .collect();
             sql.push_str(" WHERE ");
             sql.push_str(&conditions.join(" AND "));
@@ -171,3 +177,7 @@ pub fn build_display_sql(
 
     sql
 }
+
+#[cfg(test)]
+#[path = "explain_tests.rs"]
+mod explain_tests;

--- a/crates/fraiseql-core/src/runtime/executor/support/explain_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/explain_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for the EXPLAIN SQL builders, co-located with `support/explain.rs`.
+
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics acceptable
+
+use super::*;
+
+/// #486: the EXPLAIN WHERE clause must key on the `snake_case` JSONB column,
+/// not the raw camelCase variable name — otherwise EXPLAIN runs against a
+/// never-matching `data->>'organizationId'` while the real query uses
+/// `data->>'organization_id'`. This is the sixth recasing surface (the
+/// consolidated parity canary in `query_params_tests.rs` cannot reach this
+/// private function).
+#[test]
+fn explain_recases_where_variables_to_snake() {
+    let vars = serde_json::json!({ "organizationId": "x" });
+    let clause = build_where_from_variables(Some(&vars)).expect("clause built");
+    match clause {
+        WhereClause::Field { path, .. } => {
+            assert_eq!(path, vec!["organization_id".to_string()]);
+        },
+        other => panic!("expected WhereClause::Field, got {other:?}"),
+    }
+}
+
+#[test]
+fn explain_display_sql_recases_keys_to_snake() {
+    // The human-readable echo must match the column the executed EXPLAIN
+    // actually filters on (consistent with `build_where_from_variables`).
+    let vars = serde_json::json!({ "organizationId": "x" });
+    let sql = build_display_sql("v_orders", Some(&vars), None, None);
+    assert!(sql.contains("data->>'organization_id'"), "got: {sql}");
+    assert!(!sql.contains("organizationId"), "must not echo the camel key: {sql}");
+}
+
+#[test]
+fn explain_display_sql_single_word_unchanged() {
+    let vars = serde_json::json!({ "status": "open" });
+    let sql = build_display_sql("v_orders", Some(&vars), None, None);
+    assert!(sql.contains("data->>'status'"), "got: {sql}");
+}

--- a/crates/fraiseql-core/src/runtime/window_parser.rs
+++ b/crates/fraiseql-core/src/runtime/window_parser.rs
@@ -487,7 +487,10 @@ impl WindowQueryParser {
                 let operator = WhereOperator::from_str(operator_str)?;
 
                 conditions.push(WhereClause::Field {
-                    path: vec![field.to_string()],
+                    // Recase the JSONB key so a camelCase window filter
+                    // (`organizationId_eq`) builds `data->>'organization_id'`
+                    // rather than a never-matching `organizationId` key (#486).
+                    path: vec![crate::utils::to_snake_case(field)],
                     operator,
                     value: value.clone(),
                 });


### PR DESCRIPTION
## AX lever: kill silent-wrong

On the query path, a multi-word camelCase filter argument (`orders(organizationId: "x")`) built its JSONB predicate from the **raw camel name** — `data->>'organizationId'` — which never matches the stored `organization_id` key. The filter silently dropped to `[]` instead of erroring. For an autonomous agent driving FraiseQL this reads as **"no data," not "bug"** — the worst failure mode. This is the query-side analog of the merged #456 mutation-input fix.

## What changed

The JSONB key is now `snake_case`d with the **same** acronym-aware caser the WHERE-input / mutation-input paths already use (`crate::utils::to_snake_case`, re-exported from `fraiseql-db`), so `where:{organizationId}` and `orders(organizationId:…)` resolve to the **identical** column (`organization_id`; `dns1Id` → `dns_1_id`).

Closes the class across **every** arg-shaped filter surface (the earlier audit had missed four):

| Surface | Site |
|---|---|
| explicit args + inject params | `query_params.rs` |
| aggregate `where` + `groupBy` fallback dimension | `aggregate_parser.rs` |
| window `where` | `window_parser.rs` |
| EXPLAIN where-clause + display SQL | `explain.rs` |

Only the **non-native** branch recases (the native-column lookup stays on the surface name). For `groupBy`, only the JSONB extraction **path** is recased — the result **alias** keeps the camel surface name so the GraphQL response key is unchanged (`AggregationProjector` uses the alias verbatim — the #418/#410 rule).

### Documented waivers (not camel-reachable)
- **window SELECT / partitionBy** take an explicit caller-provided JSONB `path` and are validated against metadata by `WindowPlanner` (loud on mismatch), so they are outside the silent-wrong class.
- **`tenant_enforcer` `org_id`** and **relay `id`** are literal snake constants, not derived from a GraphQL surface key.

## Tests
- **Six-surface parity canary** — `organizationId` → `organization_id` identical across explicit-arg, WHERE-input, aggregate where/groupBy, window where (explain covered by a sibling unit test, since its builder is private). The canary is the regression fence: a future filter surface that forgets to recase breaks it.
- Unit truth-table (multi-word recased, single-word unchanged, inject idempotent), the groupBy path/alias split pinned explicitly, and a capturing-adapter e2e mirroring #456.

## Verification
- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- ✅ `make lint-routes` / `lint-tests-layout` / `lint-async-trait` (ratchet still 188)
- ✅ `cargo nextest run -p fraiseql-core --lib`: 2573 passed
- ✅ live-DB e2e (query + aggregate + window, serial): 86 passed

Fixes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)