### PR TITLE
fix(cli): mirror runtime single-JSONB predicate in the arity gate (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`doctor`/`validate --against-db` no longer false-fail single-JSONB mutations (#484).**
+  The #384 mutation→function contract check derived the function's *expected* arity by
+  flattening the `input` type's fields whenever the operation was not `Update` — so every
+  `Insert`/`Delete`/`Custom` mutation on the single-JSONB convention (`fn(p_input jsonb)`,
+  authored with `input_style = jsonb`) reported a spurious
+  `expected N argument(s) but the function takes [1]`, making the gate unusable as a
+  green-means-green CI check. `expected_call` now mirrors the runtime's single-JSONB
+  predicate exactly (`mutation/mod.rs:499-500`): a structured single `input` arg is
+  expected as one `jsonb` payload when the op is `Update`, **or** `input_style == jsonb`,
+  **or** the input type is absent from the schema — and the arg-1-is-`jsonb` assertion now
+  applies to all of those. Genuinely-wrong functions (wrong arity, non-`jsonb` payload)
+  are still caught. The fix lands on both `doctor --against-db` and `validate --against-db`
+  from one change (shared `mutation_contract` module).
 - **Observer execution log now populates its request/response audit columns (#468).**
   `tb_observer_log` declares `action_index`, `action_type`, `response_status_code`,
   `response_payload`, and `request_payload`, but the runtime log writer left them

--- a/crates/fraiseql-cli/src/schema/mutation_contract/mod.rs
+++ b/crates/fraiseql-cli/src/schema/mutation_contract/mod.rs
@@ -25,7 +25,9 @@
 use std::fmt;
 
 use anyhow::Result;
-use fraiseql_core::schema::{CompiledSchema, FieldType, MutationDefinition, MutationOperation};
+use fraiseql_core::schema::{
+    CompiledSchema, FieldType, InputStyle, MutationDefinition, MutationOperation,
+};
 
 use crate::schema::pg_catalog::{PgCatalog, PgFunction};
 
@@ -207,10 +209,12 @@ impl fmt::Display for ContractViolation {
 /// skipped.
 ///
 /// This mirrors the runtime arg-building in
-/// `fraiseql-core/.../runners/mutation/mod.rs` exactly, including the precedence:
-/// an update with a single `input` of an Input type always takes the
-/// jsonb-payload path (even when the input type is not in the schema); other
-/// single-`input` mutations flatten only when the input type resolves.
+/// `fraiseql-core/.../runners/mutation/mod.rs` exactly. A single structured
+/// `input` arg is forwarded as ONE jsonb payload when the operation is `Update`,
+/// the mutation opts in via `input_style = jsonb`, **or** the input type is not
+/// in the schema (see `pass_as_single_jsonb`, pinned to `mutation/mod.rs:499-500`).
+/// Otherwise a known input type flattens to one positional arg per field;
+/// everything else is flat args.
 #[must_use]
 pub fn expected_call(
     mutation: &MutationDefinition,
@@ -218,27 +222,18 @@ pub fn expected_call(
 ) -> Option<ExpectedCall> {
     let sql_source = resolve_sql_source(mutation)?;
 
-    // Single `input` argument whose type is an Input object?
-    let input_type_name = if mutation.arguments.len() == 1 && mutation.arguments[0].name == "input"
-    {
-        match &mutation.arguments[0].arg_type {
-            FieldType::Input(name) => Some(name.as_str()),
-            _ => None,
-        }
-    } else {
-        None
-    };
-    let is_update = matches!(&mutation.operation, MutationOperation::Update { .. });
+    let input_type_name = single_input_type_name(mutation);
 
-    let (shape, base_arity, first_is_jsonb_payload) = if input_type_name.is_some() && is_update {
-        // Update + single input object → one jsonb payload arg (no schema lookup).
+    let (shape, base_arity, first_is_jsonb_payload) = if pass_as_single_jsonb(mutation, schema) {
+        // Single-JSONB path: Update, `input_style = jsonb`, or unknown input type
+        // → one jsonb payload arg. `first_is_jsonb_payload` enables the arg-1-is-
+        // jsonb assertion in `check_mutation` for every such case.
         (CallShape::JsonbPayload, 1, true)
     } else if let Some(input_type) = input_type_name.and_then(|n| schema.find_input_type(n)) {
         // Insert/Delete/Custom + single input object found in schema → flatten fields.
         (CallShape::FlattenedFields, input_type.fields.len(), false)
     } else {
-        // Flat args (includes single non-Input `input`, or an input type the
-        // schema doesn't define).
+        // Flat args (a single non-Input `input`, or multiple scalar args).
         (CallShape::FlatArgs, mutation.arguments.len(), false)
     };
 
@@ -249,6 +244,40 @@ pub fn expected_call(
         inject_names: mutation.inject_params.keys().cloned().collect(),
         first_is_jsonb_payload,
     })
+}
+
+/// The name of a single `input` argument typed as an Input object, else `None`.
+///
+/// This is the structured-input form the compiled `input` arg carries
+/// (`FieldType::Input`); it mirrors the runtime's `input_type_name`
+/// (`mutation/mod.rs:444-456`) scoped to that form.
+fn single_input_type_name(mutation: &MutationDefinition) -> Option<&str> {
+    if mutation.arguments.len() == 1 && mutation.arguments[0].name == "input" {
+        match &mutation.arguments[0].arg_type {
+            FieldType::Input(name) => Some(name.as_str()),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// Faithful mirror of the runtime single-JSONB predicate
+/// (`fraiseql-core/.../runners/mutation/mod.rs:499-500`):
+/// ```text
+/// pass_input_as_single_jsonb =
+///     input_arg_is_structured && (is_update || jsonb_input_style || !known_input_type)
+/// ```
+/// A structured single `input` arg is forwarded as ONE jsonb payload when the
+/// operation is `Update`, the mutation opts in via `input_style = jsonb`, or the
+/// input type is not in the compiled schema. Keep this in sync with that line.
+fn pass_as_single_jsonb(mutation: &MutationDefinition, schema: &CompiledSchema) -> bool {
+    let input_type_name = single_input_type_name(mutation);
+    let input_arg_is_structured = input_type_name.is_some();
+    let is_update = matches!(&mutation.operation, MutationOperation::Update { .. });
+    let jsonb_input_style = matches!(mutation.input_style, InputStyle::Jsonb);
+    let known_input_type = input_type_name.and_then(|n| schema.find_input_type(n)).is_some();
+    input_arg_is_structured && (is_update || jsonb_input_style || !known_input_type)
 }
 
 /// Resolve a mutation's SQL function name: `sql_source`, else the operation's

--- a/crates/fraiseql-cli/src/schema/mutation_contract/tests.rs
+++ b/crates/fraiseql-cli/src/schema/mutation_contract/tests.rs
@@ -106,19 +106,22 @@ fn insert_single_input_flattens_input_type_fields() {
 }
 
 #[test]
-fn insert_single_input_falls_back_to_flat_when_type_missing() {
+fn insert_single_input_takes_jsonb_path_when_type_missing() {
     let mut m = MutationDefinition::new("createUser", "CreateUserResult");
     m.sql_source = Some("fn_create_user".to_string());
     m.operation = MutationOperation::Insert {
         table: String::new(),
     };
     m.arguments = vec![single_input_arg("CreateUserInput")];
-    // CreateUserInput absent → flatten can't happen → flat args (1 positional).
+    // CreateUserInput absent → the runtime can't flatten an unknown type, so it
+    // forwards the whole input as one jsonb arg (`!known_input_type`, mirroring
+    // mutation/mod.rs:500). The gate must agree: JsonbPayload(1), arg-1 is jsonb.
     let schema = CompiledSchema::default();
 
     let ec = expected_call(&m, &schema).expect("DB-backed");
-    assert_eq!(ec.shape, CallShape::FlatArgs);
+    assert_eq!(ec.shape, CallShape::JsonbPayload);
     assert_eq!(ec.base_arity, 1);
+    assert!(ec.first_is_jsonb_payload);
 }
 
 #[test]
@@ -184,6 +187,239 @@ fn falls_back_to_operation_table_when_sql_source_absent() {
     let schema = CompiledSchema::default();
     let ec = expected_call(&m, &schema).expect("table fallback is DB-backed");
     assert_eq!(ec.sql_source, "fn_create_user");
+}
+
+// ─── #484: single-JSONB arity mirror (input_style == Jsonb) ──────────────────
+//
+// The contract gate must mirror the runtime predicate
+// (`mutation/mod.rs:499-500`): a single structured `input` arg is passed as ONE
+// jsonb payload when the op is Update, OR `input_style == Jsonb`, OR the input
+// type is unknown. Before the fix the gate only routed `Update` to JsonbPayload,
+// so every single-JSONB Insert/Delete/Custom false-failed with ArityMismatch.
+
+/// End-to-end: derive the expected call from the schema, then check it against
+/// the candidate functions — exactly what `doctor`/`validate --against-db` do.
+fn check(
+    m: &MutationDefinition,
+    schema: &CompiledSchema,
+    candidates: &[PgFunction],
+) -> Vec<ContractViolation> {
+    check_mutation(&expected_call(m, schema).expect("DB-backed mutation"), candidates)
+}
+
+/// `createOrder` with a single 6-field `input`, given operation + input style.
+fn order_mutation(
+    op: MutationOperation,
+    style: fraiseql_core::schema::InputStyle,
+) -> MutationDefinition {
+    let mut m = MutationDefinition::new("createOrder", "CreateOrderResult");
+    m.sql_source = Some("fn_create_order".to_string());
+    m.operation = op;
+    m.input_style = style;
+    m.arguments = vec![single_input_arg("CreateOrderInput")];
+    m
+}
+
+fn schema_with_order_input(fields: usize) -> CompiledSchema {
+    CompiledSchema {
+        input_types: vec![input_type("CreateOrderInput", fields)],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn jsonb_insert_single_input_no_false_arity_mismatch() {
+    use fraiseql_core::schema::InputStyle;
+    // input_style = jsonb + a single-jsonb function → the runtime sends one jsonb
+    // arg, so the gate must NOT expect the 6 flattened fields. (Today: ArityMismatch{6}.)
+    let m = order_mutation(
+        MutationOperation::Insert {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Jsonb,
+    );
+    let schema = schema_with_order_input(6);
+    let candidates = vec![pg_function(
+        &["jsonb"],
+        &[Some("p_input")],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "single-jsonb insert must be clean");
+}
+
+#[test]
+fn jsonb_insert_with_inject_param_no_violations() {
+    use fraiseql_core::schema::InputStyle;
+    let mut m = order_mutation(
+        MutationOperation::Insert {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Jsonb,
+    );
+    m.inject_params = inject(&["tenant_id"]);
+    let schema = schema_with_order_input(6);
+    let candidates = vec![pg_function(
+        &["jsonb", "uuid"],
+        &[Some("p_input"), Some("tenant_id")],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "jsonb + inject must be clean");
+}
+
+#[test]
+fn jsonb_insert_against_flattened_function_is_arity_mismatch() {
+    use fraiseql_core::schema::InputStyle;
+    // input_style = jsonb but the function actually flattens 6 args → genuinely
+    // wrong: the runtime sends 1 jsonb, the function wants 6. Still caught.
+    let m = order_mutation(
+        MutationOperation::Insert {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Jsonb,
+    );
+    let schema = schema_with_order_input(6);
+    let candidates = vec![pg_function(
+        &["int4", "int4", "int4", "int4", "int4", "int4"],
+        &[None, None, None, None, None, None],
+        full_response_columns(),
+    )];
+    assert_eq!(
+        check(&m, &schema, &candidates),
+        vec![ContractViolation::ArityMismatch {
+            expected: 1,
+            found:    vec![6],
+        }],
+    );
+}
+
+#[test]
+fn flatten_insert_is_unchanged() {
+    use fraiseql_core::schema::InputStyle;
+    // Flatten style with a known 6-field input → still flattens to 6 args.
+    let m = order_mutation(
+        MutationOperation::Insert {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Flatten,
+    );
+    let schema = schema_with_order_input(6);
+    let candidates = vec![pg_function(
+        &["text", "text", "text", "text", "text", "text"],
+        &[None, None, None, None, None, None],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "flatten path unchanged");
+}
+
+#[test]
+fn update_with_flatten_style_still_takes_jsonb_path() {
+    use fraiseql_core::schema::InputStyle;
+    // Update always uses the single-JSONB path regardless of input_style.
+    let m = order_mutation(
+        MutationOperation::Update {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Flatten,
+    );
+    let schema = schema_with_order_input(6);
+    let candidates = vec![pg_function(
+        &["jsonb"],
+        &[Some("p_input")],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "update→jsonb preserved");
+}
+
+#[test]
+fn jsonb_payload_wrong_type_is_flagged() {
+    use fraiseql_core::schema::InputStyle;
+    let m = order_mutation(
+        MutationOperation::Insert {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Jsonb,
+    );
+    let schema = schema_with_order_input(6);
+    // Right arity (1) but arg-1 is text, not jsonb → the new path still asserts jsonb.
+    let candidates = vec![pg_function(
+        &["text"],
+        &[Some("p_input")],
+        full_response_columns(),
+    )];
+    assert!(
+        check(&m, &schema, &candidates).contains(&ContractViolation::PayloadNotJsonb {
+            actual: "text".to_string(),
+        }),
+        "single-jsonb path must assert arg-1 is jsonb",
+    );
+}
+
+#[test]
+fn custom_op_jsonb_style_is_not_update_only() {
+    use fraiseql_core::schema::{InputStyle, MutationOperation as Op};
+    // The gap is NOT update-only: a Custom (non-DML) op with jsonb style also
+    // takes the single-JSONB path. (Today: ArityMismatch{3}.)
+    let mut m = MutationDefinition::new("archiveOrder", "ArchiveOrderResult");
+    m.sql_source = Some("fn_archive_order".to_string());
+    m.operation = Op::Custom;
+    m.input_style = InputStyle::Jsonb;
+    m.arguments = vec![single_input_arg("ArchiveOrderInput")];
+    let schema = CompiledSchema {
+        input_types: vec![input_type("ArchiveOrderInput", 3)],
+        ..Default::default()
+    };
+    let candidates = vec![pg_function(
+        &["jsonb"],
+        &[Some("p_input")],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "custom + jsonb must be clean");
+}
+
+#[test]
+fn two_scalar_args_with_jsonb_style_stay_flat() {
+    use fraiseql_core::schema::InputStyle;
+    // No single structured `input` → input_arg_is_structured is false, so the
+    // jsonb arm must NOT fire even with input_style = jsonb. Stays FlatArgs(2).
+    let mut m = MutationDefinition::new("createOrder", "CreateOrderResult");
+    m.sql_source = Some("fn_create_order".to_string());
+    m.operation = MutationOperation::Insert {
+        table: "tb_order".to_string(),
+    };
+    m.input_style = InputStyle::Jsonb;
+    m.arguments = vec![
+        ArgumentDefinition::new("a", FieldType::Int),
+        ArgumentDefinition::new("b", FieldType::Int),
+    ];
+    let schema = CompiledSchema::default();
+    let candidates = vec![pg_function(
+        &["int4", "int4"],
+        &[None, None],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "two scalar args stay FlatArgs(2)");
+}
+
+#[test]
+fn preserve_naming_jsonb_single_input_holds() {
+    use fraiseql_core::schema::{InputStyle, NamingConvention};
+    let m = order_mutation(
+        MutationOperation::Insert {
+            table: "tb_order".to_string(),
+        },
+        InputStyle::Jsonb,
+    );
+    let schema = CompiledSchema {
+        input_types: vec![input_type("CreateOrderInput", 6)],
+        naming_convention: NamingConvention::Preserve,
+        ..Default::default()
+    };
+    let candidates = vec![pg_function(
+        &["jsonb"],
+        &[Some("p_input")],
+        full_response_columns(),
+    )];
+    assert_eq!(check(&m, &schema, &candidates), vec![], "arg-1-is-jsonb holds under Preserve");
 }
 
 // ─── check_mutation: call binding ───────────────────────────────────────────

--- a/crates/fraiseql-cli/tests/mutation_contract_against_db.rs
+++ b/crates/fraiseql-cli/tests/mutation_contract_against_db.rs
@@ -16,7 +16,10 @@ use fraiseql_cli::schema::{
     },
     pg_catalog::PgCatalog,
 };
-use fraiseql_core::schema::{ArgumentDefinition, CompiledSchema, FieldType, MutationDefinition};
+use fraiseql_core::schema::{
+    ArgumentDefinition, CompiledSchema, FieldType, InputFieldDefinition, InputObjectDefinition,
+    InputStyle, MutationDefinition, MutationOperation,
+};
 use tokio_postgres::NoTls;
 
 const SCHEMA: &str = "fql_397_test";
@@ -37,6 +40,11 @@ CREATE FUNCTION fql_397_test.fn_update_user(input jsonb, tenant_id uuid)
 CREATE FUNCTION fql_397_test.fn_create_user(p_input jsonb)
   RETURNS TABLE(succeeded boolean, state_changed boolean, entity jsonb)
   LANGUAGE plpgsql AS $$ BEGIN RETURN; END $$;
+-- Correct single-JSONB convention: an Insert that takes the whole input as one
+-- jsonb arg (input_style = jsonb), backed by a single-`jsonb` function (#484).
+CREATE FUNCTION fql_397_test.fn_create_order(p_input jsonb)
+  RETURNS SETOF fql_397_test.mutation_response LANGUAGE sql AS
+  $$ SELECT NULL::fql_397_test.mutation_response $$;
 -- Broken: first param is text, not jsonb (update payload).
 CREATE FUNCTION fql_397_test.fn_bad_payload(input text, tenant_id uuid)
   RETURNS SETOF fql_397_test.mutation_response LANGUAGE sql AS
@@ -242,6 +250,44 @@ async fn validate_mutation_contract_walks_schema_and_surfaces_violations() {
         broken.violations
     );
     assert!(report.error_count() >= 2);
+
+    teardown().await;
+}
+
+/// A single-JSONB Insert (`input_style = jsonb`) with a known multi-field input
+/// type, backed by `fn_create_order(p_input jsonb)`. Before #484 this false-failed
+/// with `ArityMismatch{expected: N}` because the gate flattened the input fields.
+#[tokio::test]
+async fn single_jsonb_insert_has_no_false_arity_mismatch() {
+    let Some(catalog) = setup().await else { return };
+
+    let mut create_order = MutationDefinition::new("createOrder", "CreateOrderResult");
+    create_order.sql_source = Some(qualified("fn_create_order"));
+    create_order.operation = MutationOperation::Insert {
+        table: "tb_order".to_string(),
+    };
+    create_order.input_style = InputStyle::Jsonb;
+    create_order.arguments = vec![ArgumentDefinition::new(
+        "input",
+        FieldType::Input("CreateOrderInput".to_string()),
+    )];
+
+    let input_fields =
+        (0..6).map(|i| InputFieldDefinition::new(format!("f{i}"), "String")).collect();
+    let schema = CompiledSchema {
+        mutations: vec![create_order],
+        input_types: vec![InputObjectDefinition::new("CreateOrderInput").with_fields(input_fields)],
+        ..Default::default()
+    };
+
+    let report = validate_mutation_contract(&schema, &catalog).await.unwrap();
+    assert_eq!(report.checked, 1, "the single-jsonb mutation is DB-backed");
+    assert_eq!(
+        report.mutations.len(),
+        0,
+        "single-jsonb insert must report no violations, got {:?}",
+        report.mutations
+    );
 
     teardown().await;
 }


### PR DESCRIPTION
## AX lever: trustworthy gate

The #384 mutation→function contract check (`doctor --against-db` / `validate --against-db`) **false-failed every single-JSONB mutation** (`fn(p_input jsonb)`) with `expected N argument(s) but the function takes [1]`. `expected_call` only routed `Update` to the jsonb-payload path; an `Insert`/`Delete`/`Custom` authored with `input_style = jsonb` was flattened to `fields.len()` while the runtime sends one jsonb arg. An agent can't treat a gate that cries wolf as green-means-green.

## What changed

`expected_call` now derives the call shape from a **faithful mirror** of the runtime predicate (`fraiseql-core/.../runners/mutation/mod.rs:499-500`), extracted into `pass_as_single_jsonb`:

```text
pass = input_arg_is_structured && (is_update || input_style==Jsonb || !known_input_type)
```

A structured single `input` arg is expected as one `jsonb` payload when the op is `Update`, **or** `input_style == jsonb`, **or** the input type is absent from the schema. `first_is_jsonb_payload` is set for all three, so the **arg-1-is-`jsonb` assertion now covers them too** — strictly tighter, no regression. The `!known_input_type` case moves from `FlatArgs` to `JsonbPayload` to match the runtime (the one existing test that asserted the old shape is updated).

The fix lands on **both** `doctor --against-db` and `validate --against-db` from one change (shared `mutation_contract` module).

## Tests
A nine-row truth-table covering: jsonb Insert/Custom clean, flatten unchanged, update→jsonb preserved, **genuinely-wrong** arity and non-`jsonb` payload still caught, a two-scalar-args regression guard (the jsonb arm must not fire without a structured input), and a `NamingConvention::Preserve` guard. Plus a live `fn_create_order(p_input jsonb)` fixture asserting zero violations through `validate_mutation_contract`.

## Verification
- ✅ `cargo +nightly fmt --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- ✅ `make lint-routes` / `lint-tests-layout` / `lint-async-trait` (ratchet still 188)
- ✅ `cargo nextest run -p fraiseql-cli --all-features` (serial, live DB): 1133 passed

Fixes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)