### PR TITLE
style: apply latest nightly rustfmt to resolve preflight drift

### DIFF
--- a/crates/fraiseql-cli/src/config/toml_schema/federation.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/federation.rs
@@ -117,7 +117,7 @@ impl FederationConfig {
                 .entities
                 .iter()
                 .map(|e| core::FederationEntity {
-                    name:       e.name.clone(),
+                    name: e.name.clone(),
                     key_fields: e.key_fields.clone(),
                     ..Default::default()
                 })

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2099,12 +2099,12 @@ mod changelog_validation_tests {
         // subgraph compiles alone), so the guardrail is a compile warning, never an
         // error; the owning subgraph legitimately sets both.
         let intermediate = IntermediateSchema {
-            version:           "2.0.0".to_string(),
-            changelog_config:  Some(ChangelogConfig {
+            version: "2.0.0".to_string(),
+            changelog_config: Some(ChangelogConfig {
                 expose: true,
                 ..Default::default()
             }),
-            observers_config:  Some(json!({ "enabled": true, "backend": "redis" })),
+            observers_config: Some(json!({ "enabled": true, "backend": "redis" })),
             federation_config: Some(json!({ "enabled": true })),
             ..IntermediateSchema::default()
         };

--- a/crates/fraiseql-core/examples/fed_sdl.rs
+++ b/crates/fraiseql-core/examples/fed_sdl.rs
@@ -10,14 +10,10 @@ use std::fs;
 use fraiseql_core::CompiledSchema;
 
 fn main() {
-    let path = std::env::args()
-        .nth(1)
-        .expect("usage: fed_sdl <schema.compiled.json>");
+    let path = std::env::args().nth(1).expect("usage: fed_sdl <schema.compiled.json>");
     let json = fs::read_to_string(&path).expect("read compiled schema");
     let schema = CompiledSchema::from_json(&json, false).expect("parse compiled schema");
-    let meta = schema
-        .federation_metadata()
-        .expect("schema has no enabled federation block");
+    let meta = schema.federation_metadata().expect("schema has no enabled federation block");
     let raw = schema.raw_schema();
     let sdl = fraiseql_core::federation::generate_service_sdl(&raw, &meta);
     println!("{sdl}");

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -513,7 +513,7 @@ mod entities_authz {
             enabled: true,
             version: Some("v2".to_string()),
             entities: vec![FederationEntity {
-                name:       "User".to_string(),
+                name: "User".to_string(),
                 key_fields: vec!["id".to_string()],
                 ..Default::default()
             }],

--- a/crates/fraiseql-core/src/schema/changelog/tests.rs
+++ b/crates/fraiseql-core/src/schema/changelog/tests.rs
@@ -196,8 +196,7 @@ fn camel_case_convention_renders_camelcase_identifiers() {
     assert_eq!(lookup.arguments.len(), 1);
     assert_eq!(lookup.arguments[0].name, "transportName");
 
-    let upsert =
-        schema.mutations.iter().find(|m| m.name == "upsertTransportCheckpoint").unwrap();
+    let upsert = schema.mutations.iter().find(|m| m.name == "upsertTransportCheckpoint").unwrap();
     let arg_names: Vec<&str> = upsert.arguments.iter().map(|a| a.name.as_str()).collect();
     assert_eq!(arg_names, vec!["transportName", "lastPk"]);
 }

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -120,7 +120,9 @@ impl CompiledSchema {
     #[must_use]
     pub fn federation_metadata(&self) -> Option<crate::federation::FederationMetadata> {
         self.federation.as_ref().filter(|fed| fed.enabled).map(|fed| {
-            use crate::federation::types::{FederatedType, FieldFederationDirectives, KeyDirective};
+            use crate::federation::types::{
+                FederatedType, FieldFederationDirectives, KeyDirective,
+            };
 
             // Entities carry an `@key` (and, for an extended entity, `extend type` +
             // `@external` on the borrowed key/fields). Per-field directives are
@@ -139,17 +141,17 @@ impl CompiledSchema {
                         field_directives.entry(f.clone()).or_default().shareable = true;
                     }
                     FederatedType {
-                        name:                e.name.clone(),
-                        keys:                vec![KeyDirective {
+                        name: e.name.clone(),
+                        keys: vec![KeyDirective {
                             fields:     e.key_fields.clone(),
                             resolvable: true,
                         }],
-                        is_extends:          e.extends,
-                        external_fields:     e.external_fields.clone(),
-                        shareable_fields:    e.shareable_fields.clone(),
+                        is_extends: e.extends,
+                        external_fields: e.external_fields.clone(),
+                        shareable_fields: e.shareable_fields.clone(),
                         inaccessible_fields: Vec::new(),
                         field_directives,
-                        type_shareable:      false,
+                        type_shareable: false,
                     }
                 })
                 .collect();

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -821,7 +821,7 @@ fn federation_metadata_some_when_enabled() {
         enabled: true,
         version: Some("v2".to_string()),
         entities: vec![FederationEntity {
-            name:       "User".to_string(),
+            name: "User".to_string(),
             key_fields: vec!["id".to_string()],
             ..Default::default()
         }],
@@ -1022,7 +1022,7 @@ fn service_sdl_advertises_root_query_fields() {
         enabled: true,
         version: Some("v2".to_string()),
         entities: vec![FederationEntity {
-            name:       "User".to_string(),
+            name: "User".to_string(),
             key_fields: vec!["id".to_string()],
             ..Default::default()
         }],

--- a/crates/fraiseql-core/src/schema/config_types.rs
+++ b/crates/fraiseql-core/src/schema/config_types.rs
@@ -39,17 +39,17 @@ pub struct FederationConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FederationEntity {
     /// Entity type name (e.g., "User", "Product").
-    pub name:       String,
+    pub name:             String,
     /// Key fields that uniquely identify this entity.
-    pub key_fields: Vec<String>,
+    pub key_fields:       Vec<String>,
     /// This subgraph `extend`s an entity owned by another subgraph (renders
     /// `extend type Name @key(...)` in the federation SDL).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub extends:         bool,
+    pub extends:          bool,
     /// Fields that are `@external` — owned by another subgraph and only referenced
     /// here (typically the `@key` field of an extended entity).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub external_fields: Vec<String>,
+    pub external_fields:  Vec<String>,
     /// Fields that are `@shareable` — resolvable in more than one subgraph.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub shareable_fields: Vec<String>,

--- a/crates/fraiseql-core/src/schema/tests.rs
+++ b/crates/fraiseql-core/src/schema/tests.rs
@@ -1507,7 +1507,7 @@ fn test_roundtrip_serialization() {
         schema_url:      None,
         shareable_types: Vec::new(),
         entities:        vec![FederationEntity {
-            name:       "User".to_string(),
+            name: "User".to_string(),
             key_fields: vec!["id".to_string()],
             ..Default::default()
         }],

--- a/crates/fraiseql-core/tests/federation_compose.rs
+++ b/crates/fraiseql-core/tests/federation_compose.rs
@@ -13,10 +13,10 @@
 //!
 //! The two subgraphs deliberately share everything a real supergraph shares:
 //! - `Money` — a keyless `@shareable` value type defined in *both* subgraphs.
-//! - `Product` — an entity *owned* by `catalog` and *extended* by `reviews`
-//!   (`extend type Product @key` with an `@external` key field).
-//! - a camelCase `catalog` subgraph that also exposes the #149 change-log, so the
-//!   SDL pins the naming-convention fix too.
+//! - `Product` — an entity *owned* by `catalog` and *extended* by `reviews` (`extend type Product
+//!   @key` with an `@external` key field).
+//! - a camelCase `catalog` subgraph that also exposes the #149 change-log, so the SDL pins the
+//!   naming-convention fix too.
 
 #![cfg(feature = "federation")]
 #![allow(clippy::expect_used, clippy::unwrap_used)] // Reason: test code, panics are acceptable.
@@ -186,7 +186,10 @@ fn catalog_sdl_holds_every_federation_invariant() {
         sdl.contains("type Product @key(fields: \"id\")"),
         "entity @key not rendered on Product (#496)"
     );
-    assert!(sdl.contains("type Money @shareable"), "shareable value type missing @shareable (#496)");
+    assert!(
+        sdl.contains("type Money @shareable"),
+        "shareable value type missing @shareable (#496)"
+    );
 
     // #496 — a keyless @shareable value type must NOT join the _Entity union (an
     // unkeyed union member is an invalid composition).
@@ -198,7 +201,10 @@ fn catalog_sdl_holds_every_federation_invariant() {
     assert!(sdl.contains("entityChangeLogs"), "change-log query not camelCased (#498)");
     assert!(sdl.contains("pkEntityChangeLog"), "change-log field not camelCased (#498)");
     assert!(!sdl.contains("entity_change_logs"), "snake_case change-log query leaked (#498)");
-    assert!(!sdl.contains("pk_entity_change_log"), "snake_case change-log field leaked (#498)");
+    assert!(
+        !sdl.contains("pk_entity_change_log"),
+        "snake_case change-log field leaked (#498)"
+    );
 }
 
 #[test]
@@ -224,7 +230,9 @@ fn reviews_sdl_extends_the_borrowed_entity() {
 
 /// Path to a committed subgraph SDL fixture.
 fn fixture_path(name: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/federation_compose").join(name)
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/federation_compose")
+        .join(name)
 }
 
 /// The committed subgraph SDL fixtures are what the real-`composeServices` CI leg


### PR DESCRIPTION
## Summary

Resolves the **Dagger preflight (fmt) failure on `dev`**. CI's preflight runs
`cargo +nightly fmt --all -- --check` against the *latest* nightly rustfmt (the
rustBase container does `rustup toolchain install nightly`). That nightly had
drifted ahead of the version these files were last formatted with, so the check
flagged **10 files** and turned the preflight gate red on `dev` (red since the
#495 federation merge `02063374c`).

Re-formatted with the current nightly (`rustfmt 1.9.0-nightly`, 2026-06-28). The
changes are **whitespace / struct-field-alignment / macro line-wrapping only** —
no semantic change (e.g. structs that gained fields in #495 had their
`struct_field_align_threshold` alignment recomputed).

## Files

```
crates/fraiseql-cli/src/config/toml_schema/federation.rs
crates/fraiseql-cli/src/schema/converter/tests.rs
crates/fraiseql-core/examples/fed_sdl.rs
crates/fraiseql-core/src/runtime/executor/tests.rs
crates/fraiseql-core/src/schema/changelog/tests.rs
crates/fraiseql-core/src/schema/compiled/schema_domain.rs
crates/fraiseql-core/src/schema/compiled/tests.rs
crates/fraiseql-core/src/schema/config_types.rs
crates/fraiseql-core/src/schema/tests.rs
crates/fraiseql-core/tests/federation_compose.rs
```

## Verification

✅ `cargo +nightly fmt --all -- --check` clean (0 files flagged) — matches CI's nightly
✅ `cargo check -p fraiseql-core -p fraiseql-cli --all-features` clean
✅ Diff is whitespace-only; the #504 `_entities` files are already clean and untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
