### PR TITLE
fix(federation): resolve owner-split extends entities from type-level sql_source (#507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Federation `_entities` resolves owner-split `extends` entities from a type-level
+  `sql_source`.** An `extend type … @key` entity resolved in a subgraph that does not
+  own it exposes no root query, so the `_entities` resolver had no backing query to
+  source its relation from and fell back to the non-existent `lower(typename)`
+  relation — silently resolving the entity to `null`. When the authoring SDK emits a
+  type-level `sql_source` on such an entity, the compiler now carries it through to
+  `types[].sql_source` (instead of always leaving it empty — chosen over the federation
+  config block because `types[]` survives the TOML federation merge), and the resolver's
+  backing-source builder (`CompiledSchema::entity_sources`) falls back to it when no
+  query supplies the relation. The fallback honours the same jsonb/flat convention as
+  the query path — a non-empty `jsonb_column` projects `<col>->'<field>'`, an empty one
+  reads bare columns — and the compiler defaults an extends entity's `jsonb_column` to
+  the standard `data` view shape (so flat-column extends entities are authored with an
+  explicit empty `jsonb_column`). Owned, query-backed entities are unaffected: a
+  query-sourced relation always wins. Completes the runtime/compiler half of the #504
+  fix; the authoring SDKs must emit the type-level `sql_source` for owner-split
+  `extends` entities. (#507)
 - **Federation `_entities` now resolves view-backed, jsonb-`data` entities.** The
   runtime `_entities` resolver built its `FROM` relation from the lowercased GraphQL
   type name and selected bare columns, but FraiseQL entities are view-backed and
@@ -26,9 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integer / text keys all match. (#504)
 
   Owner-split `extends` entities (resolved in a subgraph that does not own the type,
-  and so have neither a backing query nor a type-level `sql_source` in the compiled
-  schema) still require the authoring SDK to emit a type-level `sql_source` — tracked
-  in #507.
+  and so have no backing query) are now resolved from a type-level `sql_source` the
+  compiler carries through to the entity's `TypeDefinition` — see the #507 entry above.
 - **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**
   Two residual `_service` SDL gaps that the type-closure fix exposed: (1) the `scalar`
   declaration walk canonicalised names (`DateTime`) while fields rendered them verbatim

--- a/crates/fraiseql-cli/src/commands/extract/csharp.rs
+++ b/crates/fraiseql-cli/src/commands/extract/csharp.rs
@@ -32,6 +32,7 @@ impl SchemaExtractor for CSharpExtractor {
             let description = params.get("description").cloned();
 
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/go.rs
+++ b/crates/fraiseql-cli/src/commands/extract/go.rs
@@ -38,6 +38,7 @@ impl SchemaExtractor for GoExtractor {
 
             let description = params.get("description").cloned();
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/java.rs
+++ b/crates/fraiseql-cli/src/commands/extract/java.rs
@@ -31,6 +31,7 @@ impl SchemaExtractor for JavaExtractor {
 
             let description = params.get("description").cloned();
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/kotlin.rs
+++ b/crates/fraiseql-cli/src/commands/extract/kotlin.rs
@@ -30,6 +30,7 @@ impl SchemaExtractor for KotlinExtractor {
             let description = params.get("description").cloned();
 
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/python.rs
+++ b/crates/fraiseql-cli/src/commands/extract/python.rs
@@ -67,6 +67,7 @@ impl SchemaExtractor for PythonExtractor {
 
             let description = params.get("description").cloned();
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/rust.rs
+++ b/crates/fraiseql-cli/src/commands/extract/rust.rs
@@ -58,6 +58,7 @@ impl SchemaExtractor for RustExtractor {
 
             let description = params.get("description").cloned();
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/scala.rs
+++ b/crates/fraiseql-cli/src/commands/extract/scala.rs
@@ -30,6 +30,7 @@ impl SchemaExtractor for ScalaExtractor {
             let description = params.get("description").cloned();
 
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/swift.rs
+++ b/crates/fraiseql-cli/src/commands/extract/swift.rs
@@ -61,6 +61,7 @@ impl SchemaExtractor for SwiftExtractor {
 
             let description = params.get("description").cloned();
             types.push(IntermediateType {
+                sql_source: None,
                 name,
                 fields,
                 description,

--- a/crates/fraiseql-cli/src/commands/extract/typescript.rs
+++ b/crates/fraiseql-cli/src/commands/extract/typescript.rs
@@ -27,6 +27,7 @@ impl SchemaExtractor for TypeScriptExtractor {
             if let Some(body) = extract_balanced_braces(&source[after_match..]) {
                 let fields = extract_ts_fields(&body);
                 types.push(IntermediateType {
+                    sql_source: None,
                     name,
                     fields,
                     description: None,

--- a/crates/fraiseql-cli/src/commands/generate/tests.rs
+++ b/crates/fraiseql-cli/src/commands/generate/tests.rs
@@ -138,6 +138,7 @@ fn sample_schema() -> IntermediateSchema {
         version: "2.0.0".to_string(),
         types: vec![IntermediateType {
             name:                   "Author".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "pk".to_string(),

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -88,6 +88,75 @@ fn convert_threads_subscribable_pre_image_into_compiled() {
     assert!(compiled.subscribable[0].pre_image, "subscribable_pre_image threads through");
 }
 
+// ── #507 type-level sql_source threading (federation extends entities) ────────
+
+#[test]
+fn intermediate_type_reads_type_level_sql_source() {
+    // The authoring SDK emits a type-level `sql_source` for an owner-split
+    // `extend type … @key` federation entity that has no local backing query.
+    let json = r#"{ "name": "Organization", "fields": [], "sql_source": "v_organization" }"#;
+    let t: IntermediateType = serde_json::from_str(json).unwrap();
+    assert_eq!(t.sql_source.as_deref(), Some("v_organization"));
+}
+
+#[test]
+fn intermediate_type_sql_source_defaults_none() {
+    // The common case: an owned type binds its relation on the query that returns
+    // it, so the type-level key is absent.
+    let json = r#"{ "name": "User", "fields": [] }"#;
+    let t: IntermediateType = serde_json::from_str(json).unwrap();
+    assert!(t.sql_source.is_none(), "absent sql_source defaults to None");
+}
+
+#[test]
+fn convert_threads_type_level_sql_source_into_compiled() {
+    // An extends entity's type-level sql_source flows to TypeDefinition.sql_source
+    // so the federation `_entities` resolver can source its backing relation when
+    // no root query returns the type (#507). An owned type without one keeps the
+    // historical empty type-level sql_source.
+    let intermediate = IntermediateSchema {
+        types: vec![
+            IntermediateType {
+                name: "Organization".to_string(),
+                sql_source: Some("v_organization".to_string()),
+                ..Default::default()
+            },
+            IntermediateType {
+                name: "User".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let compiled = SchemaConverter::convert(intermediate).expect("convert");
+    let org = compiled
+        .types
+        .iter()
+        .find(|t| t.name == "Organization")
+        .expect("Organization type");
+    assert_eq!(
+        org.sql_source.as_str(),
+        "v_organization",
+        "type-level sql_source threads through to the compiled type"
+    );
+    assert_eq!(
+        org.jsonb_column, "data",
+        "an extends entity's fields default to the standard jsonb `data` column, symmetric \
+         with the query path"
+    );
+    let user = compiled.types.iter().find(|t| t.name == "User").expect("User type");
+    assert!(
+        user.sql_source.as_str().is_empty(),
+        "an owned type keeps the historical empty type-level sql_source"
+    );
+    assert!(
+        user.jsonb_column.is_empty(),
+        "an owned type keeps the historical empty type-level jsonb_column (optimizer heuristic \
+         stays off, compiled output byte-identical)"
+    );
+}
+
 #[test]
 fn test_convert_minimal_schema() {
     let intermediate = IntermediateSchema {
@@ -246,6 +315,7 @@ fn test_convert_type_with_fields() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "id".to_string(),
@@ -375,6 +445,7 @@ fn test_convert_query_with_arguments() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -453,6 +524,7 @@ fn test_list_query_without_auto_params_defaults_to_all() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Item".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -521,6 +593,7 @@ fn test_single_item_query_without_auto_params_defaults_to_none() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Item".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -591,6 +664,7 @@ fn test_convert_field_with_deprecated_directive() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "oldId".to_string(),
@@ -1145,6 +1219,7 @@ fn test_convert_type_implements_interface() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "id".to_string(),
@@ -1238,6 +1313,7 @@ fn test_validate_unknown_interface() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![IntermediateField {
                 name:           "id".to_string(),
                 field_type:     "ID".to_string(),
@@ -1298,6 +1374,7 @@ fn test_validate_missing_interface_field() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 // Missing the required 'id' field from Node interface!
                 IntermediateField {
@@ -1376,6 +1453,7 @@ fn test_convert_union() {
         types:                vec![
             IntermediateType {
                 name:                   "User".to_string(),
+                sql_source:             None,
                 fields:                 vec![IntermediateField {
                     name:           "id".to_string(),
                     field_type:     "ID".to_string(),
@@ -1397,6 +1475,7 @@ fn test_convert_union() {
             },
             IntermediateType {
                 name:                   "Post".to_string(),
+                sql_source:             None,
                 fields:                 vec![IntermediateField {
                     name:           "id".to_string(),
                     field_type:     "ID".to_string(),
@@ -1467,6 +1546,7 @@ fn test_convert_field_requires_scope() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Employee".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "id".to_string(),
@@ -1644,6 +1724,7 @@ mod tenancy_tests {
     fn make_type(name: &str, fields: Vec<IntermediateField>) -> IntermediateType {
         IntermediateType {
             name: name.to_string(),
+            sql_source: None,
             fields,
             description: None,
             implements: vec![],

--- a/crates/fraiseql-cli/src/schema/converter/types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/types.rs
@@ -29,13 +29,28 @@ impl SchemaConverter {
             .collect::<Result<Vec<_>>>()
             .context(format!("Failed to convert type '{}'", intermediate.name))?;
 
+        // Owned types bind their relation on the query that returns them, so the
+        // type-level source is normally empty. An owner-split `extend type`
+        // federation entity carries a type-level `sql_source` (it has no local
+        // backing query) which the `_entities` resolver uses as its fallback
+        // relation (#507); its fields project from the standard `data` jsonb
+        // column — symmetric with the query path, whose `jsonb_column` also
+        // defaults to `data`. Regular types keep both empty (byte-identical
+        // compiled output, and the optimizer's projection-hint heuristic stays off).
+        let type_sql_source = intermediate.sql_source.unwrap_or_default();
+        let type_jsonb_column = if type_sql_source.is_empty() {
+            String::new()
+        } else {
+            "data".to_string()
+        };
+
         Ok(TypeDefinition {
             name: intermediate.name.into(),
             fields,
             description: intermediate.description,
-            sql_source: String::new().into(), // Not used for regular types (empty string)
-            jsonb_column: String::new(),      // Not used for regular types (empty string)
-            sql_projection_hint: None,        // Will be populated by optimizer in
+            sql_source: type_sql_source.into(),
+            jsonb_column: type_jsonb_column,
+            sql_projection_hint: None, // Will be populated by optimizer in
             implements: intermediate.implements,
             requires_role: intermediate.requires_role,
             is_error: intermediate.is_error,

--- a/crates/fraiseql-cli/src/schema/intermediate/types.rs
+++ b/crates/fraiseql-cli/src/schema/intermediate/types.rs
@@ -19,6 +19,19 @@ pub struct IntermediateType {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// Type-level SQL source (backing table/view), e.g. `v_organization`.
+    ///
+    /// Owned types bind their relation on the *query* that returns them, so this
+    /// is normally absent. It is emitted by the authoring SDK only for an
+    /// owner-split `extend type … @key` federation entity: a subgraph that does
+    /// not own the entity exposes no root query returning it, so the federation
+    /// `_entities` resolver has no query to source the backing relation from and
+    /// would otherwise guess `lower(typename)` and resolve to null (#507). When
+    /// present it flows through to `TypeDefinition.sql_source` and is used as the
+    /// `_entities` fallback relation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sql_source: Option<String>,
+
     /// Interfaces this type implements (GraphQL spec §3.6)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub implements: Vec<String>,

--- a/crates/fraiseql-cli/src/schema/validator/tests.rs
+++ b/crates/fraiseql-cli/src/schema/validator/tests.rs
@@ -107,6 +107,7 @@ fn test_detect_duplicate_query_names() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -192,6 +193,7 @@ fn test_warning_for_query_without_sql_source() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -262,6 +264,7 @@ fn test_valid_observer() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Order".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -383,6 +386,7 @@ fn test_observer_with_invalid_event() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Order".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -447,6 +451,7 @@ fn test_observer_with_invalid_action_type() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Order".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -511,6 +516,7 @@ fn test_observer_with_invalid_retry_config() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "Order".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -571,6 +577,7 @@ fn test_query_injection_in_sql_source_rejected() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],
@@ -636,6 +643,7 @@ fn test_query_schema_qualified_sql_source_passes() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],

--- a/crates/fraiseql-cli/tests/e2e_schema_generation.rs
+++ b/crates/fraiseql-cli/tests/e2e_schema_generation.rs
@@ -413,6 +413,7 @@ fn test_e2e_full_field_assertion() {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "id".to_string(),

--- a/crates/fraiseql-cli/tests/query_defaults_test.rs
+++ b/crates/fraiseql-cli/tests/query_defaults_test.rs
@@ -25,6 +25,7 @@ fn base_schema_with_query(
         version: "2.0.0".to_string(),
         types: vec![IntermediateType {
             name:                   query.return_type.clone(),
+            sql_source:             None,
             fields:                 vec![],
             description:            None,
             implements:             vec![],

--- a/crates/fraiseql-cli/tests/relay_compiler_test.rs
+++ b/crates/fraiseql-cli/tests/relay_compiler_test.rs
@@ -25,6 +25,7 @@ fn relay_intermediate_schema() -> IntermediateSchema {
         version:              "2.0.0".to_string(),
         types:                vec![IntermediateType {
             name:                   "User".to_string(),
+            sql_source:             None,
             fields:                 vec![
                 IntermediateField {
                     name:           "id".to_string(),

--- a/crates/fraiseql-core/src/runtime/executor/support/federation.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/federation.rs
@@ -110,23 +110,12 @@ impl<A: DatabaseAdapter> Executor<A> {
         // not exist and could not read jsonb-backed fields, so view-backed
         // cross-subgraph joins silently returned null (#504).
         //
-        // The backing relation is carried on the *query* that returns the type (the
-        // compiler leaves every `types[].sql_source` empty), keyed by `return_type`
-        // with first-wins — the same query→type binding the Relay `node` path uses.
-        let mut entity_sources: std::collections::HashMap<String, crate::federation::EntitySource> =
-            std::collections::HashMap::new();
-        for q in &self.ctx.schema.queries {
-            if let Some(relation) = &q.sql_source {
-                entity_sources.entry(q.return_type.clone()).or_insert_with(|| {
-                    crate::federation::EntitySource {
-                        relation:     relation.clone(),
-                        jsonb_column: (!q.jsonb_column.is_empty()).then(|| q.jsonb_column.clone()),
-                    }
-                });
-            }
-        }
+        // The backing relation is sourced from the *query* that returns the type
+        // (owned entities), with a fallback to the type-level `sql_source` for an
+        // owner-split `extend type` entity that has no local query (#507). See
+        // [`CompiledSchema::entity_sources`].
         let fed_resolver = crate::federation::FederationResolver::new(fed_metadata)
-            .with_entity_sources(entity_sources);
+            .with_entity_sources(self.ctx.schema.entity_sources());
 
         // Extract actual field selection from GraphQL query AST.
         // __typename is NOT added to the SQL field list — it is a GraphQL meta-field

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -182,6 +182,62 @@ impl CompiledSchema {
         })
     }
 
+    /// Build the per-entity-type backing source map (`typename` →
+    /// [`EntitySource`](crate::federation::EntitySource)) the federation
+    /// `_entities` resolver reads from instead of guessing `lower(typename)`
+    /// (#504/#507).
+    ///
+    /// Two sources, query-wins:
+    ///
+    /// 1. **Query-sourced** (owned entities): the backing relation rides on the root query that
+    ///    returns the type, keyed by `return_type`, first-wins — the same query→type binding the
+    ///    Relay `node` path uses. The query's `jsonb_column` (which the compiler defaults to
+    ///    `"data"`) drives jsonb projection.
+    /// 2. **Type-sourced fallback** (#507): an owner-split `extend type … @key` entity resolved in
+    ///    a subgraph that does not own it exposes no root query, so there is nothing in (1) to
+    ///    source its relation from. Its relation instead rides on the type-level `sql_source` the
+    ///    compiler carries from the authoring SDK. This only fills gaps — a query-sourced entry
+    ///    always wins.
+    ///
+    /// Both sources read the entity's `jsonb_column` the same way: a non-empty column selects
+    /// jsonb-projection mode (`<col>->'<field>'`), an empty one selects flat-column mode (bare
+    /// columns). The compiler defaults both a query's and an extends type's `jsonb_column` to the
+    /// standard `"data"` view shape, so a flat-column entity must be authored with an explicit
+    /// empty `jsonb_column`.
+    #[cfg(feature = "federation")]
+    #[must_use]
+    pub fn entity_sources(&self) -> HashMap<String, crate::federation::EntitySource> {
+        use crate::federation::EntitySource;
+
+        let mut sources: HashMap<String, EntitySource> = HashMap::new();
+
+        // (1) Query-sourced — owned entities. First-wins per return_type.
+        for q in &self.queries {
+            if let Some(relation) = &q.sql_source {
+                sources.entry(q.return_type.clone()).or_insert_with(|| EntitySource {
+                    relation:     relation.clone(),
+                    jsonb_column: (!q.jsonb_column.is_empty()).then(|| q.jsonb_column.clone()),
+                });
+            }
+        }
+
+        // (2) Type-sourced fallback — owner-split `extend type` entities (#507).
+        // Skipped for owned types (their type-level sql_source is empty) and never
+        // overrides a query-sourced entry. The empty-jsonb-column → flat-mode rule
+        // mirrors the query path above, so flat-column extends entities resolve too.
+        for t in &self.types {
+            if t.sql_source.as_str().is_empty() {
+                continue;
+            }
+            sources.entry(t.name.to_string()).or_insert_with(|| EntitySource {
+                relation:     t.sql_source.to_string(),
+                jsonb_column: (!t.jsonb_column.is_empty()).then(|| t.jsonb_column.clone()),
+            });
+        }
+
+        sources
+    }
+
     /// Stub federation metadata when federation feature is disabled.
     #[cfg(not(feature = "federation"))]
     #[must_use]

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -836,6 +836,61 @@ fn federation_metadata_some_when_enabled() {
 }
 
 // -------------------------------------------------------------------------
+// entity_sources (federation _entities backing-relation map)
+// -------------------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "federation")]
+fn entity_sources_query_wins_then_type_level_fallback() {
+    let mut schema = CompiledSchema::new();
+
+    // Owned entity "User": its relation rides on the root query. The compiled
+    // type carries an EMPTY type-level sql_source (what the converter emits for
+    // an owned type).
+    schema
+        .queries
+        .push(QueryDefinition::new("user", "User").with_sql_source("v_user"));
+    schema.types.push(TypeDefinition::new("User", ""));
+
+    // Owner-split `extend type` entity "Organization": no local query, so its
+    // relation rides on the type-level sql_source (#507).
+    schema.types.push(TypeDefinition::new("Organization", "v_organization"));
+
+    // "Account" has BOTH a backing query and a type-level sql_source → the
+    // query-sourced relation wins.
+    schema
+        .queries
+        .push(QueryDefinition::new("account", "Account").with_sql_source("v_account_query"));
+    schema.types.push(TypeDefinition::new("Account", "v_account_type"));
+
+    let sources = schema.entity_sources();
+
+    let user = sources.get("User").expect("owned entity sourced from its query");
+    assert_eq!(user.relation, "v_user");
+    assert_eq!(
+        user.jsonb_column.as_deref(),
+        Some("data"),
+        "the query's jsonb_column defaults to data"
+    );
+
+    let org = sources
+        .get("Organization")
+        .expect("extends entity sourced from type-level sql_source");
+    assert_eq!(org.relation, "v_organization");
+    assert_eq!(
+        org.jsonb_column.as_deref(),
+        Some("data"),
+        "an extends entity defaults to the standard jsonb `data` column"
+    );
+
+    let account = sources.get("Account").expect("Account is present");
+    assert_eq!(
+        account.relation, "v_account_query",
+        "a query-sourced relation wins over the type-level fallback"
+    );
+}
+
+// -------------------------------------------------------------------------
 // content_hash
 // -------------------------------------------------------------------------
 

--- a/crates/fraiseql-core/tests/federation/entity_resolution.rs
+++ b/crates/fraiseql-core/tests/federation/entity_resolution.rs
@@ -11,12 +11,14 @@
 use std::collections::HashMap;
 
 use fraiseql_core::{
+    CompiledSchema,
     db::{WhereClause, WhereOperator},
     federation::{
         database_resolver::DatabaseEntityResolver,
         selection_parser::FieldSelection,
         types::{EntityRepresentation, EntitySource},
     },
+    schema::TypeDefinition,
 };
 use serde_json::{Value, json};
 
@@ -421,4 +423,78 @@ async fn test_resolve_jsonb_data_backed_entity_projects_and_recases() {
     // camelCase field projected from `data->>'is_customer'`, with the boolean type
     // preserved (not the text "true") via the single-arrow `->` jsonb projection.
     assert_eq!(customer["isCustomer"], json!(true));
+}
+
+/// #507: an owner-split `extend type … @key` entity resolved in a subgraph that
+/// does not own it exposes no root query, so there is no backing query to source
+/// its relation from. The compiler instead carries the relation on the entity's
+/// `TypeDefinition.sql_source`, and [`CompiledSchema::entity_sources`] falls back
+/// to it. This drives the whole chain end-to-end against real PostgreSQL: a
+/// `Division` entity backed by the jsonb-`data` view `v_division_507`
+/// (≠ `lower("Division")`) resolves and projects its `data`-jsonb fields, whereas
+/// without the type-level source the resolver guesses the non-existent `division`
+/// relation and errors. The `EntitySource` map is produced by the **real**
+/// production builder (not hand-injected), so this also pins that the builder
+/// derives the relation from the type level.
+#[tokio::test]
+async fn test_resolve_extends_entity_from_type_level_sql_source() {
+    let div_id = "550e8400-e29b-41d4-a716-446655440507";
+    let rows = vec![map(&[(
+        "data",
+        json!({ "id": div_id, "name": "Engineering", "is_active": true }),
+    )])];
+    // A jsonb-`data` view whose name is deliberately NOT `lower("Division")`; the
+    // `_507` suffix keeps it unique so federation tests don't race on CREATE TABLE.
+    let Some((_pg, adapter)) =
+        common::pg_entity_fixture("v_division_507", &["data jsonb"], &rows).await
+    else {
+        eprintln!("SKIP test_resolve_extends_entity_from_type_level_sql_source: no postgres");
+        return;
+    };
+
+    // The entity is an `extend type` (is_extends = true) — the #507 scenario.
+    let metadata = common::metadata_extended_type("Division", "id", &[], &[]);
+    let selection =
+        FieldSelection::new(vec!["id".to_string(), "name".to_string(), "isActive".to_string()]);
+    let representation = rep("Division", &[("id", json!(div_id))]);
+
+    // Control: a compiled type with an EMPTY type-level sql_source (and no backing
+    // query) yields no source for Division, so the resolver guesses
+    // `lower("Division")` = `division`, which does not exist → hard error.
+    let mut blind_schema = CompiledSchema::new();
+    blind_schema.types.push(TypeDefinition::new("Division", ""));
+    assert!(
+        !blind_schema.entity_sources().contains_key("Division"),
+        "without a type-level sql_source the builder has no source for Division"
+    );
+    let blind = DatabaseEntityResolver::new(adapter.clone(), metadata.clone());
+    let blind_result = blind
+        .resolve_entities_from_db("Division", std::slice::from_ref(&representation), &selection)
+        .await;
+    assert!(
+        blind_result.is_err(),
+        "querying lower(typename) must fail: relation 'division' does not exist, got: {blind_result:?}"
+    );
+
+    // Fix: the compiled schema carries the entity's relation on its TYPE (no query
+    // returns `Division` in this subgraph). The real `entity_sources` builder
+    // sources it from there, defaulting to the standard jsonb `data` column (#507).
+    let mut schema = CompiledSchema::new();
+    schema.types.push(TypeDefinition::new("Division", "v_division_507"));
+    let sources = schema.entity_sources();
+    let src = sources.get("Division").expect("Division sourced from type-level sql_source");
+    assert_eq!(src.relation, "v_division_507");
+    assert_eq!(src.jsonb_column.as_deref(), Some("data"));
+
+    let resolver = DatabaseEntityResolver::new(adapter, metadata).with_entity_sources(sources);
+    let entities = resolver
+        .resolve_entities_from_db("Division", std::slice::from_ref(&representation), &selection)
+        .await
+        .unwrap_or_else(|e| panic!("type-sourced extends entity resolution failed: {e}"));
+
+    assert_eq!(entities.len(), 1);
+    let division = entities[0].as_ref().expect("extends entity must resolve from its view");
+    assert_eq!(division["name"], "Engineering");
+    // camelCase jsonb-only field projected from `data->>'is_active'`, type preserved.
+    assert_eq!(division["isActive"], json!(true));
 }

--- a/crates/fraiseql-server/tests/federation_integration_test.rs
+++ b/crates/fraiseql-server/tests/federation_integration_test.rs
@@ -55,6 +55,41 @@ fn user_schema_with_federation() -> CompiledSchema {
     CompiledSchema::from_json(json, false).expect("test schema must be valid")
 }
 
+// ─── #507 fast guards: _entities backing-source derivation ───────────────────
+// These need neither Postgres nor HTTP (no env gate), so the fast `test` leg
+// catches a mis-derived federation backing source — the regression class that
+// otherwise surfaces only in the slow, service-backed integration leg below.
+
+/// Subgraph A *owns* User: its relation rides on the `user(id)` query reading the
+/// `v_user` jsonb-`data` view, so the `_entities` resolver is query-sourced.
+#[test]
+fn users_subgraph_sources_owned_entity_from_query() {
+    let schema = user_schema_with_federation();
+    let sources = schema.entity_sources();
+    let user = sources.get("User").expect("owned User sourced from its backing query");
+    assert_eq!(user.relation, "v_user");
+    assert_eq!(user.jsonb_column.as_deref(), Some("data"));
+}
+
+/// Subgraph B *extends* User with no backing query, so the `_entities` resolver
+/// sources its relation from the type-level `sql_source` (#507). The `user` table
+/// is flat-column (no `data`), so the explicit empty `jsonb_column` selects flat
+/// mode: the resolver SELECTs bare columns and `quote_relation` quotes the bare
+/// identifier (a pre-quoted `sql_source` would be rejected as unsafe).
+#[test]
+fn reviews_subgraph_sources_extends_entity_from_type_level_sql_source() {
+    let json = include_str!("fixtures/federation/schema_reviews.json");
+    let schema = CompiledSchema::from_json(json, false).expect("reviews schema must be valid");
+    let sources = schema.entity_sources();
+    let user = sources.get("User").expect("extends User sourced from type-level sql_source");
+    assert_eq!(user.relation, "user", "unquoted identifier; quote_relation adds the quotes");
+    assert!(
+        user.jsonb_column.is_none(),
+        "flat-column extends entity: empty jsonb_column → flat projection, got {:?}",
+        user.jsonb_column
+    );
+}
+
 // ─── PostgreSQL helpers ──────────────────────────────────────────────────────
 
 async fn setup_users_table(db_url: &str) -> tokio_postgres::Client {

--- a/crates/fraiseql-server/tests/fixtures/federation/schema_reviews.json
+++ b/crates/fraiseql-server/tests/fixtures/federation/schema_reviews.json
@@ -2,8 +2,8 @@
     "types": [
         {
             "name": "User",
-            "table": "\"user\"",
-            "sql_source": "\"user\"",
+            "sql_source": "user",
+            "jsonb_column": "",
             "fields": [
                 {"name": "id",          "field_type": "ID",  "nullable": false},
                 {"name": "reviewcount", "field_type": "Int", "nullable": false}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 | Understand the system at a glance | [`architecture.md`](../architecture.md) — framework map (crates, modules, data flow) |
 | Read the conceptual architecture | [`docs/architecture/overview.md`](architecture/overview.md) |
 | Understand the SQL compiler | [`docs/architecture/compiler.md`](architecture/compiler.md) |
-| Read why design decisions were made | [`docs/adr/`](adr/) — 12 Architecture Decision Records |
+| Read why design decisions were made | [`docs/adr/`](adr/) — 14 Architecture Decision Records |
 | Set up a development environment | [`.claude/CLAUDE.md`](../.claude/CLAUDE.md) |
 | Run the server in production | [`docs/runbooks/`](runbooks/) — 15 incident response runbooks |
 | Deploy on FreeBSD (Jails + ZFS + Caddy) | [`docs/guides/freebsd-deployment.md`](guides/freebsd-deployment.md) |
@@ -25,7 +25,7 @@
 ```
 docs/
 ├── README.md                    ← this file
-├── adr/                         ← Architecture Decision Records (12 ADRs)
+├── adr/                         ← Architecture Decision Records (14 ADRs)
 │   ├── 0001-three-layer-architecture.md
 │   ├── 0002-database-driver-choices.md
 │   ├── 0003-feature-flag-strategy.md
@@ -37,7 +37,8 @@ docs/
 │   ├── 0009-database-feature-parity.md
 │   ├── 0010-async-mutation-handlers.md
 │   ├── 0012-async-trait-retention.md
-│   └── 0013-mutation-response-v2-schema.md
+│   ├── 0013-mutation-response-v2-schema.md
+│   └── 0014-federation-entity-backing-source.md
 ├── architecture/                ← Conceptual architecture docs
 │   ├── README.md                ← Navigation guide
 │   ├── overview.md              ← 3-layer model, security, error handling

--- a/docs/adr/0014-federation-entity-backing-source.md
+++ b/docs/adr/0014-federation-entity-backing-source.md
@@ -1,0 +1,254 @@
+# ADR-0014: Federation `_entities` Backing-Source Resolution
+
+## Status: Proposed — pending GraphQL-federation-expert review
+
+This ADR documents the design used to resolve **owner-split `extends` entities** in
+FraiseQL subgraphs (issue #507), the alternatives considered, and the open questions we
+would like a federation expert to validate. It is written to be self-contained for a
+reviewer without prior FraiseQL context.
+
+Related: ADR-0001 (three-layer architecture), `docs/architecture/federation.md`,
+issues #504 / #506 / #507.
+
+---
+
+## Context
+
+### What FraiseQL is
+
+FraiseQL is a **compiled GraphQL-to-SQL engine**. Schemas are authored in Python/TS
+(authoring layer), compiled to a `CompiledSchema` JSON by a Rust CLI (compilation
+layer), and executed by a Rust server that generates SQL at runtime (runtime layer).
+There is no per-request resolver code — the server turns a GraphQL operation into a SQL
+statement using the compiled schema.
+
+### Federation and `_entities`
+
+In Apollo Federation v2 a single entity type (e.g. `User`) is split across subgraphs:
+one subgraph **owns** it, others **extend** it. The gateway resolves an entity by
+fanning out, then merging the partial results on the entity's `@key`:
+
+```
+                    ┌─────────────────────────┐
+   client ───────▶  │   Apollo Router         │
+                    └───────────┬─────────────┘
+                       fan-out  │  merge on @key(id)
+            ┌──────────────────┼──────────────────┐
+            ▼                                       ▼
+   ┌──────────────────┐                  ┌──────────────────┐
+   │  Subgraph A      │                  │  Subgraph B      │
+   │  type User @key  │                  │  extend type     │
+   │    id            │                  │    User @key     │
+   │    name          │                  │    id @external  │
+   │                  │                  │    reviewcount   │
+   └──────────────────┘                  └──────────────────┘
+       OWNS User                            EXTENDS User
+```
+
+Each subgraph implements the federation-standard `_entities(representations: [_Any!]!)`
+query. Given `[{ __typename: "User", id: "user-1" }]`, Subgraph B must return the
+fields **it** contributes (`reviewcount`) for that key.
+
+### What "resolving `_entities`" means in FraiseQL (the SQL it must emit)
+
+To answer an `_entities` request, FraiseQL generates:
+
+```
+   SELECT  <field projections>          ◀── (b) HOW are fields stored?
+   FROM    <relation>                   ◀── (a) WHICH table/view?
+   WHERE   <key> IN ($1, $2, …)
+```
+
+So per entity type it needs a **backing source** = the pair:
+
+```rust
+// crates/fraiseql-federation/src/types.rs
+pub struct EntitySource {
+    pub relation: String,             // e.g. "v_user", "user", "app.v_org"
+    pub jsonb_column: Option<String>, // Some("data") → jsonb mode; None → flat mode
+}
+```
+
+FraiseQL supports two field-storage shapes:
+
+```
+  jsonb-"data" view (the FraiseQL standard)      flat-column table/view
+  ┌───────────────────────────────────┐         ┌──────────────────────────┐
+  │ data (jsonb)                       │         │ id    │ reviewcount │ …  │
+  │ {"id":"user-1","name":"Alice"}     │         │ user-1│     42      │    │
+  └───────────────────────────────────┘         └──────────────────────────┘
+  field → data->'is_active' (typed),             field → bare column
+  key   → data->>'id'                            key   → id::text IN (…)  [PG]
+```
+
+### The gap this ADR closes
+
+Where the backing source comes from differs by entity kind:
+
+```
+  OWNED entity (Subgraph A)                EXTENDS entity (Subgraph B)
+  ─────────────────────────                ───────────────────────────
+  Has a root query:                        Has NO root query in this subgraph.
+    query user(id): User                   It only contributes fields to a User
+        sql_source = "v_user"              owned elsewhere.
+        jsonb_column = "data"
+                                           ⇒ nothing to read the relation off of.
+  ⇒ source rides on the QUERY.                                       ◀── THE GAP
+```
+
+History:
+
+| Issue | Fixed | Left |
+|-------|-------|------|
+| **#504** | Bug report: resolver guessed `FROM lower(typename)` (`user`, `organization`) — usually a non-existent relation → query errored → gateway swallowed it to `null`. | everything |
+| **#506** | **Owned** entities: source `(relation, jsonb_column)` from the backing **query** (`queries[]`, keyed by `return_type`). | **Extends** entities: no query ⇒ map stayed empty for them ⇒ still fell back to `lower(typename)` ⇒ still `null`. |
+| **#507** (this ADR) | **Extends** entities: source the relation from a **type-level `sql_source`**. | SDK must emit it (out-of-repo). |
+
+---
+
+## Decision
+
+### 1. The extends relation lives on `TypeDefinition.sql_source` (the `types[]` array)
+
+The authoring SDK emits a type-level `sql_source` (and, implicitly, a `jsonb_column`)
+for an owner-split `extend type` entity. The compiler carries it to
+`CompiledSchema.types[].sql_source`; previously this field was always written empty.
+
+### 2. A single builder unifies both entity kinds (query-first, type-fallback)
+
+```rust
+// crates/fraiseql-core/src/schema/compiled/schema_domain.rs  (feature = "federation")
+CompiledSchema::entity_sources() -> HashMap<typename, EntitySource>
+  (1) for each query with sql_source:                       ┐ OWNED — first-wins
+        map[q.return_type] = (q.sql_source, q.jsonb_column) ┘ per return_type
+  (2) for each type with non-empty sql_source NOT already mapped:  ┐ EXTENDS (#507)
+        map[t.name] = (t.sql_source, t.jsonb_column)               ┘ fills gaps only
+```
+
+A query-sourced relation **always wins**; the type-level value only fills the gap an
+extends entity leaves. (Rationale for query-first: a type can be read by *multiple*
+queries with *different* views, so the relation is not a 1:1 property of the type for
+owned entities — the query is the more precise source.)
+
+The `_entities` resolver consumes this map; absent an entry it still falls back to
+`lower(typename)` (legacy / unit-test behaviour).
+
+### 3. jsonb vs flat uses one convention, shared with the query path
+
+`jsonb_column` non-empty → jsonb projection (`<col>->'<snake(field)>'`, typed,
+camelCase→snake); empty → flat (bare columns, key cast `id::text` on PostgreSQL). The
+compiler **defaults an extends entity's `jsonb_column` to `"data"`** (the FraiseQL
+standard), symmetric with how the query path defaults a query's `jsonb_column` to
+`"data"`. A flat-column extends entity is therefore the one authored with an explicit
+empty `jsonb_column`.
+
+`relation` is quoted defensively at SQL-build time (`quote_relation`): split on `.`,
+each segment validated as a safe SQL identifier and double-quoted, so `app.v_org`
+becomes `"app"."v_org"`. The authored value must be the **bare** identifier (`user`),
+not pre-quoted (`"user"`).
+
+---
+
+## Alternatives considered
+
+### Candidate 2 — put the relation on `FederationEntity` (the `federation` config block)
+
+Tempting: federation-specific, co-located with `@key`/`extends`, and a fresh
+`Option<String>` field avoids reusing the (historically vestigial) `TypeDefinition`
+fields.
+
+**Rejected** because of a merge trap in the compile pipeline. The SDK `schema.json` and
+`fraiseql.toml` are merged before conversion. The merger **overwrites** the federation
+config from TOML whenever `[federation].enabled`, and the TOML-side entity struct is
+`#[serde(deny_unknown_fields)]` with only `{name, key_fields}`:
+
+```
+   merger.rs:625
+   if toml_schema.federation.enabled {
+       merged["federation_config"] = toml_schema.federation.to_compiled();  // OVERWRITES
+   }                                                                        // maps only
+                                                                            // {name,key_fields}
+```
+
+```
+            SDK emits federation block            TOML [federation].enabled = true
+            with sql_source on entity
+                      │                                   │
+                      ▼                                   ▼
+   Candidate 2:   present in merged ───────────▶  OVERWRITTEN, sql_source LOST  ✗
+   (federation.entities[])
+
+   Candidate 1:   present in merged.types[] ────▶  untouched (TOML never           ✓
+   (types[])                                       writes types[])
+```
+
+`types[]` is a separate top-level key the TOML merger never rewrites, so a type-level
+`sql_source` survives **both** federation-config paths. Candidate 2's value would be
+silently dropped the moment a user enables `[federation]` in TOML — the same
+silent-drop class that caused #495 and #504. This was the deciding factor.
+
+### Candidate 3 — every `TypeDefinition` owns its relation (make queries pure references)
+
+Unify owned + extends by populating `types[].sql_source` for **all** types and having
+queries reference the type. **Rejected:** a type can be returned by multiple queries
+with different views (`v_user`, `v_user_admin`), so `relation` is not a 1:1 type
+property for owned entities. Query-first + type-fallback models reality; Candidate 3
+would be wrong in the multi-view case and is a large, risky refactor of the query path.
+
+---
+
+## Consequences
+
+**Positive**
+- Extends entities resolve correctly (flat and jsonb), completing #504/#506.
+- Robust against the TOML federation-merge overwrite (the decisive property).
+- Reuses the existing query-path jsonb/flat convention — one mental model.
+- Owned entities unaffected (query always wins); compiled output for non-extends types
+  is byte-identical (type `sql_source`/`jsonb_column` stay empty).
+
+**Negative / trade-offs**
+- Reactivates two previously-dead reads of `TypeDefinition`:
+  - the CLI optimizer's projection-hint heuristic keys on a non-empty `jsonb_column`
+    (extends types now have `"data"`). Mitigated: extends stubs have few fields, the
+    heuristic needs >10, and any hint is inert for a type with no local query.
+  - the runtime mutation cache-invalidation path reads `type.sql_source`. Inert for
+    extends entities (not mutated in the extending subgraph) — or correct if they were.
+- The "empty `jsonb_column` = flat" convention is subtle: `TypeDefinition.jsonb_column`
+  has a serde default of `"data"`, so a hand-authored compiled-schema fixture that
+  *omits* the field gets jsonb mode; a flat extends entity must set it to `""` explicitly.
+- The SDK (out-of-repo) must emit the type-level `sql_source`; until then extends
+  entities are unresolved (graceful: `null`, as before).
+
+---
+
+## Open questions for the federation expert
+
+1. **Model sanity.** Is it correct for an *extending* subgraph (which does not own the
+   type) to resolve `_entities` by reading its **own** local relation keyed by the
+   entity `@key`? Our model: each subgraph stores the fields it contributes in a local
+   table/view keyed by the shared key, and `_entities` reads that. Is this the intended
+   federation contract, or is there a case where the extending subgraph should resolve
+   differently (e.g. delegate, or require a join)?
+
+2. **`@requires` / `@provides`.** A contributed field may `@requires` external fields,
+   which the gateway passes inside the representation. Our backing-relation read keys
+   only on the entity `@key` and ignores other representation fields. Is that a
+   correctness gap for `@requires`-bearing fields, and should the backing source model
+   account for it?
+
+3. **Composite & multiple `@key`s.** The backing source is per-type (one relation);
+   key shape is handled entirely in the `WHERE … IN` clause. Is anything about
+   composite keys or multiple `@key` directives incompatible with a single
+   per-type backing relation?
+
+4. **Flat-vs-jsonb default.** We default an extends entity's storage shape to the
+   jsonb-`data` view (FraiseQL's norm) and require explicit opt-out for flat columns.
+   Is defaulting (vs requiring the SDK to state the shape explicitly) reasonable?
+
+5. **Owner-side resolvability.** When an entity's `@key` is marked non-resolvable in a
+   subgraph, should `entity_sources` deliberately *omit* it so `_entities` cannot
+   resolve it locally? Currently resolvability is enforced elsewhere; should the backing
+   source respect it too?
+
+6. **Multi-subgraph / shareable.** Any concern when the same type is `@shareable` and
+   resolvable in more than one subgraph, each with its own backing relation?

--- a/docs/adr/0014-federation-entity-backing-source.md
+++ b/docs/adr/0014-federation-entity-backing-source.md
@@ -200,6 +200,7 @@ would be wrong in the multi-view case and is a large, risky refactor of the quer
 ## Consequences
 
 **Positive**
+
 - Extends entities resolve correctly (flat and jsonb), completing #504/#506.
 - Robust against the TOML federation-merge overwrite (the decisive property).
 - Reuses the existing query-path jsonb/flat convention — one mental model.
@@ -207,6 +208,7 @@ would be wrong in the multi-view case and is a large, risky refactor of the quer
   is byte-identical (type `sql_source`/`jsonb_column` stay empty).
 
 **Negative / trade-offs**
+
 - Reactivates two previously-dead reads of `TypeDefinition`:
   - the CLI optimizer's projection-hint heuristic keys on a non-empty `jsonb_column`
     (extends types now have `"data"`). Mitigated: extends stubs have few fields, the


### PR DESCRIPTION
## Summary

Closes #507 — the deferred remainder of #504/#506.

An owner-split `extend type … @key` federation entity, resolved in a subgraph that does **not** own it, exposes no root query returning it. So the `_entities` resolver had no backing query to source its relation from (the compiler always left `types[].sql_source` empty), fell back to the non-existent `lower(typename)` relation, and the gateway silently turned the entity into `null`.

This wires the relation down the full chain:

1. **Compiler** — `IntermediateType` gains an optional `sql_source`; `convert_type` carries it through to `TypeDefinition.sql_source` instead of hardcoding empty. Owned types (relation rides on the query) keep the empty default, so their compiled output is byte-identical.
2. **Runtime** — new feature-gated `CompiledSchema::entity_sources()` builder centralizes the `_entities` backing-source map: query-sourced owned entities (first-wins, unchanged from #506) **plus** a type-level `sql_source` fallback for extends entities with no local query. FraiseQL entity views are jsonb-`data` backed, so an absent jsonb column defaults to `"data"`, mirroring the query path. `execute_entities_query` now calls the builder instead of an inline loop.
3. **Authoring SDK** (out-of-repo, Python/TS) — must emit a type-level `sql_source` for owner-split `extends` entities in `schema.json`. This PR is the FraiseQL/Rust half that reads and uses it.

## Tests

- **Live-PG federation integration** (`entity_resolution.rs`): an extends entity (`is_extends = true`) backed by the jsonb-`data` view `v_division_507` (≠ `lower("Division")`) resolves end-to-end through the **real** `entity_sources()` builder (not hand-injected, unlike the #506 tests). Control proves the pre-fix `lower(typename)` path errors.
- **Converter unit tests**: type-level `sql_source` deserializes and threads through to the compiled type; owned types keep empty.
- **Builder unit test**: query-sourced wins; type-level fallback fills gaps with the `data` jsonb default.

## Verification

- ✅ `cargo clippy --workspace --all-targets --all-features`
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- ✅ `make lint-tests-layout`; `bash tools/check-test-imports.sh`
- ✅ `cargo +nightly fmt --all -- --check` (nightly 2026-06-28, CI parity)
- ✅ core lib 2597 + cli lib 605 pass; federation **176 pass** on live PG (serialized `--test-threads=1`)
- ✅ builds with `--no-default-features` (cfg gating)
- No new `#[async_trait]` (ratchet untouched); POST/GET/existing behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)