### PR TITLE
fix(federation): resolve _entities from sql_source, cast key column to text (#504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Federation `_entities` now resolves from the entity's `sql_source`, not
+  `lower(typename)`.** The runtime `_entities` resolver built its `FROM` relation
+  from the lowercased GraphQL type name, but FraiseQL entities are view-backed
+  (`v_organization` / `tv_organization`), so it queried a relation that does not
+  exist — the query errored and the gateway silently turned the field into `null`,
+  making cross-subgraph entity joins non-functional for standard view-backed
+  entities. Each entity type's `sql_source` is now threaded to the resolver (from
+  the compiled schema's per-type `sql_source`) and used as the `FROM` relation,
+  with schema-qualified names quoted segment-by-segment. Additionally, `@key`
+  values are bound as text while key columns are frequently `uuid`, so the key
+  column is now cast to text on PostgreSQL (`id::text IN ($1)`) — making the
+  comparison succeed uniformly for `uuid` / integer / text keys (other dialects
+  coerce implicitly and are unchanged). (#504)
 - **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**
   Two residual `_service` SDL gaps that the type-closure fix exposed: (1) the `scalar`
   declaration walk canonicalised names (`DateTime`) while fields rendered them verbatim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Federation `_entities` now resolves from the entity's `sql_source`, not
-  `lower(typename)`.** The runtime `_entities` resolver built its `FROM` relation
-  from the lowercased GraphQL type name, but FraiseQL entities are view-backed
-  (`v_organization` / `tv_organization`), so it queried a relation that does not
-  exist — the query errored and the gateway silently turned the field into `null`,
-  making cross-subgraph entity joins non-functional for standard view-backed
-  entities. Each entity type's `sql_source` is now threaded to the resolver (from
-  the compiled schema's per-type `sql_source`) and used as the `FROM` relation,
-  with schema-qualified names quoted segment-by-segment. Additionally, `@key`
-  values are bound as text while key columns are frequently `uuid`, so the key
-  column is now cast to text on PostgreSQL (`id::text IN ($1)`) — making the
-  comparison succeed uniformly for `uuid` / integer / text keys (other dialects
-  coerce implicitly and are unchanged). (#504)
+- **Federation `_entities` now resolves view-backed, jsonb-`data` entities.** The
+  runtime `_entities` resolver built its `FROM` relation from the lowercased GraphQL
+  type name and selected bare columns, but FraiseQL entities are view-backed and
+  expose their fields inside a `data` jsonb column — so it queried a relation that
+  does not exist and could not read jsonb fields. The query errored and the gateway
+  silently turned the field into `null`, making cross-subgraph entity joins
+  non-functional for standard entities. The resolver now sources each entity's
+  backing relation **and** jsonb column from the compiled schema's backing query
+  (keyed by `return_type`; the compiler leaves `types[].sql_source` empty), reads
+  from that relation (schema-qualified names quoted segment-by-segment), and
+  projects each requested field as `data->'<snake(field)>'` with camelCase→snake
+  recasing and type fidelity — mirroring the normal query path. The `@key` lookup
+  matches `data->>'<snake(key)>'` for jsonb views, and falls back to a text-cast
+  flat-column comparison (`id::text IN ($1)`) for flat-column views, so `uuid` /
+  integer / text keys all match. (#504)
+
+  Owner-split `extends` entities (resolved in a subgraph that does not own the type,
+  and so have neither a backing query nor a type-level `sql_source` in the compiled
+  schema) still require the authoring SDK to emit a type-level `sql_source` — tracked
+  in #507.
 - **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**
   Two residual `_service` SDL gaps that the type-closure fix exposed: (1) the `scalar`
   declaration walk canonicalised names (`DateTime`) while fields rendered them verbatim

--- a/crates/fraiseql-core/src/runtime/executor/support/federation.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/federation.rs
@@ -104,18 +104,27 @@ impl<A: DatabaseAdapter> Executor<A> {
         crate::federation::validate_representations(&representations, &fed_metadata)?;
 
         // Create federation resolver, carrying each entity type's backing relation
-        // (`sql_source`) so the `_entities` resolver reads from the real view
-        // (`v_organization`) instead of `lower(typename)` — the latter names a
-        // relation that does not exist, so view-backed cross-subgraph joins silently
-        // returned null (#504).
-        let entity_sources: std::collections::HashMap<String, String> = self
-            .ctx
-            .schema
-            .types
-            .iter()
-            .filter(|t| !t.sql_source.as_str().is_empty())
-            .map(|t| (t.name.as_str().to_string(), t.sql_source.as_str().to_string()))
-            .collect();
+        // and jsonb projection column so the `_entities` resolver reads from the real
+        // view (`v_organization`) and projects its `data`-jsonb fields — instead of
+        // `lower(typename)` selecting bare columns, which named a relation that does
+        // not exist and could not read jsonb-backed fields, so view-backed
+        // cross-subgraph joins silently returned null (#504).
+        //
+        // The backing relation is carried on the *query* that returns the type (the
+        // compiler leaves every `types[].sql_source` empty), keyed by `return_type`
+        // with first-wins — the same query→type binding the Relay `node` path uses.
+        let mut entity_sources: std::collections::HashMap<String, crate::federation::EntitySource> =
+            std::collections::HashMap::new();
+        for q in &self.ctx.schema.queries {
+            if let Some(relation) = &q.sql_source {
+                entity_sources.entry(q.return_type.clone()).or_insert_with(|| {
+                    crate::federation::EntitySource {
+                        relation:     relation.clone(),
+                        jsonb_column: (!q.jsonb_column.is_empty()).then(|| q.jsonb_column.clone()),
+                    }
+                });
+            }
+        }
         let fed_resolver = crate::federation::FederationResolver::new(fed_metadata)
             .with_entity_sources(entity_sources);
 

--- a/crates/fraiseql-core/src/runtime/executor/support/federation.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/federation.rs
@@ -103,8 +103,21 @@ impl<A: DatabaseAdapter> Executor<A> {
         // Validate representations
         crate::federation::validate_representations(&representations, &fed_metadata)?;
 
-        // Create federation resolver
-        let fed_resolver = crate::federation::FederationResolver::new(fed_metadata);
+        // Create federation resolver, carrying each entity type's backing relation
+        // (`sql_source`) so the `_entities` resolver reads from the real view
+        // (`v_organization`) instead of `lower(typename)` — the latter names a
+        // relation that does not exist, so view-backed cross-subgraph joins silently
+        // returned null (#504).
+        let entity_sources: std::collections::HashMap<String, String> = self
+            .ctx
+            .schema
+            .types
+            .iter()
+            .filter(|t| !t.sql_source.as_str().is_empty())
+            .map(|t| (t.name.as_str().to_string(), t.sql_source.as_str().to_string()))
+            .collect();
+        let fed_resolver = crate::federation::FederationResolver::new(fed_metadata)
+            .with_entity_sources(entity_sources);
 
         // Extract actual field selection from GraphQL query AST.
         // __typename is NOT added to the SQL field list — it is a GraphQL meta-field

--- a/crates/fraiseql-core/tests/federation/entity_connection.rs
+++ b/crates/fraiseql-core/tests/federation/entity_connection.rs
@@ -162,6 +162,7 @@ fn test_database_parameterized_queries() {
             .unwrap();
 
     // The value is bound as a parameter, not escaped into the SQL text.
-    assert_eq!(where_clause, "id IN ($1)");
+    // Key column cast to text on PostgreSQL (#504).
+    assert_eq!(where_clause, "id::text IN ($1)");
     assert_eq!(params, vec![json!("O'Brien")]);
 }

--- a/crates/fraiseql-core/tests/federation/entity_connection.rs
+++ b/crates/fraiseql-core/tests/federation/entity_connection.rs
@@ -157,9 +157,14 @@ fn test_database_parameterized_queries() {
         all_fields: common::row(&[("id", json!("O'Brien"))]),
     };
 
-    let (where_clause, params) =
-        construct_where_in_clause("User", &[representation], &metadata, DatabaseType::PostgreSQL)
-            .unwrap();
+    let (where_clause, params) = construct_where_in_clause(
+        "User",
+        &[representation],
+        &metadata,
+        DatabaseType::PostgreSQL,
+        None,
+    )
+    .unwrap();
 
     // The value is bound as a parameter, not escaped into the SQL text.
     // Key column cast to text on PostgreSQL (#504).

--- a/crates/fraiseql-core/tests/federation/entity_resolution.rs
+++ b/crates/fraiseql-core/tests/federation/entity_resolution.rs
@@ -279,3 +279,58 @@ async fn test_resolve_entities_enforced_filters_cross_tenant() {
         entities[1]
     );
 }
+
+/// #504: a FraiseQL entity is backed by a view (`v_organization`), not a relation
+/// literally named `lower(typename)` (`organization`), and its `@key` is a `uuid`.
+/// Without the per-type `sql_source` map the resolver queries the non-existent
+/// `organization` and errors (the gateway swallowed this into a null); with it —
+/// and with the key column cast to text — the uuid-keyed row resolves.
+#[tokio::test]
+async fn test_resolve_view_backed_uuid_entity_uses_sql_source() {
+    let org_id = "550e8400-e29b-41d4-a716-446655440000";
+    let rows = vec![map(&[("id", json!(org_id)), ("name", json!("Acme"))])];
+    // Backing relation `v_organization` is deliberately *not* `lower("Organization")`,
+    // with a real `uuid` key column.
+    let Some((_pg, adapter)) =
+        common::pg_entity_fixture("v_organization", &["id uuid", "name text"], &rows).await
+    else {
+        eprintln!("SKIP test_resolve_view_backed_uuid_entity_uses_sql_source: no postgres");
+        return;
+    };
+
+    let metadata = common::metadata_single_key("Organization", "id");
+    let selection = FieldSelection::new(vec!["id".to_string(), "name".to_string()]);
+
+    // Control: without the source map the resolver guesses `lower(typename)` =
+    // `organization`, which does not exist → hard error (the pre-#504 behaviour).
+    let blind = DatabaseEntityResolver::new(adapter.clone(), metadata.clone());
+    let blind_result = blind
+        .resolve_entities_from_db(
+            "Organization",
+            &[rep("Organization", &[("id", json!(org_id))])],
+            &selection,
+        )
+        .await;
+    assert!(
+        blind_result.is_err(),
+        "querying lower(typename) must fail: relation 'organization' does not exist, got: {blind_result:?}"
+    );
+
+    // Fix: thread the entity's `sql_source` so the resolver reads `v_organization`,
+    // and the uuid key matches via the `::text` cast.
+    let mut sources = HashMap::new();
+    sources.insert("Organization".to_string(), "v_organization".to_string());
+    let resolver = DatabaseEntityResolver::new(adapter, metadata).with_entity_sources(sources);
+    let entities = resolver
+        .resolve_entities_from_db(
+            "Organization",
+            &[rep("Organization", &[("id", json!(org_id))])],
+            &selection,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("view-backed uuid entity resolution failed: {e}"));
+
+    assert_eq!(entities.len(), 1);
+    let org = entities[0].as_ref().expect("uuid-keyed org must resolve from its view");
+    assert_eq!(org["name"], "Acme");
+}

--- a/crates/fraiseql-core/tests/federation/entity_resolution.rs
+++ b/crates/fraiseql-core/tests/federation/entity_resolution.rs
@@ -13,8 +13,9 @@ use std::collections::HashMap;
 use fraiseql_core::{
     db::{WhereClause, WhereOperator},
     federation::{
-        database_resolver::DatabaseEntityResolver, selection_parser::FieldSelection,
-        types::EntityRepresentation,
+        database_resolver::DatabaseEntityResolver,
+        selection_parser::FieldSelection,
+        types::{EntityRepresentation, EntitySource},
     },
 };
 use serde_json::{Value, json};
@@ -316,10 +317,17 @@ async fn test_resolve_view_backed_uuid_entity_uses_sql_source() {
         "querying lower(typename) must fail: relation 'organization' does not exist, got: {blind_result:?}"
     );
 
-    // Fix: thread the entity's `sql_source` so the resolver reads `v_organization`,
-    // and the uuid key matches via the `::text` cast.
+    // Fix: thread the entity's relation so the resolver reads `v_organization`. This
+    // is the flat-column shape (no jsonb column), so the uuid key matches via the
+    // `::text` cast.
     let mut sources = HashMap::new();
-    sources.insert("Organization".to_string(), "v_organization".to_string());
+    sources.insert(
+        "Organization".to_string(),
+        EntitySource {
+            relation:     "v_organization".to_string(),
+            jsonb_column: None,
+        },
+    );
     let resolver = DatabaseEntityResolver::new(adapter, metadata).with_entity_sources(sources);
     let entities = resolver
         .resolve_entities_from_db(
@@ -333,4 +341,84 @@ async fn test_resolve_view_backed_uuid_entity_uses_sql_source() {
     assert_eq!(entities.len(), 1);
     let org = entities[0].as_ref().expect("uuid-keyed org must resolve from its view");
     assert_eq!(org["name"], "Acme");
+}
+
+/// #504 (jsonb projection): a standard FraiseQL entity view exposes its fields in a
+/// `data` jsonb column, not flat columns. With `jsonb_column = Some("data")` the
+/// resolver projects each field as `data->'<snake(field)>'` (camelCase→snake
+/// recasing, type-preserving) and matches the key as `data->>'id'`, so a
+/// jsonb-backed entity with a camelCase, non-string field resolves. The flat-column
+/// control fails because there is no bare `id` column.
+#[tokio::test]
+async fn test_resolve_jsonb_data_backed_entity_projects_and_recases() {
+    let org_id = "550e8400-e29b-41d4-a716-446655440000";
+    let rows = vec![map(&[(
+        "data",
+        json!({ "id": org_id, "name": "Acme", "is_customer": true }),
+    )])];
+    // A real jsonb-`data` view: the only column is `data`.
+    let Some((_pg, adapter)) =
+        common::pg_entity_fixture("v_customer", &["data jsonb"], &rows).await
+    else {
+        eprintln!("SKIP test_resolve_jsonb_data_backed_entity_projects_and_recases: no postgres");
+        return;
+    };
+
+    let metadata = common::metadata_single_key("Customer", "id");
+    // `isCustomer` is camelCase and jsonb-only (stored as `data->>'is_customer'`).
+    let selection = FieldSelection::new(vec![
+        "id".to_string(),
+        "name".to_string(),
+        "isCustomer".to_string(),
+    ]);
+
+    // Control: flat mode selects bare columns (`SELECT id, name, isCustomer`), which
+    // do not exist on a jsonb-`data` view → hard error.
+    let mut flat = HashMap::new();
+    flat.insert(
+        "Customer".to_string(),
+        EntitySource {
+            relation:     "v_customer".to_string(),
+            jsonb_column: None,
+        },
+    );
+    let flat_resolver =
+        DatabaseEntityResolver::new(adapter.clone(), metadata.clone()).with_entity_sources(flat);
+    let flat_result = flat_resolver
+        .resolve_entities_from_db(
+            "Customer",
+            &[rep("Customer", &[("id", json!(org_id))])],
+            &selection,
+        )
+        .await;
+    assert!(
+        flat_result.is_err(),
+        "flat column SELECT must fail on a jsonb view: {flat_result:?}"
+    );
+
+    // jsonb mode: project from `data` with recasing and type fidelity.
+    let mut sources = HashMap::new();
+    sources.insert(
+        "Customer".to_string(),
+        EntitySource {
+            relation:     "v_customer".to_string(),
+            jsonb_column: Some("data".to_string()),
+        },
+    );
+    let resolver = DatabaseEntityResolver::new(adapter, metadata).with_entity_sources(sources);
+    let entities = resolver
+        .resolve_entities_from_db(
+            "Customer",
+            &[rep("Customer", &[("id", json!(org_id))])],
+            &selection,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("jsonb-data entity resolution failed: {e}"));
+
+    assert_eq!(entities.len(), 1);
+    let customer = entities[0].as_ref().expect("jsonb-backed customer must resolve");
+    assert_eq!(customer["name"], "Acme");
+    // camelCase field projected from `data->>'is_customer'`, with the boolean type
+    // preserved (not the text "true") via the single-arrow `->` jsonb projection.
+    assert_eq!(customer["isCustomer"], json!(true));
 }

--- a/crates/fraiseql-core/tests/federation/entity_where_clause.rs
+++ b/crates/fraiseql-core/tests/federation/entity_where_clause.rs
@@ -45,7 +45,9 @@ fn test_where_clause_single_key_field() {
     let (where_clause, params) =
         construct_where_in_clause("User", &[rep1, rep2], &metadata, DatabaseType::PostgreSQL)
             .unwrap();
-    assert_eq!(where_clause, "id IN ($1, $2)");
+    // Key column cast to text on PostgreSQL so a text-bound key matches a non-text
+    // (e.g. uuid) column (#504).
+    assert_eq!(where_clause, "id::text IN ($1, $2)");
     assert_eq!(params, vec![json!("123"), json!("456")]);
 }
 
@@ -67,7 +69,7 @@ fn test_where_clause_composite_keys() {
 
     let (where_clause, params) =
         construct_where_in_clause("Order", &[rep1], &metadata, DatabaseType::PostgreSQL).unwrap();
-    assert_eq!(where_clause, "(user_id, order_id) IN (($1, $2))");
+    assert_eq!(where_clause, "(user_id::text, order_id::text) IN (($1, $2))");
     assert_eq!(params, vec![json!("user1"), json!("order1")]);
 }
 
@@ -88,7 +90,7 @@ fn test_where_clause_value_with_quote_is_bound_not_escaped() {
     let (where_clause, params) =
         construct_where_in_clause("User", &[rep], &metadata, DatabaseType::PostgreSQL).unwrap();
     // The value is bound verbatim — no inline escaping in the SQL text.
-    assert_eq!(where_clause, "name IN ($1)");
+    assert_eq!(where_clause, "name::text IN ($1)");
     assert_eq!(params, vec![json!("O'Brien")]);
 }
 
@@ -110,7 +112,7 @@ fn test_where_clause_sql_injection_prevention() {
     let (where_clause, params) =
         construct_where_in_clause("User", &[rep], &metadata, DatabaseType::PostgreSQL).unwrap();
     // The injection payload is carried as a bound parameter, never spliced into SQL.
-    assert_eq!(where_clause, "id IN ($1)");
+    assert_eq!(where_clause, "id::text IN ($1)");
     assert!(!where_clause.contains("DROP"));
     assert_eq!(params, vec![json!(payload)]);
 }
@@ -133,6 +135,6 @@ fn test_where_clause_type_coercion() {
         construct_where_in_clause("Order", &[rep], &metadata, DatabaseType::PostgreSQL).unwrap();
     // Numeric keys are stringified (matching the prior literal-comparison semantics)
     // and bound as text parameters.
-    assert_eq!(where_clause, "order_id IN ($1)");
+    assert_eq!(where_clause, "order_id::text IN ($1)");
     assert_eq!(params, vec![json!("789")]);
 }

--- a/crates/fraiseql-core/tests/federation/entity_where_clause.rs
+++ b/crates/fraiseql-core/tests/federation/entity_where_clause.rs
@@ -43,7 +43,7 @@ fn test_where_clause_single_key_field() {
     };
 
     let (where_clause, params) =
-        construct_where_in_clause("User", &[rep1, rep2], &metadata, DatabaseType::PostgreSQL)
+        construct_where_in_clause("User", &[rep1, rep2], &metadata, DatabaseType::PostgreSQL, None)
             .unwrap();
     // Key column cast to text on PostgreSQL so a text-bound key matches a non-text
     // (e.g. uuid) column (#504).
@@ -68,7 +68,8 @@ fn test_where_clause_composite_keys() {
     };
 
     let (where_clause, params) =
-        construct_where_in_clause("Order", &[rep1], &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("Order", &[rep1], &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
     assert_eq!(where_clause, "(user_id::text, order_id::text) IN (($1, $2))");
     assert_eq!(params, vec![json!("user1"), json!("order1")]);
 }
@@ -88,7 +89,8 @@ fn test_where_clause_value_with_quote_is_bound_not_escaped() {
     };
 
     let (where_clause, params) =
-        construct_where_in_clause("User", &[rep], &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("User", &[rep], &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
     // The value is bound verbatim — no inline escaping in the SQL text.
     assert_eq!(where_clause, "name::text IN ($1)");
     assert_eq!(params, vec![json!("O'Brien")]);
@@ -110,7 +112,8 @@ fn test_where_clause_sql_injection_prevention() {
     };
 
     let (where_clause, params) =
-        construct_where_in_clause("User", &[rep], &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("User", &[rep], &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
     // The injection payload is carried as a bound parameter, never spliced into SQL.
     assert_eq!(where_clause, "id::text IN ($1)");
     assert!(!where_clause.contains("DROP"));
@@ -132,7 +135,8 @@ fn test_where_clause_type_coercion() {
     };
 
     let (where_clause, params) =
-        construct_where_in_clause("Order", &[rep], &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("Order", &[rep], &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
     // Numeric keys are stringified (matching the prior literal-comparison semantics)
     // and bound as text parameters.
     assert_eq!(where_clause, "order_id::text IN ($1)");

--- a/crates/fraiseql-federation/benches/federation_bench.rs
+++ b/crates/fraiseql-federation/benches/federation_bench.rs
@@ -88,6 +88,7 @@ fn where_in_clause(c: &mut Criterion) {
                     black_box(reps),
                     black_box(&metadata),
                     black_box(DatabaseType::PostgreSQL),
+                    black_box(None),
                 )
                 .unwrap()
             });

--- a/crates/fraiseql-federation/src/database_resolver.rs
+++ b/crates/fraiseql-federation/src/database_resolver.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use ::tracing::warn;
 use fraiseql_db::{
     DatabaseType, GenericWhereGenerator, MySqlDialect, PostgresDialect, SqlServerDialect,
-    SqliteDialect, WhereClause, traits::DatabaseAdapter,
+    SqliteDialect, WhereClause, traits::DatabaseAdapter, utils::to_snake_case,
 };
 use fraiseql_error::{FraiseQLError, Result};
 use serde_json::Value;
@@ -20,7 +20,7 @@ use crate::{
     selection_parser::FieldSelection,
     sql_utils::is_safe_sql_identifier,
     tracing::FederationTraceContext,
-    types::{EntityRepresentation, FederatedType, FederationMetadata},
+    types::{EntityRepresentation, EntitySource, FederatedType, FederationMetadata},
 };
 
 /// Resolves federation entities from local databases.
@@ -29,9 +29,9 @@ pub struct DatabaseEntityResolver<A: DatabaseAdapter> {
     adapter:        Arc<A>,
     /// Federation metadata
     metadata:       FederationMetadata,
-    /// Backing relation (`sql_source`) per entity type name. Empty → the resolver
-    /// falls back to `lower(typename)` (#504).
-    entity_sources: std::collections::HashMap<String, String>,
+    /// Backing [`EntitySource`] per entity type name. Empty → the resolver falls
+    /// back to `lower(typename)` with flat columns (#504).
+    entity_sources: std::collections::HashMap<String, EntitySource>,
 }
 
 impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
@@ -49,12 +49,13 @@ impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
         }
     }
 
-    /// Attach the per-entity-type backing relation map (`typename` → `sql_source`),
-    /// so the resolver reads from the real view instead of `lower(typename)` (#504).
+    /// Attach the per-entity-type [`EntitySource`] map (`typename` → relation +
+    /// jsonb column), so the resolver reads from the real view and projects its
+    /// jsonb fields instead of `lower(typename)` with flat columns (#504).
     #[must_use]
     pub fn with_entity_sources(
         mut self,
-        entity_sources: std::collections::HashMap<String, String>,
+        entity_sources: std::collections::HashMap<String, EntitySource>,
     ) -> Self {
         self.entity_sources = entity_sources;
         self
@@ -173,21 +174,31 @@ impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
         // Find type definition using metadata helpers (whitelist check)
         let fed_type = find_federation_type(typename, &self.metadata)?;
 
-        // Resolve the backing relation. FraiseQL entities are view-backed, so the
-        // FROM relation is the type's configured `sql_source` (e.g. `v_organization`),
-        // not `lower(typename)` — which names a relation that does not exist and made
-        // every view-backed cross-subgraph join return null (#504). Falls back to
-        // `lower(typename)` only when no source map is attached (unit paths).
-        let quoted_table = match self.entity_sources.get(typename) {
-            Some(source) => quote_relation(source)?,
-            None => quote_relation(&typename.to_lowercase())?,
-        };
+        // Resolve the backing relation and (optional) jsonb projection column.
+        // FraiseQL entities are view-backed and normally expose their fields inside a
+        // `data` jsonb column, so the resolver reads from the entity's configured
+        // relation — not `lower(typename)`, which names a relation that does not exist
+        // and made every view-backed cross-subgraph join return null (#504) — and
+        // projects fields out of that column the way the normal query path does. Falls
+        // back to `lower(typename)` with flat columns only when no source is attached
+        // (unit paths / flat-column views).
+        let source = self.entity_sources.get(typename);
+        let relation = source.map_or_else(|| typename.to_lowercase(), |s| s.relation.clone());
+        let quoted_table = quote_relation(&relation)?;
+        let jsonb_column = source.and_then(|s| s.jsonb_column.as_deref());
 
         // Build the parameterized WHERE IN clause. Key-field values are bound (not
-        // interpolated), so the dialect must match the executing adapter.
+        // interpolated), so the dialect must match the executing adapter. In jsonb mode
+        // the key is matched as `<col>->>'<snake(key)>'` (text vs text); in flat mode the
+        // key column is cast to text on PostgreSQL.
         let db_type = self.adapter.database_type();
-        let (where_clause, mut params) =
-            construct_where_in_clause(typename, representations, &self.metadata, db_type)?;
+        let (where_clause, mut params) = construct_where_in_clause(
+            typename,
+            representations,
+            &self.metadata,
+            db_type,
+            jsonb_column,
+        )?;
 
         // Compose the per-row enforcement predicate (tenant/owner scoping) onto the
         // key lookup. Placeholders are offset past the IN-clause params, and the
@@ -205,18 +216,13 @@ impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
         // Build the SELECT list. Each requested field must be a safe SQL identifier
         // AND exposed: `@inaccessible` / `@external` fields are never selected, so a
         // client naming them cannot exfiltrate them via `_entities` (M-fed-select-
-        // list). The selection comes from a text scanner, so any token that is not a
-        // plain identifier is dropped here too. Fields are interpolated unquoted (the
-        // entity views rely on PostgreSQL case-folding); the charset guard is what
-        // keeps that interpolation injection-safe.
-        let select_fields = build_select_fields(selection, fed_type);
+        // list). In jsonb mode each field is projected as
+        // `<col>->'<snake(field)>' AS "<field>"` (typed via the adapter's jsonb
+        // decoding, with camelCase→snake recasing); in flat mode fields are bare
+        // columns interpolated unquoted (relying on PostgreSQL case-folding).
+        let select_list = build_select_list(selection, fed_type, jsonb_column);
 
-        let sql = format!(
-            "SELECT {} FROM {} WHERE {}",
-            select_fields.join(", "),
-            quoted_table,
-            where_clause
-        );
+        let sql = format!("SELECT {select_list} FROM {quoted_table} WHERE {where_clause}");
 
         // Execute with bound parameters (no value interpolation), pinning session
         // variables to the read's connection so `current_setting()` RLS is effective.
@@ -282,8 +288,7 @@ fn render_row_filter(
     }
 }
 
-/// Build the validated, exposure-filtered SELECT field list for an `_entities`
-/// query.
+/// Build the validated, exposure-filtered SELECT list for an `_entities` query.
 ///
 /// A requested field is kept only if it is a safe SQL identifier AND exposed:
 /// `@inaccessible` (via either `field_directives` or the `inaccessible_fields`
@@ -292,8 +297,18 @@ fn render_row_filter(
 /// non-identifier scanner token are dropped too. The type's key fields are
 /// always appended — they are schema-defined identifiers and `project_results`
 /// needs them to match rows to representations.
-fn build_select_fields(selection: &FieldSelection, fed_type: &FederatedType) -> Vec<String> {
-    let mut select_fields: Vec<String> = Vec::new();
+///
+/// In **jsonb mode** (`jsonb_column = Some(col)`) each field `F` is projected as
+/// `"col"->'snake(F)' AS "F"`, so a `data`-jsonb-backed view resolves with
+/// camelCase→snake recasing and type fidelity (the single-arrow `->` yields jsonb,
+/// which the adapter decodes back to a typed value). In **flat mode** (`None`)
+/// fields are emitted as bare column identifiers (the legacy flat-column shape).
+fn build_select_list(
+    selection: &FieldSelection,
+    fed_type: &FederatedType,
+    jsonb_column: Option<&str>,
+) -> String {
+    let mut fields: Vec<String> = Vec::new();
     for field in &selection.fields {
         if field == "__typename" {
             continue;
@@ -305,18 +320,39 @@ fn build_select_fields(selection: &FieldSelection, fed_type: &FederatedType) -> 
         {
             continue;
         }
-        if !select_fields.contains(field) {
-            select_fields.push(field.clone());
+        if !fields.contains(field) {
+            fields.push(field.clone());
         }
     }
     for key in &fed_type.keys {
         for field in &key.fields {
-            if is_safe_sql_identifier(field) && !select_fields.contains(field) {
-                select_fields.push(field.clone());
+            if is_safe_sql_identifier(field) && !fields.contains(field) {
+                fields.push(field.clone());
             }
         }
     }
-    select_fields
+    fields
+        .iter()
+        .map(|f| select_expr(f, jsonb_column))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Render one SELECT expression for `field`: a jsonb projection
+/// (`"col"->'snake(field)' AS "field"`) in jsonb mode, or a bare column in flat
+/// mode. `field` is an already-validated safe identifier; the jsonb key is its
+/// `snake_case` form (single-quoted, inner quotes doubled) and the alias preserves
+/// the GraphQL field name so `project_results` can read it back by name.
+fn select_expr(field: &str, jsonb_column: Option<&str>) -> String {
+    match jsonb_column {
+        Some(col) => {
+            let column = col.replace('"', "\"\"");
+            let key = to_snake_case(field).replace('\'', "''");
+            let alias = field.replace('"', "\"\"");
+            format!("\"{column}\"->'{key}' AS \"{alias}\"")
+        },
+        None => field.to_string(),
+    }
 }
 
 /// Project database results to federation format, maintaining order of representations.

--- a/crates/fraiseql-federation/src/database_resolver.rs
+++ b/crates/fraiseql-federation/src/database_resolver.rs
@@ -26,16 +26,38 @@ use crate::{
 /// Resolves federation entities from local databases.
 pub struct DatabaseEntityResolver<A: DatabaseAdapter> {
     /// Database adapter for executing queries
-    adapter:  Arc<A>,
+    adapter:        Arc<A>,
     /// Federation metadata
-    metadata: FederationMetadata,
+    metadata:       FederationMetadata,
+    /// Backing relation (`sql_source`) per entity type name. Empty → the resolver
+    /// falls back to `lower(typename)` (#504).
+    entity_sources: std::collections::HashMap<String, String>,
 }
 
 impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
     /// Create a new database entity resolver.
+    ///
+    /// The `_entities` `FROM` relation falls back to `lower(typename)` unless a
+    /// per-type `sql_source` map is attached via
+    /// [`with_entity_sources`](Self::with_entity_sources).
     #[must_use]
-    pub const fn new(adapter: Arc<A>, metadata: FederationMetadata) -> Self {
-        Self { adapter, metadata }
+    pub fn new(adapter: Arc<A>, metadata: FederationMetadata) -> Self {
+        Self {
+            adapter,
+            metadata,
+            entity_sources: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Attach the per-entity-type backing relation map (`typename` → `sql_source`),
+    /// so the resolver reads from the real view instead of `lower(typename)` (#504).
+    #[must_use]
+    pub fn with_entity_sources(
+        mut self,
+        entity_sources: std::collections::HashMap<String, String>,
+    ) -> Self {
+        self.entity_sources = entity_sources;
+        self
     }
 
     /// Resolve entities from database.
@@ -151,12 +173,15 @@ impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
         // Find type definition using metadata helpers (whitelist check)
         let fed_type = find_federation_type(typename, &self.metadata)?;
 
-        // Get table name from typename (already validated as a safe identifier
-        // above). The table identifier is quoted — its lowercased form has no
-        // embedded quotes after the `is_safe_sql_identifier` check — so reserved-word
-        // type names like `User` -> `user` still produce valid SQL.
-        let table_name = typename.to_lowercase();
-        let quoted_table = format!("\"{}\"", table_name.replace('"', "\"\""));
+        // Resolve the backing relation. FraiseQL entities are view-backed, so the
+        // FROM relation is the type's configured `sql_source` (e.g. `v_organization`),
+        // not `lower(typename)` — which names a relation that does not exist and made
+        // every view-backed cross-subgraph join return null (#504). Falls back to
+        // `lower(typename)` only when no source map is attached (unit paths).
+        let quoted_table = match self.entity_sources.get(typename) {
+            Some(source) => quote_relation(source)?,
+            None => quote_relation(&typename.to_lowercase())?,
+        };
 
         // Build the parameterized WHERE IN clause. Key-field values are bound (not
         // interpolated), so the dialect must match the executing adapter.
@@ -203,6 +228,32 @@ impl<A: DatabaseAdapter> DatabaseEntityResolver<A> {
         // Project results maintaining order
         project_results(&rows, representations, fed_type, typename)
     }
+}
+
+/// Quote a (possibly schema-qualified) relation name for use as a `FROM` target.
+///
+/// Splits on `.` so a qualified `sql_source` like `app.v_organization` becomes
+/// `"app"."v_organization"` rather than a single mis-quoted identifier. Each
+/// segment is validated as a safe SQL identifier (defense-in-depth — `sql_source`
+/// is compiler-authored, not client input) and quoted, doubling any inner quote.
+/// Returns a [`FraiseQLError::Validation`] if a segment is empty or unsafe.
+fn quote_relation(relation: &str) -> Result<String> {
+    let segments: Vec<&str> = relation.split('.').collect();
+    if segments.iter().any(|s| s.is_empty()) || !segments.iter().all(|s| is_safe_sql_identifier(s))
+    {
+        return Err(FraiseQLError::Validation {
+            message: format!(
+                "Federation entity relation '{relation}' is not a valid (optionally \
+                 schema-qualified) SQL identifier"
+            ),
+            path:    None,
+        });
+    }
+    Ok(segments
+        .iter()
+        .map(|s| format!("\"{}\"", s.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join("."))
 }
 
 /// Render an already-composed per-row WHERE predicate to a dialect-native SQL

--- a/crates/fraiseql-federation/src/database_resolver/tests.rs
+++ b/crates/fraiseql-federation/src/database_resolver/tests.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use fraiseql_db::{DatabaseType, WhereClause, WhereOperator};
 use serde_json::json;
 
-use super::{build_select_fields, quote_relation, render_row_filter};
+use super::{build_select_list, quote_relation, render_row_filter, select_expr};
 use crate::{
     selection_parser::FieldSelection,
     types::{FederatedType, KeyDirective},
@@ -58,7 +58,7 @@ fn user_type_with_inaccessible() -> FederatedType {
 /// M-fed-select-list: `@inaccessible` / `@external` fields and injection-shaped
 /// tokens are dropped from the SELECT list; key fields are always present.
 #[test]
-fn build_select_fields_drops_inaccessible_external_and_injection() {
+fn build_select_list_drops_inaccessible_external_and_injection() {
     let fed_type = user_type_with_inaccessible();
     let selection = FieldSelection::new(vec![
         "name".to_string(),
@@ -68,22 +68,40 @@ fn build_select_fields_drops_inaccessible_external_and_injection() {
         "id, (SELECT 1)".to_string(), // not a plain identifier -> dropped
     ]);
 
-    let fields = build_select_fields(&selection, &fed_type);
+    // Flat mode: bare columns.
+    let flat = build_select_list(&selection, &fed_type, None);
+    assert!(flat.contains("name"), "exposed field kept");
+    assert!(flat.contains("id"), "key field always present");
+    assert!(!flat.contains("password_hash"), "@inaccessible field must never be selected");
+    assert!(!flat.contains("externalOnly"), "@external field must never be selected");
+    assert!(!flat.contains("__typename"), "__typename is not a stored column");
+    assert!(!flat.contains("SELECT"), "injection-shaped token must be dropped");
+}
 
-    assert!(fields.contains(&"name".to_string()), "exposed field kept");
-    assert!(fields.contains(&"id".to_string()), "key field always present");
-    assert!(
-        !fields.contains(&"password_hash".to_string()),
-        "@inaccessible field must never be selected"
-    );
-    assert!(
-        !fields.contains(&"externalOnly".to_string()),
-        "@external field must never be selected"
-    );
-    assert!(!fields.iter().any(|f| f == "__typename"), "__typename is not a stored column");
-    assert!(
-        !fields.iter().any(|f| f.contains("SELECT")),
-        "injection-shaped token must be dropped"
+/// jsonb mode projects each kept field out of the jsonb column with camelCase→
+/// snake recasing and a response-key alias; exposure filtering is unchanged.
+#[test]
+fn build_select_list_projects_jsonb_fields_with_recasing() {
+    let mut fed_type = user_type_with_inaccessible();
+    fed_type.external_fields.clear();
+    let selection = FieldSelection::new(vec!["isCustomer".to_string(), "name".to_string()]);
+
+    let sql = build_select_list(&selection, &fed_type, Some("data"));
+
+    assert!(sql.contains(r#""data"->'is_customer' AS "isCustomer""#), "got: {sql}");
+    assert!(sql.contains(r#""data"->'name' AS "name""#), "got: {sql}");
+    // The key field is still projected (project_results matches rows by it).
+    assert!(sql.contains(r#""data"->'id' AS "id""#), "key field projected: {sql}");
+}
+
+/// `select_expr` renders a bare column in flat mode and a recased jsonb projection
+/// in jsonb mode.
+#[test]
+fn select_expr_flat_vs_jsonb() {
+    assert_eq!(select_expr("name", None), "name");
+    assert_eq!(
+        select_expr("isCustomer", Some("data")),
+        r#""data"->'is_customer' AS "isCustomer""#
     );
 }
 

--- a/crates/fraiseql-federation/src/database_resolver/tests.rs
+++ b/crates/fraiseql-federation/src/database_resolver/tests.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use fraiseql_db::{DatabaseType, WhereClause, WhereOperator};
 use serde_json::json;
 
-use super::{build_select_fields, render_row_filter};
+use super::{build_select_fields, quote_relation, render_row_filter};
 use crate::{
     selection_parser::FieldSelection,
     types::{FederatedType, KeyDirective},
@@ -15,6 +15,28 @@ use crate::{
 fn test_database_resolver_creation() {
     // Test that resolver can be created (mock adapter would be used)
     // Actual DB tests are in integration tests
+}
+
+#[test]
+fn quote_relation_quotes_a_bare_view_name() {
+    assert_eq!(quote_relation("v_organization").unwrap(), "\"v_organization\"");
+}
+
+#[test]
+fn quote_relation_quotes_each_schema_qualified_segment() {
+    // A qualified sql_source becomes "schema"."relation", not a single mis-quoted
+    // identifier — the bug that made `schema.v_organization` unresolvable (#504).
+    assert_eq!(quote_relation("app.v_organization").unwrap(), "\"app\".\"v_organization\"");
+}
+
+#[test]
+fn quote_relation_rejects_unsafe_or_empty_segments() {
+    // sql_source is compiler-authored, but the FROM relation is interpolated, so the
+    // identifier guard is defense-in-depth.
+    assert!(quote_relation("v_org; DROP TABLE x").is_err());
+    assert!(quote_relation("app.").is_err());
+    assert!(quote_relation(".v_org").is_err());
+    assert!(quote_relation("").is_err());
 }
 
 fn user_type_with_inaccessible() -> FederatedType {

--- a/crates/fraiseql-federation/src/entity_resolver.rs
+++ b/crates/fraiseql-federation/src/entity_resolver.rs
@@ -210,8 +210,11 @@ pub async fn resolve_entities_from_db_enforced<A: DatabaseAdapter>(
         };
     }
 
-    // Create database entity resolver
-    let db_resolver = DatabaseEntityResolver::new(adapter, fed_resolver.metadata.clone());
+    // Create database entity resolver, carrying the per-type backing relations so
+    // the `_entities` FROM targets the real view (`sql_source`), not `lower(typename)`
+    // (#504). Empty in unit paths → resolver falls back to `lower(typename)`.
+    let db_resolver = DatabaseEntityResolver::new(adapter, fed_resolver.metadata.clone())
+        .with_entity_sources(fed_resolver.entity_sources.clone());
 
     // Resolve from database with tracing and the composed per-row enforcement
     match db_resolver

--- a/crates/fraiseql-federation/src/query_builder.rs
+++ b/crates/fraiseql-federation/src/query_builder.rs
@@ -6,7 +6,7 @@
 //! including MySQL's default backslash-escape mode, where the former
 //! single-quote-only escaping was unsafe (H3).
 
-use fraiseql_db::DatabaseType;
+use fraiseql_db::{DatabaseType, utils::to_snake_case};
 use fraiseql_error::{FraiseQLError, Result};
 use serde_json::Value;
 
@@ -16,21 +16,31 @@ use crate::{
     types::{EntityRepresentation, FederationMetadata},
 };
 
-/// Render a key column for the `WHERE … IN` comparison, casting it to text on
-/// PostgreSQL.
+/// Render the left-hand side of a key `WHERE … IN` comparison, as text.
 ///
-/// `@key` values arrive as JSON and are bound as `text` parameters, but the key
-/// column is frequently `uuid` (or another non-text type). PostgreSQL is strictly
-/// typed, so `id IN ($1)` with a text-bound `$1` fails with `operator does not
-/// exist: uuid = text` — silently turning every cross-subgraph join null (#504).
-/// Casting the column to text (`id::text IN ($1)`) makes the comparison succeed
-/// uniformly for `uuid` / integer / text keys, since the bound value is the
-/// canonical text form the owning subgraph emitted. Other dialects coerce text
-/// operands implicitly, so their SQL is left byte-for-byte unchanged.
-fn key_match_column(field: &str, db_type: DatabaseType) -> String {
-    match db_type {
-        DatabaseType::PostgreSQL => format!("{field}::text"),
-        _ => field.to_string(),
+/// `@key` values arrive as JSON and are bound as `text` parameters, so the key
+/// expression must produce text too:
+///
+/// - **jsonb mode** (`jsonb_column = Some(col)`): the key lives in the entity's jsonb column, so it
+///   is read as `"col"->>'snake(field)'` (the `->>` operator yields text, with camelCase→snake
+///   recasing) — already text, no cast needed.
+/// - **flat mode** (`None`): the key is a real column. The column is frequently `uuid` (or
+///   integer), and PostgreSQL is strictly typed, so `id IN ($1)` with a text-bound `$1` fails with
+///   `operator does not exist: uuid = text` — silently turning every cross-subgraph join null
+///   (#504). Casting the column to text (`id::text`) makes the comparison succeed uniformly for
+///   `uuid` / integer / text keys. Other dialects coerce text operands implicitly, so their SQL is
+///   left byte-for-byte unchanged.
+fn key_match_expr(field: &str, db_type: DatabaseType, jsonb_column: Option<&str>) -> String {
+    match jsonb_column {
+        Some(col) => {
+            let column = col.replace('"', "\"\"");
+            let key = to_snake_case(field).replace('\'', "''");
+            format!("\"{column}\"->>'{key}'")
+        },
+        None => match db_type {
+            DatabaseType::PostgreSQL => format!("{field}::text"),
+            _ => field.to_string(),
+        },
     }
 }
 
@@ -58,6 +68,7 @@ pub fn construct_where_in_clause(
     representations: &[EntityRepresentation],
     metadata: &FederationMetadata,
     db_type: DatabaseType,
+    jsonb_column: Option<&str>,
 ) -> Result<(String, Vec<Value>)> {
     // Find the entity type and its key directive
     let fed_type = find_federation_type(typename, metadata)?;
@@ -80,10 +91,13 @@ pub fn construct_where_in_clause(
             .join(", ");
         let params = key_values.into_iter().map(Value::String).collect();
 
-        Ok((format!("{} IN ({placeholders})", key_match_column(key_field, db_type)), params))
+        Ok((
+            format!("{} IN ({placeholders})", key_match_expr(key_field, db_type, jsonb_column)),
+            params,
+        ))
     } else {
         // For composite keys, build: (key1, key2) IN (($1, $2), ...)
-        construct_composite_where_in(&key_directive.fields, representations, db_type)
+        construct_composite_where_in(&key_directive.fields, representations, db_type, jsonb_column)
     }
 }
 
@@ -117,6 +131,7 @@ fn construct_composite_where_in(
     key_fields: &[String],
     representations: &[EntityRepresentation],
     db_type: DatabaseType,
+    jsonb_column: Option<&str>,
 ) -> Result<(String, Vec<Value>)> {
     if representations.is_empty() {
         return Ok(("1 = 0".to_string(), Vec::new()));
@@ -148,7 +163,7 @@ fn construct_composite_where_in(
 
     let fields_list = key_fields
         .iter()
-        .map(|f| key_match_column(f, db_type))
+        .map(|f| key_match_expr(f, db_type, jsonb_column))
         .collect::<Vec<_>>()
         .join(", ");
     let tuples_str = value_tuples.join(", ");

--- a/crates/fraiseql-federation/src/query_builder.rs
+++ b/crates/fraiseql-federation/src/query_builder.rs
@@ -16,6 +16,24 @@ use crate::{
     types::{EntityRepresentation, FederationMetadata},
 };
 
+/// Render a key column for the `WHERE … IN` comparison, casting it to text on
+/// PostgreSQL.
+///
+/// `@key` values arrive as JSON and are bound as `text` parameters, but the key
+/// column is frequently `uuid` (or another non-text type). PostgreSQL is strictly
+/// typed, so `id IN ($1)` with a text-bound `$1` fails with `operator does not
+/// exist: uuid = text` — silently turning every cross-subgraph join null (#504).
+/// Casting the column to text (`id::text IN ($1)`) makes the comparison succeed
+/// uniformly for `uuid` / integer / text keys, since the bound value is the
+/// canonical text form the owning subgraph emitted. Other dialects coerce text
+/// operands implicitly, so their SQL is left byte-for-byte unchanged.
+fn key_match_column(field: &str, db_type: DatabaseType) -> String {
+    match db_type {
+        DatabaseType::PostgreSQL => format!("{field}::text"),
+        _ => field.to_string(),
+    }
+}
+
 /// Build a parameterized WHERE IN clause for batch entity resolution.
 ///
 /// Returns the SQL fragment (with dialect-native bind placeholders) and the
@@ -62,7 +80,7 @@ pub fn construct_where_in_clause(
             .join(", ");
         let params = key_values.into_iter().map(Value::String).collect();
 
-        Ok((format!("{key_field} IN ({placeholders})"), params))
+        Ok((format!("{} IN ({placeholders})", key_match_column(key_field, db_type)), params))
     } else {
         // For composite keys, build: (key1, key2) IN (($1, $2), ...)
         construct_composite_where_in(&key_directive.fields, representations, db_type)
@@ -128,7 +146,11 @@ fn construct_composite_where_in(
         value_tuples.push(format!("({})", placeholders.join(", ")));
     }
 
-    let fields_list = key_fields.join(", ");
+    let fields_list = key_fields
+        .iter()
+        .map(|f| key_match_column(f, db_type))
+        .collect::<Vec<_>>()
+        .join(", ");
     let tuples_str = value_tuples.join(", ");
 
     Ok((format!("({fields_list}) IN ({tuples_str})"), params))

--- a/crates/fraiseql-federation/src/query_builder/tests.rs
+++ b/crates/fraiseql-federation/src/query_builder/tests.rs
@@ -50,7 +50,9 @@ fn test_construct_simple_where_in_binds_values() {
         construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL).unwrap();
 
     // Values are bound, not interpolated: the clause carries placeholders only.
-    assert_eq!(clause, "id IN ($1, $2)");
+    // The key column is cast to text on PostgreSQL so a text-bound key matches a
+    // non-text (e.g. uuid) key column (#504).
+    assert_eq!(clause, "id::text IN ($1, $2)");
     assert!(!clause.contains("123"));
     assert!(!clause.contains("456"));
     assert_eq!(params, vec![json!("123"), json!("456")]);
@@ -62,7 +64,8 @@ fn test_dialect_placeholders() {
     let reps = vec![rep("a")];
     let (pg, _) =
         construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL).unwrap();
-    assert_eq!(pg, "id IN ($1)");
+    // PostgreSQL casts the key column to text (#504); other dialects coerce.
+    assert_eq!(pg, "id::text IN ($1)");
     let (my, _) = construct_where_in_clause("User", &reps, &metadata, DatabaseType::MySQL).unwrap();
     assert_eq!(my, "id IN (?)");
     let (ms, _) =
@@ -153,7 +156,8 @@ fn test_construct_composite_where_in_binds_values() {
         construct_where_in_clause("OrderItem", &[rep], &metadata, DatabaseType::PostgreSQL)
             .unwrap();
 
-    assert_eq!(clause, "(order_id, product_id) IN (($1, $2))");
+    // Each composite key column is cast to text on PostgreSQL (#504).
+    assert_eq!(clause, "(order_id::text, product_id::text) IN (($1, $2))");
     // Values are bound as parameters, never interpolated into the SQL text.
     assert!(!clause.contains("O1") && !clause.contains("P1"));
     assert_eq!(params, vec![json!("O1"), json!("P1")]);

--- a/crates/fraiseql-federation/src/query_builder/tests.rs
+++ b/crates/fraiseql-federation/src/query_builder/tests.rs
@@ -47,7 +47,8 @@ fn test_construct_simple_where_in_binds_values() {
     let reps = vec![rep("123"), rep("456")];
 
     let (clause, params) =
-        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
 
     // Values are bound, not interpolated: the clause carries placeholders only.
     // The key column is cast to text on PostgreSQL so a text-bound key matches a
@@ -63,13 +64,15 @@ fn test_dialect_placeholders() {
     let metadata = make_test_metadata();
     let reps = vec![rep("a")];
     let (pg, _) =
-        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
     // PostgreSQL casts the key column to text (#504); other dialects coerce.
     assert_eq!(pg, "id::text IN ($1)");
-    let (my, _) = construct_where_in_clause("User", &reps, &metadata, DatabaseType::MySQL).unwrap();
+    let (my, _) =
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::MySQL, None).unwrap();
     assert_eq!(my, "id IN (?)");
     let (ms, _) =
-        construct_where_in_clause("User", &reps, &metadata, DatabaseType::SQLServer).unwrap();
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::SQLServer, None).unwrap();
     assert_eq!(ms, "id IN (@P1)");
 }
 
@@ -82,7 +85,7 @@ fn test_sql_injection_value_is_bound_not_interpolated() {
     let reps = vec![rep(payload)];
 
     let (clause, params) =
-        construct_where_in_clause("User", &reps, &metadata, DatabaseType::MySQL).unwrap();
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::MySQL, None).unwrap();
 
     assert_eq!(clause, "id IN (?)");
     assert!(!clause.contains("DROP"), "payload must not appear in SQL text");
@@ -96,7 +99,8 @@ fn test_empty_representations() {
     let reps = vec![];
 
     let (clause, params) =
-        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL).unwrap();
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL, None)
+            .unwrap();
     assert_eq!(clause, "1 = 0"); // No rows to resolve
     assert!(params.is_empty());
 }
@@ -106,7 +110,8 @@ fn test_missing_type_error() {
     let metadata = make_test_metadata();
     let reps = vec![];
 
-    let result = construct_where_in_clause("NotFound", &reps, &metadata, DatabaseType::PostgreSQL);
+    let result =
+        construct_where_in_clause("NotFound", &reps, &metadata, DatabaseType::PostgreSQL, None);
     assert!(
         matches!(result, Err(FraiseQLError::Validation { .. })),
         "expected Validation error for unknown type, got: {result:?}"
@@ -153,7 +158,7 @@ fn test_construct_composite_where_in_binds_values() {
     };
 
     let (clause, params) =
-        construct_where_in_clause("OrderItem", &[rep], &metadata, DatabaseType::PostgreSQL)
+        construct_where_in_clause("OrderItem", &[rep], &metadata, DatabaseType::PostgreSQL, None)
             .unwrap();
 
     // Each composite key column is cast to text on PostgreSQL (#504).
@@ -161,4 +166,19 @@ fn test_construct_composite_where_in_binds_values() {
     // Values are bound as parameters, never interpolated into the SQL text.
     assert!(!clause.contains("O1") && !clause.contains("P1"));
     assert_eq!(params, vec![json!("O1"), json!("P1")]);
+}
+
+/// jsonb mode (`#504`): the key is matched as `"data"->>'<snake(key)>'` (already
+/// text — no `::text` cast), so a `data`-jsonb-backed entity view resolves.
+#[test]
+fn test_construct_where_in_jsonb_mode_matches_key_from_data_column() {
+    let metadata = make_test_metadata();
+    let reps = vec![rep("123"), rep("456")];
+
+    let (clause, params) =
+        construct_where_in_clause("User", &reps, &metadata, DatabaseType::PostgreSQL, Some("data"))
+            .unwrap();
+
+    assert_eq!(clause, "\"data\"->>'id' IN ($1, $2)");
+    assert_eq!(params, vec![json!("123"), json!("456")]);
 }

--- a/crates/fraiseql-federation/src/types.rs
+++ b/crates/fraiseql-federation/src/types.rs
@@ -369,6 +369,25 @@ impl std::fmt::Display for ResolutionStrategy {
     }
 }
 
+/// Backing relation (and optional jsonb projection column) for a federation
+/// entity type, derived from the compiled schema's backing query (#504).
+///
+/// FraiseQL entities are view-backed and normally expose their fields inside a
+/// `data` jsonb column, so the `_entities` resolver needs both the relation to
+/// read from and the column to project fields out of — which `lower(typename)`
+/// (the pre-#504 guess) and the federation metadata alone cannot supply.
+#[derive(Debug, Clone)]
+pub struct EntitySource {
+    /// The relation to read, e.g. `v_organization` (possibly schema-qualified).
+    pub relation: String,
+
+    /// The jsonb column the entity's fields are projected from (e.g. `data`).
+    /// `Some` → fields are read as `<col>->'<snake(field)>'` and the key as
+    /// `<col>->>'<snake(key)>'`, mirroring the normal query path. `None` → a
+    /// flat-column view; fields are read as bare columns (the legacy shape).
+    pub jsonb_column: Option<String>,
+}
+
 /// Federation resolver - orchestrates entity resolution
 pub struct FederationResolver {
     /// Federation metadata for the schema
@@ -377,16 +396,17 @@ pub struct FederationResolver {
     /// Cached resolution strategies
     pub strategy_cache: std::sync::Mutex<HashMap<String, ResolutionStrategy>>,
 
-    /// Backing relation (`sql_source`) per entity type name, e.g.
-    /// `{"Organization": "v_organization"}`.
+    /// Backing [`EntitySource`] per entity type name, e.g.
+    /// `{"Organization": EntitySource { relation: "v_organization", jsonb_column: Some("data")
+    /// }}`.
     ///
-    /// FraiseQL entities are view-backed, so the `_entities` resolver must read
-    /// from the type's configured `sql_source` — **not** `lower(typename)`, which
-    /// names a relation that does not exist (#504). Populated at the production
-    /// call site from the compiled schema's per-type `sql_source` via
+    /// The `_entities` resolver reads from the entity's real relation — **not**
+    /// `lower(typename)`, which names a relation that does not exist (#504) — and
+    /// projects fields from its jsonb column. Populated at the production call site
+    /// from the compiled schema's backing queries via
     /// [`with_entity_sources`](Self::with_entity_sources); empty in unit paths,
-    /// where the resolver falls back to `lower(typename)`.
-    pub entity_sources: HashMap<String, String>,
+    /// where the resolver falls back to `lower(typename)` with flat columns.
+    pub entity_sources: HashMap<String, EntitySource>,
 }
 
 impl FederationResolver {
@@ -400,11 +420,11 @@ impl FederationResolver {
         }
     }
 
-    /// Attach the per-entity-type backing relation map (`typename` → `sql_source`),
-    /// so the `_entities` resolver reads from the real view instead of guessing
-    /// `lower(typename)` (#504).
+    /// Attach the per-entity-type [`EntitySource`] map (`typename` → relation +
+    /// jsonb column), so the `_entities` resolver reads from the real view and
+    /// projects its jsonb fields instead of guessing `lower(typename)` (#504).
     #[must_use]
-    pub fn with_entity_sources(mut self, entity_sources: HashMap<String, String>) -> Self {
+    pub fn with_entity_sources(mut self, entity_sources: HashMap<String, EntitySource>) -> Self {
         self.entity_sources = entity_sources;
         self
     }

--- a/crates/fraiseql-federation/src/types.rs
+++ b/crates/fraiseql-federation/src/types.rs
@@ -376,6 +376,17 @@ pub struct FederationResolver {
 
     /// Cached resolution strategies
     pub strategy_cache: std::sync::Mutex<HashMap<String, ResolutionStrategy>>,
+
+    /// Backing relation (`sql_source`) per entity type name, e.g.
+    /// `{"Organization": "v_organization"}`.
+    ///
+    /// FraiseQL entities are view-backed, so the `_entities` resolver must read
+    /// from the type's configured `sql_source` — **not** `lower(typename)`, which
+    /// names a relation that does not exist (#504). Populated at the production
+    /// call site from the compiled schema's per-type `sql_source` via
+    /// [`with_entity_sources`](Self::with_entity_sources); empty in unit paths,
+    /// where the resolver falls back to `lower(typename)`.
+    pub entity_sources: HashMap<String, String>,
 }
 
 impl FederationResolver {
@@ -385,7 +396,17 @@ impl FederationResolver {
         Self {
             metadata,
             strategy_cache: std::sync::Mutex::new(HashMap::new()),
+            entity_sources: HashMap::new(),
         }
+    }
+
+    /// Attach the per-entity-type backing relation map (`typename` → `sql_source`),
+    /// so the `_entities` resolver reads from the real view instead of guessing
+    /// `lower(typename)` (#504).
+    #[must_use]
+    pub fn with_entity_sources(mut self, entity_sources: HashMap<String, String>) -> Self {
+        self.entity_sources = entity_sources;
+        self
     }
 
     /// Get or determine resolution strategy for type.


### PR DESCRIPTION
## Summary

Fixes #504. The runtime `_entities` resolver could not resolve standard FraiseQL
view-backed entities, so cross-subgraph entity joins silently returned `null`.
Two root causes, both fixed here (the second commit reworks the first after the
reporter verified it was a no-op against a real compiled schema):

1. **Wrong / missing relation.** The resolver built its `FROM` from `lower(typename)`,
   which names a relation that does not exist — the query errored and the gateway
   turned the field into `null`.
2. **Flat-column SELECT.** Even against the right relation it `SELECT`ed bare columns
   by GraphQL field name, but FraiseQL entity views expose their fields inside a `data`
   **jsonb** column. Any jsonb-only field (e.g. `isCustomer` → `data->>'is_customer'`)
   has no flat column, so the SELECT errored and the whole representation went `null`.
3. **uuid key binding.** `@key` values are bound as text while key columns are frequently
   `uuid`, so `id IN ($1)` failed with `operator does not exist: uuid = text`.

## Fix

- **Source each entity's backing relation *and* jsonb column from the compiled schema's
  backing query** (`queries[]`, keyed by `return_type`, first-wins — the same query→type
  binding the Relay `node` path uses). The compiler always leaves `types[].sql_source`
  empty (the relation lives on the query), which is why the first cut — reading
  `types[].sql_source` — was empty in practice and fell back to `lower(typename)`. A new
  `EntitySource { relation, jsonb_column }` is threaded onto `FederationResolver` /
  `DatabaseEntityResolver` via `with_entity_sources`, populated at the single production
  call site; an empty map preserves the legacy `lower(typename)` + flat-column path
  byte-for-byte, so every unit path is unchanged.
- **Project requested fields out of the jsonb column** the way the normal query path does:
  `"<col>"->'<snake(field)>' AS "<field>"` (typed via the adapter's jsonb decoding, with
  camelCase→snake recasing). The `@key` lookup matches `"<col>"->>'<snake(key)>'` (text vs
  text). Flat-column views (no jsonb column) keep the bare-column path with the PostgreSQL
  `id::text IN ($1)` cast so `uuid` / integer / text keys all match uniformly; other
  dialects coerce text operands implicitly and are left unchanged.
- Schema-qualified relations are quoted segment-by-segment behind the identifier guard.

## Scope / follow-up

Owner-split `extends` entities — resolved in a subgraph that does **not** own the type, so
they have neither a backing query nor a type-level `sql_source` in the compiled schema —
still need the authoring SDK + compiler to emit a type-level `sql_source`. Tracked in
**#507** (out of scope here).

## Tests

- New live-PG integration tests (`entity_resolution.rs`):
  - `test_resolve_jsonb_data_backed_entity_projects_and_recases` — a jsonb-`data` view with a
    camelCase, non-string field (`isCustomer`) resolves with type fidelity.
  - `test_resolve_view_backed_uuid_entity_uses_sql_source` — a `uuid`-keyed entity backed by a
    relation ≠ `lower(typename)` resolves only with the source map attached; a control asserts
    the pre-fix `lower(typename)` path errors.
- Unit tests for the jsonb-aware SELECT/WHERE construction and `quote_relation`
  (bare / schema-qualified / unsafe-and-empty rejection).
- Updated the PostgreSQL WHERE-clause assertions across the federation suites
  (MySQL / SQL Server assertions unchanged).

## Verification

✅ `cargo clippy --workspace --all-targets --all-features` clean
✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps` clean; fmt (touched files) clean
✅ federation lib + core lib pass
✅ federation integration target **175 pass on live PostgreSQL** (serialized);
   both new tests green
✅ `make lint-tests-layout` / `check-test-imports` gates pass

> Note: the `_service` SDL / composition side was already correct — this is purely the
> runtime `_entities` resolution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
