### PR TITLE
feat(federation): subgraph directive passthrough, camelCase changelog, golden compose suite

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -589,12 +589,14 @@ func (m *FraiseqlCi) TestIntegration(
 		return m.integrationServerStorage(ctx, source)
 	case "federation":
 		return m.integrationFederation(ctx, source)
+	case "federation-compose":
+		return m.integrationFederationCompose(ctx, source)
 	case "cross-db":
 		return m.integrationCrossDb(ctx, source)
 	case "saml":
 		return m.integrationSaml(ctx, source)
 	default:
-		return "", fmt.Errorf("unknown integration suite %q (known: postgres, sqlite, mysql, nats, observers, http-e2e, tls, sqlserver, server, redis, vault, wire, storage, server-storage, federation, cross-db, saml)", suite)
+		return "", fmt.Errorf("unknown integration suite %q (known: postgres, sqlite, mysql, nats, observers, http-e2e, tls, sqlserver, server, redis, vault, wire, storage, server-storage, federation, federation-compose, cross-db, saml)", suite)
 	}
 }
 
@@ -666,6 +668,39 @@ func (m *FraiseqlCi) integrationSaml(ctx context.Context, source *dagger.Directo
 	return m.integrationBase(source, rustMsrv).
 		WithServiceBinding(pgBindHost, m.pgService(source)).
 		WithEnvVariable("DATABASE_URL", dbURL).
+		WithExec([]string{"bash", "-c", script}).
+		Stdout(ctx)
+}
+
+// integrationFederationCompose is the real-composer half of the golden two-subgraph
+// federation suite (the #495/#496/#497/#498 cluster). It composes the committed
+// FraiseQL-rendered subgraph SDLs with Apollo Federation v2 composition
+// (@apollo/composition — the engine `rover supergraph compose` wraps) and asserts the
+// positive case composes cleanly and the #497 two-change-log-owner case is rejected with
+// INVALID_FIELD_SHARING. Node-only — no Rust, no DB.
+//
+// This is the step the old federation leg never ran: it routed a *pre-composed, committed*
+// single-subgraph supergraph, so a broken subgraph SDL (missing scalar, dropped directive,
+// snake_case change-log) sailed through. The committed SDL fixtures here are kept in
+// lock-step with live FraiseQL rendering by the hermetic Rust test `federation_compose`,
+// which runs in the postgres integration leg's `--test '*'` sweep (federation feature).
+//
+// Built on shellBase (the ghcr-mirrored ubuntu image, not Docker Hub) + apt nodejs/npm, so
+// it adds no new base image. `run-compose-check.sh` restores deps via `npm ci` from the
+// committed lockfile.
+func (m *FraiseqlCi) integrationFederationCompose(ctx context.Context, source *dagger.Directory) (string, error) {
+	script := strings.Join([]string{
+		"set -e",
+		"echo \"### node: $(node --version) / npm: $(npm --version)\"",
+		"echo '### integration: federation-compose (Apollo Federation v2 composition of FraiseQL-rendered subgraph SDLs)'",
+		"bash tools/federation/run-compose-check.sh",
+		"echo 'test-integration OK: federation-compose suite passed'",
+	}, "\n")
+
+	return m.shellBase().
+		WithExec([]string{"apt-get", "install", "-y", "--no-install-recommends", "nodejs", "npm"}).
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
 		WithExec([]string{"bash", "-c", script}).
 		Stdout(ctx)
 }

--- a/.github/workflows/dagger-integration.yml
+++ b/.github/workflows/dagger-integration.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        suite: [postgres, sqlite, mysql, nats, observers, http-e2e, tls, sqlserver, server, redis, vault, wire, storage, server-storage, federation, cross-db, saml]
+        suite: [postgres, sqlite, mysql, nats, observers, http-e2e, tls, sqlserver, server, redis, vault, wire, storage, server-storage, federation, federation-compose, cross-db, saml]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ composer-setup.php
 .phpunit.result.cache
 # Studio frontend dependencies (rebuilt by build.rs)
 crates/fraiseql-server/studio/node_modules/
+# Federation compose-check deps (restored via `npm ci` from the committed lockfile)
+tools/federation/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`[federation]`) workflow already carried through the merger and is unchanged. As a
   guardrail against a future silent regression, the legacy JSON path now fails the
   compile if a non-empty input `federation` block does not bind into the schema.
+- **TOML `[federation]` now carries the subgraph identity.** The `[federation]`
+  section gained `service_name`, `version` (Apollo spec string, e.g. `"v2"`), and
+  `schema_url`; the legacy integer `apollo_version` is still accepted (`2` ⇒ `"v2"`,
+  and `version` wins when both are set). The merger now lowers the TOML config into the
+  compiled shape explicitly, so `service_name`/`version` and per-entity circuit-breaker
+  overrides (`[[federation.circuit_breaker.per_database]]` ⇒ runtime `per_entity`) reach
+  the runtime instead of being silently dropped on a field-name mismatch.
 
 ## [2.10.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**
+  Two residual `_service` SDL gaps that the type-closure fix exposed: (1) the `scalar`
+  declaration walk canonicalised names (`DateTime`) while fields rendered them verbatim
+  (`datetime`), so the reference dangled (`Unknown type datetime`); declarations are now
+  collected from the exact rendered field names (covering `LTree`, `FloatRange`, lowercase
+  date/time scalars). (2) the generated rich-filter `*WhereInput` types declared `eq`
+  twice — the standard operator set was hardcoded and the type's operator set (which also
+  contains `eq`) was appended — producing an invalid input type (`Field eq already
+  exists`); the generated fields are now de-duplicated by name. A FraiseQL subgraph's SDL
+  now composes through a gateway with zero consumer-side workarounds.
 - **Federation `_service` SDL is now type-complete.** Building on the root-operations
   fix, the generated SDL rendered only object types and the root `Query`/`Mutation` —
   it omitted input objects, enums, non-built-in scalar declarations (`DateTime`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Federation `_service` SDL is now type-complete.** Building on the root-operations
+  fix, the generated SDL rendered only object types and the root `Query`/`Mutation` —
+  it omitted input objects, enums, non-built-in scalar declarations (`DateTime`,
+  `JSON`, `Decimal`, rich/custom scalars), and synthesized mutation result unions. A
+  gateway composing a subgraph whose operations referenced those types failed with
+  `Unknown type CreateQuoteInput` (and the like). `raw_schema()` now renders the full
+  type closure — `scalar`/`enum`/`interface`/`input`/`union` declarations alongside the
+  object types and root operations — so a FraiseQL subgraph composes without
+  consumer-side scalar stubs. The federation `@link` directive definition was also
+  corrected (`for: String` → `for: link__Purpose`, with the supporting `link__Purpose`
+  enum and `link__Import` scalar), which composers were rejecting.
 - **Federation `_service` SDL now advertises root operations.** A subgraph's
   `_service { sdl }` (and the `/schema` SDL endpoint) is generated from
   `CompiledSchema::raw_schema()`, which only rendered object types — FraiseQL keeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Federation `_service` SDL now advertises root operations.** A subgraph's
+  `_service { sdl }` (and the `/schema` SDL endpoint) is generated from
+  `CompiledSchema::raw_schema()`, which only rendered object types — FraiseQL keeps
+  root operations in `queries`/`mutations`, not as `Query`/`Mutation` object types, so
+  the emitted SDL exposed **no root fields**. A gateway composing that SDL (Apollo
+  Router, Hive Router — both read `_service.sdl`) failed with `NO_QUERIES`, making
+  FraiseQL subgraphs uncomposable despite advertising their entities and `@key`s. The
+  generated SDL now renders the root `type Query`/`type Mutation` from `queries`/
+  `mutations` with correct argument and list/nullable signatures, so subgraphs compose
+  into a working supergraph. (Router-independent; the fix is upstream of the gateway.)
 - **`fraiseql compile` no longer drops the `federation` block.** Schemas authored
   with federation enabled (e.g. the Python SDK's `export_schema(federation=...)`)
   emit the configuration under the top-level `federation` key, but the compiler only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fraiseql compile` no longer drops the `federation` block.** Schemas authored
+  with federation enabled (e.g. the Python SDK's `export_schema(federation=...)`)
+  emit the configuration under the top-level `federation` key, but the compiler only
+  bound `federation_config` — so the legacy JSON workflow silently produced a
+  non-federated `schema.compiled.json` (`jq 'has("federation")'` ⇒ `false`), and the
+  server it loaded never advertised itself as a subgraph (`_service` / SDL absent).
+  `IntermediateSchema.federation_config` now also binds the `federation` key (serde
+  alias), so the block carries through to `CompiledSchema.federation` and the
+  compiled subgraph serves a proper Apollo Federation v2 `_service { sdl }`. The TOML
+  (`[federation]`) workflow already carried through the merger and is unchanged. As a
+  guardrail against a future silent regression, the legacy JSON path now fails the
+  compile if a non-empty input `federation` block does not bind into the schema.
+
 ## [2.10.0] - 2026-06-26
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test test-unit test-integration test-federation test-full test-all-ignored clippy fmt check clean clean-test-containers install dev doc bench memory-profile db-up db-down db-logs db-reset db-status federation-up federation-down demo-start demo-stop demo-logs demo-status demo-clean demo-restart examples-start examples-stop examples-logs examples-status examples-clean e2e e2e-setup e2e-all e2e-python e2e-typescript e2e-java e2e-go e2e-php e2e-velocitybench e2e-clean e2e-status parity-generate parity-compare test-parity security audit test-count lint-gate lint-gate-db lint-gate-wire lint-gate-core lint-unwrap lint-expect lint-tests-layout release release-validate release-validate-semver load-test load-test-all helm-lint changelog changelog-full
+.PHONY: help build test test-unit test-integration test-federation federation-compose-check test-full test-all-ignored clippy fmt check clean clean-test-containers install dev doc bench memory-profile db-up db-down db-logs db-reset db-status federation-up federation-down demo-start demo-stop demo-logs demo-status demo-clean demo-restart examples-start examples-stop examples-logs examples-status examples-clean e2e e2e-setup e2e-all e2e-python e2e-typescript e2e-java e2e-go e2e-php e2e-velocitybench e2e-clean e2e-status parity-generate parity-compare test-parity security audit test-count lint-gate lint-gate-db lint-gate-wire lint-gate-core lint-unwrap lint-expect lint-tests-layout release release-validate release-validate-semver load-test load-test-all helm-lint changelog changelog-full
 
 # Default target
 help:
@@ -650,6 +650,15 @@ test-federation: federation-up
 		EXIT=$$?; \
 		$(MAKE) federation-down; \
 		exit $$EXIT
+
+# Golden two-subgraph compose suite — no Docker. Verifies the committed subgraph SDL
+# fixtures still match live FraiseQL rendering (hermetic Rust test), then composes them
+# with real Apollo Federation v2 composition (positive + the #497 negative case). This
+# is the suite that would have caught the #495/#496/#497/#498 federation cluster.
+federation-compose-check:
+	@echo "=== Federation golden compose (SDL invariants + real composition) ==="
+	@cargo test -p fraiseql-core --test federation_compose --features federation
+	@bash tools/federation/run-compose-check.sh
 
 # ============================================================================
 # Legacy database commands (local PostgreSQL)

--- a/crates/fraiseql-cli/Cargo.toml
+++ b/crates/fraiseql-cli/Cargo.toml
@@ -106,6 +106,10 @@ name = "cli_federation_validation"
 required-features = ["federation"]
 
 [[test]]
+name = "compile_federation_passthrough"
+required-features = ["federation"]
+
+[[test]]
 name = "federation_cli_advanced"
 required-features = ["federation"]
 

--- a/crates/fraiseql-cli/src/commands/compile.rs
+++ b/crates/fraiseql-cli/src/commands/compile.rs
@@ -169,9 +169,28 @@ pub async fn compile_to_schema(
         info!("Using legacy JSON workflow");
         let schema_json = fs::read_to_string(input_path).context("Failed to read schema.json")?;
 
-        // 2. Parse JSON into IntermediateSchema (language-agnostic format)
+        // 2. Parse JSON into IntermediateSchema (language-agnostic format). Parse via Value first
+        //    so we can detect a federation block that the SDK emitted but that failed to bind into
+        //    the schema (the silent-drop class this issue fixed): the block must carry through or
+        //    fail loudly, never vanish into a non-federated subgraph.
         info!("Parsing intermediate schema...");
-        serde_json::from_str(&schema_json).context("Failed to parse schema.json")?
+        let raw: serde_json::Value =
+            serde_json::from_str(&schema_json).context("Failed to parse schema.json")?;
+        let input_has_federation = ["federation", "federation_config"].iter().any(|key| {
+            raw.get(*key)
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|o| !o.is_empty())
+        });
+        let intermediate: IntermediateSchema =
+            serde_json::from_value(raw).context("Failed to parse schema.json")?;
+        if input_has_federation && intermediate.federation_config.is_none() {
+            anyhow::bail!(
+                "schema.json carries a `federation` block that did not bind into the compiled \
+                 schema — refusing to compile a silently non-federated subgraph. This is a \
+                 compiler bug; please report it."
+            );
+        }
+        intermediate
     };
 
     // 2a. Load and apply security configuration from fraiseql.toml if it exists.

--- a/crates/fraiseql-cli/src/config/toml_schema/federation.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/federation.rs
@@ -112,12 +112,14 @@ impl FederationConfig {
             version:         self.effective_version(),
             service_name:    self.service_name.clone(),
             schema_url:      self.schema_url.clone(),
+            shareable_types: Vec::new(),
             entities:        self
                 .entities
                 .iter()
                 .map(|e| core::FederationEntity {
                     name:       e.name.clone(),
                     key_fields: e.key_fields.clone(),
+                    ..Default::default()
                 })
                 .collect(),
             circuit_breaker: self.circuit_breaker.as_ref().map(|cb| core::CircuitBreakerConfig {

--- a/crates/fraiseql-cli/src/config/toml_schema/federation.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/federation.rs
@@ -51,7 +51,19 @@ pub struct FederationConfig {
     /// Enable Apollo federation
     #[serde(default)]
     pub enabled:         bool,
-    /// Apollo federation version
+    /// Subgraph service name (surfaced in Apollo Studio and the subgraph listing)
+    pub service_name:    Option<String>,
+    /// Apollo Federation spec version string (e.g. `"v2"`).
+    ///
+    /// Preferred over [`apollo_version`](Self::apollo_version); when both are set,
+    /// `version` wins. When neither is set, the runtime defaults to `"v2"`.
+    pub version:         Option<String>,
+    /// Subgraph SDL URL (exposed at `/__subgraph_schema`)
+    pub schema_url:      Option<String>,
+    /// Apollo federation major version (legacy integer form; `2` ⇒ `"v2"`).
+    ///
+    /// Retained for backward compatibility; prefer the [`version`](Self::version)
+    /// string. Ignored when `version` is set.
     pub apollo_version:  Option<u32>,
     /// Federated entities
     pub entities:        Vec<FederationEntity>,
@@ -63,9 +75,67 @@ impl Default for FederationConfig {
     fn default() -> Self {
         Self {
             enabled:         false,
+            service_name:    None,
+            version:         None,
+            schema_url:      None,
             apollo_version:  Some(2),
             entities:        vec![],
             circuit_breaker: None,
+        }
+    }
+}
+
+impl FederationConfig {
+    /// The effective Apollo Federation spec version string.
+    ///
+    /// Prefers the explicit [`version`](Self::version) string, falling back to the
+    /// legacy integer [`apollo_version`](Self::apollo_version) (`2` ⇒ `"v2"`).
+    /// `None` when neither is set, in which case the runtime defaults to `"v2"`.
+    #[must_use]
+    pub fn effective_version(&self) -> Option<String> {
+        self.version.clone().or_else(|| self.apollo_version.map(|v| format!("v{v}")))
+    }
+
+    /// Lower this TOML-authored config into the compiled
+    /// [`fraiseql_core::schema::FederationConfig`] the runtime consumes.
+    ///
+    /// The mapping is explicit (rather than a raw serde passthrough) so the TOML and
+    /// compiled field names cannot silently diverge: in particular `apollo_version`
+    /// becomes `version`, and per-entity circuit-breaker overrides authored as
+    /// `per_database` become the runtime's `per_entity` list.
+    #[must_use]
+    pub fn to_compiled(&self) -> fraiseql_core::schema::FederationConfig {
+        use fraiseql_core::schema as core;
+
+        core::FederationConfig {
+            enabled:         self.enabled,
+            version:         self.effective_version(),
+            service_name:    self.service_name.clone(),
+            schema_url:      self.schema_url.clone(),
+            entities:        self
+                .entities
+                .iter()
+                .map(|e| core::FederationEntity {
+                    name:       e.name.clone(),
+                    key_fields: e.key_fields.clone(),
+                })
+                .collect(),
+            circuit_breaker: self.circuit_breaker.as_ref().map(|cb| core::CircuitBreakerConfig {
+                enabled:               cb.enabled,
+                failure_threshold:     cb.failure_threshold,
+                recovery_timeout_secs: cb.recovery_timeout_secs,
+                success_threshold:     cb.success_threshold,
+                per_entity:            cb
+                    .per_database
+                    .iter()
+                    .map(|o| core::EntityCircuitBreakerOverride {
+                        entity:            o.database.clone(),
+                        failure_threshold: o.failure_threshold,
+                        recovery_timeout:  o.recovery_timeout_secs,
+                        success_threshold: o.success_threshold,
+                    })
+                    .collect(),
+            }),
         }
     }
 }

--- a/crates/fraiseql-cli/src/config/toml_schema/tests.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/tests.rs
@@ -173,6 +173,113 @@ success_threshold = 1
     }
 
     #[test]
+    fn test_federation_service_name_and_version_parse_and_compile() {
+        // The TOML `[federation]` section must accept (and carry through) the
+        // subgraph identity fields the compiled schema needs — previously absent,
+        // so `deny_unknown_fields` rejected them and the subgraph had no name.
+        let toml = r#"
+[schema]
+name = "orders"
+
+[types.Order]
+sql_source = "v_orders"
+
+[federation]
+enabled = true
+service_name = "orders"
+version = "v2"
+schema_url = "https://orders.example.com/graphql"
+
+[[federation.entities]]
+name = "Order"
+key_fields = ["id"]
+"#;
+        let schema = TomlSchema::parse_toml(toml).expect("Failed to parse");
+        schema.validate().expect("Failed to validate");
+        assert_eq!(schema.federation.service_name.as_deref(), Some("orders"));
+        assert_eq!(schema.federation.version.as_deref(), Some("v2"));
+
+        let compiled = schema.federation.to_compiled();
+        assert!(compiled.enabled);
+        assert_eq!(compiled.service_name.as_deref(), Some("orders"));
+        assert_eq!(compiled.version.as_deref(), Some("v2"));
+        assert_eq!(compiled.schema_url.as_deref(), Some("https://orders.example.com/graphql"));
+        assert_eq!(compiled.entities.len(), 1);
+        assert_eq!(compiled.entities[0].name, "Order");
+        assert_eq!(compiled.entities[0].key_fields, vec!["id".to_string()]);
+    }
+
+    #[test]
+    fn test_federation_apollo_version_back_compat_maps_to_version() {
+        // The legacy integer `apollo_version` keeps working: `2` ⇒ "v2".
+        let toml = r#"
+[schema]
+name = "orders"
+
+[federation]
+enabled = true
+apollo_version = 2
+"#;
+        let schema = TomlSchema::parse_toml(toml).expect("Failed to parse");
+        assert_eq!(schema.federation.to_compiled().version.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn test_federation_explicit_version_wins_over_apollo_version() {
+        let toml = r#"
+[schema]
+name = "orders"
+
+[federation]
+enabled = true
+apollo_version = 1
+version = "v2"
+"#;
+        let schema = TomlSchema::parse_toml(toml).expect("Failed to parse");
+        assert_eq!(schema.federation.to_compiled().version.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn test_federation_per_database_override_maps_to_per_entity() {
+        // Per-entity circuit-breaker overrides authored as `per_database` must reach
+        // the runtime (`circuit_breaker.per_entity`); the raw serde passthrough used
+        // to drop them on the `per_database` ⇒ `per_entity` key rename.
+        let toml = r#"
+[schema]
+name = "orders"
+
+[types.Order]
+sql_source = "v_orders"
+
+[federation]
+enabled = true
+
+[[federation.entities]]
+name = "Order"
+key_fields = ["id"]
+
+[federation.circuit_breaker]
+enabled = true
+failure_threshold = 5
+recovery_timeout_secs = 30
+success_threshold = 2
+
+[[federation.circuit_breaker.per_database]]
+database = "Order"
+failure_threshold = 10
+recovery_timeout_secs = 60
+"#;
+        let schema = TomlSchema::parse_toml(toml).expect("Failed to parse");
+        schema.validate().expect("Failed to validate");
+        let cb = schema.federation.to_compiled().circuit_breaker.expect("circuit_breaker");
+        assert_eq!(cb.per_entity.len(), 1);
+        assert_eq!(cb.per_entity[0].entity, "Order");
+        assert_eq!(cb.per_entity[0].failure_threshold, Some(10));
+        assert_eq!(cb.per_entity[0].recovery_timeout, Some(60));
+        assert_eq!(cb.per_entity[0].success_threshold, None);
+    }
+
+    #[test]
     fn test_federation_circuit_breaker_zero_failure_threshold_rejected() {
         let toml = r#"
 [schema]

--- a/crates/fraiseql-cli/src/schema/converter/mod.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mod.rs
@@ -242,6 +242,24 @@ impl SchemaConverter {
                      the observer system."
                 );
             }
+            // #497: the change-log surface is a per-database stream, not a federated
+            // value type — the injected `EntityChangeLog` type and `entity_change_logs`
+            // root query are not `@shareable`. Two subgraphs in one supergraph that both
+            // `expose` it inject the identical type/root field, which `rover supergraph
+            // compose` rejects with INVALID_FIELD_SHARING. We can't detect the collision
+            // here (each subgraph compiles alone), so warn on the federated+exposed combo
+            // and point at the single-owner pattern. This is a reminder, not an error —
+            // the owning subgraph legitimately sets both.
+            if cl.expose && compiled.federation.as_ref().is_some_and(|f| f.enabled) {
+                warn!(
+                    "[changelog] expose = true on a federation subgraph: EntityChangeLog / \
+                     entity_change_logs are not @shareable, so expose the change-log in exactly \
+                     one subgraph per supergraph (others keep capturing via [changelog] \
+                     write_enabled). Two exposing subgraphs fail `rover supergraph compose` with \
+                     INVALID_FIELD_SHARING. See the changelog-graphql guide for the single-owner \
+                     pattern."
+                );
+            }
         }
 
         // Inject synthetic Relay types (PageInfo, Node interface, XxxConnection, XxxEdge).

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2091,4 +2091,27 @@ mod changelog_validation_tests {
         );
         assert!(SchemaConverter::convert(intermediate).is_ok());
     }
