### PR TITLE
fix(federation): keep first _entities field on minified gateway queries (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Federation `_entities` no longer drops the first field of each entity on minified
+  gateway queries.** Federation gateways (Hive Router, Apollo Router) routinely send
+  subgraph `_entities` queries minified — no spaces around the type condition or the
+  selection braces (`...on User{name email}`). The hand-rolled selection scanner did
+  not flush the pending token when a `{` opened the inline-fragment body, so the type
+  condition fused onto the first field (`User` + `name` → `Username`), and it failed to
+  skip the type name after the minifier-merged `...on` token. The first requested field
+  of every federated entity was projected under a mangled response key — a non-existent
+  column — and silently returned as `null`. The scanner now flushes on `{` and skips the
+  type condition for both `... on Type` and `...on Type`; pretty-printed queries are
+  unaffected. The `_entities` projection logic added in #504/#507 was already correct —
+  only the parser feeding it was wrong. (#512)
 - **Federation `_entities` now resolves view-backed, jsonb-`data` entities.** The
   runtime `_entities` resolver built its `FROM` relation from the lowercased GraphQL
   type name and selected bare columns, but FraiseQL entities are view-backed and

--- a/crates/fraiseql-federation/src/selection_parser.rs
+++ b/crates/fraiseql-federation/src/selection_parser.rs
@@ -74,6 +74,15 @@ fn extract_fields_from_selection_set(query: &str) -> Result<Vec<String>> {
     for ch in query.chars() {
         match ch {
             '{' => {
+                // A `{` opens a (possibly nested) selection set — e.g. the body of an
+                // inline fragment. Flush any pending token first, exactly as whitespace
+                // does, so a type condition butted directly against the body brace
+                // (minified `...on User{name email}`) does not fuse with the first field
+                // and yield `Username`. A space before `{` previously masked this. (#512)
+                if in_selection && !current_field.is_empty() {
+                    fields.push(current_field.trim().to_string());
+                    current_field.clear();
+                }
                 depth += 1;
                 if depth == 2 {
                     // Entering selection set for _entities
@@ -112,20 +121,25 @@ fn extract_fields_from_selection_set(query: &str) -> Result<Vec<String>> {
     let mut skip_type_after_on = false;
     for field in fields {
         let field = field.trim();
+        if skip_type_after_on {
+            // The previous token introduced an inline-fragment type condition
+            // (`on` or the minified `...on`); this token is the bare type name. Skip it.
+            skip_type_after_on = false;
+            continue;
+        }
         if field.is_empty() || field.contains('(') || field.contains(':') {
             continue;
         }
-        if field.starts_with("...") {
-            // Inline-fragment spread or named-fragment spread — not a field.
-            continue;
-        }
-        if field == "on" {
-            // The `on` keyword introduces a type condition; skip the type name next.
+        if field == "on" || field == "...on" {
+            // Inline-fragment type condition. Pretty-printed input emits `on` as its own
+            // token (`... on User`); a minifier fuses the spread and keyword into a single
+            // `...on` token (`...on User`). Either way the *type name* follows next, so
+            // skip it. `on` is a reserved word, so `...on` is never a named-fragment spread. (#512)
             skip_type_after_on = true;
             continue;
         }
-        if skip_type_after_on {
-            skip_type_after_on = false;
+        if field.starts_with("...") {
+            // Bare spread (`...`) or named-fragment spread (`...Fragment`) — not a field.
             continue;
         }
         result.push(field.to_string());

--- a/crates/fraiseql-federation/src/selection_parser/tests.rs
+++ b/crates/fraiseql-federation/src/selection_parser/tests.rs
@@ -78,3 +78,83 @@ fn test_field_selection_excludes_invalid_patterns() {
     assert!(selection.contains("name"));
     // Should not include the function call or directive
 }
+
+/// Regression for #512: a minifying federation gateway (Hive/Apollo Router)
+/// sends the `_entities` query with no spaces around the type condition or the
+/// selection braces (`...on User{name email}`). The char scanner used to fuse
+/// the type condition `User` onto the first field `name`, projecting a
+/// non-existent column and returning the first field of every entity as null.
+#[test]
+fn test_minified_inline_fragment_selection() {
+    let query = r"query($representations:[_Any!]!){_entities(representations:$representations){...on User{name email}}}";
+
+    let selection = parse_field_selection(query).unwrap();
+    assert!(selection.contains("name"), "name should be selected: {selection:?}");
+    assert!(selection.contains("email"), "email should be selected: {selection:?}");
+    // The fused token `Username` must never appear — that is the bug.
+    assert!(
+        !selection.contains("Username"),
+        "type condition fused onto field: {selection:?}"
+    );
+    // The inline-fragment scaffolding must not leak into the SQL projection.
+    assert!(!selection.contains("User"), "type condition is not a field: {selection:?}");
+    assert!(!selection.contains("on"), "`on` keyword is not a field: {selection:?}");
+}
+
+/// The defect is positional, not field-name-specific: the first field is lost
+/// regardless of which field it is. Cover the three shapes from the issue.
+#[test]
+fn test_minified_first_field_not_dropped_for_any_name() {
+    let cases = [
+        ("{_entities(representations:$r){...on User{name}}}", "name"),
+        ("{_entities(representations:$r){...on User{email}}}", "email"),
+        ("{_entities(representations:$r){...on User{id}}}", "id"),
+    ];
+    for (query, first_field) in cases {
+        let selection = parse_field_selection(query).unwrap();
+        assert!(
+            selection.contains(first_field),
+            "{first_field:?} should be selected for {query:?}: {selection:?}"
+        );
+        assert!(
+            !selection.contains(&format!("User{first_field}")),
+            "type condition fused onto {first_field:?} for {query:?}: {selection:?}"
+        );
+    }
+}
+
+/// A space-separated spread with no space before the body brace
+/// (`... on User{name}`) is another shape minifiers emit — the type condition
+/// must still be flushed before the body and skipped.
+#[test]
+fn test_spread_spaced_but_brace_minified() {
+    let query = "{_entities(representations:$r){... on User{name email}}}";
+
+    let selection = parse_field_selection(query).unwrap();
+    assert!(selection.contains("name"), "name should be selected: {selection:?}");
+    assert!(selection.contains("email"), "email should be selected: {selection:?}");
+    assert!(
+        !selection.contains("Username"),
+        "type condition fused onto field: {selection:?}"
+    );
+    assert!(!selection.contains("User"), "type condition is not a field: {selection:?}");
+}
+
+/// Heterogeneous `_entities` with multiple back-to-back minified inline
+/// fragments must keep the first field of *each* fragment.
+#[test]
+fn test_minified_heterogeneous_inline_fragments() {
+    let query = "{_entities(representations:$r){...on User{name email}...on Product{title}}}";
+
+    let selection = parse_field_selection(query).unwrap();
+    assert!(selection.contains("name"), "User.name should be selected: {selection:?}");
+    assert!(selection.contains("email"), "User.email should be selected: {selection:?}");
+    assert!(selection.contains("title"), "Product.title should be selected: {selection:?}");
+    assert!(!selection.contains("Username"), "User fused onto name: {selection:?}");
+    assert!(!selection.contains("Producttitle"), "Product fused onto title: {selection:?}");
+    assert!(!selection.contains("User"), "User type condition is not a field: {selection:?}");
+    assert!(
+        !selection.contains("Product"),
+        "Product type condition is not a field: {selection:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #512. A minifying federation gateway (Hive Router, Apollo Router) sends
subgraph `_entities` queries with **no spaces** around the type condition or the
selection braces (`...on User{name email}`). The hand-rolled selection scanner in
`selection_parser.rs` dropped the **first field of every entity** on these queries:

1. It never flushed `current_field` when `{` opened the inline-fragment body, so the
   type condition fused onto the first field (`User` + `name` → `Username`).
2. It did not skip the type name after the minifier-merged `...on` token (only the
   spaced `... on` form was handled).

The mangled first field projected a non-existent column (`data->'username'`) and was
silently returned as `null` over a real gateway. Pretty-printed queries flush every
token on whitespace, which is why the bug hid behind the existing spaced-only tests.

The `_entities` projection logic added in #504/#507 was already correct — only the
parser feeding it was wrong; it predates those PRs and was simply never exercised by
minified selections.

## Changes

- `extract_fields_from_selection_set`: flush the pending token on `{` (mirroring the
  whitespace separator), and skip the type condition for both `... on Type` and the
  merged `...on Type` form. `on` is a GraphQL reserved word, so `...on` is never a
  named-fragment spread — the disambiguation is safe.
- Regression tests for the minified, half-minified, positional (id/name/email-first),
  and heterogeneous multi-fragment shapes a gateway actually emits.

## Verification

- ✅ `cargo test -p fraiseql-federation` — 303 lib tests, 9 in `selection_parser` (4 new)
- ✅ `cargo clippy -p fraiseql-federation --all-targets --all-features -- -D warnings`
- ✅ `cargo +nightly fmt --all -- --check`
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc -p fraiseql-federation`
- ✅ `make lint-tests-layout`

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)