### PR TITLE
chore(deps): bump opentelemetry 0.32, async-nats 0.49, kamadak-exif 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.47.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
+checksum = "fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -611,7 +611,7 @@ dependencies = [
  "nuid",
  "pin-project",
  "portable-atomic",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -621,7 +621,7 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -3421,7 +3421,7 @@ dependencies = [
  "jsonwebtoken",
  "parquet",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sqlx",
@@ -3462,7 +3462,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "samael",
  "serde",
  "serde_json",
@@ -3526,7 +3526,7 @@ dependencies = [
  "notify",
  "predicates",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3596,7 +3596,7 @@ dependencies = [
  "rdkafka",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -3677,7 +3677,7 @@ dependencies = [
  "futures",
  "lru 0.18.0",
  "proptest",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",
@@ -3706,7 +3706,7 @@ dependencies = [
  "fraiseql-storage",
  "fraiseql-test-support",
  "hex",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3750,7 +3750,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3781,7 +3781,7 @@ dependencies = [
  "mutants",
  "proptest",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "temp-env",
@@ -3850,7 +3850,7 @@ dependencies = [
  "prost-reflect",
  "rand 0.9.4",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "rmcp",
  "rmp-serde",
  "rust-embed",
@@ -3906,7 +3906,7 @@ dependencies = [
  "jsonwebtoken",
  "kamadak-exif",
  "parking_lot",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4720,7 +4720,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -5142,9 +5142,9 @@ dependencies = [
 
 [[package]]
 name = "kamadak-exif"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
 dependencies = [
  "mutate_once",
 ]
@@ -6089,9 +6089,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6103,22 +6103,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.2",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.2",
  "opentelemetry",
@@ -6126,35 +6126,33 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -6939,7 +6937,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6976,7 +6974,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7441,9 +7439,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -7471,6 +7467,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -9572,9 +9599,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/crates/fraiseql-cdc-sinks/Cargo.toml
+++ b/crates/fraiseql-cdc-sinks/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-async-nats = {version = "0.47", optional = true}
+async-nats = {version = "0.49", optional = true}
 chrono = {workspace = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/crates/fraiseql-observers/Cargo.toml
+++ b/crates/fraiseql-observers/Cargo.toml
@@ -1,7 +1,7 @@
 [dependencies]
 arrow = {version = "57", optional = true}
 # NATS Dependencies
-async-nats = {version = "0.47", optional = true}
+async-nats = {version = "0.49", optional = true}
 async-trait = "0.1"
 base64 = "0.22"
 bb8 = {version = "0.8", optional = true}

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -82,10 +82,10 @@ jsonwebtoken = {version = "10", features = ["rust_crypto"]}
 # pulls a matching `metrics` 0.24 transitively. The previous direct `metrics` 0.22
 # pin was unreferenced and conflicted with the exporter's 0.24 (audit H45).
 metrics-exporter-prometheus = {version = "0.18", optional = true}
-# OpenTelemetry (optional) — versions must match tracing-opentelemetry 0.32
-opentelemetry = {version = "0.31", optional = true}
-opentelemetry-otlp = {version = "0.31", features = ["http-proto"], optional = true}
-opentelemetry_sdk = {version = "0.31", features = ["rt-tokio"], optional = true}
+# OpenTelemetry (optional) — versions must match tracing-opentelemetry 0.33
+opentelemetry = {version = "0.32", optional = true}
+opentelemetry-otlp = {version = "0.32", features = ["http-proto"], optional = true}
+opentelemetry_sdk = {version = "0.32", features = ["rt-tokio"], optional = true}
 parking_lot = {workspace = true}
 pin-project = "1"
 prost = { version = "0.14.3", optional = true }
@@ -121,7 +121,7 @@ tower = {version = "0.5", features = ["full"]}
 tower-http = {version = "0.6", features = ["trace", "cors", "compression-full", "limit", "timeout", "request-id"]}
 # Tracing
 tracing = "0.1"
-tracing-opentelemetry = {version = "0.32", optional = true}
+tracing-opentelemetry = {version = "0.33", optional = true}
 tracing-subscriber = {version = "0.3", features = ["env-filter", "json"]}
 url = {workspace = true}
 urlencoding = "2.1"

--- a/crates/fraiseql-storage/Cargo.toml
+++ b/crates/fraiseql-storage/Cargo.toml
@@ -46,7 +46,7 @@ hmac = { workspace = true, optional = true }
 
 # Image transforms (feature-gated)
 image = { version = "0.25", optional = true }
-kamadak-exif = { version = "0.5", optional = true }
+kamadak-exif = { version = "0.6", optional = true }
 # google-cloud-storage = { version = "...", optional = true }
 # azure_storage_blobs = { version = "0.20", optional = true }
 

--- a/deny.toml
+++ b/deny.toml
@@ -277,6 +277,11 @@ reason = "transitive via newer dependency chain pulling rand 0.10"
 version = "=0.10.1"
 
 [[bans.skip]]
+name = "reqwest"
+reason = "transitive via opentelemetry-otlp 0.32 → opentelemetry-http (reqwest 0.13); workspace direct on reqwest 0.12"
+version = "=0.13.4"
+
+[[bans.skip]]
 name = "rustc_version"
 reason = "transitive via older build dependencies"
 version = "=0.2.3"


### PR DESCRIPTION
Groups three breaking minor-version dependency bumps (each previously a standalone dependabot PR) into one verified change.

| dep | from → to | crate(s) | supersedes |
|-----|-----------|----------|------------|
| opentelemetry / -otlp / _sdk | 0.31 → 0.32 | fraiseql-server | #307 |
| tracing-opentelemetry | 0.32 → 0.33 | fraiseql-server | #307 |
| async-nats | 0.47 → 0.49 | fraiseql-cdc-sinks, fraiseql-observers | #308 |
| kamadak-exif | 0.5 → 0.6 | fraiseql-storage | #310 |

**No source changes were needed** — all affected crates compile and are clippy-clean (`-D warnings`) against the new APIs. The opentelemetry family is bumped in lockstep (dependabot's #307 bumped only `opentelemetry`, which would not have built).

`opentelemetry-otlp 0.32` pulls `reqwest 0.13` transitively (workspace stays on `reqwest 0.12`), so a `cargo-deny` duplicate skip is added.

**`deadpool` (#309) is intentionally excluded** — it needs `deadpool-postgres` to move in lockstep and is load-bearing (db/core/federation/cli); it warrants its own PR.

## Verification
- ✅ `cargo check` + `cargo clippy -D warnings` on storage / cdc-sinks / observers / server (otel)
- ✅ `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- ✅ `cargo metadata --locked` consistent
- The 5 Dagger legs are dispatched on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)