+
+    #[test]
+    fn changelog_expose_on_federation_subgraph_warns_but_compiles() {
+        // #497: exposing the change-log on a federation subgraph is the single-owner
+        // pattern — allowed. The cross-subgraph collision can't be detected here (each
+        // subgraph compiles alone), so the guardrail is a compile warning, never an
+        // error; the owning subgraph legitimately sets both.
+        let intermediate = IntermediateSchema {
+            version:           "2.0.0".to_string(),
+            changelog_config:  Some(ChangelogConfig {
+                expose: true,
+                ..Default::default()
+            }),
+            observers_config:  Some(json!({ "enabled": true, "backend": "redis" })),
+            federation_config: Some(json!({ "enabled": true })),
+            ..IntermediateSchema::default()
+        };
+        let compiled =
+            SchemaConverter::convert(intermediate).expect("federated expose warns, never errors");
+        assert!(compiled.changelog.as_ref().unwrap().expose);
+        assert!(compiled.federation.as_ref().unwrap().enabled);
+        assert!(compiled.types.iter().any(|t| t.name == "EntityChangeLog"));
+    }
 }

--- a/crates/fraiseql-cli/src/schema/intermediate/mod.rs
+++ b/crates/fraiseql-cli/src/schema/intermediate/mod.rs
@@ -119,11 +119,16 @@ pub struct IntermediateSchema {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observers_config: Option<serde_json::Value>,
 
-    /// Federation configuration (from fraiseql.toml).
+    /// Federation configuration.
     ///
-    /// Contains Apollo Federation settings and circuit breaker configuration compiled
-    /// from the `[federation]` TOML section. Embedded verbatim into the compiled schema.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Two authoring workflows feed this field:
+    /// - The TOML merger embeds the `[federation]` section under `federation_config`.
+    /// - Language SDKs (e.g. the Python SDK's `export_schema(federation=...)`) emit the block
+    ///   under the top-level `federation` key in `schema.json`; the `alias` binds it here so the
+    ///   legacy JSON workflow does not silently drop it.
+    ///
+    /// Carried verbatim by the converter into `CompiledSchema.federation`.
+    #[serde(default, alias = "federation", skip_serializing_if = "Option::is_none")]
     pub federation_config: Option<serde_json::Value>,
 
     /// WebSocket subscription configuration (hooks, limits).

--- a/crates/fraiseql-cli/src/schema/intermediate/tests.rs
+++ b/crates/fraiseql-cli/src/schema/intermediate/tests.rs
@@ -5,6 +5,44 @@ mod intermediate_tests {
     use super::super::*;
 
     #[test]
+    fn test_federation_key_aliases_into_federation_config() {
+        // SDKs emit the federation block under the top-level `federation` key; it
+        // must bind into `federation_config` (the serde alias), not silently drop.
+        let json = r#"{
+            "types": [],
+            "queries": [],
+            "mutations": [],
+            "federation": {
+                "enabled": true,
+                "service_name": "orders",
+                "entities": [{"name": "Order", "key_fields": ["id"]}]
+            }
+        }"#;
+
+        let schema: IntermediateSchema = serde_json::from_str(json).unwrap();
+        let fed = schema
+            .federation_config
+            .expect("`federation` key must bind to federation_config");
+        assert_eq!(fed["enabled"], serde_json::json!(true));
+        assert_eq!(fed["service_name"], serde_json::json!("orders"));
+    }
+
+    #[test]
+    fn test_federation_config_key_still_binds() {
+        // The merger writes the canonical `federation_config` key; it must keep working
+        // alongside the `federation` alias.
+        let json = r#"{
+            "types": [],
+            "queries": [],
+            "mutations": [],
+            "federation_config": {"enabled": true}
+        }"#;
+
+        let schema: IntermediateSchema = serde_json::from_str(json).unwrap();
+        assert!(schema.federation_config.is_some());
+    }
+
+    #[test]
     fn test_parse_minimal_schema() {
         let json = r#"{
             "types": [],

--- a/crates/fraiseql-cli/src/schema/merger.rs
+++ b/crates/fraiseql-cli/src/schema/merger.rs
@@ -618,10 +618,14 @@ impl SchemaMerger {
             });
         }
 
-        // Embed federation configuration if enabled
+        // Embed federation configuration if enabled. Lower the TOML config into the
+        // compiled (`fraiseql_core`) shape explicitly so the merged JSON matches what
+        // the converter/runtime deserialize — a raw passthrough silently dropped
+        // `service_name`/`version` and the `per_database` → `per_entity` overrides.
         if toml_schema.federation.enabled {
-            merged["federation_config"] = serde_json::to_value(&toml_schema.federation)
-                .context("Failed to serialize federation config")?;
+            merged["federation_config"] =
+                serde_json::to_value(toml_schema.federation.to_compiled())
+                    .context("Failed to serialize federation config")?;
         }
 
         // Embed subscriptions configuration (hooks, limits)

--- a/crates/fraiseql-cli/src/schema/rich_filters.rs
+++ b/crates/fraiseql-cli/src/schema/rich_filters.rs
@@ -222,6 +222,14 @@ fn generate_where_input_type(
         });
     }
 
+    // Deduplicate fields by name, keeping the first occurrence. A type's operator
+    // set may include an operator (notably `eq`) already emitted as a standard
+    // operator above; declaring it twice produces an invalid GraphQL input type
+    // (`Field eq already exists`). SQL-template metadata is built from
+    // `operator_names` below and is unaffected.
+    let mut seen_field_names = std::collections::HashSet::new();
+    fields.retain(|field| seen_field_names.insert(field.name.clone()));
+
     // Build SQL template metadata for this rich type
     let operator_refs: Vec<&str> = operator_names.iter().map(std::string::String::as_str).collect();
     let sql_metadata = sql_templates::build_sql_templates_metadata(&operator_refs);

--- a/crates/fraiseql-cli/tests/compile_federation_passthrough.rs
+++ b/crates/fraiseql-cli/tests/compile_federation_passthrough.rs
@@ -1,0 +1,263 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics are acceptable
+//! End-to-end coverage for the `federation` block surviving `fraiseql compile`.
+//!
+//! Regression for the bug where `fraiseql compile` silently dropped the input
+//! schema's federation configuration: the SDK emits the block under the top-level
+//! `"federation"` key, but `IntermediateSchema` only bound `"federation_config"`,
+//! so the compiled subgraph lost all federation metadata (`_service` / SDL gone).
+//!
+//! These tests exercise both authoring workflows:
+//! - **Legacy JSON** (`compile schema.json`): the SDK's `"federation"` key must bind into
+//!   `IntermediateSchema.federation_config` and carry through to `CompiledSchema.federation`.
+//! - **TOML** (`compile fraiseql.toml`): the `[federation]` section must carry through the merger
+//!   into the compiled schema.
+//!
+//! The headline assertion is a server-readable round-trip: the compiled schema's
+//! `federation_metadata()` must produce an Apollo Federation v2 `_service` SDL.
+
+use std::io::Write;
+
+use fraiseql_cli::{
+    commands::compile::{CompileOptions, compile_to_schema},
+    schema::{IntermediateSchema, converter::SchemaConverter, merger::SchemaMerger},
+};
+use tempfile::{NamedTempFile, TempDir};
+
+/// A realistic SDK-shaped `schema.json` carrying a federation block exactly as the
+/// Python SDK's `export_schema(..., federation=Federation(...))` emits it:
+/// top-level `"federation"` key, `apollo_version`, and entities shaped as
+/// `{ "name": ..., "key_fields": [...] }` (NOT `{type_name, key_fields: "id"}`).
+const SDK_SCHEMA_WITH_FEDERATION: &str = r#"
+{
+  "version": "2.0.0",
+  "types": [
+    {
+      "name": "Order",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false},
+        {"name": "total", "type": "Float", "nullable": false}
+      ],
+      "sql_source": "v_orders",
+      "is_input": false
+    }
+  ],
+  "queries": [
+    {
+      "name": "list_orders",
+      "return_type": "Order",
+      "returns_list": true,
+      "sql_source": "v_orders",
+      "nullable": false,
+      "arguments": []
+    }
+  ],
+  "mutations": [],
+  "subscriptions": [],
+  "federation": {
+    "enabled": true,
+    "service_name": "orders",
+    "apollo_version": 2,
+    "entities": [
+      {"name": "Order", "key_fields": ["id"]}
+    ]
+  }
+}
+"#;
+
+/// The same schema with no federation block at all.
+const SDK_SCHEMA_WITHOUT_FEDERATION: &str = r#"
+{
+  "version": "2.0.0",
+  "types": [
+    {
+      "name": "Order",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false}
+      ],
+      "sql_source": "v_orders",
+      "is_input": false
+    }
+  ],
+  "queries": [
+    {
+      "name": "list_orders",
+      "return_type": "Order",
+      "returns_list": true,
+      "sql_source": "v_orders",
+      "nullable": false,
+      "arguments": []
+    }
+  ],
+  "mutations": [],
+  "subscriptions": []
+}
+"#;
+
+// ---- Legacy JSON workflow: deserialize + convert (CWD-free, parallel-safe) ----
+
+#[test]
+fn legacy_json_federation_key_binds_into_intermediate() {
+    // The crux of the bug: the SDK's top-level `"federation"` key must bind into
+    // `IntermediateSchema.federation_config` (it deserialized only from
+    // `"federation_config"` before, so the block silently vanished here).
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_WITH_FEDERATION).expect("parse SDK schema.json");
+    assert!(
+        intermediate.federation_config.is_some(),
+        "the SDK's `federation` key must bind into IntermediateSchema.federation_config"
+    );
+}
+
+#[test]
+fn legacy_json_federation_carries_into_compiled_schema() {
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_WITH_FEDERATION).expect("parse SDK schema.json");
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+
+    let fed = compiled.federation.as_ref().expect("compiled schema must carry federation");
+    assert!(fed.enabled, "federation must be enabled");
+    assert_eq!(fed.service_name.as_deref(), Some("orders"));
+    assert_eq!(fed.entities.len(), 1);
+    assert_eq!(fed.entities[0].name, "Order");
+    assert_eq!(fed.entities[0].key_fields, vec!["id".to_string()]);
+
+    // The compiled JSON must expose the top-level `federation` key (the consumer's
+    // `jq 'has("federation")'` check that returned `false` before the fix).
+    let json = serde_json::to_value(&compiled).expect("serialize compiled schema");
+    assert!(
+        json.get("federation").is_some(),
+        "serialized compiled schema must have a top-level `federation` key"
+    );
+}
+
+#[test]
+fn legacy_json_federation_produces_apollo_v2_service_sdl() {
+    // Server-readable round-trip: compiled federation → `_service { sdl }` emits a
+    // proper Apollo Federation v2 SDL with `@key` directives on the entity.
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_WITH_FEDERATION).expect("parse SDK schema.json");
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+
+    let metadata = compiled
+        .federation_metadata()
+        .expect("federation_metadata must be Some when federation is enabled");
+    let sdl = fraiseql_core::federation::generate_service_sdl(&compiled.raw_schema(), &metadata);
+
+    assert!(
+        sdl.contains("https://specs.apollo.dev/federation/v2.0"),
+        "SDL must @link the Apollo Federation v2 spec, got:\n{sdl}"
+    );
+    assert!(
+        sdl.contains("@key(fields: \"id\")"),
+        "SDL must carry the Order entity's @key directive, got:\n{sdl}"
+    );
+}
+
+#[test]
+fn legacy_json_absent_federation_stays_absent() {
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_WITHOUT_FEDERATION).expect("parse SDK schema.json");
+    assert!(intermediate.federation_config.is_none());
+
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+    assert!(compiled.federation.is_none(), "no federation block ⇒ no compiled federation");
+    assert!(compiled.federation_metadata().is_none());
+
+    let json = serde_json::to_value(&compiled).expect("serialize compiled schema");
+    assert!(
+        json.get("federation").is_none(),
+        "absent federation must not synthesize a `federation` key in the compiled JSON"
+    );
+}
+
+#[test]
+fn legacy_json_malformed_federation_fails_loudly() {
+    // A non-empty federation block that cannot be carried must fail the compile,
+    // not silently vanish: `entities` typed as a string is structurally invalid.
+    let malformed = r#"
+    {
+      "version": "2.0.0",
+      "types": [
+        {"name": "Order", "fields": [{"name": "id", "type": "ID", "nullable": false}],
+         "sql_source": "v_orders", "is_input": false}
+      ],
+      "queries": [],
+      "mutations": [],
+      "subscriptions": [],
+      "federation": {"enabled": true, "entities": "not-an-array"}
+    }
+    "#;
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(malformed).expect("federation_config is untyped JSON, so this parses");
+    let err = SchemaConverter::convert(intermediate)
+        .expect_err("a structurally invalid federation block must fail conversion, not vanish");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("federation"),
+        "the error must point at the federation block, got: {msg}"
+    );
+}
+
+// ---- TOML workflow: the merger must carry `[federation]` through ----
+
+#[test]
+fn toml_federation_carries_through_merger_and_converter() {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(
+        br#"
+        [schema]
+        name = "orders"
+
+        [types.Order]
+        sql_source = "v_orders"
+
+        [federation]
+        enabled = true
+        apollo_version = 2
+
+        [[federation.entities]]
+        name = "Order"
+        key_fields = ["id"]
+    "#,
+    )
+    .unwrap();
+    f.flush().unwrap();
+
+    let intermediate = SchemaMerger::merge_toml_only(f.path().to_str().unwrap()).unwrap();
+    assert!(
+        intermediate.federation_config.is_some(),
+        "the merger must carry `[federation]` into IntermediateSchema.federation_config"
+    );
+
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+    let fed = compiled.federation.as_ref().expect("compiled schema must carry federation");
+    assert!(fed.enabled);
+    assert_eq!(fed.entities.len(), 1);
+    assert_eq!(fed.entities[0].name, "Order");
+    assert_eq!(fed.entities[0].key_fields, vec!["id".to_string()]);
+}
+
+// ---- Real CLI pipeline: `compile_to_schema` (mutates CWD; keep it alone) ----
+
+#[tokio::test]
+async fn compile_to_schema_legacy_json_carries_federation_end_to_end() {
+    let dir = TempDir::new().expect("temp dir");
+    std::fs::write(dir.path().join("schema.json"), SDK_SCHEMA_WITH_FEDERATION)
+        .expect("write schema.json");
+
+    let original = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(dir.path()).expect("chdir into temp dir");
+    let result = compile_to_schema(CompileOptions::new("schema.json")).await;
+    std::env::set_current_dir(original).expect("restore cwd");
+
+    let (schema, _report) = result.expect("compile must succeed");
+    let fed = schema.federation.as_ref().expect("compiled schema must carry federation");
+    assert!(fed.enabled);
+    assert_eq!(fed.service_name.as_deref(), Some("orders"));
+
+    let json = serde_json::to_value(&schema).expect("serialize compiled schema");
+    assert!(
+        json.get("federation").is_some(),
+        "the real compile pipeline must write a top-level `federation` key"
+    );
+}

