### PR TITLE
chore(security): resolve RUSTSEC-2026-0190 (anyhow bump) + ignore -0188 (wasmtime-wasi)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,7 +18,11 @@ ignore = [
   "RUSTSEC-2026-0098",
   "RUSTSEC-2026-0099",
   # rustls-webpki 0.101.7 CRL parsing panic; same root cause as 0098/0099. Deadline 2026-06-15.
-  "RUSTSEC-2026-0104"
+  "RUSTSEC-2026-0104",
+  # wasmtime-wasi FilePerms bypass (hard-link/rename); transitive via fraiseql-functions'
+  # opt-in runtime-wasm feature only (wasmtime pinned to 44, NOT in default build). Patched in
+  # 45.0.3/46.0.1 — needs a wasmtime 44->45+ major bump tracked separately. Deadline 2026-10-01.
+  "RUSTSEC-2026-0188"
 ]
 # Surface unsound + unmaintained advisories as warnings so new soundness issues are visible
 # in `cargo audit` output.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/deny.toml
+++ b/deny.toml
@@ -40,7 +40,16 @@ ignore = [
   # rustls-webpki 0.101.7: CRL parsing panic; transitive via aws-smithy-http-client (rustls 0.21).
   # Affects optional aws-s3 feature only; same root cause as RUSTSEC-2026-0098/0099.
   # deadline: 2026-09-01 — resolved when aws-sdk migrates to rustls 0.23.
-  {id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic; transitive via aws-smithy-http-client (rustls 0.21); optional aws-s3 feature only. Deadline 2026-09-01."}
+  {id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic; transitive via aws-smithy-http-client (rustls 0.21); optional aws-s3 feature only. Deadline 2026-09-01."},
+  # wasmtime-wasi: WASI hard-link/rename bypasses FilePerms on the destination path.
+  # Transitive via fraiseql-functions' opt-in `runtime-wasm` feature only (wasmtime/wasmtime-wasi
+  # are pinned to major "44"); NOT in the default build, no exposure for a standard FraiseQL server.
+  # Patched in 45.0.3 / 46.0.1 — there is no fix within the 44.x line, so resolution requires a
+  # wasmtime 44 -> 45+ MAJOR bump that also moves the `wasmtime::component::bindgen!` glue, tracked
+  # as standalone work (out of scope for an advisory-hygiene pass; the env can't build/verify the
+  # wasmtime stack safely here).
+  # deadline: 2026-10-01 — re-evaluate when the standalone wasmtime 45+ bump lands.
+  {id = "RUSTSEC-2026-0188", reason = "wasmtime-wasi FilePerms bypass; transitive via opt-in runtime-wasm feature only (wasmtime pinned to 44); patched in 45.0.3/46.0.1 needs a major bump tracked separately. Deadline 2026-10-01."}
 ]
 unmaintained = "workspace"
 


### PR DESCRIPTION
## Summary

Two RustSec advisories published 2026-06-29 turned the Dagger **security** leg red across
`dev` (both `cargo-deny` and `cargo-audit`). Neither is introduced by recent work — both
sit in the dependency graph. This restores the security leg to green.

- **RUSTSEC-2026-0190** — `anyhow` `Error::downcast_mut()` unsoundness. **Fixed** by bumping
  `anyhow` 1.0.102 → **1.0.103** (first patched release; an API-identical patch bump).
- **RUSTSEC-2026-0188** — `wasmtime-wasi` WASI hard-link/rename bypasses `FilePerms` on the
  destination. **Ignored** with a 2026-10-01 deadline in both `deny.toml` and `.cargo/audit.toml`
  (kept in lockstep). It reaches the graph only via fraiseql-functions' opt-in `runtime-wasm`
  feature (wasmtime pinned to major `"44"`) — **no default-build exposure**. The fix is in
  45.0.3 / 46.0.1, i.e. a wasmtime 44 → 45+ **major** bump that also moves the
  `wasmtime::component::bindgen!` glue — out of scope for an advisory-hygiene change, tracked
  as standalone work.

This follows the repo's existing policy for opt-in-feature advisories with no clean in-range
fix (the mysql / aws-s3 precedents already in the ignore list).

## Verification

- ✅ `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- ✅ `cargo audit` — exit 0 (only informational unmaintained/unsound warnings remain)
- ✅ `tools/check-audit-lockstep.sh` — deny.toml and .cargo/audit.toml in lockstep

🤖 Generated with [Claude Code](https://claude.com/claude-code)