### PR TITLE
fix(auth): populate SecurityContext.roles from JWT claims (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Owner-split `extends` entities (resolved in a subgraph that does not own the type,
   and so have no backing query) are now resolved from a type-level `sql_source` the
   compiler carries through to the entity's `TypeDefinition` — see the #507 entry above.
+- **HTTP GraphQL now populates `SecurityContext.roles` from the JWT `role`/`roles`
+  claim, so `requires_role` operations are reachable over HTTP.** `SecurityContext::from_user`
+  hard-coded `roles: vec![]` (`// Will be populated from JWT claims`) and nothing ever
+  filled it, so every `requires_role` / `read_role` / `write_role`-gated operation was
+  unreachable over the HTTP path regardless of the bearer token — the enumeration-safe
+  `Query '<name>' not found in schema` response made the cause non-obvious. `from_user`
+  (the common chokepoint for every auth transport — OIDC, HS256, gRPC, MCP — alongside
+  the existing actor classification) now derives `roles` from the signature-verified
+  `role` (scalar), `roles` (array) and `fraiseql_roles` (array) claims, sorted and
+  de-duplicated, matching the claim names already honoured by the observer-admin RBAC
+  engine. The claims continue to be forwarded into `attributes` for RLS / session-var
+  injection — the two surfaces are independent. (#503)
 - **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**
   Two residual `_service` SDL gaps that the type-closure fix exposed: (1) the `scalar`
   declaration walk canonicalised names (`DateTime`) while fields rendered them verbatim

--- a/crates/fraiseql-core/src/security/security_context.rs
+++ b/crates/fraiseql-core/src/security/security_context.rs
@@ -37,6 +37,35 @@ use crate::{
     types::{TenantId, UserId},
 };
 
+/// Extract the user's roles from the (signature-verified) JWT custom claims.
+///
+/// Reads, in order, the scalar `role` claim, the `roles` array, and the
+/// `fraiseql_roles` array, then sorts and de-duplicates. This mirrors the
+/// claim names honoured by `fraiseql_auth::operation_rbac` so the GraphQL
+/// `requires_role` gate and the observer-admin RBAC engine agree on what a
+/// token grants. Without this, `SecurityContext.roles` was always empty and
+/// every `requires_role` operation was unreachable over HTTP (#503).
+fn roles_from_claims(extra_claims: &HashMap<String, serde_json::Value>) -> Vec<String> {
+    let mut roles = Vec::new();
+
+    if let Some(serde_json::Value::String(role)) = extra_claims.get("role") {
+        roles.push(role.clone());
+    }
+
+    for key in ["roles", "fraiseql_roles"] {
+        if let Some(serde_json::Value::Array(values)) = extra_claims.get(key) {
+            roles.extend(values.iter().filter_map(|v| match v {
+                serde_json::Value::String(role) => Some(role.clone()),
+                _ => None,
+            }));
+        }
+    }
+
+    roles.sort();
+    roles.dedup();
+    roles
+}
+
 /// Security context for authorization evaluation.
 ///
 /// Carries information about the authenticated user and their permissions
@@ -172,7 +201,7 @@ impl SecurityContext {
             derive_actor(user.user_id.as_str(), &user.scopes, &user.extra_claims);
         SecurityContext {
             user_id: user.user_id.clone(),
-            roles: vec![], // Will be populated from JWT claims
+            roles: roles_from_claims(&user.extra_claims),
             tenant_id: None,
             scopes: user.scopes.clone(),
             attributes: HashMap::new(),

--- a/crates/fraiseql-core/src/security/tests.rs
+++ b/crates/fraiseql-core/src/security/tests.rs
@@ -3785,4 +3785,59 @@ mod actor_context_tests {
         let ctx = SecurityContext::from_user(&user("u", &[], HashMap::new()), "r".to_string());
         assert_eq!(ctx.actor_type(), ActorType::HumanUser);
     }
+
+    /// A scalar `role` claim populates `roles` so `requires_role` gates are
+    /// reachable over every transport that builds a context via `from_user` (#503).
+    #[test]
+    fn from_user_populates_roles_from_scalar_role_claim() {
+        let mut extra = HashMap::new();
+        extra.insert("role".to_string(), json!("report_reader"));
+
+        let ctx = SecurityContext::from_user(&user("u", &[], extra), "r".to_string());
+
+        assert_eq!(ctx.roles, vec!["report_reader".to_string()]);
+        assert!(ctx.has_role("report_reader"));
+    }
+
+    /// A `roles` array claim populates `roles` (sorted, deduplicated).
+    #[test]
+    fn from_user_populates_roles_from_roles_array_claim() {
+        let mut extra = HashMap::new();
+        extra.insert("roles".to_string(), json!(["moderator", "admin", "moderator"]));
+
+        let ctx = SecurityContext::from_user(&user("u", &[], extra), "r".to_string());
+
+        assert_eq!(ctx.roles, vec!["admin".to_string(), "moderator".to_string()]);
+    }
+
+    /// The `fraiseql_roles` array claim is also honoured.
+    #[test]
+    fn from_user_populates_roles_from_fraiseql_roles_claim() {
+        let mut extra = HashMap::new();
+        extra.insert("fraiseql_roles".to_string(), json!(["report_reader"]));
+
+        let ctx = SecurityContext::from_user(&user("u", &[], extra), "r".to_string());
+
+        assert_eq!(ctx.roles, vec!["report_reader".to_string()]);
+    }
+
+    /// `role` and `roles` claims are merged and de-duplicated across sources.
+    #[test]
+    fn from_user_merges_and_dedups_role_sources() {
+        let mut extra = HashMap::new();
+        extra.insert("role".to_string(), json!("admin"));
+        extra.insert("roles".to_string(), json!(["admin", "editor"]));
+
+        let ctx = SecurityContext::from_user(&user("u", &[], extra), "r".to_string());
+
+        assert_eq!(ctx.roles, vec!["admin".to_string(), "editor".to_string()]);
+    }
+
+    /// No role claims → empty `roles` (gated operations stay denied, as before).
+    #[test]
+    fn from_user_roles_empty_without_role_claims() {
+        let ctx =
+            SecurityContext::from_user(&user("u", &["read:user"], HashMap::new()), "r".to_string());
+        assert!(ctx.roles.is_empty());
+    }
 }

--- a/crates/fraiseql-server/src/extractors.rs
+++ b/crates/fraiseql-server/src/extractors.rs
@@ -2,6 +2,9 @@
 //!
 //! Provides extractors for `SecurityContext` and other request-level data.
 
+#[cfg(test)]
+mod tests;
+
 use std::{convert::Infallible, future::Future, net::SocketAddr};
 
 use axum::{

--- a/crates/fraiseql-server/src/extractors/tests.rs
+++ b/crates/fraiseql-server/src/extractors/tests.rs
@@ -1,0 +1,83 @@
+//! Tests for request-level extractors.
+
+use std::collections::HashMap;
+
+use axum::extract::FromRequestParts;
+use chrono::Utc;
+use fraiseql_core::{security::AuthenticatedUser, types::UserId};
+use serde_json::json;
+
+use super::OptionalSecurityContext;
+use crate::middleware::AuthUser;
+
+/// Build an empty request and run the extractor against the given authenticated
+/// user, returning the resulting `SecurityContext` (the user is always present).
+async fn context_for(user: AuthenticatedUser) -> fraiseql_core::security::SecurityContext {
+    let (mut parts, _body) = axum::http::Request::builder()
+        .body(axum::body::Body::empty())
+        .expect("empty request body builds")
+        .into_parts();
+    parts.extensions.insert(AuthUser(user));
+
+    let OptionalSecurityContext(ctx) = OptionalSecurityContext::from_request_parts(&mut parts, &())
+        .await
+        .expect("OptionalSecurityContext extraction is infallible here");
+    ctx.expect("an AuthUser in extensions yields a SecurityContext")
+}
+
+fn user_with_claims(extra_claims: HashMap<String, serde_json::Value>) -> AuthenticatedUser {
+    AuthenticatedUser {
+        user_id: UserId::new("user-1"),
+        scopes: vec![],
+        expires_at: Utc::now() + chrono::Duration::hours(1),
+        email: None,
+        display_name: None,
+        extra_claims,
+    }
+}
+
+/// The HTTP extractor surfaces JWT `roles` into `SecurityContext.roles`, so a
+/// `requires_role`-gated operation becomes reachable over HTTP with a correctly
+/// scoped bearer token (#503).
+#[tokio::test]
+async fn extractor_populates_roles_from_jwt_roles_claim() {
+    let mut extra = HashMap::new();
+    extra.insert("roles".to_string(), json!(["report_reader"]));
+
+    let ctx = context_for(user_with_claims(extra)).await;
+
+    assert!(
+        ctx.has_role("report_reader"),
+        "roles must be reachable for the requires_role gate"
+    );
+}
+
+/// A scalar `role` claim is honoured the same way.
+#[tokio::test]
+async fn extractor_populates_roles_from_scalar_role_claim() {
+    let mut extra = HashMap::new();
+    extra.insert("role".to_string(), json!("admin"));
+
+    let ctx = context_for(user_with_claims(extra)).await;
+
+    assert_eq!(ctx.roles, vec!["admin".to_string()]);
+}
+
+/// The role claim is still forwarded into `attributes` (for RLS / session vars),
+/// in addition to populating `roles` — the two surfaces are independent.
+#[tokio::test]
+async fn extractor_keeps_role_claim_in_attributes_too() {
+    let mut extra = HashMap::new();
+    extra.insert("roles".to_string(), json!(["report_reader"]));
+
+    let ctx = context_for(user_with_claims(extra)).await;
+
+    assert_eq!(ctx.attributes.get("roles"), Some(&json!(["report_reader"])));
+}
+
+/// Without any role claim, `roles` stays empty — gated operations remain denied.
+#[tokio::test]
+async fn extractor_leaves_roles_empty_without_claim() {
+    let ctx = context_for(user_with_claims(HashMap::new())).await;
+    assert!(ctx.roles.is_empty());
+}


### PR DESCRIPTION
## Summary

Fixes #503. `SecurityContext::from_user` hard-coded `roles: vec![]` (`// Will be populated from JWT claims`) and nothing ever populated it, so every `requires_role` / `read_role` / `write_role`-gated operation was **unreachable over the HTTP GraphQL path regardless of the bearer token**. The gate (`runtime/executor/runners/query_regular.rs`) reads `security_context.roles`, so an always-empty list returned the enumeration-safe `Query '<name>' not found in schema` — masking the cause as a missing field rather than a denied role.

## Fix

Populate `roles` in `from_user` rather than the HTTP extractor the issue suggested — `from_user` is the common chokepoint **every** auth transport routes through (OIDC, HS256, gRPC, MCP), it already derives the actor classification from `extra_claims` there, and it's unit-testable in the fast leg. A new `roles_from_claims` helper reads the signature-verified `role` (scalar), `roles` (array) and `fraiseql_roles` (array) custom claims, sorted + de-duplicated, mirroring the claim names already honoured by `fraiseql_auth::operation_rbac::extract_user_roles`.

The claims are still forwarded into `SecurityContext.attributes` for RLS / session-variable injection — the two surfaces are independent.

> Note: two distinct `AuthenticatedUser` types exist — the `fraiseql_core::security` one (carries `extra_claims`, consumed here) and the `fraiseql-auth` one (`get_custom_claim`, consumed by `operation_rbac`). The extraction logic is mirrored in core rather than reused across the crate boundary.

## Tests

- 5 core `from_user_*` unit tests (scalar / array / `fraiseql_roles` / merge-dedup / empty), RED-verified before the fix.
- 4 server-side extractor tests (new `crates/fraiseql-server/src/extractors/tests.rs`) proving the HTTP extractor path yields `roles` for the `requires_role` gate and still forwards the claim into `attributes`.

## Verification

✅ `cargo clippy --workspace --all-targets --all-features` clean
✅ `rustdoc -D warnings` clean; fmt (touched files) clean
✅ `fraiseql-core` lib 2592 pass; `fraiseql-server` lib 1149 pass
✅ `make lint-tests-layout` / `check-test-imports` gates pass
✅ No new `async_trait` (ratchet untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)