--- a/crates/fraiseql-cli/tests/compile_federation_passthrough.rs
+++ b/crates/fraiseql-cli/tests/compile_federation_passthrough.rs
@@ -151,6 +151,13 @@ fn legacy_json_federation_produces_apollo_v2_service_sdl() {
         sdl.contains("@key(fields: \"id\")"),
         "SDL must carry the Order entity's @key directive, got:\n{sdl}"
     );
+    // The subgraph SDL must expose its root operations, or a gateway composes a
+    // subgraph with no root fields and fails with NO_QUERIES.
+    assert!(sdl.contains("type Query {"), "SDL must declare a root Query type, got:\n{sdl}");
+    assert!(
+        sdl.contains("[Order"),
+        "SDL must expose the list-orders root query returning Order, got:\n{sdl}"
+    );
 }
 
 #[test]

--- a/crates/fraiseql-cli/tests/compile_federation_passthrough.rs
+++ b/crates/fraiseql-cli/tests/compile_federation_passthrough.rs
@@ -237,6 +237,46 @@ fn toml_federation_carries_through_merger_and_converter() {
     assert_eq!(fed.entities[0].key_fields, vec!["id".to_string()]);
 }
 
+#[test]
+fn toml_federation_service_name_and_version_reach_compiled_schema() {
+    // The `[federation]` section must be able to name the subgraph and pin the spec
+    // version — these used to be rejected by `deny_unknown_fields` and, even once
+    // accepted, were dropped on the way to the compiled schema.
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(
+        br#"
+        [schema]
+        name = "orders"
+
+        [types.Order]
+        sql_source = "v_orders"
+
+        [federation]
+        enabled = true
+        service_name = "orders"
+        version = "v2"
+
+        [[federation.entities]]
+        name = "Order"
+        key_fields = ["id"]
+    "#,
+    )
+    .unwrap();
+    f.flush().unwrap();
+
+    let intermediate = SchemaMerger::merge_toml_only(f.path().to_str().unwrap()).unwrap();
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+    let fed = compiled.federation.as_ref().expect("compiled schema must carry federation");
+    assert_eq!(fed.service_name.as_deref(), Some("orders"));
+    assert_eq!(fed.version.as_deref(), Some("v2"));
+
+    // Server-readable round-trip: the named subgraph serves an Apollo Fed v2 SDL.
+    let metadata = compiled.federation_metadata().expect("federation metadata");
+    let sdl = fraiseql_core::federation::generate_service_sdl(&compiled.raw_schema(), &metadata);
+    assert!(sdl.contains("https://specs.apollo.dev/federation/v2.0"), "got:\n{sdl}");
+    assert!(sdl.contains("@key(fields: \"id\")"), "got:\n{sdl}");
+}
+
 // ---- Real CLI pipeline: `compile_to_schema` (mutates CWD; keep it alone) ----
 
 #[tokio::test]

--- a/crates/fraiseql-cli/tests/integration_rich_filters.rs
+++ b/crates/fraiseql-cli/tests/integration_rich_filters.rs
@@ -11,6 +11,36 @@
 use fraiseql_cli::schema::{converter::SchemaConverter, intermediate::IntermediateSchema};
 use fraiseql_core::schema::NamingConvention;
 
+/// Test: generated `*WhereInput` types must not declare a field twice.
+///
+/// The standard operators (`eq`, `neq`, …) are hardcoded and the type's operator set
+/// was also appended, so any overlap (notably `eq`) emitted the field twice — an
+/// invalid GraphQL input type (`Field eq already exists`) that breaks federation
+/// composition once inputs are rendered into the SDL.
+#[test]
+fn rich_filter_where_inputs_have_no_duplicate_fields() {
+    let compiled = SchemaConverter::convert(IntermediateSchema::default())
+        .expect("Compilation should succeed");
+
+    for input in &compiled.input_types {
+        let mut seen = std::collections::HashSet::new();
+        for field in &input.fields {
+            assert!(
+                seen.insert(field.name.as_str()),
+                "duplicate field `{}` on generated input type `{}`",
+                field.name,
+                input.name
+            );
+        }
+    }
+
+    // Sanity: the scalar-filter WhereInputs from the bug report were generated.
+    assert!(
+        compiled.input_types.iter().any(|t| t.name == "TimezoneWhereInput"),
+        "TimezoneWhereInput should be generated"
+    );
+}
+
 /// Test: Complete rich filter compilation pipeline
 #[test]
 fn test_rich_filter_compilation_pipeline() {

--- a/crates/fraiseql-core/Cargo.toml
+++ b/crates/fraiseql-core/Cargo.toml
@@ -39,6 +39,10 @@ harness = true
 name = "memory_profile"
 required-features = ["dhat-heap"]
 
+[[example]]
+name = "fed_sdl"
+required-features = ["federation"]
+
 [dependencies]
 ahash = {workspace = true}
 # Arrow Flight integration (optional)

--- a/crates/fraiseql-core/examples/fed_sdl.rs
+++ b/crates/fraiseql-core/examples/fed_sdl.rs
@@ -1,0 +1,23 @@
+//! Render a subgraph's Apollo-Federation `_service { sdl }` from its compiled schema,
+//! without starting a server. Mirrors the server's path:
+//! `generate_service_sdl(raw_schema(), federation_metadata())`.
+//!
+//! Usage: cargo run --example fed_sdl --features federation -- <schema.compiled.json>
+
+use std::fs;
+
+use fraiseql_core::CompiledSchema;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: fed_sdl <schema.compiled.json>");
+    let json = fs::read_to_string(&path).expect("read compiled schema");
+    let schema = CompiledSchema::from_json(&json, false).expect("parse compiled schema");
+    let meta = schema
+        .federation_metadata()
+        .expect("schema has no enabled federation block");
+    let raw = schema.raw_schema();
+    let sdl = fraiseql_core::federation::generate_service_sdl(&raw, &meta);
+    println!("{sdl}");
+}

--- a/crates/fraiseql-core/examples/fed_sdl.rs
+++ b/crates/fraiseql-core/examples/fed_sdl.rs
@@ -2,7 +2,8 @@
 //! without starting a server. Mirrors the server's path:
 //! `generate_service_sdl(raw_schema(), federation_metadata())`.
 //!
-//! Usage: cargo run --example fed_sdl --features federation -- <schema.compiled.json>
+//! Usage: `cargo run --example fed_sdl --features federation -- <schema.compiled.json>`
+#![allow(clippy::print_stdout)] // Printing the SDL to stdout is this tool's purpose.
 
 use std::fs;
 

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -515,6 +515,7 @@ mod entities_authz {
             entities: vec![FederationEntity {
                 name:       "User".to_string(),
                 key_fields: vec!["id".to_string()],
+                ..Default::default()
             }],
             ..Default::default()
         });

--- a/crates/fraiseql-core/src/schema/changelog.rs
+++ b/crates/fraiseql-core/src/schema/changelog.rs
@@ -22,13 +22,39 @@
 
 use super::{
     AutoParams, ChangelogConfig, CompiledSchema, FieldDefinition, FieldType, MutationDefinition,
-    QueryDefinition, TypeDefinition, compiled::ArgumentDefinition,
+    NamingConvention, QueryDefinition, TypeDefinition, compiled::ArgumentDefinition,
 };
+use crate::utils::casing::to_camel_case;
 
 /// GraphQL type name for change-log entries.
 const ENTITY_CHANGE_LOG: &str = "EntityChangeLog";
 /// GraphQL type name for transport checkpoints.
 const TRANSPORT_CHECKPOINT: &str = "TransportCheckpoint";
+
+/// Render a changelog field/operation/argument identifier in the schema's naming
+/// convention (#498).
+///
+/// The changelog's canonical identifiers are authored `snake_case` to match the
+/// view's JSONB `data` keys and the upsert function's positional parameters. Under
+/// [`NamingConvention::CamelCase`] they must render camelCase like every other
+/// SDK-emitted type/field/operation, otherwise the injected surface is the only
+/// `snake_case` corner of an otherwise camelCase API. The SQL contract is
+/// unchanged: the runtime recovers the `snake_case` JSONB key via `to_snake_case`
+/// (bijective with `to_camel_case`), and mutation arguments bind to the function
+/// positionally — argument *names* never reach SQL. Type names
+/// (`EntityChangeLog` / `TransportCheckpoint`) are `PascalCase` under both
+/// conventions and are not passed through here.
+///
+/// This mirrors [`CompiledSchema::display_name`](super::CompiledSchema::display_name),
+/// applied at injection time so the verbatim-rendering surfaces (the federation
+/// `_service` SDL via `raw_schema()`, and object-field introspection) are
+/// consistent too.
+fn cased(name: &str, convention: NamingConvention) -> String {
+    match convention {
+        NamingConvention::CamelCase => to_camel_case(name),
+        NamingConvention::Preserve => name.to_string(),
+    }
+}
 
 /// Inject the changelog GraphQL surface into `schema` when `[changelog] expose = true`.
 ///
@@ -43,63 +69,75 @@ pub fn inject_changelog(schema: &mut CompiledSchema) {
         return;
     }
 
-    schema.types.push(entity_change_log_type(&cfg));
-    schema.types.push(transport_checkpoint_type(&cfg));
-    schema.queries.push(entity_change_logs_query(&cfg));
-    schema.queries.push(transport_checkpoint_query(&cfg));
-    schema.mutations.push(upsert_checkpoint_mutation(&cfg));
+    // GraphQL identifiers follow the schema-wide naming convention (#498); the
+    // backing SQL (views/function) stays snake_case regardless.
+    let nc = schema.naming_convention;
+
+    schema.types.push(entity_change_log_type(&cfg, nc));
+    schema.types.push(transport_checkpoint_type(&cfg, nc));
+    schema.queries.push(entity_change_logs_query(&cfg, nc));
+    schema.queries.push(transport_checkpoint_query(&cfg, nc));
+    schema.mutations.push(upsert_checkpoint_mutation(&cfg, nc));
 
     schema.build_indexes();
 }
 
 /// `EntityChangeLog` — read-only projection over `{schema}.v_entity_change_log`.
