### PR TITLE
chore: bump markdownlint-cli pre-commit hook to v0.49.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
 
   # Markdown linting
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         args: [--fix]


### PR DESCRIPTION
Lands the pre-commit.ci autoupdate from #449, which has been failing since 2026-06-22.

**Why #449 failed:** the `v0.48 → v0.49` bump is clean, but #449's branch predates the docs whose `# 392` / `# 411` issue-reference lines (wrapped to line-start in prose) parse as H1 headings under the stricter v0.49 — and `markdownlint --fix` could not resolve the resulting `MD025` (multiple top-level headings). Those lines were since fixed on dev by #507 / #412, so on **current dev** the markdownlint hook passes cleanly with v0.49.0. Only the version bump remains; #449's stale `--fix` doc edits are dropped.

## Verification
- ✅ `pre-commit run markdownlint --all-files` → Passed
- Single-line config change; no source/docs touched.

Supersedes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)