### PR TITLE
feat(cli): short-lived runtime executor + doctor --runtime smoke (#501)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -344,7 +344,10 @@ func (m *FraiseqlCi) Test(
 	// Per-toolchain target cache: stable and 1.92 produce incompatible artifacts,
 	// so they must not share a target dir (kept separate from the Phase-02 gates'
 	// `fraiseql-rust-target`, which holds clippy/rustdoc check artifacts).
-	targetVol := "fraiseql-rust-target-test-" + strings.ReplaceAll(toolchain, ".", "-")
+	// `test2-` bump (2026-06-30): the `test-` volume held stale fraiseql-cli/-db
+	// artifacts that cargo reused across branches, hiding newly-added public items
+	// (#501's `commands::query` / `runtime_probe_checks`) → false E0432 on msrv only.
+	targetVol := "fraiseql-rust-target-test2-" + strings.ReplaceAll(toolchain, ".", "-")
 
 	// Skip patterns for the testcontainers lib tests (storage + functions); wire's
 	// container tests live in tests/*, so we run only its lib unit tests.
@@ -1410,7 +1413,7 @@ func (m *FraiseqlCi) integrationHTTPE2e(ctx context.Context, source *dagger.Dire
 // test container can reach it. Dagger starts the Postgres dependency (and waits for
 // its port) before the server starts, and the caller waits for :8815 before testing.
 func (m *FraiseqlCi) serverE2eService(source *dagger.Directory) *dagger.Service {
-	const targetVol = "fraiseql-rust-target-integ2-1-92"
+	const targetVol = "fraiseql-rust-target-integ3-1-92"
 	dbURL := fmt.Sprintf("postgresql://%s:%s@%s:5432/%s", pgUser, pgPassword, pgBindHost, pgDatabase)
 
 	// Build the binary and copy it out of the (cache-mounted) target dir to a plain
@@ -1612,7 +1615,10 @@ func (m *FraiseqlCi) pgService(source *dagger.Directory) *dagger.Service {
 // feature/artifact sets) and sets RUST_LOG=debug like the legacy integration jobs.
 func (m *FraiseqlCi) integrationBase(source *dagger.Directory, rust string) *dagger.Container {
 	toolchain := resolveToolchain(rust)
-	targetVol := "fraiseql-rust-target-integ2-" + strings.ReplaceAll(toolchain, ".", "-")
+	// `integ3-` bump (2026-06-30): bust the stale integ2 target cache that reused
+	// pre-#501 fraiseql-db artifacts, hiding `execute_function_call_dry_run` → false
+	// E0599 in the integration postgres leg. Mirrors the `test2-` bump above.
+	targetVol := "fraiseql-rust-target-integ3-" + strings.ReplaceAll(toolchain, ".", "-")
 	return m.rustBaseFor(toolchain).
 		WithMountedDirectory("/src", source).
 		WithWorkdir("/src").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Short-lived runtime executor: `fraiseql query` + `doctor --runtime` (#501).** A
+  scriptable way to exercise a compiled schema against a database without standing up
+  the long-lived server, closing the gap between "static checks pass" and "the server
+  resolves it". `fraiseql query --schema schema.compiled.json --db "$DATABASE_URL"
+  '{ orders(limit: 1) { id } }'` boots the engine in-process (PostgreSQL; no HTTP
+  layer, no `run-server` feature), runs one operation, prints the GraphQL JSON to
+  stdout, and exits non-zero on a resolution error — a one-shot "does this resolve?"
+  for CI and the inner loop. `--variables '{...}'` passes GraphQL variables.
+  `fraiseql doctor --runtime --against-db "$DATABASE_URL"` probes every root query
+  field with a minimal selection (and dry-runs no-argument mutations), reporting each
+  as resolving or failing; operations that require arguments are skipped with a warning.
+  Mutations run by `query` COMMIT unless `--dry-run` is given, which executes the
+  mutation inside a transaction that is **rolled back** — the function binds and runs
+  (constraints, triggers, and the `mutation_response` shape are all validated) but no
+  writes persist. Dry-run is PostgreSQL-only; other adapters return a clear
+  "not supported" error rather than silently committing.
+
 ### Fixed
 
 - **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**

--- a/crates/fraiseql-cli/src/cli.rs
+++ b/crates/fraiseql-cli/src/cli.rs
@@ -620,6 +620,45 @@ EXAMPLES:
         command: SchemaCommands,
     },
 
+    /// Execute one GraphQL operation against a database and print the JSON result
+    ///
+    /// Boots the compiled schema in-process (no long-lived server, no HTTP layer)
+    /// against PostgreSQL, runs a single query or mutation, prints the GraphQL JSON
+    /// response to stdout, and exits. Exits non-zero on a resolution error — a
+    /// scriptable "does this actually resolve?" check for CI and the inner loop.
+    ///
+    /// Mutations COMMIT unless `--dry-run` is given, which runs the mutation inside
+    /// a transaction that is rolled back (validate-bind-without-commit).
+    #[command(after_help = "\
+EXAMPLES:
+    fraiseql query '{ orders(limit: 1) { id } }'
+    fraiseql query --schema schema.compiled.json --database postgres://localhost/db '{ users { id } }'
+    fraiseql query --variables '{\"id\": 42}' 'query($id: Int!) { user(id: $id) { id } }'
+    fraiseql query --dry-run 'mutation { createUser(name: \"x\") { id } }'")]
+    Query {
+        /// GraphQL operation to execute (a single query or mutation document).
+        #[arg(value_name = "QUERY")]
+        query: String,
+
+        /// Path to schema.compiled.json.
+        #[arg(short = 's', long, default_value = "schema.compiled.json")]
+        schema: std::path::PathBuf,
+
+        /// Database URL (PostgreSQL only). Falls back to the DATABASE_URL env var.
+        #[arg(long, value_name = "DATABASE_URL")]
+        database: Option<String>,
+
+        /// GraphQL variables as a JSON object string (e.g. '{"id": 42}').
+        #[arg(long, value_name = "JSON")]
+        variables: Option<String>,
+
+        /// Run mutations inside a rolled-back transaction: the function binds and
+        /// executes (constraints, triggers, and response shape are validated) but
+        /// nothing is committed. No effect on queries. PostgreSQL only.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Run diagnostic checks for common FraiseQL setup problems
     ///
     /// Checks schema file, TOML config, DATABASE_URL, JWT secret, Redis, TLS,
@@ -630,6 +669,7 @@ EXAMPLES:
     fraiseql doctor
     fraiseql doctor --schema schema.compiled.json --config fraiseql.toml
     fraiseql doctor --db-url postgres://user:pass@host:5432/db
+    fraiseql doctor --runtime --against-db postgres://user:pass@host:5432/db
     fraiseql doctor --json")]
     Doctor {
         /// Path to fraiseql.toml configuration file.
@@ -656,6 +696,15 @@ EXAMPLES:
         /// skips with a hint when it is unavailable.
         #[arg(long, value_name = "DATABASE_URL")]
         against_db: Option<String>,
+
+        /// Runtime smoke mode (#501): boot the compiled schema in-process and
+        /// probe each root query field with a minimal selection, dry-running each
+        /// no-argument mutation (rolled back). Confirms operations actually
+        /// *resolve* end-to-end, complementing the static `--against-db` drift
+        /// checks. Requires a PostgreSQL URL via `--against-db` (or `--db-url`).
+        /// Queries / mutations that require arguments are skipped with a warning.
+        #[arg(long)]
+        runtime: bool,
 
         /// Schemas to scan in the body-resolution pass (comma-separated).
         #[arg(

--- a/crates/fraiseql-cli/src/commands/doctor.rs
+++ b/crates/fraiseql-cli/src/commands/doctor.rs
@@ -5,9 +5,13 @@
 //!   fraiseql doctor --config fraiseql.toml --schema schema.compiled.json
 //!   fraiseql doctor --json
 
-use std::{net::TcpStream, path::Path, time::Duration};
+use std::{net::TcpStream, path::Path, sync::Arc, time::Duration};
 
-use fraiseql_core::schema::CompiledSchema;
+use fraiseql_core::{
+    db::postgres::PostgresAdapter,
+    runtime::{Executor, RuntimeConfig},
+    schema::{ArgumentDefinition, CompiledSchema, MutationDefinition, QueryDefinition},
+};
 use fraiseql_observers::migrations::ENTITY_CHANGE_LOG_CONTRACT;
 use serde::{Deserialize, Serialize};
 
@@ -556,6 +560,7 @@ pub async fn run_with_db_checks(
     schema: &Path,
     db_url: Option<&str>,
     against_db: Option<&str>,
+    runtime: bool,
     schemas: &[String],
     json: bool,
 ) -> bool {
@@ -573,6 +578,12 @@ pub async fn run_with_db_checks(
         checks.extend(mutation_contract_checks(url, schema).await);
     }
 
+    // Runtime smoke (#501): actually execute each probeable root operation. Prefers
+    // the live `--against-db` URL, falling back to `--db-url`.
+    if runtime {
+        checks.extend(runtime_probe_checks(against_db.or(db_url), schema).await);
+    }
+
     if json {
         print_json_report(&checks);
     } else {
@@ -580,6 +591,199 @@ pub async fn run_with_db_checks(
     }
 
     checks.iter().all(|c| c.status != CheckStatus::Fail)
+}
+
+// ─── Runtime smoke (#501) ───────────────────────────────────────────────────────
+
+const RUNTIME_NAME: &str = "Runtime smoke";
+const RUNTIME_QUERY_LABEL: &str = "Runtime query probe";
+const RUNTIME_MUTATION_LABEL: &str = "Runtime mutation probe (dry-run)";
+
+/// Boot the compiled schema in-process and probe each root operation end-to-end.
+///
+/// For every root query (and every mutation, dry-run / rolled back) that takes no
+/// required arguments, a minimal operation is executed against the database; a
+/// success becomes a `Pass`, a resolution error a `Fail`. Operations that require
+/// arguments cannot be probed automatically (input would have to be fabricated)
+/// and are reported as `Warn` (skipped) — `Warn` never fails the overall run.
+///
+/// Never panics: a missing URL, an unreadable schema, or a connection failure all
+/// become a single `Fail` check.
+pub async fn runtime_probe_checks(db_url: Option<&str>, schema_path: &Path) -> Vec<DoctorCheck> {
+    let Some(url) = db_url else {
+        return vec![DoctorCheck::fail(
+            RUNTIME_NAME,
+            "no database URL provided for --runtime",
+            "Pass --against-db <postgres-url> (or --db-url) together with --runtime.",
+        )];
+    };
+    if !(url.starts_with("postgres://") || url.starts_with("postgresql://")) {
+        return vec![DoctorCheck::fail(
+            RUNTIME_NAME,
+            "runtime smoke supports PostgreSQL only",
+            "Pass a postgres:// URL to --against-db.",
+        )];
+    }
+
+    let schema = match load_compiled_schema(schema_path) {
+        Ok(schema) => schema,
+        Err(detail) => {
+            return vec![DoctorCheck::fail(
+                RUNTIME_NAME,
+                detail,
+                "Run `fraiseql compile` to (re)generate the compiled schema.",
+            )];
+        },
+    };
+
+    let adapter = match PostgresAdapter::new(url).await {
+        Ok(adapter) => Arc::new(adapter),
+        Err(e) => {
+            return vec![DoctorCheck::fail(
+                RUNTIME_NAME,
+                format!("cannot connect: {e}"),
+                "Pass a reachable postgres:// URL to --against-db.",
+            )];
+        },
+    };
+
+    // dry_run_mutations: mutation probes run inside a rolled-back transaction so a
+    // smoke check never commits side effects.
+    let config = RuntimeConfig {
+        dry_run_mutations: true,
+        ..RuntimeConfig::default()
+    };
+    // Clone for iteration so the borrow is independent of the executor that owns
+    // the schema (one-shot CLI; the clone cost is negligible).
+    let probe_schema = schema.clone();
+    let executor = Executor::with_config(schema, adapter, config);
+
+    let mut checks = Vec::new();
+    for query in &probe_schema.queries {
+        if let Some(op) = minimal_query_probe(query, &probe_schema) {
+            let result = executor.execute(&op, None).await;
+            checks.push(probe_outcome(RUNTIME_QUERY_LABEL, &query.name, &result));
+        } else {
+            checks.push(DoctorCheck::warn(
+                RUNTIME_QUERY_LABEL,
+                format!("{} skipped — requires arguments", query.name),
+                format!("Probe manually: fraiseql query '{{ {}(…) {{ … }} }}'", query.name),
+            ));
+        }
+    }
+    for mutation in &probe_schema.mutations {
+        if let Some(op) = minimal_mutation_probe(mutation, &probe_schema) {
+            let result = executor.execute(&op, None).await;
+            checks.push(probe_outcome(RUNTIME_MUTATION_LABEL, &mutation.name, &result));
+        } else {
+            checks.push(DoctorCheck::warn(
+                RUNTIME_MUTATION_LABEL,
+                format!("{} skipped — requires arguments", mutation.name),
+                format!(
+                    "Dry-run manually: fraiseql query --dry-run 'mutation {{ {}(…) {{ … }} }}'",
+                    mutation.name
+                ),
+            ));
+        }
+    }
+
+    if checks.is_empty() {
+        checks.push(DoctorCheck::warn(
+            RUNTIME_NAME,
+            "no root queries or mutations to probe",
+            "Compile a schema that declares queries or mutations.",
+        ));
+    }
+    checks
+}
+
+/// Read and parse a compiled schema, mapping any failure to a display string.
+fn load_compiled_schema(path: &Path) -> Result<CompiledSchema, String> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    CompiledSchema::from_json(&text, false)
+        .map_err(|e| format!("cannot parse {}: {e}", path.display()))
+}
+
+/// Map a single probe execution result to a doctor check.
+fn probe_outcome(
+    label: &'static str,
+    op_name: &str,
+    result: &fraiseql_core::error::Result<serde_json::Value>,
+) -> DoctorCheck {
+    match result {
+        Ok(value) if !crate::commands::query::has_errors(value) => {
+            DoctorCheck::pass(label, format!("{op_name} resolves"))
+        },
+        Ok(value) => DoctorCheck::fail(
+            label,
+            format!(
+                "{op_name}: {}",
+                first_error_message(value).unwrap_or_else(|| "resolution error".to_string())
+            ),
+            "Inspect with `fraiseql query`.",
+        ),
+        Err(e) => {
+            DoctorCheck::fail(label, format!("{op_name}: {e}"), "Inspect with `fraiseql query`.")
+        },
+    }
+}
+
+/// Extract the first GraphQL error message from a response envelope, if any.
+fn first_error_message(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("errors")?
+        .as_array()?
+        .first()?
+        .get("message")?
+        .as_str()
+        .map(ToString::to_string)
+}
+
+/// Whether any declared argument is required (non-null and has no default), in
+/// which case the operation cannot be probed without fabricating input.
+pub(crate) fn probe_requires_arguments(args: &[ArgumentDefinition]) -> bool {
+    args.iter().any(|a| !a.nullable && a.default_value.is_none())
+}
+
+/// Build a minimal sub-selection for an object return type: the first scalar
+/// field, falling back to `__typename`. Returns `None` when `type_name` is a leaf
+/// (scalar / enum) that needs no sub-selection.
+pub(crate) fn minimal_selection_for_type(
+    type_name: &str,
+    schema: &CompiledSchema,
+) -> Option<String> {
+    let type_def = schema.types.iter().find(|t| t.name.as_str() == type_name)?;
+    let field = type_def.fields.iter().find(|f| f.field_type.is_scalar());
+    Some(field.map_or_else(|| "__typename".to_string(), |f| f.name.as_str().to_string()))
+}
+
+/// Build a minimal probe document for a root query, or `None` if it requires args.
+pub(crate) fn minimal_query_probe(
+    query: &QueryDefinition,
+    schema: &CompiledSchema,
+) -> Option<String> {
+    if probe_requires_arguments(&query.arguments) {
+        return None;
+    }
+    Some(match minimal_selection_for_type(&query.return_type, schema) {
+        Some(sel) => format!("{{ {} {{ {sel} }} }}", query.name),
+        None => format!("{{ {} }}", query.name),
+    })
+}
+
+/// Build a minimal probe document for a root mutation, or `None` if it requires args.
+pub(crate) fn minimal_mutation_probe(
+    mutation: &MutationDefinition,
+    schema: &CompiledSchema,
+) -> Option<String> {
+    if probe_requires_arguments(&mutation.arguments) {
+        return None;
+    }
+    Some(match minimal_selection_for_type(&mutation.return_type, schema) {
+        Some(sel) => format!("mutation {{ {} {{ {sel} }} }}", mutation.name),
+        None => format!("mutation {{ {} }}", mutation.name),
+    })
 }
 
 /// Run the PL/pgSQL body-resolution pass and map its outcome to doctor checks.

--- a/crates/fraiseql-cli/src/commands/mod.rs
+++ b/crates/fraiseql-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod introspect_facts;
 pub mod lint;
 pub mod migrate;
 pub mod perf;
+pub mod query;
 #[cfg(feature = "run-server")]
 pub mod run;
 pub mod sbom;

--- a/crates/fraiseql-cli/src/commands/query.rs
+++ b/crates/fraiseql-cli/src/commands/query.rs
@@ -1,0 +1,143 @@
+//! `fraiseql query` — execute one GraphQL operation in-process and print JSON.
+//!
+//! Boots the compiled schema directly on top of `fraiseql-core`'s `Executor`
+//! (no long-lived server, no HTTP layer, no axum) against PostgreSQL, runs a
+//! single query or mutation, prints the GraphQL JSON response to stdout, and
+//! exits. A scriptable "does this actually resolve?" check that closes the gap
+//! between `compile`/`validate` (static) and the full server (runtime).
+//!
+//! Exit code: non-zero on a resolution error — whether `execute` returns an
+//! outright error or the response carries a non-empty top-level `errors` array.
+//!
+//! Mutations COMMIT unless `--dry-run` is given, in which case the mutation runs
+//! inside a transaction the adapter rolls back (validate-bind-without-commit,
+//! via [`RuntimeConfig::dry_run_mutations`]).
+
+use std::{path::Path, sync::Arc};
+
+use anyhow::{Context, Result, bail};
+use fraiseql_core::{
+    db::postgres::PostgresAdapter,
+    runtime::{Executor, RuntimeConfig},
+    schema::CompiledSchema,
+};
+
+/// Run the `fraiseql query` command.
+///
+/// # Arguments
+///
+/// * `query`       - The GraphQL operation to execute (a single query or mutation).
+/// * `schema_path` - Path to `schema.compiled.json`.
+/// * `database`    - Database URL override; falls back to the `DATABASE_URL` env var.
+/// * `variables`   - Optional GraphQL variables as a JSON object string.
+/// * `dry_run`     - Run mutations inside a rolled-back transaction (no commit).
+///
+/// # Errors
+///
+/// Returns an error if the schema file is missing or invalid, no PostgreSQL URL
+/// is available, the URL is not a `postgres://` scheme, the `--variables` JSON is
+/// malformed, the database connection fails, or the operation fails to execute.
+pub async fn run(
+    query: &str,
+    schema_path: &Path,
+    database: Option<String>,
+    variables: Option<String>,
+    dry_run: bool,
+) -> Result<()> {
+    let schema = load_schema(schema_path)?;
+    let db_url = resolve_db_url(database)?;
+    ensure_postgres_url(&db_url)?;
+    let variables = parse_variables(variables.as_deref())?;
+
+    // Safety notice: a mutation without --dry-run commits against the live DB.
+    if !dry_run && is_mutation(query) {
+        eprintln!(
+            "warning: executing a mutation — changes will be COMMITTED. \
+             Pass --dry-run to validate the binding without committing."
+        );
+    }
+
+    let adapter =
+        Arc::new(PostgresAdapter::new(&db_url).await.context("failed to connect to PostgreSQL")?);
+    let config = RuntimeConfig {
+        dry_run_mutations: dry_run,
+        ..RuntimeConfig::default()
+    };
+    let executor = Executor::with_config(schema, adapter, config);
+
+    let result = executor.execute(query, variables.as_ref()).await.context("execution failed")?;
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&result).context("failed to serialize result")?
+    );
+
+    // A resolution error surfaced in-band (top-level `errors`) must fail the
+    // process even though `execute` returned the response envelope as `Ok`.
+    if has_errors(&result) {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Read and parse the compiled schema file.
+fn load_schema(path: &Path) -> Result<CompiledSchema> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read schema file {}", path.display()))?;
+    // `strict_integrity = false`: tolerate a missing/legacy `_content_hash` so the
+    // command runs against schemas compiled by any toolchain version.
+    CompiledSchema::from_json(&text, false)
+        .with_context(|| format!("failed to parse compiled schema {}", path.display()))
+}
+
+/// Resolve the database URL: CLI flag first, then the `DATABASE_URL` env var.
+fn resolve_db_url(cli: Option<String>) -> Result<String> {
+    cli.or_else(|| std::env::var("DATABASE_URL").ok()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "No database URL provided. Pass --database or set the DATABASE_URL env var."
+        )
+    })
+}
+
+/// Guard: `fraiseql query` supports PostgreSQL only (slice 1).
+pub(crate) fn ensure_postgres_url(url: &str) -> Result<()> {
+    if url.starts_with("postgres://") || url.starts_with("postgresql://") {
+        Ok(())
+    } else {
+        bail!(
+            "`fraiseql query` currently supports PostgreSQL only. \
+             Pass a postgres:// (or postgresql://) connection string."
+        )
+    }
+}
+
+/// Parse the optional `--variables` JSON string into a value.
+///
+/// GraphQL variables are an object; a non-object value is rejected up front so
+/// the failure is a clear CLI error rather than an opaque execution error.
+pub(crate) fn parse_variables(raw: Option<&str>) -> Result<Option<serde_json::Value>> {
+    match raw {
+        None => Ok(None),
+        Some(s) => {
+            let value: serde_json::Value =
+                serde_json::from_str(s).context("--variables is not valid JSON")?;
+            if !value.is_object() {
+                bail!("--variables must be a JSON object (e.g. '{{\"id\": 42}}').");
+            }
+            Ok(Some(value))
+        },
+    }
+}
+
+/// Whether a GraphQL response carries a non-empty top-level `errors` array.
+pub(crate) fn has_errors(result: &serde_json::Value) -> bool {
+    result
+        .get("errors")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|a| !a.is_empty())
+}
+
+/// Whether the operation parses as a mutation (best-effort; false on parse error).
+fn is_mutation(query: &str) -> bool {
+    fraiseql_core::graphql::parse_query(query).is_ok_and(|p| p.operation_type == "mutation")
+}

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -2980,3 +2980,152 @@ mod validate_facts_tests {
         assert!(errors[0].message.contains("profit"));
     }
 }
+
+mod query_tests {
+    use serde_json::json;
+
+    use super::super::query::{ensure_postgres_url, has_errors, parse_variables};
+
+    #[test]
+    fn ensure_postgres_url_accepts_postgres_schemes() {
+        assert!(ensure_postgres_url("postgres://localhost/db").is_ok());
+        assert!(ensure_postgres_url("postgresql://u:p@h:5432/db").is_ok());
+    }
+
+    #[test]
+    fn ensure_postgres_url_rejects_other_schemes() {
+        assert!(ensure_postgres_url("mysql://localhost/db").is_err());
+        assert!(ensure_postgres_url("sqlite://./x.db").is_err());
+        assert!(ensure_postgres_url("not-a-url").is_err());
+    }
+
+    #[test]
+    fn parse_variables_none_is_none() {
+        assert!(parse_variables(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_variables_valid_object() {
+        let v = parse_variables(Some(r#"{"id": 42}"#)).unwrap().unwrap();
+        assert_eq!(v, json!({"id": 42}));
+    }
+
+    #[test]
+    fn parse_variables_rejects_non_object() {
+        assert!(parse_variables(Some("42")).is_err());
+        assert!(parse_variables(Some("[1, 2]")).is_err());
+    }
+
+    #[test]
+    fn parse_variables_rejects_invalid_json() {
+        assert!(parse_variables(Some("{not json")).is_err());
+    }
+
+    #[test]
+    fn has_errors_detects_non_empty_errors_array() {
+        assert!(has_errors(&json!({"data": null, "errors": [{"message": "boom"}]})));
+    }
+
+    #[test]
+    fn has_errors_false_for_clean_response() {
+        assert!(!has_errors(&json!({"data": {"users": []}})));
+        assert!(!has_errors(&json!({"data": {}, "errors": []})));
+    }
+}
+
+mod doctor_runtime_tests {
+    use fraiseql_core::schema::{
+        ArgumentDefinition, CompiledSchema, FieldDefinition, FieldType, MutationDefinition,
+        QueryDefinition, TypeDefinition,
+    };
+
+    use super::super::doctor::{
+        minimal_mutation_probe, minimal_query_probe, minimal_selection_for_type,
+        probe_requires_arguments,
+    };
+
+    fn user_type() -> TypeDefinition {
+        let mut t = TypeDefinition::new("User", "v_user");
+        t.fields.push(FieldDefinition::new("id", FieldType::Id));
+        t.fields.push(FieldDefinition::new("name", FieldType::String));
+        t
+    }
+
+    #[test]
+    fn requires_arguments_true_for_required_arg() {
+        let args = vec![ArgumentDefinition::new("id", FieldType::Id)];
+        assert!(probe_requires_arguments(&args));
+    }
+
+    #[test]
+    fn requires_arguments_false_for_optional_or_empty() {
+        assert!(!probe_requires_arguments(&[]));
+        let args = vec![ArgumentDefinition::optional("limit", FieldType::Int)];
+        assert!(!probe_requires_arguments(&args));
+    }
+
+    #[test]
+    fn minimal_selection_picks_first_scalar_field() {
+        let mut schema = CompiledSchema::new();
+        schema.types.push(user_type());
+        assert_eq!(minimal_selection_for_type("User", &schema).as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn minimal_selection_falls_back_to_typename() {
+        let mut schema = CompiledSchema::new();
+        schema.types.push(TypeDefinition::new("Empty", "v_empty"));
+        assert_eq!(minimal_selection_for_type("Empty", &schema).as_deref(), Some("__typename"));
+    }
+
+    #[test]
+    fn minimal_selection_none_for_leaf_type() {
+        let schema = CompiledSchema::new(); // "Int" is not an object type
+        assert!(minimal_selection_for_type("Int", &schema).is_none());
+    }
+
+    #[test]
+    fn query_probe_for_object_return() {
+        let mut schema = CompiledSchema::new();
+        schema.types.push(user_type());
+        schema.queries.push(QueryDefinition::new("users", "User"));
+        let op = minimal_query_probe(&schema.queries[0], &schema).unwrap();
+        assert_eq!(op, "{ users { id } }");
+    }
+
+    #[test]
+    fn query_probe_for_scalar_return_has_no_subselection() {
+        let mut schema = CompiledSchema::new();
+        schema.queries.push(QueryDefinition::new("count", "Int"));
+        let op = minimal_query_probe(&schema.queries[0], &schema).unwrap();
+        assert_eq!(op, "{ count }");
+    }
+
+    #[test]
+    fn query_probe_skipped_when_required_arg() {
+        let mut schema = CompiledSchema::new();
+        schema.types.push(user_type());
+        let mut q = QueryDefinition::new("user", "User");
+        q.arguments.push(ArgumentDefinition::new("id", FieldType::Id));
+        schema.queries.push(q);
+        assert!(minimal_query_probe(&schema.queries[0], &schema).is_none());
+    }
+
+    #[test]
+    fn mutation_probe_dry_run_shape() {
+        let mut schema = CompiledSchema::new();
+        schema.types.push(user_type());
+        schema.mutations.push(MutationDefinition::new("ping", "User"));
+        let op = minimal_mutation_probe(&schema.mutations[0], &schema).unwrap();
+        assert_eq!(op, "mutation { ping { id } }");
+    }
+
+    #[test]
+    fn mutation_probe_skipped_when_required_arg() {
+        let mut schema = CompiledSchema::new();
+        let mut m = MutationDefinition::new("createUser", "User");
+        m.arguments.push(ArgumentDefinition::new("name", FieldType::String));
+        schema.mutations.push(m);
+        assert!(minimal_mutation_probe(&schema.mutations[0], &schema).is_none());
+    }
+}

--- a/crates/fraiseql-cli/src/runner.rs
+++ b/crates/fraiseql-cli/src/runner.rs
@@ -477,11 +477,24 @@ pub async fn run() {
             },
         },
 
+        Commands::Query {
+            query,
+            schema,
+            database,
+            variables,
+            dry_run,
+        } => {
+            // Box::pin: the in-process executor + adapter init future is large
+            // enough to trip clippy's `large_futures` stack threshold.
+            Box::pin(commands::query::run(&query, &schema, database, variables, dry_run)).await
+        },
+
         Commands::Doctor {
             config,
             schema,
             db_url,
             against_db,
+            runtime,
             schemas,
             json: json_flag,
         } => {
@@ -490,6 +503,7 @@ pub async fn run() {
                 &schema,
                 db_url.as_deref(),
                 against_db.as_deref(),
+                runtime,
                 &schemas,
                 json_flag,
             )

--- a/crates/fraiseql-cli/tests/runtime_smoke.rs
+++ b/crates/fraiseql-cli/tests/runtime_smoke.rs
@@ -1,0 +1,196 @@
+//! Live-PostgreSQL smoke tests for `fraiseql query` and `doctor --runtime` (#501).
+//!
+//! Self-skips when no `DATABASE_URL` is set (the `--all-features` fast leg compiles
+//! these but skips at runtime; they run fully against the integration DB / locally).
+//! Uniquely-named objects (`*_501`) keep the suite isolated from the shared database.
+
+#![cfg(feature = "test-postgres")]
+#![allow(clippy::unwrap_used, clippy::print_stderr, clippy::panic)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use std::io::Write;
+
+use fraiseql_cli::commands::{
+    doctor::{CheckStatus, runtime_probe_checks},
+    query,
+};
+use fraiseql_core::schema::{
+    CompiledSchema, FieldDefinition, FieldType, MutationDefinition, QueryDefinition, TypeDefinition,
+};
+use tempfile::{Builder, NamedTempFile};
+
+const VIEW: &str = "public.v_rt_smoke_thing_501";
+
+/// A one-row view exposing the FraiseQL `data` JSONB column the executor projects.
+async fn setup_view(url: &str) -> tokio_postgres::Client {
+    let (client, connection) =
+        tokio_postgres::connect(url, tokio_postgres::NoTls).await.expect("connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+    client
+        .batch_execute(&format!(
+            "DROP VIEW IF EXISTS {VIEW}; \
+             CREATE VIEW {VIEW} AS \
+               SELECT jsonb_build_object('id', gen_random_uuid()::text, 'name', 'Acme') AS data;"
+        ))
+        .await
+        .expect("create probe view");
+    client
+}
+
+/// Build a compiled schema with one list query `things` backed by `sql_source`.
+fn thing_schema(sql_source: &str) -> CompiledSchema {
+    let mut schema = CompiledSchema::new();
+    let mut thing = TypeDefinition::new("Thing", sql_source);
+    thing.jsonb_column = "data".to_string();
+    thing.fields.push(FieldDefinition::new("id", FieldType::Id));
+    thing.fields.push(FieldDefinition::new("name", FieldType::String));
+    schema.types.push(thing);
+    schema.queries.push(
+        QueryDefinition::new("things", "Thing")
+            .returning_list()
+            .with_sql_source(sql_source),
+    );
+    schema
+}
+
+/// Serialize a compiled schema to a temp `.json` file the CLI can load.
+fn schema_file(schema: &CompiledSchema) -> NamedTempFile {
+    let json = schema.to_json().expect("serialize schema");
+    let mut f = Builder::new().suffix(".json").tempfile().unwrap();
+    f.write_all(json.as_bytes()).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+#[tokio::test]
+async fn query_command_resolves_against_db() {
+    let Some(url) = fraiseql_test_support::try_database_url() else {
+        eprintln!("skipping #501 query smoke: no DATABASE_URL");
+        return;
+    };
+    let client = setup_view(&url).await;
+    let file = schema_file(&thing_schema("v_rt_smoke_thing_501"));
+
+    let result = query::run("{ things { id name } }", file.path(), Some(url), None, false).await;
+
+    client.batch_execute(&format!("DROP VIEW IF EXISTS {VIEW};")).await.ok();
+    assert!(result.is_ok(), "query should resolve against the seeded view: {result:?}");
+}
+
+#[tokio::test]
+async fn doctor_runtime_passes_on_resolvable_schema() {
+    let Some(url) = fraiseql_test_support::try_database_url() else {
+        eprintln!("skipping #501 doctor --runtime pass smoke: no DATABASE_URL");
+        return;
+    };
+    let client = setup_view(&url).await;
+    let file = schema_file(&thing_schema("v_rt_smoke_thing_501"));
+
+    let checks = runtime_probe_checks(Some(&url), file.path()).await;
+
+    client.batch_execute(&format!("DROP VIEW IF EXISTS {VIEW};")).await.ok();
+
+    assert!(
+        checks.iter().all(|c| c.status != CheckStatus::Fail),
+        "no probe should fail on a resolvable schema: {checks:?}"
+    );
+    assert!(
+        checks
+            .iter()
+            .any(|c| c.detail.contains("things") && c.detail.contains("resolves")),
+        "the `things` query should report as resolving: {checks:?}"
+    );
+}
+
+#[tokio::test]
+async fn doctor_runtime_fails_on_missing_view() {
+    let Some(url) = fraiseql_test_support::try_database_url() else {
+        eprintln!("skipping #501 doctor --runtime fail smoke: no DATABASE_URL");
+        return;
+    };
+    // Schema points the query at a view that does not exist → the probe must FAIL.
+    let file = schema_file(&thing_schema("v_rt_smoke_absent_501"));
+
+    let checks = runtime_probe_checks(Some(&url), file.path()).await;
+
+    assert!(
+        checks.iter().any(|c| c.status == CheckStatus::Fail),
+        "a probe against a missing view must fail: {checks:?}"
+    );
+}
+
+/// End-to-end proof that `--dry-run` wiring (CLI flag → `RuntimeConfig` →
+/// mutation runner → adapter rollback) holds through the full GraphQL path: a
+/// mutation executed via `query --dry-run` runs its function but commits nothing.
+#[tokio::test]
+async fn query_dry_run_mutation_rolls_back_end_to_end() {
+    let Some(url) = fraiseql_test_support::try_database_url() else {
+        eprintln!("skipping #501 query --dry-run e2e: no DATABASE_URL");
+        return;
+    };
+
+    let (client, connection) =
+        tokio_postgres::connect(&url, tokio_postgres::NoTls).await.expect("connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {e}");
+        }
+    });
+
+    // Provision: mutation_response contract + a probe table + a no-arg function
+    // that INSERTs and returns a success response carrying the new entity.
+    client
+        .batch_execute(
+            "CREATE SCHEMA IF NOT EXISTS app;
+             DO $$ BEGIN CREATE TYPE app.mutation_error_class AS ENUM ('validation','conflict',\
+             'not_found','unauthorized','forbidden','internal','transaction_failed','timeout',\
+             'rate_limited','service_unavailable'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+             DO $$ BEGIN CREATE TYPE app.mutation_response AS (succeeded BOOLEAN, \
+             state_changed BOOLEAN, error_class app.mutation_error_class, status_detail TEXT, \
+             http_status SMALLINT, message TEXT, entity_id UUID, entity_type TEXT, entity JSONB, \
+             updated_fields TEXT[], cascade JSONB, error_detail JSONB, metadata JSONB); \
+             EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+             DROP TABLE IF EXISTS public.tb_dry_run_e2e_501;
+             CREATE TABLE public.tb_dry_run_e2e_501 (id uuid PRIMARY KEY, name text);
+             CREATE OR REPLACE FUNCTION public.fn_create_thing_501() \
+             RETURNS app.mutation_response LANGUAGE plpgsql AS $$ \
+             DECLARE v app.mutation_response; r_id uuid := gen_random_uuid(); BEGIN \
+             INSERT INTO public.tb_dry_run_e2e_501 (id, name) VALUES (r_id, 'e2e'); \
+             v.succeeded := true; v.state_changed := true; \
+             v.entity_type := 'Thing'; v.entity_id := r_id; \
+             v.entity := jsonb_build_object('id', r_id::text, 'name', 'e2e'); \
+             RETURN v; END; $$;",
+        )
+        .await
+        .expect("provision mutation fixture");
+
+    // Schema: a Thing type + a createThing mutation backed by the function.
+    let mut schema = CompiledSchema::new();
+    let mut thing = TypeDefinition::new("Thing", "v_unused_501");
+    thing.jsonb_column = "data".to_string();
+    thing.fields.push(FieldDefinition::new("id", FieldType::Id));
+    schema.types.push(thing);
+    let mut mutation = MutationDefinition::new("createThing", "Thing");
+    mutation.sql_source = Some("public.fn_create_thing_501".to_string());
+    schema.mutations.push(mutation);
+    let file = schema_file(&schema);
+
+    let result =
+        query::run("mutation { createThing { id } }", file.path(), Some(url), None, true).await;
+
+    let committed: i64 = client
+        .query_one("SELECT COUNT(*) FROM public.tb_dry_run_e2e_501", &[])
+        .await
+        .unwrap()
+        .get(0);
+    client
+        .batch_execute("DROP TABLE IF EXISTS public.tb_dry_run_e2e_501;")
+        .await
+        .ok();
+
+    assert!(result.is_ok(), "dry-run mutation should execute: {result:?}");
+    assert_eq!(committed, 0, "--dry-run must roll back the mutation's INSERT");
+}

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -772,15 +772,25 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
                 // default → no extra column, byte-for-byte today's behavior.
                 .with_pre_image(mutation_def.changelog_pre_image)
         });
-        let rows = ctx
-            .adapter
-            .execute_function_call_with_changelog(
-                sql_source,
-                &args,
-                &session_pairs,
-                changelog.as_ref(),
-            )
-            .await?;
+        let rows = if ctx.config.dry_run_mutations {
+            // Validate-bind-without-commit (#501): run the function inside a
+            // transaction the adapter rolls back, so nothing persists and no
+            // outbox row is written. The `changelog` descriptor above is unused
+            // on this path. PostgreSQL implements the rollback; other adapters
+            // return `Unsupported` rather than silently committing.
+            ctx.adapter
+                .execute_function_call_dry_run(sql_source, &args, &session_pairs)
+                .await?
+        } else {
+            ctx.adapter
+                .execute_function_call_with_changelog(
+                    sql_source,
+                    &args,
+                    &session_pairs,
+                    changelog.as_ref(),
+                )
+                .await?
+        };
 
         // 5. Expect at least one row
         let row = rows.into_iter().next().ok_or_else(|| FraiseQLError::Validation {

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -76,6 +76,7 @@ mod query {
             query_validation:     None,
             audit_mutations:      false,
             changelog_enabled:    true,
+            dry_run_mutations:    false,
         };
         let executor = Executor::with_config(schema, adapter, config);
 
@@ -513,7 +514,7 @@ mod entities_authz {
             enabled: true,
             version: Some("v2".to_string()),
             entities: vec![FederationEntity {
-                name:       "User".to_string(),
+                name: "User".to_string(),
                 key_fields: vec!["id".to_string()],
                 ..Default::default()
             }],
@@ -864,6 +865,7 @@ mod config {
             query_validation:     None,
             audit_mutations:      false,
             changelog_enabled:    true,
+            dry_run_mutations:    false,
         };
 
         assert_eq!(config.jsonb_optimization.default_strategy, JsonbStrategy::Project);
@@ -892,6 +894,7 @@ mod config {
             query_validation:     None,
             audit_mutations:      false,
             changelog_enabled:    true,
+            dry_run_mutations:    false,
         };
 
         assert_eq!(config.jsonb_optimization.default_strategy, JsonbStrategy::Stream);

--- a/crates/fraiseql-core/src/runtime/mod.rs
+++ b/crates/fraiseql-core/src/runtime/mod.rs
@@ -246,6 +246,20 @@ pub struct RuntimeConfig {
     /// Sourced from `[changelog] enabled` in `fraiseql.toml`, overridable at
     /// runtime by `FRAISEQL_CHANGELOG_ENABLED`.
     pub changelog_enabled: bool,
+
+    /// Validate-bind-without-commit mode for mutations (default `false`).
+    ///
+    /// When `true`, every state-changing mutation is executed inside a database
+    /// transaction that is **rolled back** instead of committed: the function
+    /// binds and runs (so constraints, triggers, and the `mutation_response`
+    /// shape are all validated) but no writes persist and no change-log row is
+    /// emitted. Powers the `fraiseql query --dry-run` CLI smoke check and the
+    /// `doctor --runtime` mutation probes.
+    ///
+    /// Currently honoured only by the PostgreSQL adapter; other adapters return
+    /// a `Validation` error from `execute_function_call_dry_run` rather than
+    /// silently committing. Queries are unaffected (they never commit).
+    pub dry_run_mutations: bool,
 }
 
 impl std::fmt::Debug for RuntimeConfig {
@@ -265,6 +279,7 @@ impl std::fmt::Debug for RuntimeConfig {
             .field("query_validation", &self.query_validation)
             .field("audit_mutations", &self.audit_mutations)
             .field("changelog_enabled", &self.changelog_enabled)
+            .field("dry_run_mutations", &self.dry_run_mutations)
             .finish()
     }
 }
@@ -286,6 +301,7 @@ impl Default for RuntimeConfig {
             query_validation:     None,
             audit_mutations:      false,
             changelog_enabled:    true,
+            dry_run_mutations:    false,
         }
     }
 }

--- a/crates/fraiseql-core/tests/security/integration_executor_field_rbac.rs
+++ b/crates/fraiseql-core/tests/security/integration_executor_field_rbac.rs
@@ -319,6 +319,7 @@ fn test_executor_runtime_config_with_field_filter() {
         query_validation:     None,
         audit_mutations:      false,
         changelog_enabled:    true,
+        dry_run_mutations:    false,
     };
 
     // WHEN: Config is created

--- a/crates/fraiseql-db/src/postgres/adapter/database.rs
+++ b/crates/fraiseql-db/src/postgres/adapter/database.rs
@@ -701,6 +701,69 @@ impl DatabaseAdapter for PostgresAdapter {
         }
     }
 
+    async fn execute_function_call_dry_run(
+        &self,
+        function_name: &str,
+        args: &[serde_json::Value],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        // Validate-bind-without-commit: run the mutation function inside a
+        // transaction we ROLL BACK unconditionally. The function executes for
+        // real (constraints, triggers, and the app.mutation_response shape are all
+        // exercised), but no writes persist. Mirrors execute_function_call's
+        // statement build + FlexParam binding; the only difference is rollback
+        // instead of commit, and no change-log outbox write.
+        let quoted_fn = quote_postgres_identifier(function_name);
+        let placeholders: Vec<String> = (1..=args.len()).map(|i| format!("${i}")).collect();
+        let sql = format!("SELECT * FROM {quoted_fn}({})", placeholders.join(", "));
+
+        // See execute_function_call for why FlexParam is required here.
+        let flex_args: Vec<FlexParam> = args
+            .iter()
+            .map(|v| match v {
+                serde_json::Value::Null => FlexParam::Null,
+                serde_json::Value::String(s) => FlexParam::Text(s.clone()),
+                _ => FlexParam::Text(v.to_string()),
+            })
+            .collect();
+        let params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = flex_args
+            .iter()
+            .map(|v| v as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
+
+        let mut client = self.acquire_connection_with_retry().await?;
+        // Parse/plan once per connection (statement cache), before the txn.
+        let stmt = prepare_cached_stmt(&client, sql.as_str()).await?;
+        let txn =
+            client.build_transaction().start().await.map_err(|e| FraiseQLError::Database {
+                message:   format!("Failed to start dry-run transaction: {e}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            })?;
+
+        // Apply the same transaction-local context a real call would see, so the
+        // dry-run exercises RLS / the function body identically (no-op when empty).
+        apply_session_vars(&txn, session_vars).await?;
+        // Suppress the fallback-capture trigger (#366) for parity with the real
+        // mutation path; the marker rolls back with everything else.
+        mark_cdc_mediated(&txn).await?;
+
+        let rows: Vec<Row> = txn.query(&stmt, params.as_slice()).await.map_err(|e| {
+            let detail = e.as_db_error().map_or("", |d| d.message());
+            FraiseQLError::Database {
+                message:   format!("Dry-run function call {function_name} failed: {e}: {detail}"),
+                sql_state: e.code().map(|c| c.code().to_string()),
+            }
+        })?;
+
+        // The whole point of dry-run: discard every write.
+        txn.rollback().await.map_err(|e| FraiseQLError::Database {
+            message:   format!("Failed to roll back dry-run transaction: {e}"),
+            sql_state: e.code().map(|c| c.code().to_string()),
+        })?;
+
+        Ok(rows.iter().map(row_to_map).collect())
+    }
+
     // PostgreSQL session variables are applied connection-affinely by the
     // `*_with_session` methods below: `set_config(..., true)` and the operation
     // share one transaction on one connection, so transaction-local GUCs are

--- a/crates/fraiseql-db/src/traits.rs
+++ b/crates/fraiseql-db/src/traits.rs
@@ -1084,6 +1084,41 @@ pub trait DatabaseAdapter: Send + Sync {
         self.execute_function_call_with_session(function_name, args, session_vars).await
     }
 
+    /// Validate-bind-without-commit variant of
+    /// [`execute_function_call`](Self::execute_function_call): run the mutation
+    /// function inside a transaction that is **rolled back** instead of committed.
+    ///
+    /// The function binds and executes — so constraints, triggers, and the
+    /// `app.mutation_response` shape are all exercised — but no writes persist and
+    /// no change-log outbox row is emitted. Powers `fraiseql query --dry-run` and
+    /// the `doctor --runtime` mutation probes (driven by the executor's
+    /// `RuntimeConfig::dry_run_mutations` flag).
+    ///
+    /// Only the PostgreSQL adapter overrides this today; every other adapter keeps
+    /// the default below, which returns `Unsupported` rather than silently
+    /// committing. (SQL Server already wraps mutations in `BEGIN TRANSACTION` and
+    /// could override this with a `ROLLBACK`; SQLite uses `MutationStrategy::DirectSql`
+    /// and would need its own variant.)
+    ///
+    /// # Errors
+    ///
+    /// Returns `FraiseQLError::Unsupported` on adapters that do not implement a
+    /// rollback path. PostgreSQL returns `FraiseQLError::Database` on execution
+    /// failure (mirroring [`execute_function_call`](Self::execute_function_call)).
+    async fn execute_function_call_dry_run(
+        &self,
+        _function_name: &str,
+        _args: &[serde_json::Value],
+        _session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        Err(FraiseQLError::Unsupported {
+            message:
+                "--dry-run mutations (validate-bind-without-commit) are only supported by the \
+                      PostgreSQL adapter."
+                    .to_string(),
+        })
+    }
+
     /// Connection-affine variant of [`execute_where_query_arc`](Self::execute_where_query_arc).
     ///
     /// Applies `session_vars` transaction-locally on the same connection that

--- a/crates/fraiseql-db/tests/dry_run_rollback_test.rs
+++ b/crates/fraiseql-db/tests/dry_run_rollback_test.rs
@@ -1,0 +1,121 @@
+#![cfg(feature = "postgres")]
+#![allow(clippy::unwrap_used, clippy::print_stderr, clippy::panic)] // Reason: test code, panics are acceptable
+
+//! Behavioural proof of `--dry-run` mutations (#501).
+//!
+//! The PostgreSQL adapter's `execute_function_call_dry_run` runs the mutation
+//! function **for real** — so its `app.mutation_response` row is produced and any
+//! constraint / trigger fires — but rolls the transaction back, so no writes
+//! persist. The contrast test runs the same function via the committing
+//! `execute_function_call` to prove the function genuinely inserts; the `0` rows
+//! the dry-run leaves behind therefore come from the ROLLBACK, not a no-op.
+//!
+//! Runs against the harness-provided PostgreSQL (Dagger-bound in CI via the
+//! `--test '*'` integration leg, or a local spawn with `local-testcontainers`).
+//! Uniquely-named objects (`*_501`) keep it isolated from the shared database.
+
+use fraiseql_db::{DatabaseAdapter, PostgresAdapter};
+use serde_json::json;
+
+/// Connect a raw client (for assertions) and build an adapter (under test).
+async fn connect() -> (tokio_postgres::Client, PostgresAdapter, fraiseql_test_support::Service) {
+    let svc = fraiseql_test_support::postgres()
+        .await
+        .expect("DATABASE_URL must be set (or enable fraiseql-test-support/local-testcontainers)");
+    let (client, connection) = tokio_postgres::connect(svc.url(), tokio_postgres::NoTls)
+        .await
+        .expect("failed to connect");
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("Connection error: {e}");
+        }
+    });
+    let adapter = PostgresAdapter::new(svc.url()).await.expect("build adapter");
+    (client, adapter, svc)
+}
+
+/// Provision the `app.mutation_response` contract, a probe table, and a function
+/// that INSERTs into it and returns a success response.
+async fn provision(client: &tokio_postgres::Client) {
+    client
+        .batch_execute(
+            "CREATE SCHEMA IF NOT EXISTS app;
+             DO $$ BEGIN CREATE TYPE app.mutation_error_class AS ENUM ('validation','conflict',\
+             'not_found','unauthorized','forbidden','internal','transaction_failed','timeout',\
+             'rate_limited','service_unavailable'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+             DO $$ BEGIN CREATE TYPE app.mutation_response AS (succeeded BOOLEAN, \
+             state_changed BOOLEAN, error_class app.mutation_error_class, status_detail TEXT, \
+             http_status SMALLINT, message TEXT, entity_id UUID, entity_type TEXT, entity JSONB, \
+             updated_fields TEXT[], cascade JSONB, error_detail JSONB, metadata JSONB); \
+             EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+             DROP TABLE IF EXISTS public.tb_dry_run_probe_501;
+             CREATE TABLE public.tb_dry_run_probe_501 (id uuid PRIMARY KEY, name text);
+             CREATE OR REPLACE FUNCTION public.fn_dry_run_insert_501(p_id uuid, p_name text) \
+             RETURNS app.mutation_response LANGUAGE plpgsql AS $$ \
+             DECLARE v app.mutation_response; BEGIN \
+             INSERT INTO public.tb_dry_run_probe_501 (id, name) VALUES (p_id, p_name); \
+             v.succeeded := true; v.state_changed := true; \
+             v.entity_type := 'Thing'; v.entity_id := p_id; \
+             v.entity := jsonb_build_object('id', p_id, 'name', p_name); \
+             RETURN v; END; $$;",
+        )
+        .await
+        .unwrap();
+}
+
+/// Count probe rows for a given id (the persistence check).
+async fn probe_count(client: &tokio_postgres::Client, id: uuid::Uuid) -> i64 {
+    client
+        .query_one("SELECT COUNT(*) FROM public.tb_dry_run_probe_501 WHERE id = $1", &[&id])
+        .await
+        .unwrap()
+        .get::<_, i64>(0)
+}
+
+#[tokio::test]
+async fn dry_run_executes_function_but_rolls_back() {
+    let (client, adapter, _svc) = connect().await;
+    provision(&client).await;
+
+    let id = uuid::Uuid::new_v4();
+    let rows = adapter
+        .execute_function_call_dry_run(
+            "public.fn_dry_run_insert_501",
+            &[json!(id.to_string()), json!("DryRunOnly")],
+            &[],
+        )
+        .await
+        .expect("dry-run executes the function");
+
+    // The function ran: its mutation_response row is returned to the caller.
+    assert_eq!(rows.len(), 1, "the function's row is still returned");
+    assert_eq!(rows[0].get("succeeded"), Some(&json!(true)), "function reports success");
+
+    // …but nothing was committed: the INSERT was rolled back.
+    assert_eq!(probe_count(&client, id).await, 0, "dry-run must not persist the INSERT");
+}
+
+#[tokio::test]
+async fn committing_call_persists_for_contrast() {
+    let (client, adapter, _svc) = connect().await;
+    provision(&client).await;
+
+    // The same function, via the COMMITTING path, must persist its INSERT — proving
+    // the `0` rows in the dry-run test come from the rollback, not a no-op function.
+    let id = uuid::Uuid::new_v4();
+    adapter
+        .execute_function_call(
+            "public.fn_dry_run_insert_501",
+            &[json!(id.to_string()), json!("Committed")],
+        )
+        .await
+        .expect("committing call executes the function");
+
+    assert_eq!(probe_count(&client, id).await, 1, "committing call persists the INSERT");
+
+    // Leave the shared table clean for any subsequent run.
+    client
+        .execute("DELETE FROM public.tb_dry_run_probe_501 WHERE id = $1", &[&id])
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

Closes #501. Adds a short-lived, scriptable way to execute a compiled schema against a database **without standing up the long-lived server** — closing the gap between "static checks pass" (`compile`/`validate`/`doctor --against-db`) and "the production server resolves it".

The in-process execution path lives entirely in `fraiseql-core` (`Executor`), which the CLI already depends on, so the new command needs **no axum and no `fraiseql-server`** — it is ungated (available in the default build), unlike `run`. PostgreSQL-only for this first slice (matches `doctor --against-db`).

## What's included

- **`fraiseql query --schema schema.compiled.json --db "$DATABASE_URL" '{ … }'`** — boots the engine in-process, runs one query or mutation, prints the GraphQL JSON to stdout, and exits non-zero on a resolution error (either an outright error or a non-empty top-level `errors` array). `--variables '{...}'` passes GraphQL variables. Diagnostics go to stderr so stdout stays pipeable to `jq`.

- **`fraiseql doctor --runtime --against-db "$DATABASE_URL"`** — boots the compiled schema and probes each root query field with a minimal selection (and dry-runs each no-argument mutation), reporting whether every operation resolves end-to-end. Operations that require arguments are skipped with a warning (warnings don't fail the run). The execution-half complement to the existing existence-half `--against-db` drift checks.

- **`--dry-run` (validate-bind-without-commit)** — mutations run by `query` COMMIT unless `--dry-run` is given, which executes the mutation inside a transaction that is **rolled back**: the function binds and runs (constraints, triggers, and the `mutation_response` shape are all validated) but no writes persist and no change-log row is emitted. Implemented via a new `DatabaseAdapter::execute_function_call_dry_run` (default impl errors → PostgreSQL-only; other adapters never silently commit) gated by a new `RuntimeConfig::dry_run_mutations` flag branched in the mutation runner.

## Design notes

- **Postgres-only by deliberate design.** Postgres is the only adapter with a live CI integration leg, so it is the only dry-run path we can prove. The trait-method-with-default-impl is the clean extension point: SQL Server (which already wraps mutations in `BEGIN TRANSACTION`) can add its own `ROLLBACK` override when it has a CI leg; SQLite uses a separate `DirectSql` path.
- No new `#[async_trait]` attribute is introduced — the async-trait ratchet stays at 188.

## Verification

- ✅ `cargo clippy --workspace --all-targets --all-features` clean
- ✅ `cargo +nightly fmt --check` clean (changed files)
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc` clean
- ✅ 3592 lib/unit tests pass; live-PostgreSQL integration tests pass — dry-run rollback proof (`crates/fraiseql-db/tests/dry_run_rollback_test.rs`), `query` resolves, `doctor --runtime` pass/fail, end-to-end dry-run rollback through the GraphQL path, and the committing mutation path intact (`crates/fraiseql-cli/tests/runtime_smoke.rs`)
- ✅ shell gates (lint-tests-layout, check-test-imports, lint-routes, lint-gate) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