-fn entity_change_log_type(cfg: &ChangelogConfig) -> TypeDefinition {
+///
+/// Field identifiers follow `nc` (#498); the runtime maps them back to the view's
+/// `snake_case` JSONB keys via `to_snake_case`.
+fn entity_change_log_type(cfg: &ChangelogConfig, nc: NamingConvention) -> TypeDefinition {
+    let cursor = cased("pk_entity_change_log", nc);
     let mut t =
         TypeDefinition::new(ENTITY_CHANGE_LOG, format!("{}.v_entity_change_log", cfg.schema))
-            .with_description(
+            .with_description(format!(
                 "An observer entity-change-log entry. Read-only; populated by the observer \
-             system. Paginate via the `pk_entity_change_log` cursor.",
-            )
-            .with_field(FieldDefinition::new("id", FieldType::Id))
-            .with_field(FieldDefinition::new("pk_entity_change_log", FieldType::Int))
-            .with_field(FieldDefinition::nullable("fk_customer_org", FieldType::String))
-            .with_field(FieldDefinition::nullable("fk_contact", FieldType::String))
-            .with_field(FieldDefinition::new("object_type", FieldType::String))
-            .with_field(FieldDefinition::new("object_id", FieldType::String))
-            .with_field(FieldDefinition::new("modification_type", FieldType::String))
-            .with_field(FieldDefinition::nullable("change_status", FieldType::String))
-            .with_field(FieldDefinition::new("object_data", FieldType::Json))
-            .with_field(FieldDefinition::nullable("extra_metadata", FieldType::Json))
-            .with_field(FieldDefinition::new("created_at", FieldType::DateTime));
+                 system. Paginate via the `{cursor}` cursor.",
+            ))
+            .with_field(FieldDefinition::new(cased("id", nc), FieldType::Id))
+            .with_field(FieldDefinition::new(cursor, FieldType::Int))
+            .with_field(FieldDefinition::nullable(cased("fk_customer_org", nc), FieldType::String))
+            .with_field(FieldDefinition::nullable(cased("fk_contact", nc), FieldType::String))
+            .with_field(FieldDefinition::new(cased("object_type", nc), FieldType::String))
+            .with_field(FieldDefinition::new(cased("object_id", nc), FieldType::String))
+            .with_field(FieldDefinition::new(cased("modification_type", nc), FieldType::String))
+            .with_field(FieldDefinition::nullable(cased("change_status", nc), FieldType::String))
+            .with_field(FieldDefinition::new(cased("object_data", nc), FieldType::Json))
+            .with_field(FieldDefinition::nullable(cased("extra_metadata", nc), FieldType::Json))
+            .with_field(FieldDefinition::new(cased("created_at", nc), FieldType::DateTime));
     t.requires_role.clone_from(&cfg.read_role);
     t
 }
 
 /// `TransportCheckpoint` — read-only projection over `{schema}.v_transport_checkpoint`.
-fn transport_checkpoint_type(cfg: &ChangelogConfig) -> TypeDefinition {
+fn transport_checkpoint_type(cfg: &ChangelogConfig, nc: NamingConvention) -> TypeDefinition {
+    let key = cased("transport_name", nc);
     let mut t =
         TypeDefinition::new(TRANSPORT_CHECKPOINT, format!("{}.v_transport_checkpoint", cfg.schema))
-            .with_description(
-                "A consumer's change-log cursor checkpoint, keyed by `transport_name`.",
-            )
-            .with_field(FieldDefinition::new("transport_name", FieldType::String))
-            .with_field(FieldDefinition::new("last_pk", FieldType::Int))
-            .with_field(FieldDefinition::new("updated_at", FieldType::DateTime));
+            .with_description(format!(
+                "A consumer's change-log cursor checkpoint, keyed by `{key}`.",
+            ))
+            .with_field(FieldDefinition::new(key, FieldType::String))
+            .with_field(FieldDefinition::new(cased("last_pk", nc), FieldType::Int))
+            .with_field(FieldDefinition::new(cased("updated_at", nc), FieldType::DateTime));
     t.requires_role.clone_from(&cfg.read_role);
     t
 }
 
 /// `entity_change_logs` — cursor-paginated list query using the generic filter machinery.
-fn entity_change_logs_query(cfg: &ChangelogConfig) -> QueryDefinition {
-    let mut q = QueryDefinition::new("entity_change_logs", ENTITY_CHANGE_LOG)
+fn entity_change_logs_query(cfg: &ChangelogConfig, nc: NamingConvention) -> QueryDefinition {
+    let cursor = cased("pk_entity_change_log", nc);
+    let mut q = QueryDefinition::new(cased("entity_change_logs", nc), ENTITY_CHANGE_LOG)
         .returning_list()
         .with_sql_source(format!("{}.v_entity_change_log", cfg.schema));
     q.description = Some(format!(
         "Cursor-paginate the observer change-log. Poll with \
-         `where: {{ pk_entity_change_log: {{ gt: $cursor }} }}`, \
-         `orderBy: [{{ field: \"pk_entity_change_log\", direction: ASC }}]`, and a \
-         `limit` (server max {}). Optional equality filters: object_type, modification_type.",
-        cfg.max_limit
+         `where: {{ {cursor}: {{ gt: $cursor }} }}`, \
+         `orderBy: [{{ field: \"{cursor}\", direction: ASC }}]`, and a \
+         `limit` (server max {}). Optional equality filters: {}, {}.",
+        cfg.max_limit,
+        cased("object_type", nc),
+        cased("modification_type", nc),
     ));
     q.auto_params = AutoParams {
         has_where:    true,
@@ -114,27 +152,32 @@ fn entity_change_logs_query(cfg: &ChangelogConfig) -> QueryDefinition {
 }
 
 /// `transport_checkpoint(transport_name)` — point lookup of a single checkpoint.
-fn transport_checkpoint_query(cfg: &ChangelogConfig) -> QueryDefinition {
-    let mut q = QueryDefinition::new("transport_checkpoint", TRANSPORT_CHECKPOINT)
+fn transport_checkpoint_query(cfg: &ChangelogConfig, nc: NamingConvention) -> QueryDefinition {
+    let key = cased("transport_name", nc);
+    let mut q = QueryDefinition::new(cased("transport_checkpoint", nc), TRANSPORT_CHECKPOINT)
         .with_sql_source(format!("{}.v_transport_checkpoint", cfg.schema));
     q.nullable = true;
-    q.description = Some("Fetch one consumer's checkpoint by transport_name.".to_string());
-    // Named scalar arg → `WHERE data->>'transport_name' = $1` equality lookup.
-    q.arguments = vec![ArgumentDefinition::new("transport_name", FieldType::String)];
+    q.description = Some(format!("Fetch one consumer's checkpoint by {key}."));
+    // Named scalar arg → `WHERE data->>'transport_name' = $1` equality lookup; the
+    // runtime recases the (possibly camelCase) argument name to the JSONB key.
+    q.arguments = vec![ArgumentDefinition::new(key, FieldType::String)];
     q.cache_ttl_seconds = Some(0);
     q.requires_role.clone_from(&cfg.read_role);
     q
 }
 
 /// `upsert_transport_checkpoint(transport_name, last_pk)` — advance a consumer cursor.
-fn upsert_checkpoint_mutation(cfg: &ChangelogConfig) -> MutationDefinition {
-    let mut m = MutationDefinition::new("upsert_transport_checkpoint", TRANSPORT_CHECKPOINT);
+fn upsert_checkpoint_mutation(cfg: &ChangelogConfig, nc: NamingConvention) -> MutationDefinition {
+    let mut m =
+        MutationDefinition::new(cased("upsert_transport_checkpoint", nc), TRANSPORT_CHECKPOINT);
     m.sql_source = Some(format!("{}.fn_upsert_transport_checkpoint", cfg.schema));
     m.description =
         Some("Create or advance a consumer's change-log checkpoint (idempotent).".to_string());
+    // Arguments bind to the PG function positionally, so renaming them to camelCase
+    // is safe — the function never sees the GraphQL argument names, only their order.
     m.arguments = vec![
-        ArgumentDefinition::new("transport_name", FieldType::String),
-        ArgumentDefinition::new("last_pk", FieldType::Int),
+        ArgumentDefinition::new(cased("transport_name", nc), FieldType::String),
+        ArgumentDefinition::new(cased("last_pk", nc), FieldType::Int),
     ];
     m.requires_role.clone_from(&cfg.write_role);
     m

--- a/crates/fraiseql-core/src/schema/changelog/tests.rs
+++ b/crates/fraiseql-core/src/schema/changelog/tests.rs
@@ -3,10 +3,15 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
 use super::{ENTITY_CHANGE_LOG, TRANSPORT_CHECKPOINT, inject_changelog};
-use crate::schema::{ChangelogConfig, CompiledSchema, FieldType};
+use crate::schema::{ChangelogConfig, CompiledSchema, FieldType, NamingConvention};
 
 fn exposed_schema(cfg: ChangelogConfig) -> CompiledSchema {
+    exposed_schema_with(cfg, NamingConvention::default())
+}
+
+fn exposed_schema_with(cfg: ChangelogConfig, naming: NamingConvention) -> CompiledSchema {
     let mut schema = CompiledSchema::new();
+    schema.naming_convention = naming;
     schema.changelog = Some(cfg);
     inject_changelog(&mut schema);
     schema
@@ -116,4 +121,129 @@ fn schema_name_parameterizes_sql_sources() {
         .find(|m| m.name == "upsert_transport_checkpoint")
         .unwrap();
     assert_eq!(upsert.sql_source.as_deref(), Some("audit.fn_upsert_transport_checkpoint"));
+}
+
+// --- #498: injected identifiers honour the schema-wide naming convention. ------
+
+/// Under the default `Preserve` convention the GraphQL-facing identifiers stay
+/// `snake_case` (matching the authored form and the view's JSONB `data` keys).
+#[test]
+fn preserve_convention_keeps_snake_case_identifiers() {
+    let schema = exposed_schema_with(
+        ChangelogConfig {
+            expose: true,
+            ..Default::default()
+        },
+        NamingConvention::Preserve,
+    );
+
+    let ecl = schema.types.iter().find(|t| t.name == ENTITY_CHANGE_LOG).unwrap();
+    assert!(ecl.find_field("pk_entity_change_log").is_some());
+    assert!(ecl.find_field("object_type").is_some());
+    assert!(schema.queries.iter().any(|q| q.name == "entity_change_logs"));
+    assert!(schema.queries.iter().any(|q| q.name == "transport_checkpoint"));
+    assert!(schema.mutations.iter().any(|m| m.name == "upsert_transport_checkpoint"));
+}
+
+/// Under `camelCase` every changelog field/operation/argument renders camelCase
+/// like the rest of the SDK-emitted surface (#498). Type names stay `PascalCase`.
+#[test]
+fn camel_case_convention_renders_camelcase_identifiers() {
+    let schema = exposed_schema_with(
+        ChangelogConfig {
+            expose: true,
+            ..Default::default()
+        },
+        NamingConvention::CamelCase,
+    );
+
+    // Type names are PascalCase under both conventions.
+    let ecl = schema.types.iter().find(|t| t.name == ENTITY_CHANGE_LOG).unwrap();
+    let chk = schema.types.iter().find(|t| t.name == TRANSPORT_CHECKPOINT).unwrap();
+
+    // Object fields are camelCase; the snake_case forms are gone.
+    for camel in [
+        "pkEntityChangeLog",
+        "fkCustomerOrg",
+        "fkContact",
+        "objectType",
+        "objectId",
+        "modificationType",
+        "changeStatus",
+        "objectData",
+        "extraMetadata",
+        "createdAt",
+    ] {
+        assert!(ecl.find_field(camel).is_some(), "missing camelCase field {camel}");
+    }
+    assert!(ecl.find_field("id").is_some(), "single-word field stays as-is");
+    assert!(ecl.find_field("pk_entity_change_log").is_none(), "snake_case field leaked");
+    assert!(ecl.find_field("object_type").is_none(), "snake_case field leaked");
+
+    for camel in ["transportName", "lastPk", "updatedAt"] {
+        assert!(chk.find_field(camel).is_some(), "missing camelCase field {camel}");
+    }
+    assert!(chk.find_field("transport_name").is_none(), "snake_case field leaked");
+
+    // Operation names are camelCase.
+    assert!(schema.queries.iter().any(|q| q.name == "entityChangeLogs"));
+    assert!(schema.queries.iter().any(|q| q.name == "transportCheckpoint"));
+    assert!(schema.mutations.iter().any(|m| m.name == "upsertTransportCheckpoint"));
+    assert!(!schema.queries.iter().any(|q| q.name == "entity_change_logs"));
+
+    // Argument names are camelCase.
+    let lookup = schema.queries.iter().find(|q| q.name == "transportCheckpoint").unwrap();
+    assert_eq!(lookup.arguments.len(), 1);
+    assert_eq!(lookup.arguments[0].name, "transportName");
+
+    let upsert =
+        schema.mutations.iter().find(|m| m.name == "upsertTransportCheckpoint").unwrap();
+    let arg_names: Vec<&str> = upsert.arguments.iter().map(|a| a.name.as_str()).collect();
+    assert_eq!(arg_names, vec!["transportName", "lastPk"]);
+}
+
+/// The camelCase identifiers round-trip back to the exact `snake_case` JSONB keys
+/// the views expose, so the SQL contract is unchanged — only the GraphQL surface
+/// is recased (#498).
+#[test]
+fn camel_case_fields_round_trip_to_snake_jsonb_keys() {
+    use crate::utils::to_snake_case;
+
+    assert_eq!(to_snake_case("pkEntityChangeLog"), "pk_entity_change_log");
+    assert_eq!(to_snake_case("fkCustomerOrg"), "fk_customer_org");
+    assert_eq!(to_snake_case("objectType"), "object_type");
+    assert_eq!(to_snake_case("changeStatus"), "change_status");
+    assert_eq!(to_snake_case("extraMetadata"), "extra_metadata");
+    assert_eq!(to_snake_case("transportName"), "transport_name");
+    assert_eq!(to_snake_case("lastPk"), "last_pk");
+}
+
+/// The federation `_service` SDL (built from `raw_schema()`, which renders names
+/// verbatim) is the surface where the `snake_case` leak was first observed (#498).
+/// Under `camelCase` the rendered changelog surface must be camelCase end-to-end.
+#[test]
+fn federation_sdl_renders_changelog_camelcase() {
+    let schema = exposed_schema_with(
+        ChangelogConfig {
+            expose: true,
+            ..Default::default()
+        },
+        NamingConvention::CamelCase,
+    );
+    let sdl = schema.raw_schema();
+
+    // Object fields + root operations + arguments render camelCase. The list
+    // query's filter args come from `auto_params`, not `ArgumentDefinition`, so it
+    // renders without parentheses (`entityChangeLogs: [EntityChangeLog!]!`).
+    assert!(sdl.contains("pkEntityChangeLog"), "SDL missing camelCase field");
+    assert!(sdl.contains("objectType"), "SDL missing camelCase field");
+    assert!(sdl.contains("entityChangeLogs"), "SDL missing camelCase query");
+    assert!(sdl.contains("transportName"), "SDL missing camelCase argument");
+    assert!(sdl.contains("upsertTransportCheckpoint("), "SDL missing camelCase mutation");
+
+    // No snake_case identifiers leak into the rendered SDL.
+    assert!(!sdl.contains("pk_entity_change_log"), "snake_case field leaked into SDL");
+    assert!(!sdl.contains("object_type"), "snake_case field leaked into SDL");
+    assert!(!sdl.contains("entity_change_logs"), "snake_case query leaked into SDL");
+    assert!(!sdl.contains("transport_name"), "snake_case argument leaked into SDL");
 }

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -120,23 +120,56 @@ impl CompiledSchema {
     #[must_use]
     pub fn federation_metadata(&self) -> Option<crate::federation::FederationMetadata> {
         self.federation.as_ref().filter(|fed| fed.enabled).map(|fed| {
-            let types = fed
+            use crate::federation::types::{FederatedType, FieldFederationDirectives, KeyDirective};
+
+            // Entities carry an `@key` (and, for an extended entity, `extend type` +
+            // `@external` on the borrowed key/fields). Per-field directives are
+            // rebuilt from the entity's `external_fields` / `shareable_fields` so the
+            // SDL renderer can append `@external` / `@shareable` to each field line.
+            let mut types: Vec<FederatedType> = fed
                 .entities
                 .iter()
-                .map(|e| crate::federation::types::FederatedType {
-                    name:                e.name.clone(),
-                    keys:                vec![crate::federation::types::KeyDirective {
-                        fields:     e.key_fields.clone(),
-                        resolvable: true,
-                    }],
+                .map(|e| {
+                    let mut field_directives: HashMap<String, FieldFederationDirectives> =
+                        HashMap::new();
+                    for f in &e.external_fields {
+                        field_directives.entry(f.clone()).or_default().external = true;
+                    }
+                    for f in &e.shareable_fields {
+                        field_directives.entry(f.clone()).or_default().shareable = true;
+                    }
+                    FederatedType {
+                        name:                e.name.clone(),
+                        keys:                vec![KeyDirective {
+                            fields:     e.key_fields.clone(),
+                            resolvable: true,
+                        }],
+                        is_extends:          e.extends,
+                        external_fields:     e.external_fields.clone(),
+                        shareable_fields:    e.shareable_fields.clone(),
+                        inaccessible_fields: Vec::new(),
+                        field_directives,
+                        type_shareable:      false,
+                    }
+                })
+                .collect();
+
+            // Non-entity `@shareable` value types (e.g. a shared `MutationError`):
+            // no `@key`, never a member of the `_Entity` union — they only receive a
+            // type-level `@shareable` so both subgraphs can define the identical type
+            // without an `INVALID_FIELD_SHARING` composition error.
+            for name in &fed.shareable_types {
+                types.push(FederatedType {
+                    name:                name.clone(),
+                    keys:                Vec::new(),
                     is_extends:          false,
                     external_fields:     Vec::new(),
                     shareable_fields:    Vec::new(),
                     inaccessible_fields: Vec::new(),
-                    field_directives:    std::collections::HashMap::new(),
-                    type_shareable:      false,
-                })
-                .collect();
+                    field_directives:    HashMap::new(),
+                    type_shareable:      true,
+                });
+            }
 
             crate::federation::FederationMetadata {
                 enabled: fed.enabled,

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -273,18 +273,59 @@ impl CompiledSchema {
     ///
     /// # Returns
     ///
-    /// Raw schema string if available, otherwise generates from type definitions
+    /// Raw schema string if available, otherwise generates from type definitions,
+    /// including the root `Query`/`Mutation` types.
+    ///
+    /// Root operations are stored in [`self.queries`](Self::queries) /
+    /// [`self.mutations`](Self::mutations) rather than as `Query`/`Mutation` object
+    /// types in [`self.types`](Self::types), so they are rendered here explicitly.
+    /// Omitting them produces an SDL that advertises no root fields — which makes the
+    /// federation `_service` SDL (built from this output) fail gateway composition
+    /// with `NO_QUERIES`.
     #[must_use]
     pub fn raw_schema(&self) -> String {
         self.schema_sdl.clone().unwrap_or_else(|| {
             // Generate basic SDL from type definitions if not provided
             let mut sdl = String::new();
 
-            // Add types
+            // Add output/object types
             for type_def in &self.types {
                 let _ = writeln!(sdl, "type {} {{", type_def.name);
                 for field in &type_def.fields {
                     let _ = writeln!(sdl, "  {}: {}", field.name, field.field_type);
+                }
+                sdl.push_str("}\n\n");
+            }
+
+            // Root Query type (rendered from `self.queries`, never present in `types`)
+            if !self.queries.is_empty() {
+                sdl.push_str("type Query {\n");
+                for q in &self.queries {
+                    let _ = writeln!(
+                        sdl,
+                        "  {}",
+                        render_operation_field(
+                            &q.name,
+                            &q.arguments,
+                            &q.return_type,
+                            q.returns_list,
+                            q.nullable,
+                        )
+                    );
+                }
+                sdl.push_str("}\n\n");
+            }
+
+            // Root Mutation type (rendered from `self.mutations`). Mutation payloads
+            // are single, non-null values, so they render as `Name(args): Return!`.
+            if !self.mutations.is_empty() {
+                sdl.push_str("type Mutation {\n");
+                for m in &self.mutations {
+                    let _ = writeln!(
+                        sdl,
+                        "  {}",
+                        render_operation_field(&m.name, &m.arguments, &m.return_type, false, false)
+                    );
                 }
                 sdl.push_str("}\n\n");
             }
@@ -360,6 +401,34 @@ impl CompiledSchema {
             Err(errors)
         }
     }
+}
+
+/// Render a root operation as a GraphQL SDL field: `name(arg: T!, …): Return`.
+///
+/// `return_type` is a bare type name; list-ness and nullability are applied here so
+/// the rendered signature matches GraphQL conventions (`[User!]!`, `User`, `User!`).
+fn render_operation_field(
+    name: &str,
+    arguments: &[crate::schema::ArgumentDefinition],
+    return_type: &str,
+    returns_list: bool,
+    nullable: bool,
+) -> String {
+    let non_null = if nullable { "" } else { "!" };
+    let ret = if returns_list {
+        format!("[{return_type}!]{non_null}")
+    } else {
+        format!("{return_type}{non_null}")
+    };
+    if arguments.is_empty() {
+        return format!("{name}: {ret}");
+    }
+    let args = arguments
+        .iter()
+        .map(|a| format!("{}: {}{}", a.name, a.arg_type, if a.nullable { "" } else { "!" }))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{name}({args}): {ret}")
 }
 
 /// Check if a type name is a built-in scalar type.

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -395,55 +395,88 @@ impl CompiledSchema {
 
     /// Collect the non-built-in scalar type names the schema references, so
     /// [`raw_schema`](Self::raw_schema) can declare each one (`scalar Name`) and the
-    /// SDL is type-complete. Sources: the custom-scalar registry, every field /
-    /// argument [`FieldType`](crate::schema::FieldType), and the string-typed input
-    /// fields and operation return types. Built-in GraphQL scalars and the federation
-    /// `_Any` (supplied separately) are excluded.
+    /// SDL is type-complete.
+    ///
+    /// A referenced type is treated as a scalar to declare when it is neither a
+    /// built-in GraphQL scalar nor a type the schema defines as an object, enum,
+    /// input, interface, or union. Names are collected **exactly as the fields render
+    /// them** (the verbatim leaf of each field/argument type and each operation return
+    /// type) so the declaration and the reference always agree — declaring a canonical
+    /// alias (`DateTime`) while a field renders `datetime` would leave the reference
+    /// dangling (`Unknown type datetime`). The custom-scalar registry is also included.
+    /// The federation `_Any`/`_Entity`/`_Service`/`_FieldSet` built-ins (supplied by the
+    /// federation layer) are excluded.
     fn referenced_scalars(&self) -> Vec<String> {
-        use std::collections::BTreeSet;
+        use std::collections::{BTreeSet, HashSet};
 
-        use crate::schema::FieldType;
+        const BUILTINS: [&str; 5] = ["String", "Int", "Float", "Boolean", "ID"];
+        const FED_BUILTINS: [&str; 4] = ["_Any", "_Entity", "_Service", "_FieldSet"];
 
-        let mut scalars: BTreeSet<String> = BTreeSet::new();
-
-        for (name, _) in self.custom_scalars.list_all() {
-            scalars.insert(name);
+        // Names the schema defines as composite types — never re-declared as scalars.
+        let mut defined: HashSet<&str> = HashSet::new();
+        for t in &self.types {
+            defined.insert(t.name.as_str());
         }
-        let collect = |ft: &FieldType, set: &mut BTreeSet<String>| {
-            if let Some(name) = scalar_leaf_name(ft) {
-                set.insert(name);
+        for e in &self.enums {
+            defined.insert(e.name.as_str());
+        }
+        for i in &self.input_types {
+            defined.insert(i.name.as_str());
+        }
+        for i in &self.interfaces {
+            defined.insert(i.name.as_str());
+        }
+        for u in &self.unions {
+            defined.insert(u.name.as_str());
+        }
+
+        // Every type reference, collected as the verbatim leaf name fields render.
+        let mut referenced: BTreeSet<String> = BTreeSet::new();
+        let add = |rendered: &str, set: &mut BTreeSet<String>| {
+            let leaf = leaf_type_name(rendered);
+            if !leaf.is_empty() {
+                set.insert(leaf);
             }
         };
         for type_def in &self.types {
             for field in &type_def.fields {
-                collect(&field.field_type, &mut scalars);
+                add(&field.field_type.to_string(), &mut referenced);
             }
         }
         for iface in &self.interfaces {
             for field in &iface.fields {
-                collect(&field.field_type, &mut scalars);
+                add(&field.field_type.to_string(), &mut referenced);
             }
         }
         for query in &self.queries {
             for arg in &query.arguments {
-                collect(&arg.arg_type, &mut scalars);
+                add(&arg.arg_type.to_string(), &mut referenced);
             }
-            collect(&FieldType::parse(&query.return_type), &mut scalars);
+            add(&query.return_type, &mut referenced);
         }
         for mutation in &self.mutations {
             for arg in &mutation.arguments {
-                collect(&arg.arg_type, &mut scalars);
+                add(&arg.arg_type.to_string(), &mut referenced);
             }
-            collect(&FieldType::parse(&mutation.return_type), &mut scalars);
+            add(&mutation.return_type, &mut referenced);
         }
         for input in &self.input_types {
             for field in &input.fields {
-                collect(&FieldType::parse(&field.field_type), &mut scalars);
+                add(&field.field_type, &mut referenced);
             }
         }
+        for (name, _) in self.custom_scalars.list_all() {
+            referenced.insert(name);
+        }
 
-        scalars.remove("_Any"); // federation built-in, declared by the federation layer
-        scalars.into_iter().collect()
+        referenced
+            .into_iter()
+            .filter(|name| {
+                !defined.contains(name.as_str())
+                    && !BUILTINS.contains(&name.as_str())
+                    && !FED_BUILTINS.contains(&name.as_str())
+            })
+            .collect()
     }
 
     /// Validate the schema for internal consistency.
@@ -543,37 +576,15 @@ fn render_operation_field(
     format!("{name}({args}): {ret}")
 }
 
-/// Extract the leaf scalar type name from a [`FieldType`](crate::schema::FieldType),
-/// or `None` for built-in GraphQL scalars, vectors, and composite types.
-///
-/// Lists are unwrapped to their element type. Non-built-in standard scalars render
-/// under their GraphQL name (`DateTime`, `JSON`, `UUID`, …); rich/custom scalars under
-/// their registered name.
-fn scalar_leaf_name(field_type: &crate::schema::FieldType) -> Option<String> {
-    use crate::schema::FieldType as F;
-    match field_type {
-        F::List(inner) => scalar_leaf_name(inner),
-        F::DateTime => Some("DateTime".to_string()),
-        F::Date => Some("Date".to_string()),
-        F::Time => Some("Time".to_string()),
-        F::Json => Some("JSON".to_string()),
-        F::Uuid => Some("UUID".to_string()),
-        F::Decimal => Some("Decimal".to_string()),
-        F::Scalar(name) => Some(name.clone()),
-        // Built-in GraphQL scalars, vectors (`[Float!]!`), and composite types need
-        // no `scalar` declaration.
-        F::String
-        | F::Int
-        | F::Float
-        | F::Boolean
-        | F::Id
-        | F::Vector
-        | F::Object(_)
-        | F::Enum(_)
-        | F::Input(_)
-        | F::Interface(_)
-        | F::Union(_) => None,
-    }
+/// Strip GraphQL list and non-null markers from a rendered type string, leaving the
+/// bare leaf type name: `[User!]!` → `User`, `datetime` → `datetime`.
+fn leaf_type_name(rendered: &str) -> String {
+    rendered
+        .chars()
+        .filter(|c| !matches!(c, '[' | ']' | '!'))
+        .collect::<String>()
+        .trim()
+        .to_string()
 }
 
 /// Check if a type name is a built-in scalar type.

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -288,6 +288,65 @@ impl CompiledSchema {
             // Generate basic SDL from type definitions if not provided
             let mut sdl = String::new();
 
+            // Non-built-in scalar declarations. The rendered operations and fields
+            // reference custom and standard-but-non-built-in scalars (`DateTime`,
+            // `JSON`, `Decimal`, rich scalars, …); a gateway composing the subgraph
+            // reports `Unknown type` for any it isn't declared.
+            for name in self.referenced_scalars() {
+                let _ = writeln!(sdl, "scalar {name}");
+            }
+            if !self.enums.is_empty()
+                || !self.interfaces.is_empty()
+                || !self.input_types.is_empty()
+                || !self.unions.is_empty()
+                || !self.types.is_empty()
+            {
+                sdl.push('\n');
+            }
+
+            // Enum types
+            for enum_def in &self.enums {
+                let _ = writeln!(sdl, "enum {} {{", enum_def.name);
+                for value in &enum_def.values {
+                    let _ = writeln!(sdl, "  {}", value.name);
+                }
+                sdl.push_str("}\n\n");
+            }
+
+            // Interface types
+            for iface in &self.interfaces {
+                let _ = writeln!(sdl, "interface {} {{", iface.name);
+                for field in &iface.fields {
+                    let _ = writeln!(sdl, "  {}: {}", field.name, field.field_type);
+                }
+                sdl.push_str("}\n\n");
+            }
+
+            // Input object types (`field_type` is a pre-rendered GraphQL string;
+            // normalise the trailing non-null marker against the `nullable` flag).
+            for input in &self.input_types {
+                let _ = writeln!(sdl, "input {} {{", input.name);
+                for field in &input.fields {
+                    let base = field.field_type.trim_end_matches('!');
+                    let non_null = if field.nullable { "" } else { "!" };
+                    let _ = writeln!(sdl, "  {}: {base}{non_null}", field.name);
+                }
+                sdl.push_str("}\n\n");
+            }
+
+            // Union types (covers synthesized mutation result unions)
+            for union_def in &self.unions {
+                let _ = writeln!(
+                    sdl,
+                    "union {} = {}",
+                    union_def.name,
+                    union_def.member_types.join(" | ")
+                );
+            }
+            if !self.unions.is_empty() {
+                sdl.push('\n');
+            }
+
             // Add output/object types
             for type_def in &self.types {
                 let _ = writeln!(sdl, "type {} {{", type_def.name);
@@ -332,6 +391,59 @@ impl CompiledSchema {
 
             sdl
         })
+    }
+
+    /// Collect the non-built-in scalar type names the schema references, so
+    /// [`raw_schema`](Self::raw_schema) can declare each one (`scalar Name`) and the
+    /// SDL is type-complete. Sources: the custom-scalar registry, every field /
+    /// argument [`FieldType`](crate::schema::FieldType), and the string-typed input
+    /// fields and operation return types. Built-in GraphQL scalars and the federation
+    /// `_Any` (supplied separately) are excluded.
+    fn referenced_scalars(&self) -> Vec<String> {
+        use std::collections::BTreeSet;
+
+        use crate::schema::FieldType;
+
+        let mut scalars: BTreeSet<String> = BTreeSet::new();
+
+        for (name, _) in self.custom_scalars.list_all() {
+            scalars.insert(name);
+        }
+        let collect = |ft: &FieldType, set: &mut BTreeSet<String>| {
+            if let Some(name) = scalar_leaf_name(ft) {
+                set.insert(name);
+            }
+        };
+        for type_def in &self.types {
+            for field in &type_def.fields {
+                collect(&field.field_type, &mut scalars);
+            }
+        }
+        for iface in &self.interfaces {
+            for field in &iface.fields {
+                collect(&field.field_type, &mut scalars);
+            }
+        }
+        for query in &self.queries {
+            for arg in &query.arguments {
+                collect(&arg.arg_type, &mut scalars);
+            }
+            collect(&FieldType::parse(&query.return_type), &mut scalars);
+        }
+        for mutation in &self.mutations {
+            for arg in &mutation.arguments {
+                collect(&arg.arg_type, &mut scalars);
+            }
+            collect(&FieldType::parse(&mutation.return_type), &mut scalars);
+        }
+        for input in &self.input_types {
+            for field in &input.fields {
+                collect(&FieldType::parse(&field.field_type), &mut scalars);
+            }
+        }
+
+        scalars.remove("_Any"); // federation built-in, declared by the federation layer
+        scalars.into_iter().collect()
     }
 
     /// Validate the schema for internal consistency.
@@ -429,6 +541,39 @@ fn render_operation_field(
         .collect::<Vec<_>>()
         .join(", ");
     format!("{name}({args}): {ret}")
+}
+
+/// Extract the leaf scalar type name from a [`FieldType`](crate::schema::FieldType),
+/// or `None` for built-in GraphQL scalars, vectors, and composite types.
+///
+/// Lists are unwrapped to their element type. Non-built-in standard scalars render
+/// under their GraphQL name (`DateTime`, `JSON`, `UUID`, …); rich/custom scalars under
+/// their registered name.
+fn scalar_leaf_name(field_type: &crate::schema::FieldType) -> Option<String> {
+    use crate::schema::FieldType as F;
+    match field_type {
+        F::List(inner) => scalar_leaf_name(inner),
+        F::DateTime => Some("DateTime".to_string()),
+        F::Date => Some("Date".to_string()),
+        F::Time => Some("Time".to_string()),
+        F::Json => Some("JSON".to_string()),
+        F::Uuid => Some("UUID".to_string()),
+        F::Decimal => Some("Decimal".to_string()),
+        F::Scalar(name) => Some(name.clone()),
+        // Built-in GraphQL scalars, vectors (`[Float!]!`), and composite types need
+        // no `scalar` declaration.
+        F::String
+        | F::Int
+        | F::Float
+        | F::Boolean
+        | F::Id
+        | F::Vector
+        | F::Object(_)
+        | F::Enum(_)
+        | F::Input(_)
+        | F::Interface(_)
+        | F::Union(_) => None,
+    }
 }
 
 /// Check if a type name is a built-in scalar type.

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -1038,6 +1038,67 @@ fn service_sdl_advertises_root_query_fields() {
     assert!(sdl.contains("_service"), "federation plumbing must be present:\n{sdl}");
 }
 
+#[test]
+fn raw_schema_renders_full_type_closure() {
+    // The generated SDL must be type-complete: input objects, enums, unions, and
+    // non-built-in scalar declarations the root operations reference. Otherwise a
+    // gateway composing the subgraph hits `Unknown type CreateQuoteInput` (and the
+    // same for every custom scalar / enum / result union).
+    use crate::schema::{
+        ArgumentDefinition, EnumDefinition, EnumValueDefinition, FieldType, InputFieldDefinition,
+        InputObjectDefinition, UnionDefinition,
+    };
+
+    let mut schema = CompiledSchema::new();
+    schema.types.push(make_type_def("QuoteSuccess"));
+    schema.types.push(make_type_def("MutationError"));
+
+    let mut status = EnumDefinition::new("QuoteStatus");
+    status.values = vec![
+        EnumValueDefinition::new("DRAFT"),
+        EnumValueDefinition::new("SENT"),
+    ];
+    schema.enums.push(status);
+
+    let mut input = InputObjectDefinition::new("CreateQuoteInput");
+    input.fields = vec![
+        InputFieldDefinition::new("amount", "Decimal"), // non-built-in scalar
+        InputFieldDefinition::new("status", "QuoteStatus"), // enum
+    ];
+    schema.input_types.push(input);
+
+    schema.unions.push(UnionDefinition {
+        name:         "CreateQuoteResult".to_string(),
+        member_types: vec!["QuoteSuccess".to_string(), "MutationError".to_string()],
+        description:  None,
+    });
+
+    let mut create = MutationDefinition::new("createQuote", "CreateQuoteResult");
+    create.arguments = vec![ArgumentDefinition::new(
+        "input",
+        FieldType::Input("CreateQuoteInput".to_string()),
+    )];
+    schema.mutations.push(create);
+
+    let sdl = schema.raw_schema();
+
+    assert!(sdl.contains("enum QuoteStatus {"), "enum must be declared:\n{sdl}");
+    assert!(sdl.contains("DRAFT"), "enum values must be rendered:\n{sdl}");
+    assert!(
+        sdl.contains("input CreateQuoteInput {"),
+        "input object must be declared:\n{sdl}"
+    );
+    assert!(
+        sdl.contains("union CreateQuoteResult = QuoteSuccess | MutationError"),
+        "result union must be declared:\n{sdl}"
+    );
+    assert!(sdl.contains("scalar Decimal"), "non-built-in scalar must be declared:\n{sdl}");
+    assert!(
+        sdl.contains("createQuote(input: CreateQuoteInput!): CreateQuoteResult"),
+        "mutation signature references the now-declared input + result:\n{sdl}"
+    );
+}
+
 // -------------------------------------------------------------------------
 // is_builtin_type (private fn — tested via validate())
 // -------------------------------------------------------------------------

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -975,6 +975,69 @@ fn raw_schema_generates_from_types_when_sdl_absent() {
     assert!(sdl.contains("User"));
 }
 
+#[test]
+fn raw_schema_includes_root_query_and_mutation() {
+    // Root operations live in `queries`/`mutations`, NOT as `Query`/`Mutation`
+    // object types in `types`. The generated SDL must still render them — otherwise
+    // it advertises no root fields, and the federation `_service` SDL built from it
+    // fails gateway composition with NO_QUERIES.
+    use crate::schema::{ArgumentDefinition, FieldType};
+
+    let mut schema = CompiledSchema::new();
+    schema.types.push(make_type_def("User"));
+
+    let mut users = QueryDefinition::new("users", "User");
+    users.returns_list = true;
+    let mut user = QueryDefinition::new("user", "User");
+    user.nullable = true;
+    user.arguments = vec![ArgumentDefinition::new("id", FieldType::Id)];
+    schema.queries.push(users);
+    schema.queries.push(user);
+
+    let mut create = MutationDefinition::new("createUser", "User");
+    create.arguments = vec![ArgumentDefinition::new("name", FieldType::String)];
+    schema.mutations.push(create);
+
+    let sdl = schema.raw_schema();
+
+    assert!(sdl.contains("type Query {"), "SDL must declare a root Query type:\n{sdl}");
+    assert!(sdl.contains("users: [User!]!"), "list query rendered as a list type:\n{sdl}");
+    assert!(sdl.contains("user(id: ID!): User"), "nullable single query with arg:\n{sdl}");
+    assert!(sdl.contains("type Mutation {"), "SDL must declare a root Mutation type:\n{sdl}");
+    assert!(sdl.contains("createUser(name: String!): User"), "mutation field:\n{sdl}");
+}
+
+#[cfg(feature = "federation")]
+#[test]
+fn service_sdl_advertises_root_query_fields() {
+    // End-to-end: the `_service { sdl }` a gateway composes must expose the root
+    // query fields, the entity `@key`, and the federation plumbing together.
+    let mut schema = CompiledSchema::new();
+    schema.types.push(make_type_def("User"));
+    let mut users = QueryDefinition::new("users", "User");
+    users.returns_list = true;
+    schema.queries.push(users);
+    schema.federation = Some(FederationConfig {
+        enabled: true,
+        version: Some("v2".to_string()),
+        entities: vec![FederationEntity {
+            name:       "User".to_string(),
+            key_fields: vec!["id".to_string()],
+        }],
+        ..Default::default()
+    });
+
+    let meta = schema.federation_metadata().expect("federation enabled");
+    let sdl = crate::federation::generate_service_sdl(&schema.raw_schema(), &meta);
+
+    assert!(
+        sdl.contains("users: [User!]!"),
+        "root query must be in the _service SDL:\n{sdl}"
+    );
+    assert!(sdl.contains("@key(fields: \"id\")"), "entity key must be present:\n{sdl}");
+    assert!(sdl.contains("_service"), "federation plumbing must be present:\n{sdl}");
+}
+
 // -------------------------------------------------------------------------
 // is_builtin_type (private fn — tested via validate())
 // -------------------------------------------------------------------------

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -1099,6 +1099,33 @@ fn raw_schema_renders_full_type_closure() {
     );
 }
 
+#[test]
+fn raw_schema_declares_scalars_under_the_name_fields_reference() {
+    // The `scalar` declaration and the field that references it must agree on one
+    // name. Fields render scalar type names verbatim (`datetime`, `FloatRange`); the
+    // declaration walk must declare those same names, or composition reports
+    // `Unknown type datetime`.
+    use crate::schema::{InputFieldDefinition, InputObjectDefinition};
+
+    let mut schema = CompiledSchema::new();
+    let mut input = InputObjectDefinition::new("EventFilter");
+    input.fields = vec![
+        InputFieldDefinition::new("at", "datetime"), // lowercase scalar name
+        InputFieldDefinition::new("span", "FloatRange"), // rich scalar not previously declared
+    ];
+    schema.input_types.push(input);
+
+    let sdl = schema.raw_schema();
+
+    assert!(sdl.contains("at: datetime"), "field renders the verbatim scalar name:\n{sdl}");
+    assert!(
+        sdl.contains("scalar datetime"),
+        "the referenced scalar must be declared under the SAME name:\n{sdl}"
+    );
+    assert!(sdl.contains("span: FloatRange"), "field renders FloatRange:\n{sdl}");
+    assert!(sdl.contains("scalar FloatRange"), "FloatRange must be declared:\n{sdl}");
+}
+
 // -------------------------------------------------------------------------
 // is_builtin_type (private fn — tested via validate())
 // -------------------------------------------------------------------------

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -823,6 +823,7 @@ fn federation_metadata_some_when_enabled() {
         entities: vec![FederationEntity {
             name:       "User".to_string(),
             key_fields: vec!["id".to_string()],
+            ..Default::default()
         }],
         ..Default::default()
     });
@@ -1023,6 +1024,7 @@ fn service_sdl_advertises_root_query_fields() {
         entities: vec![FederationEntity {
             name:       "User".to_string(),
             key_fields: vec!["id".to_string()],
+            ..Default::default()
         }],
         ..Default::default()
     });

--- a/crates/fraiseql-core/src/schema/config_types.rs
+++ b/crates/fraiseql-core/src/schema/config_types.rs
@@ -23,18 +23,36 @@ pub struct FederationConfig {
     /// Federated entities defined in this subgraph.
     #[serde(default)]
     pub entities:        Vec<FederationEntity>,
+    /// Non-entity object types that are `@shareable` across subgraphs (e.g. a shared
+    /// `MutationError` value type). Unlike `entities`, these carry no `@key` and are
+    /// not members of the `_Entity` union — they only receive a type-level
+    /// `@shareable` directive so two subgraphs can both define the identical type
+    /// without an Apollo Federation `INVALID_FIELD_SHARING` composition error.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shareable_types: Vec<String>,
     /// Circuit breaker configuration for federation fan-out requests.
     #[serde(default)]
     pub circuit_breaker: Option<CircuitBreakerConfig>,
 }
 
 /// Federated entity configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FederationEntity {
     /// Entity type name (e.g., "User", "Product").
     pub name:       String,
     /// Key fields that uniquely identify this entity.
     pub key_fields: Vec<String>,
+    /// This subgraph `extend`s an entity owned by another subgraph (renders
+    /// `extend type Name @key(...)` in the federation SDL).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub extends:         bool,
+    /// Fields that are `@external` — owned by another subgraph and only referenced
+    /// here (typically the `@key` field of an extended entity).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_fields: Vec<String>,
+    /// Fields that are `@shareable` — resolvable in more than one subgraph.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shareable_fields: Vec<String>,
 }
 
 /// Circuit breaker configuration for federation entity resolution.

--- a/crates/fraiseql-core/src/schema/tests.rs
+++ b/crates/fraiseql-core/src/schema/tests.rs
@@ -1505,9 +1505,11 @@ fn test_roundtrip_serialization() {
         version:         Some("v2".to_string()),
         service_name:    Some("my-service".to_string()),
         schema_url:      None,
+        shareable_types: Vec::new(),
         entities:        vec![FederationEntity {
             name:       "User".to_string(),
             key_fields: vec!["id".to_string()],
+            ..Default::default()
         }],
         circuit_breaker: Some(CircuitBreakerConfig::default()),
     };

--- a/crates/fraiseql-core/tests/federation_compose.rs
+++ b/crates/fraiseql-core/tests/federation_compose.rs
@@ -1,0 +1,285 @@
+//! Golden two-subgraph federation compose test (hermetic layer).
+//!
+//! Every federation bug we have shipped — the `_service` SDL chain (`NO_QUERIES`,
+//! `Unknown type`), dropped `@shareable`/`@external`/`extends` directives, and the
+//! `snake_case` change-log surface — shared one root cause: a single subgraph always
+//! composed clean, so nothing exercised the path where two subgraphs share a type.
+//!
+//! This test renders two subgraphs through the *real* chain the server uses —
+//! [`CompiledSchema::raw_schema`] → [`CompiledSchema::federation_metadata`] →
+//! [`generate_service_sdl`] — and asserts the SDL invariants each of those bugs
+//! individually broke. It is hermetic (no Docker, no composer binary); the
+//! companion real-`composeServices` check lives in the federation-compose CI leg.
+//!
+//! The two subgraphs deliberately share everything a real supergraph shares:
+//! - `Money` — a keyless `@shareable` value type defined in *both* subgraphs.
+//! - `Product` — an entity *owned* by `catalog` and *extended* by `reviews`
+//!   (`extend type Product @key` with an `@external` key field).
+//! - a camelCase `catalog` subgraph that also exposes the #149 change-log, so the
+//!   SDL pins the naming-convention fix too.
+
+#![cfg(feature = "federation")]
+#![allow(clippy::expect_used, clippy::unwrap_used)] // Reason: test code, panics are acceptable.
+
+use std::path::PathBuf;
+
+use fraiseql_core::schema::{
+    ChangelogConfig, CompiledSchema, FederationConfig, FederationEntity, FieldDefinition,
+    FieldType, NamingConvention, QueryDefinition, TypeDefinition, inject_changelog,
+};
+
+/// Render a subgraph's Apollo-Federation `_service { sdl }` exactly as the server
+/// does: `generate_service_sdl(raw_schema(), federation_metadata())`.
+fn service_sdl(schema: &CompiledSchema) -> String {
+    let raw = schema.raw_schema();
+    let meta = schema.federation_metadata().expect("subgraph has an enabled federation block");
+    fraiseql_core::federation::generate_service_sdl(&raw, &meta)
+}
+
+/// Shared `@shareable` value type — `Money { amount, currency }`. Defined
+/// identically in both subgraphs; composition only succeeds if both mark it
+/// `@shareable` (otherwise `INVALID_FIELD_SHARING`).
+fn money_type() -> TypeDefinition {
+    TypeDefinition::new("Money", "public.v_money")
+        .with_field(FieldDefinition::new("amount", FieldType::Int))
+        .with_field(FieldDefinition::new("currency", FieldType::String))
+}
+
+/// `catalog` subgraph — owns `Product @key(id)`, defines the shared `@shareable`
+/// `Money`, exposes a root query + the camelCase #149 change-log.
+fn subgraph_catalog() -> CompiledSchema {
+    let mut s = CompiledSchema::new();
+    s.naming_convention = NamingConvention::CamelCase;
+
+    s.types.push(money_type());
+    s.types.push(
+        // `createdAt: DateTime` forces a non-built-in scalar declaration — the
+        // exact gap that made gateways report `Unknown type DateTime` (#495).
+        TypeDefinition::new("Product", "public.v_product")
+            .with_field(FieldDefinition::new("id", FieldType::Id))
+            .with_field(FieldDefinition::new("name", FieldType::String))
+            .with_field(FieldDefinition::new("price", FieldType::Object("Money".into())))
+            .with_field(FieldDefinition::new("createdAt", FieldType::DateTime)),
+    );
+
+    s.queries.push(
+        QueryDefinition::new("products", "Product")
+            .returning_list()
+            .with_sql_source("public.v_product"),
+    );
+
+    s.federation = Some(FederationConfig {
+        enabled: true,
+        version: Some("v2".to_string()),
+        service_name: Some("catalog".to_string()),
+        entities: vec![FederationEntity {
+            name: "Product".to_string(),
+            key_fields: vec!["id".to_string()],
+            ..Default::default()
+        }],
+        shareable_types: vec!["Money".to_string()],
+        ..Default::default()
+    });
+
+    // The single supergraph owner of the change-log (#497), in camelCase (#498).
+    s.changelog = Some(ChangelogConfig {
+        expose: true,
+        ..Default::default()
+    });
+    inject_changelog(&mut s);
+
+    s.build_indexes();
+    s
+}
+
+/// `reviews` subgraph — owns `Review @key(id)`, *extends* `Product` (owned by
+/// `catalog`) via an `@external` key, and also defines the shared `@shareable`
+/// `Money`.
+fn subgraph_reviews() -> CompiledSchema {
+    let mut s = CompiledSchema::new();
+    s.naming_convention = NamingConvention::CamelCase;
+
+    s.types.push(money_type());
+    s.types.push(
+        TypeDefinition::new("Review", "public.v_review")
+            .with_field(FieldDefinition::new("id", FieldType::Id))
+            .with_field(FieldDefinition::new("body", FieldType::String))
+            .with_field(FieldDefinition::new("rating", FieldType::Int)),
+    );
+    s.types.push(
+        // The extension stub: `id` is owned elsewhere (`@external`); this subgraph
+        // only contributes `reviews`.
+        TypeDefinition::new("Product", "public.v_product_reviews")
+            .with_field(FieldDefinition::new("id", FieldType::Id))
+            .with_field(FieldDefinition::new(
+                "reviews",
+                FieldType::List(Box::new(FieldType::Object("Review".into()))),
+            )),
+    );
+
+    s.queries.push(
+        QueryDefinition::new("reviews", "Review")
+            .returning_list()
+            .with_sql_source("public.v_review"),
+    );
+
+    s.federation = Some(FederationConfig {
+        enabled: true,
+        version: Some("v2".to_string()),
+        service_name: Some("reviews".to_string()),
+        entities: vec![
+            FederationEntity {
+                name: "Review".to_string(),
+                key_fields: vec!["id".to_string()],
+                ..Default::default()
+            },
+            FederationEntity {
+                name: "Product".to_string(),
+                key_fields: vec!["id".to_string()],
+                extends: true,
+                external_fields: vec!["id".to_string()],
+                ..Default::default()
+            },
+        ],
+        shareable_types: vec!["Money".to_string()],
+        ..Default::default()
+    });
+
+    s.build_indexes();
+    s
+}
+
+/// `reviews`, but *also* exposing the change-log — the #497 misconfiguration: two
+/// subgraphs both owning the (non-`@shareable`) `EntityChangeLog` type and
+/// `entityChangeLogs` root query. Composing this against `catalog` MUST fail with
+/// `INVALID_FIELD_SHARING`; the real-composer CI leg asserts exactly that.
+fn subgraph_reviews_with_changelog() -> CompiledSchema {
+    let mut s = subgraph_reviews();
+    s.changelog = Some(ChangelogConfig {
+        expose: true,
+        ..Default::default()
+    });
+    inject_changelog(&mut s);
+    s.build_indexes();
+    s
+}
+
+#[test]
+fn catalog_sdl_holds_every_federation_invariant() {
+    let sdl = service_sdl(&subgraph_catalog());
+
+    // Federation v2 envelope.
+    assert!(sdl.contains("extend schema @link("), "missing @link federation header");
+    assert!(sdl.contains("scalar _Any"), "missing _Any scalar");
+
+    // #495 — non-built-in scalars referenced by fields MUST be declared, or a
+    // gateway rejects the subgraph with `Unknown type`.
+    assert!(sdl.contains("scalar DateTime"), "DateTime referenced but not declared (#495)");
+
+    // #495 — root operations must render, or composition fails with NO_QUERIES.
+    assert!(sdl.contains("type Query {"), "no root Query type rendered (#495)");
+    assert!(sdl.contains("products"), "root query field missing from Query (#495)");
+
+    // #496 — owned entity carries @key; the shared value type carries a type-level
+    // @shareable so both subgraphs can define it.
+    assert!(
+        sdl.contains("type Product @key(fields: \"id\")"),
+        "entity @key not rendered on Product (#496)"
+    );
+    assert!(sdl.contains("type Money @shareable"), "shareable value type missing @shareable (#496)");
+
+    // #496 — a keyless @shareable value type must NOT join the _Entity union (an
+    // unkeyed union member is an invalid composition).
+    assert!(sdl.contains("union _Entity = Product"), "Product missing from _Entity union");
+    assert!(!sdl.contains("Money |"), "keyless Money leaked into _Entity union (#496)");
+    assert!(!sdl.contains("| Money"), "keyless Money leaked into _Entity union (#496)");
+
+    // #498 — the injected change-log honours the camelCase naming convention.
+    assert!(sdl.contains("entityChangeLogs"), "change-log query not camelCased (#498)");
+    assert!(sdl.contains("pkEntityChangeLog"), "change-log field not camelCased (#498)");
+    assert!(!sdl.contains("entity_change_logs"), "snake_case change-log query leaked (#498)");
+    assert!(!sdl.contains("pk_entity_change_log"), "snake_case change-log field leaked (#498)");
+}
+
+#[test]
+fn reviews_sdl_extends_the_borrowed_entity() {
+    let sdl = service_sdl(&subgraph_reviews());
+
+    // #496 — a borrowed entity renders `extend type … @key` with an `@external` key.
+    assert!(
+        sdl.contains("extend type Product @key(fields: \"id\")"),
+        "extended entity not rendered (#496)"
+    );
+    assert!(sdl.contains("@external"), "external key field not marked @external (#496)");
+
+    // Its own entity + the shared value type.
+    assert!(sdl.contains("type Review @key(fields: \"id\")"), "owned entity @key missing");
+    assert!(sdl.contains("type Money @shareable"), "shareable value type missing @shareable");
+
+    // Both keyed entities are resolvable via _entities.
+    assert!(sdl.contains("union _Entity ="), "no _Entity union rendered");
+    assert!(sdl.contains("Review"), "Review missing from _Entity union");
+    assert!(sdl.contains("Product"), "Product missing from _Entity union");
+}
+
+/// Path to a committed subgraph SDL fixture.
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/federation_compose").join(name)
+}
+
+/// The committed subgraph SDL fixtures are what the real-`composeServices` CI leg
+/// composes, so they must match what FraiseQL renders *today* — otherwise the leg
+/// would validate stale SDL while the live output drifted. This test renders both
+/// subgraphs and diffs them against the committed `.graphql` files, failing on any
+/// drift. Re-bless after an intentional rendering change with:
+///
+/// ```sh
+/// BLESS_FEDERATION_SDL=1 \
+///   cargo test -p fraiseql-core --test federation_compose --features federation
+/// ```
+#[test]
+fn committed_sdl_fixtures_are_current() {
+    let cases = [
+        ("catalog.graphql", subgraph_catalog()),
+        ("reviews.graphql", subgraph_reviews()),
+        // Negative fixture: a second change-log owner (composes → INVALID_FIELD_SHARING).
+        ("reviews_conflict.graphql", subgraph_reviews_with_changelog()),
+    ];
+    let bless = std::env::var_os("BLESS_FEDERATION_SDL").is_some();
+
+    for (file, schema) in cases {
+        let rendered = format!("{}\n", service_sdl(&schema).trim_end());
+        let path = fixture_path(file);
+
+        if bless {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, &rendered).unwrap();
+            continue;
+        }
+
+        let committed = std::fs::read_to_string(&path)
+            .expect("missing federation_compose SDL fixture; re-bless with BLESS_FEDERATION_SDL=1");
+        assert_eq!(
+            committed,
+            rendered,
+            "{} is stale; re-bless with BLESS_FEDERATION_SDL=1",
+            path.display()
+        );
+    }
+}
+
+/// The shared `Money` value type must be byte-identical across subgraphs, or
+/// Apollo composition rejects the supergraph even with `@shareable`. This guards
+/// the field set the two builders emit (a drift here would only surface at real
+/// `composeServices`, which the CI leg runs).
+#[test]
+fn shared_value_type_is_identical_across_subgraphs() {
+    let catalog = service_sdl(&subgraph_catalog());
+    let reviews = service_sdl(&subgraph_reviews());
+
+    for sdl in [&catalog, &reviews] {
+        assert!(sdl.contains("type Money @shareable {"), "Money header drifted");
+        assert!(sdl.contains("amount: Int"), "Money.amount drifted");
+        assert!(sdl.contains("currency: String"), "Money.currency drifted");
+    }
+}

--- a/crates/fraiseql-core/tests/fixtures/federation_compose/catalog.graphql
+++ b/crates/fraiseql-core/tests/fixtures/federation_compose/catalog.graphql
@@ -1,0 +1,77 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@extends"])
+scalar DateTime
+scalar JSON
+
+type Money @shareable {
+  amount: Int
+  currency: String
+}
+
+type Product @key(fields: "id") {
+  id: ID
+  name: String
+  price: Money
+  createdAt: DateTime
+}
+
+type EntityChangeLog {
+  id: ID
+  pkEntityChangeLog: Int
+  fkCustomerOrg: String
+  fkContact: String
+  objectType: String
+  objectId: String
+  modificationType: String
+  changeStatus: String
+  objectData: JSON
+  extraMetadata: JSON
+  createdAt: DateTime
+}
+
+type TransportCheckpoint {
+  transportName: String
+  lastPk: Int
+  updatedAt: DateTime
+}
+
+type Query {
+  products: [Product!]!
+  entityChangeLogs: [EntityChangeLog!]!
+  transportCheckpoint(transportName: String!): TransportCheckpoint
+}
+
+type Mutation {
+  upsertTransportCheckpoint(transportName: String!, lastPk: Int!): TransportCheckpoint!
+}
+
+
+
+directive @key(fields: String!, resolvable: Boolean = true) repeatable on OBJECT
+directive @extends on OBJECT
+directive @external on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+scalar link__Import
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+union _Entity = Product
+
+extend type Query {
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}

--- a/crates/fraiseql-core/tests/fixtures/federation_compose/reviews.graphql
+++ b/crates/fraiseql-core/tests/fixtures/federation_compose/reviews.graphql
@@ -1,0 +1,53 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@extends"])
+
+type Money @shareable {
+  amount: Int
+  currency: String
+}
+
+type Review @key(fields: "id") {
+  id: ID
+  body: String
+  rating: Int
+}
+
+extend type Product @key(fields: "id") {
+  id: ID @external
+  reviews: [Review]
+}
+
+type Query {
+  reviews: [Review!]!
+}
+
+
+
+directive @key(fields: String!, resolvable: Boolean = true) repeatable on OBJECT
+directive @extends on OBJECT
+directive @external on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+scalar link__Import
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+union _Entity = Review | Product
+
+extend type Query {
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}

--- a/crates/fraiseql-core/tests/fixtures/federation_compose/reviews_conflict.graphql
+++ b/crates/fraiseql-core/tests/fixtures/federation_compose/reviews_conflict.graphql
@@ -1,0 +1,81 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@extends"])
+scalar DateTime
+scalar JSON
+
+type Money @shareable {
+  amount: Int
+  currency: String
+}
+
+type Review @key(fields: "id") {
+  id: ID
+  body: String
+  rating: Int
+}
+
+extend type Product @key(fields: "id") {
+  id: ID @external
+  reviews: [Review]
+}
+
+type EntityChangeLog {
+  id: ID
+  pkEntityChangeLog: Int
+  fkCustomerOrg: String
+  fkContact: String
+  objectType: String
+  objectId: String
+  modificationType: String
+  changeStatus: String
+  objectData: JSON
+  extraMetadata: JSON
+  createdAt: DateTime
+}
+
+type TransportCheckpoint {
+  transportName: String
+  lastPk: Int
+  updatedAt: DateTime
+}
+
+type Query {
+  reviews: [Review!]!
+  entityChangeLogs: [EntityChangeLog!]!
+  transportCheckpoint(transportName: String!): TransportCheckpoint
+}
+
+type Mutation {
+  upsertTransportCheckpoint(transportName: String!, lastPk: Int!): TransportCheckpoint!
+}
+
+
+
+directive @key(fields: String!, resolvable: Boolean = true) repeatable on OBJECT
+directive @extends on OBJECT
+directive @external on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+scalar link__Import
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+union _Entity = Review | Product
+
+extend type Query {
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}

--- a/crates/fraiseql-federation/src/service_sdl.rs
+++ b/crates/fraiseql-federation/src/service_sdl.rs
@@ -15,7 +15,14 @@ directive @provides(fields: String!) on FIELD_DEFINITION
 directive @shareable on FIELD_DEFINITION | OBJECT
 directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 directive @override(from: String!) on FIELD_DEFINITION
-directive @link(url: String!, as: String, for: String, import: [String]) repeatable on SCHEMA
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+scalar link__Import
 
 type _Service {
   sdl: String!

--- a/crates/fraiseql-federation/src/service_sdl.rs
+++ b/crates/fraiseql-federation/src/service_sdl.rs
@@ -310,8 +310,15 @@ pub fn generate_service_sdl(base_schema: &str, metadata: &FederationMetadata) ->
     sdl.push_str(FEDERATION_SCHEMA);
     sdl.push('\n');
 
-    // _Entity union
-    let entity_types: Vec<&str> = metadata.types.iter().map(|t| t.name.as_str()).collect();
+    // _Entity union — only true entities (those with a `@key`) are resolvable via
+    // `_entities`. `@shareable` value types carry no key and must NOT appear here, or
+    // composition rejects a union member with no key.
+    let entity_types: Vec<&str> = metadata
+        .types
+        .iter()
+        .filter(|t| !t.keys.is_empty())
+        .map(|t| t.name.as_str())
+        .collect();
     if entity_types.is_empty() {
         sdl.push_str("union _Entity\n");
     } else {

--- a/crates/fraiseql-federation/src/service_sdl/tests.rs
+++ b/crates/fraiseql-federation/src/service_sdl/tests.rs
@@ -677,3 +677,14 @@ fn test_resolve_federation_version() {
     assert_eq!(resolve_federation_version("v2.3"), "v2.3");
     assert_eq!(resolve_federation_version("v2.5"), "v2.5");
 }
+
+#[test]
+fn link_directive_definition_uses_link_purpose_enum() {
+    // The `@link` directive's `for` argument must be the `link__Purpose` enum, not
+    // `String` — federation composition rejects `for: String`. The supporting
+    // `link__Purpose` enum must be defined alongside it.
+    let sdl = generate_service_sdl("type Query { test: String }", &enabled_metadata());
+    assert!(sdl.contains("for: link__Purpose"), "@link `for` must be link__Purpose:\n{sdl}");
+    assert!(!sdl.contains("for: String"), "@link must not declare `for: String`:\n{sdl}");
+    assert!(sdl.contains("enum link__Purpose"), "link__Purpose enum must be defined:\n{sdl}");
+}

--- a/docs/architecture/federation.md
+++ b/docs/architecture/federation.md
@@ -169,13 +169,29 @@ fraiseql-server = { version = "2", features = ["federation"] }
 # fraiseql.toml
 [federation]
 enabled = true
+service_name = "users"   # subgraph name (Apollo Studio / subgraph listing)
+version = "v2"           # Apollo Federation spec version (defaults to "v2")
+# schema_url = "https://users.example.com/graphql"  # optional, for /__subgraph_schema
+
+# Entities this subgraph owns and their key fields.
+[[federation.entities]]
+name = "User"
+key_fields = ["id"]
 
 [federation.circuit_breaker]
 enabled = true
 failure_threshold = 5
 recovery_timeout_secs = 30
 success_threshold = 2
+
+# Optional per-entity overrides (entity name must match a federation entity).
+[[federation.circuit_breaker.per_database]]
+database = "User"
+failure_threshold = 10
 ```
+
+> The legacy integer form `apollo_version = 2` is still accepted (`2` ⇒ `"v2"`);
+> prefer the `version` string. When both are set, `version` wins.
 
 ## Related Docs
 

--- a/docs/guides/changelog-graphql.md
+++ b/docs/guides/changelog-graphql.md
@@ -73,6 +73,49 @@ On the next `fraiseql compile`, the changelog migration installs:
 Callers without the role see `"not found in schema"` (not `FORBIDDEN`) — the
 operations are hidden behind the role gate to prevent enumeration.
 
+### Naming convention
+
+The change-log identifiers follow the schema's `naming_convention`, exactly like
+every user-authored type and operation. The examples below use the default
+`preserve` (snake_case) form; under `naming_convention = "camelCase"` the same
+surface is `entityChangeLogs`, `pkEntityChangeLog`, `objectType`,
+`transportCheckpoint`, `upsertTransportCheckpoint`, and so on. The backing
+view/function names and the JSONB `data` keys stay snake_case regardless — only
+the GraphQL-facing identifiers change.
+
+## Federation: one owner per supergraph
+
+The change-log is a **per-database** stream: the same `pk_entity_change_log` in
+two subgraphs is not the same row. So the injected `EntityChangeLog` /
+`TransportCheckpoint` types and the `entity_change_logs` root query are **not**
+`@shareable` — a single subgraph owns them. If two subgraphs in one supergraph
+both set `expose = true`, they inject the identical type and root field, and
+`rover supergraph compose` rejects the supergraph with `INVALID_FIELD_SHARING`.
+
+Expose the change-log in **exactly one** subgraph. Every other subgraph keeps
+capturing to its own `tb_entity_change_log` — the observer trigger writes it
+regardless of `expose` — it simply doesn't surface it over GraphQL:
+
+```toml
+# the one subgraph that owns the change-log API
+[changelog]
+expose = true
+
+# every other subgraph: capture, but no GraphQL surface
+[changelog]
+expose        = false   # no EntityChangeLog type / entity_change_logs query
+write_enabled = true    # default — the capture trigger still writes the log
+```
+
+`expose` gates only the read/GraphQL surface; `write_enabled` (default `true`)
+gates the transactional outbox write. They are independent, so a non-exposing
+subgraph still records its own change-log for sidecars that read it directly. To
+consume more than one subgraph's stream, query each in its owning subgraph — they
+are genuinely different streams, not one federated entity.
+
+The compiler emits a warning when `[changelog] expose = true` on a federation
+subgraph, restating the single-owner rule (the owning subgraph can ignore it).
+
 ## Cursor pagination
 
 `entity_change_logs` is a standard FraiseQL list query: it uses the generic

--- a/sdks/official/fraiseql-python/src/fraiseql/decorators.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/decorators.py
@@ -409,6 +409,7 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
     plural_name: str | None = None,
     key_fields: list[str] | None = None,
     extends: bool = False,
+    shareable: bool = False,
     subscribable_tables: list[str] | None = None,
     subscribable_pre_image: bool = False,
 ) -> type[T] | Callable[[type[T]], type[T]]:
@@ -431,6 +432,15 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
         plural_name: Override the auto-pluralized name for the CRUD list query.
             Only used when ``crud`` includes ``"read"``. When ``None``, the name
             is derived by pluralizing the snake_case class name.
+        extends: This subgraph extends an entity owned by another subgraph
+            (renders ``extend type Name @key(...)`` in the federation SDL). Mark the
+            borrowed ``@key`` field(s) ``field(external=True)``.
+        shareable: Mark this type a federation ``@shareable`` value type — a keyless
+            type that every subgraph may define identically (e.g. a shared
+            ``MutationError`` returned by mutation result unions). Mutually exclusive
+            with ``key_fields``: a type is either a keyless shareable value type or a
+            keyed entity. For a single shareable field on an *entity*, use
+            ``field(shareable=True)`` instead.
         subscribable_tables: Physical base table(s) backing this type whose
             *external* writes (a raw ``INSERT``/``UPDATE``/``DELETE`` from psql, a
             migration, or a third-party tool) should reach GraphQL subscribers
@@ -487,6 +497,16 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
                 )
                 raise ValueError(msg)
 
+        # A type is either a keyless @shareable value type or a keyed entity, never
+        # both (a type-level @shareable type is excluded from the _Entity union).
+        if shareable and key_fields is not None:
+            msg = (
+                f"@fraiseql.type on {c.__name__!r}: shareable=True is for a keyless value "
+                "type and cannot be combined with key_fields. For a shareable field on an "
+                "entity, use field(shareable=True)."
+            )
+            raise ValueError(msg)
+
         # Validate the @subscribable opt-in + its pre-image flag (#366).
         _validate_subscribable(
             subscribable_tables, subscribable_pre_image, f"@fraiseql.type on {c.__name__!r}"
@@ -529,6 +549,7 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
             sql_source=sql_source,
             key_fields=key_fields,
             extends=extends,
+            shareable=shareable,
             subscribable_tables=subscribable_tables,
             subscribable_pre_image=subscribable_pre_image,
         )
@@ -896,7 +917,11 @@ def mutation(func: F | None = None, **config_kwargs: Any) -> F | Callable[[F], F
     return decorator(func)
 
 
-def error(cls: type[T]) -> type[T]:
+def error(
+    cls: type[T] | None = None,
+    *,
+    shareable: bool = False,
+) -> type[T] | Callable[[type[T]], type[T]]:
     """Decorator to mark a Python class as a GraphQL error type.
 
     Like @type, but sets is_error=True in the schema output. Error types are
@@ -905,6 +930,11 @@ def error(cls: type[T]) -> type[T]:
 
     Args:
         cls: Python class with type annotations
+        shareable: Mark this error a federation ``@shareable`` value type, so two
+            subgraphs can both define the identical error (e.g. a shared
+            ``MutationError`` returned by every mutation result union) without an
+            Apollo ``INVALID_FIELD_SHARING`` composition error. See
+            ``@fraiseql.type(shareable=...)``.
 
     Returns:
         The original class (unmodified)
@@ -915,16 +945,29 @@ def error(cls: type[T]) -> type[T]:
         ...     '''Error when user lookup fails.'''
         ...     message: str
         ...     code: str
+
+        >>> @fraiseql.error(shareable=True)
+        ... class MutationError:
+        ...     '''Shared across subgraphs.'''
+        ...     message: str
     """
-    cls.__fraiseql_type__ = True
-    fields = extract_field_info(cls)
-    SchemaRegistry.register_type(
-        name=cls.__name__,
-        fields=fields,
-        description=cls.__doc__,
-        is_error=True,
-    )
-    return cls
+
+    def decorator(c: type[T]) -> type[T]:
+        c.__fraiseql_type__ = True
+        fields = extract_field_info(c)
+        SchemaRegistry.register_type(
+            name=c.__name__,
+            fields=fields,
+            description=c.__doc__,
+            is_error=True,
+            shareable=shareable,
+        )
+        return c
+
+    # Support both @error and @error(shareable=True).
+    if cls is None:
+        return decorator
+    return decorator(cls)
 
 
 def enum(cls: type[E]) -> type[E]:

--- a/sdks/official/fraiseql-python/src/fraiseql/registry.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/registry.py
@@ -84,6 +84,7 @@ class SchemaRegistry:
         sql_source: str | None = None,
         key_fields: list[str] | None = None,
         extends: bool = False,
+        shareable: bool = False,
         subscribable_tables: list[str] | None = None,
         subscribable_pre_image: bool = False,
     ) -> None:
@@ -144,6 +145,12 @@ class SchemaRegistry:
 
         if extends:
             type_def["extends"] = True
+
+        # #496: type-level @shareable marks a keyless value type that every subgraph
+        # may define identically (e.g. a shared MutationError). The compiler lifts
+        # these into the federation block's `shareable_types`; emitted only when set.
+        if shareable:
+            type_def["shareable"] = True
 
         # #366: emit only when non-empty (snake_case, like requires_role); the
         # compiler reads it from the type JSON and aggregates the capture-trigger

--- a/sdks/official/fraiseql-python/src/fraiseql/schema.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/schema.py
@@ -17,31 +17,87 @@ from typing import Any
 from fraiseql.registry import SchemaRegistry
 
 
+def _fields_with_directive(type_def: dict[str, Any], directive: str) -> list[str]:
+    """Names of the type's fields carrying the given field-level federation directive.
+
+    Field-level directives are recorded on each field's ``federation`` sub-dict by
+    ``field(external=...)`` / ``field(shareable=...)`` etc.
+    """
+    return [
+        field["name"]
+        for field in type_def.get("fields", [])
+        if field.get("federation", {}).get(directive)
+    ]
+
+
 def _build_federation_block(federation: Federation, schema: dict[str, Any]) -> dict[str, Any]:
     """Build the ``federation`` block for schema output.
 
+    Derives the per-entity directive lists (#496) the Rust compiler/SDL renderer
+    consumes from the per-type/field decorators, so a project never has to
+    hand-author them:
+
+    - ``entities[].extends`` from ``@type(extends=True)``;
+    - ``entities[].external_fields`` from ``field(external=True)``;
+    - ``entities[].shareable_fields`` from ``field(shareable=True)``;
+    - top-level ``shareable_types`` from ``@type(shareable=True)`` /
+      ``@error(shareable=True)`` — keyless value types that are excluded from the
+      ``_Entity`` union and carry a type-level ``@shareable``.
+
+    A plain entity with no directives stays exactly ``{name, key_fields}`` so the
+    common case is byte-for-byte unchanged.
+
     Args:
         federation: Federation metadata from the caller.
-        schema: The full schema dict (used to iterate types).
+        schema: The full schema dict (used to iterate types and their fields).
 
     Returns:
         Dictionary suitable for inclusion as ``schema["federation"]``.
     """
     entities: list[dict[str, Any]] = []
+    shareable_types: list[str] = []
     for type_def in schema.get("types", []):
-        # Skip error types
+        name = type_def["name"]
+
+        # Type-level @shareable → a keyless shared value type, not an entity. (The
+        # Rust renderer gives it a type-level @shareable and keeps it out of the
+        # _Entity union.) Covers shareable error/value types too.
+        if type_def.get("shareable"):
+            shareable_types.append(name)
+            continue
+
+        # Non-shareable error types stay out of the federation graph entirely.
         if type_def.get("is_error"):
             continue
-        key_fields = type_def.get("key_fields", federation.default_key_fields)
-        entities.append({"name": type_def["name"], "key_fields": key_fields})
+
+        entity: dict[str, Any] = {
+            "name": name,
+            "key_fields": type_def.get("key_fields", federation.default_key_fields),
+        }
+        # Additive keys only when set, so the no-directive entity is unchanged.
+        if type_def.get("extends"):
+            entity["extends"] = True
+        external_fields = _fields_with_directive(type_def, "external")
+        if external_fields:
+            entity["external_fields"] = external_fields
+        shareable_fields = _fields_with_directive(type_def, "shareable")
+        if shareable_fields:
+            entity["shareable_fields"] = shareable_fields
+        entities.append(entity)
 
     apollo_version = 2 if federation.version == "v2" else 1
-    return {
+    block: dict[str, Any] = {
         "enabled": True,
         "service_name": federation.service_name,
+        # The Rust core FederationConfig reads `version` (the @link spec URL); the
+        # legacy int `apollo_version` is kept for back-compat but ignored there.
+        "version": federation.version,
         "apollo_version": apollo_version,
         "entities": entities,
     }
+    if shareable_types:
+        block["shareable_types"] = shareable_types
+    return block
 
 
 def _validate_schema_before_export(schema: dict[str, Any]) -> None:

--- a/sdks/official/fraiseql-python/tests/test_federation.py
+++ b/sdks/official/fraiseql-python/tests/test_federation.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Annotated
 
 import pytest
 
@@ -218,3 +219,164 @@ def test_federation_json_matches_rust_format():
         assert isinstance(entity["name"], str)
         assert isinstance(entity["key_fields"], list)
         assert all(isinstance(k, str) for k in entity["key_fields"])
+
+
+# ---------------------------------------------------------------------------
+# #496: derive per-entity / type-level federation directives from decorators
+# ---------------------------------------------------------------------------
+
+
+def test_type_shareable_stored():
+    @fraiseql.type(shareable=True)
+    class Money:
+        amount: int
+        currency: str
+
+    schema = SchemaRegistry.get_schema()
+    assert schema["types"][0]["shareable"] is True
+
+
+def test_type_not_shareable_by_default():
+    @fraiseql.type
+    class Money:
+        amount: int
+
+    schema = SchemaRegistry.get_schema()
+    assert "shareable" not in schema["types"][0]
+
+
+def test_type_shareable_with_key_fields_rejected():
+    # A type is either a keyless @shareable value type or a keyed entity — never
+    # both. (For a shareable field on an entity, use field(shareable=True).)
+    with pytest.raises(ValueError, match="shareable"):
+
+        @fraiseql.type(key_fields=["id"], shareable=True)
+        class Bad:
+            id: ID
+
+
+def test_error_accepts_shareable_kwarg():
+    @fraiseql.error(shareable=True)
+    class MutationError:
+        message: str
+
+    schema = SchemaRegistry.get_schema()
+    assert schema["types"][0]["is_error"] is True
+    assert schema["types"][0]["shareable"] is True
+
+
+def test_error_without_parens_still_works():
+    @fraiseql.error
+    class NotFound:
+        message: str
+
+    schema = SchemaRegistry.get_schema()
+    assert schema["types"][0]["is_error"] is True
+    assert "shareable" not in schema["types"][0]
+
+
+def test_federation_derives_extends():
+    @fraiseql.type(key_fields=["id"], extends=True)
+    class Product:
+        id: ID
+
+    fed = fraiseql.Federation(service_name="reviews")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    product = next(e for e in block["entities"] if e["name"] == "Product")
+    assert product["extends"] is True
+
+
+def test_federation_derives_external_fields():
+    @fraiseql.type(key_fields=["id"], extends=True)
+    class Product:
+        id: Annotated[ID, fraiseql.field(external=True)]
+        weight: Annotated[float, fraiseql.field(external=True)]
+        reviews: str
+
+    fed = fraiseql.Federation(service_name="reviews")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    product = next(e for e in block["entities"] if e["name"] == "Product")
+    assert set(product["external_fields"]) == {"id", "weight"}
+    assert "reviews" not in product["external_fields"]
+
+
+def test_federation_derives_shareable_fields():
+    @fraiseql.type(key_fields=["id"])
+    class Product:
+        id: ID
+        name: Annotated[str, fraiseql.field(shareable=True)]
+
+    fed = fraiseql.Federation(service_name="catalog")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    product = next(e for e in block["entities"] if e["name"] == "Product")
+    assert product["shareable_fields"] == ["name"]
+
+
+def test_federation_shareable_type_goes_to_shareable_types_not_entities():
+    @fraiseql.type
+    class User:
+        id: ID
+
+    @fraiseql.type(shareable=True)
+    class Money:
+        amount: int
+        currency: str
+
+    fed = fraiseql.Federation(service_name="catalog")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    entity_names = [e["name"] for e in block["entities"]]
+    assert "User" in entity_names
+    assert "Money" not in entity_names  # keyless value type, not an entity
+    assert block["shareable_types"] == ["Money"]
+
+
+def test_federation_shareable_error_type_is_shareable_value_type():
+    @fraiseql.type
+    class User:
+        id: ID
+
+    @fraiseql.error(shareable=True)
+    class MutationError:
+        message: str
+
+    fed = fraiseql.Federation(service_name="catalog")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    entity_names = [e["name"] for e in block["entities"]]
+    assert "MutationError" not in entity_names
+    assert block["shareable_types"] == ["MutationError"]
+
+
+def test_federation_plain_entity_has_no_directive_keys():
+    # Guards the byte-exact entity contract (see test_export_schema_federation_json):
+    # an entity with no directives stays exactly {name, key_fields}.
+    @fraiseql.type
+    class User:
+        id: ID
+        name: str
+
+    fed = fraiseql.Federation(service_name="users")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    user = next(e for e in block["entities"] if e["name"] == "User")
+    assert user == {"name": "User", "key_fields": ["id"]}
+
+
+def test_federation_no_shareable_types_key_when_none():
+    @fraiseql.type
+    class User:
+        id: ID
+
+    fed = fraiseql.Federation(service_name="users")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    assert "shareable_types" not in block
+
+
+def test_federation_emits_version_string():
+    # The Rust core FederationConfig reads `version` (the @link spec URL); the legacy
+    # int `apollo_version` is ignored there. Emit both.
+    @fraiseql.type
+    class User:
+        id: ID
+
+    fed = fraiseql.Federation(service_name="users")
+    block = fraiseql.get_schema_dict(federation=fed)["federation"]
+    assert block["version"] == "v2"

--- a/tools/federation/compose-check.mjs
+++ b/tools/federation/compose-check.mjs
@@ -1,0 +1,75 @@
+// Compose FraiseQL-rendered subgraph SDLs with Apollo Federation v2 composition
+// (`@apollo/composition`, the engine `rover supergraph compose` wraps) and fail on
+// any composition error. This is the "real composer" half of the golden two-subgraph
+// federation suite: the hermetic Rust test (crates/fraiseql-core/tests/federation_compose.rs)
+// checks each subgraph's `_service` SDL invariants; this checks that the subgraphs
+// actually compose into a supergraph together — the exact step CI never ran before
+// (the old federation leg routed a *pre-composed, committed* single-subgraph fixture).
+//
+// Usage:
+//   node compose-check.mjs <name>=<file.graphql> [<name>=<file.graphql> ...]
+//   node compose-check.mjs --expect-fail=<CODE> <name>=<file> ...   # negative case
+//
+// Exit codes: 0 = composed as expected, 1 = unexpected result, 2 = bad invocation.
+
+import { readFileSync } from "node:fs";
+import { parse } from "graphql";
+import { composeServices } from "@apollo/composition";
+
+const raw = process.argv.slice(2);
+let expectFailCode = null;
+const specs = [];
+for (const arg of raw) {
+  if (arg.startsWith("--expect-fail=")) {
+    expectFailCode = arg.slice("--expect-fail=".length);
+    continue;
+  }
+  const eq = arg.indexOf("=");
+  if (eq === -1) {
+    console.error(`bad argument '${arg}' (expected <name>=<file>)`);
+    process.exit(2);
+  }
+  specs.push({ name: arg.slice(0, eq), file: arg.slice(eq + 1) });
+}
+
+if (specs.length < 2) {
+  console.error("usage: compose-check.mjs <name>=<file> <name>=<file> [...]");
+  process.exit(2);
+}
+
+const services = specs.map(({ name, file }) => ({
+  name,
+  url: `http://localhost/${name}`,
+  typeDefs: parse(readFileSync(file, "utf8")),
+}));
+
+const result = composeServices(services);
+const errors = result.errors ?? [];
+const names = specs.map((s) => s.name).join(" + ");
+
+if (expectFailCode !== null) {
+  // Negative case: composition MUST fail with the expected error code (e.g. two
+  // change-log owners → INVALID_FIELD_SHARING).
+  const codes = errors.map((e) => e.extensions?.code ?? "ERROR");
+  if (codes.includes(expectFailCode)) {
+    console.log(`✓ ${names}: composition correctly rejected with ${expectFailCode}`);
+    process.exit(0);
+  }
+  console.error(
+    `✗ ${names}: expected composition to fail with ${expectFailCode}, ` +
+      (errors.length ? `got [${codes.join(", ")}]` : "but it composed cleanly"),
+  );
+  for (const e of errors) console.error(`    - [${e.extensions?.code ?? "ERROR"}] ${e.message}`);
+  process.exit(1);
+}
+
+if (errors.length) {
+  console.error(`✗ ${names}: composition FAILED with ${errors.length} error(s):`);
+  for (const e of errors) console.error(`    - [${e.extensions?.code ?? "ERROR"}] ${e.message}`);
+  process.exit(1);
+}
+
+const hints = result.hints ?? [];
+console.log(`✓ ${names}: composed cleanly (${hints.length} hint(s))`);
+for (const h of hints) console.log(`    · [${h.code ?? "HINT"}] ${h.message ?? h.toString()}`);
+process.exit(0);

--- a/tools/federation/package-lock.json
+++ b/tools/federation/package-lock.json
@@ -1,0 +1,1075 @@
+{
+  "name": "fraiseql-federation-compose-check",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fraiseql-federation-compose-check",
+      "version": "0.0.0",
+      "dependencies": {
+        "@apollo/composition": "^2.9.0",
+        "graphql": "^16.9.0"
+      }
+    },
+    "node_modules/@apollo/composition": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.14.1.tgz",
+      "integrity": "sha512-VWtB2jb19lnR5JaD181x7g2oyCpNsLEAetYdB41McmxHIemFAv0AEs679bPmr0IL8dzf74Cm8dL5bxWCaHBnBQ==",
+      "license": "Elastic-2.0",
+      "dependencies": {
+        "@apollo/federation-internals": "2.14.1",
+        "@apollo/query-graphs": "2.14.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "graphql": "^16.5.0"
+      }
+    },
+    "node_modules/@apollo/federation-internals": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.14.1.tgz",
+      "integrity": "sha512-BVgwDr9H9mR/9LEzRzhBXJqo2cYdjkwSK/2uEgMa+B45oXvMI5r69y6qdFvMjRyP1R6y4wjnR9UtYGpx5uhhdw==",
+      "license": "Elastic-2.0",
+      "dependencies": {
+        "@types/uuid": "^9.0.0",
+        "chalk": "^4.1.0",
+        "js-levenshtein": "^1.1.6",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "graphql": "^16.5.0"
+      }
+    },
+    "node_modules/@apollo/query-graphs": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.14.1.tgz",
+      "integrity": "sha512-gi3TWpkrr7Yq1SqpDdZp0yWtnIMQxrwd1K8wJJnp5KBiebH3qT20zcyBqKNDEGvE5Q9+4neH0g1I2xElwpLg5w==",
+      "license": "Elastic-2.0",
+      "dependencies": {
+        "@apollo/federation-internals": "2.14.1",
+        "deep-equal": "^2.0.5",
+        "ts-graphviz": "^1.5.4",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "graphql": "^16.5.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-graphviz": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-1.8.2.tgz",
+      "integrity": "sha512-5YhbFoHmjxa7pgQLkB07MtGnGJ/yhvjmc9uhsnDBEICME6gkPf83SBwLDQqGDoCa3XzUMWLk1AU2Wn1u1naDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ts-graphviz"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/tools/federation/package.json
+++ b/tools/federation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fraiseql-federation-compose-check",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Composes FraiseQL-rendered subgraph SDLs with @apollo/composition (the Federation v2 engine `rover supergraph compose` wraps) to gate composition validity in CI.",
+  "scripts": {
+    "compose-check": "node compose-check.mjs"
+  },
+  "dependencies": {
+    "@apollo/composition": "^2.9.0",
+    "graphql": "^16.9.0"
+  }
+}

--- a/tools/federation/run-compose-check.sh
+++ b/tools/federation/run-compose-check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Real-composer half of the golden two-subgraph federation suite.
+#
+# Composes the committed FraiseQL-rendered subgraph SDLs with Apollo Federation v2
+# composition (@apollo/composition — the engine `rover supergraph compose` wraps)
+# and asserts both golden cases:
+#   - catalog + reviews          → composes cleanly
+#   - catalog + reviews_conflict → rejected with INVALID_FIELD_SHARING (#497)
+#
+# The fixtures are kept in lock-step with live FraiseQL output by the Rust test
+# `committed_sdl_fixtures_are_current`; run that (or `make federation-compose-check`,
+# which runs both) after any change to federation SDL rendering.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixtures="$here/../../crates/fraiseql-core/tests/fixtures/federation_compose"
+
+cd "$here"
+if [[ ! -d node_modules ]]; then
+  echo "→ installing compose-check deps (npm ci)"
+  npm ci --no-audit --no-fund
+fi
+
+echo "→ positive: catalog + reviews must compose"
+node compose-check.mjs \
+  "catalog=$fixtures/catalog.graphql" \
+  "reviews=$fixtures/reviews.graphql"
+
+echo "→ negative: catalog + reviews_conflict must be rejected (#497)"
+node compose-check.mjs --expect-fail=INVALID_FIELD_SHARING \
+  "catalog=$fixtures/catalog.graphql" \
+  "reviews_conflict=$fixtures/reviews_conflict.graphql"
+
+echo "✓ federation compose check passed"


### PR DESCRIPTION
Federation hardening cluster surfaced by a real two-subgraph beta deployment. Each piece was TDD'd and verified independently.

## #496 — `@shareable`/`@external`/extends through compile into the `_service` SDL
- **Rust:** the federation block now carries `entities[].extends`/`external_fields`/`shareable_fields` + top-level `shareable_types`; `federation_metadata()` rebuilds per-field directives; `generate_service_sdl` filters the `_Entity` union to keyed types.
- **Python SDK:** `export_schema(federation=...)` now **derives** that block from the `@type`/`field` decorators (`extends`, `field(external=)`/`field(shareable=)`) plus a new `@type(shareable=)`/`@error(shareable=)` ergonomic for keyless value types; also emits `version` (fixes a malformed `@link` spec URL on the SDK path). Verified end-to-end SDK → `fraiseql compile` → SDL.

## #498 — changelog honours the `camelCase` `naming_convention`
`inject_changelog` rendered snake_case identifiers even under camelCase. Now cased per the schema convention (type fields, op names, args). SQL contract unchanged: the runtime recovers the snake_case JSONB key, and mutation args bind positionally.

## #497 — single-owner change-log across a supergraph
Two subgraphs both exposing the change-log collide (`INVALID_FIELD_SHARING`). Documented the single-owner pattern (`expose` ⊥ `write_enabled`) + a non-fatal compile guardrail.

## Golden two-subgraph compose suite
The blind spot behind all of the above: nothing ever composed two subgraphs (the old federation CI routed a frozen single-subgraph supergraph). Adds a hermetic SDL-invariant test (runs in the core test leg; a freshness test keeps the committed fixtures in lock-step with live rendering) + a real Apollo Federation v2 composition check (`@apollo/composition`) wired as a new `federation-compose` Dagger leg. Positive composes clean; the #497 two-owner case is rejected with `INVALID_FIELD_SHARING`.

## Also
- `fed_sdl` example gated behind the `federation` feature + a `print_stdout` allow.

## Verification
Full core lib + SDK suites + `clippy --all-targets --all-features` + `ruff` + `ty` clean; the `federation-compose` leg path validated in a fresh `ubuntu:24.04` container (apt node + `npm ci` + compose).

Closes #496
Closes #497
Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
