### PR TITLE
feat(federation): wire saga compensation under unstable-saga (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Saga compensation (rollback) is now wired under `unstable-saga` (#429).** When a
+  distributed saga fails partway, `SagaCompensator::compensate_saga_local` rolls back the
+  already-completed steps in strict reverse execution order by executing each step's
+  registered compensation (inverse) mutation through the local SQL adapter, then persists
+  a real `Compensated` step state — never a fabricated rollback (audit H33). Compensation
+  is best-effort: a step whose inverse fails, or that has no compensation registered,
+  leaves the saga `Failed` and is reported `PartiallyCompensated` rather than marking the
+  saga `Compensated` having undone only part of its work. The saga step schema gained
+  nullable `compensation_mutation` / `compensation_variables` columns (added idempotently
+  by `migrate_schema`; rows that predate them read back as `None`). The published fail-loud
+  placeholders `SagaCompensator::{compensate_saga, compensate_step}` are unchanged and
+  still return `SagaStoreError::NotImplemented`; remote (HTTP) compensation, recovery, and
+  the coordinator facade remain unwired. Requires the `unstable-saga` Cargo feature; the
+  API may change without semver guarantees.
 - **Short-lived runtime executor: `fraiseql query` + `doctor --runtime` (#501).** A
   scriptable way to exercise a compiled schema against a database without standing up
   the long-lived server, closing the gap between "static checks pass" and "the server

--- a/crates/fraiseql-federation/src/lib.rs
+++ b/crates/fraiseql-federation/src/lib.rs
@@ -15,7 +15,8 @@
 //! | Subgraph mode — `HttpEntityResolver` (`_entities` HTTP resolution) | ✅ Production | SSRF-protected, retry, tracing |
 //! | Composition validation — `CompositionValidator` | ✅ Production | compile-time only |
 //! | Saga forward execution — `SagaExecutor::{execute_step_local, execute_saga_local, execution_state}` | 🚧 Unstable | requires `unstable-saga` feature; dispatches real local mutations and persists real step/saga state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Remote (HTTP) dispatch and `@requires` pre-fetch are not yet wired. |
-//! | Saga forward placeholders — `SagaExecutor::{execute_step, execute_saga, get_execution_state}` + compensation / recovery / coordination | 🚧 Not implemented | return `SagaStoreError::NotImplemented` in every build (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). `PostgresSagaStore` persistence is real. |
+//! | Saga compensation — `SagaCompensator::{compensate_step_local, compensate_saga_local}` | 🚧 Unstable | requires `unstable-saga` feature; rolls back completed steps in reverse execution order via the local SQL adapter and persists real `Compensated` state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Remote (HTTP) compensation is not yet wired. |
+//! | Saga placeholders — `SagaExecutor::{execute_step, execute_saga, get_execution_state}` + `SagaCompensator::{compensate_step, compensate_saga}` + recovery / coordination | 🚧 Not implemented | return `SagaStoreError::NotImplemented` in every build (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). `PostgresSagaStore` persistence is real. |
 //! | HTTP mutation propagation — `HttpMutationClient` | ✅ Production | SSRF-protected |
 //! | Gateway mode — `ConnectionManager::get_or_create_connection` | 🚧 Unstable | requires `unstable` feature |
 //! | Direct-DB federation — `DirectDbResolver` | 🚧 Unstable | stub only; not yet implemented |

--- a/crates/fraiseql-federation/src/saga_compensator.rs
+++ b/crates/fraiseql-federation/src/saga_compensator.rs
@@ -110,6 +110,10 @@ use uuid::Uuid;
 
 use crate::saga_store::{PostgresSagaStore, Result as SagaStoreResult, SagaState, StepState};
 
+/// Pure compensation-phase decision helpers (always compiled; see the module docs
+/// for why the logic lives outside the feature gate).
+mod compensation;
+
 /// Represents the result of a compensation step execution
 ///
 /// Contains the outcome of executing a single compensation mutation, including:
@@ -428,6 +432,180 @@ impl SagaCompensator {
 impl Default for SagaCompensator {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Wired compensation phase (the `unstable-saga` feature).
+///
+/// Additive: the fail-loud [`SagaCompensator::compensate_saga`] /
+/// [`SagaCompensator::compensate_step`] above keep their signatures and behaviour
+/// in every build (the `#429` H33 acceptance spec exercises them). The real
+/// local-SQL rollback is exposed as the `*_local` methods, gated behind
+/// `unstable-saga` until proven. Remote (HTTP) compensation is Phase 04.
+#[cfg(feature = "unstable-saga")]
+mod wired {
+    use fraiseql_db::traits::DatabaseAdapter;
+    use uuid::Uuid;
+
+    use super::{
+        CompensationResult, CompensationStatus, CompensationStepResult, SagaCompensator,
+        compensation,
+    };
+    use crate::{
+        mutation_executor::FederationMutationExecutor,
+        saga_store::{Result as SagaStoreResult, SagaState, SagaStoreError, StepState},
+    };
+
+    impl SagaCompensator {
+        /// Compensate a single completed step by executing its registered
+        /// compensation (inverse) mutation against the local SQL adapter.
+        ///
+        /// The stored `compensation_mutation` name drives the mutation kind
+        /// (`determine_mutation_type`), so a create is undone by a `delete…`
+        /// compensation, etc.; the `compensation_variables` (falling back to the
+        /// forward `variables`) carry the entity key. On a successful inverse the
+        /// step is persisted [`StepState::Compensated`]; a failed inverse or a step
+        /// with no registered compensation leaves the step untouched and is reported
+        /// `success: false` — a rollback that did not happen is never fabricated
+        /// (audit H33). Remote (HTTP) compensation is Phase 04.
+        ///
+        /// # Arguments
+        ///
+        /// * `mutation_executor` - Local mutation transport for the step's subgraph
+        /// * `step` - The persisted (completed) step to roll back
+        ///
+        /// # Errors
+        ///
+        /// Returns [`SagaStoreError::Database`] if no saga store is configured, or
+        /// any store error encountered while persisting the compensated state.
+        pub async fn compensate_step_local<A: DatabaseAdapter>(
+            &self,
+            mutation_executor: &FederationMutationExecutor<A>,
+            step: &crate::saga_store::SagaStep,
+        ) -> SagaStoreResult<CompensationStepResult> {
+            let store = self.store.as_ref().ok_or_else(|| {
+                SagaStoreError::Database(
+                    "saga compensation requires a configured saga store".to_string(),
+                )
+            })?;
+
+            let step_number = u32::try_from(step.order).unwrap_or(u32::MAX).saturating_add(1);
+
+            // A step with no registered compensation cannot be rolled back — report
+            // a best-effort miss rather than fabricating a rollback (H33).
+            if !compensation::step_is_compensatable(step) {
+                return Ok(CompensationStepResult {
+                    step_number,
+                    success: false,
+                    data: None,
+                    error: Some("no compensation mutation registered".to_string()),
+                    duration_ms: 0,
+                });
+            }
+            // `step_is_compensatable` guaranteed a present, non-empty name.
+            let mutation = step.compensation_mutation.as_deref().unwrap_or_default();
+
+            // Compensation variables carry the entity key for the inverse mutation;
+            // fall back to the forward variables when none were registered.
+            let variables = step.compensation_variables.as_ref().unwrap_or(&step.variables);
+
+            let started = std::time::Instant::now();
+            let outcome = mutation_executor
+                .execute_local_mutation(&step.typename, mutation, variables)
+                .await;
+            let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+            let result = compensation::compensation_result_from(step_number, &outcome, duration_ms);
+
+            // Persist the rollback only when the inverse mutation actually ran: a
+            // successful compensation transitions the step Compensated; a failed one
+            // leaves it Completed for a later best-effort retry.
+            if result.success {
+                store.update_saga_step_state(step.id, &StepState::Compensated).await?;
+            }
+
+            Ok(result)
+        }
+
+        /// Execute the compensation phase for a saga: roll back every completed
+        /// step in strict reverse execution order.
+        ///
+        /// Marks the saga `Compensating`, then for each completed step (most-recent
+        /// first) dispatches [`Self::compensate_step_local`], continuing past
+        /// individual failures (best-effort resilience). If every completed step
+        /// rolled back the saga is marked [`SagaState::Compensated`]; if any step
+        /// could not be compensated the saga stays [`SagaState::Failed`] and the
+        /// result reports [`CompensationStatus::PartiallyCompensated`] — a saga is
+        /// never marked `Compensated` having undone only part of its work (H33).
+        ///
+        /// # Arguments
+        ///
+        /// * `saga_id` - ID of the saga to compensate
+        /// * `mutation_executor` - Local mutation transport for the steps' subgraph
+        ///
+        /// # Errors
+        ///
+        /// Returns [`SagaStoreError::Database`] if no saga store is configured,
+        /// [`SagaStoreError::SagaNotFound`] if the saga does not exist, or any store
+        /// error encountered while loading steps or persisting state.
+        pub async fn compensate_saga_local<A: DatabaseAdapter>(
+            &self,
+            saga_id: Uuid,
+            mutation_executor: &FederationMutationExecutor<A>,
+        ) -> SagaStoreResult<CompensationResult> {
+            let store = self.store.as_ref().ok_or_else(|| {
+                SagaStoreError::Database(
+                    "saga compensation requires a configured saga store".to_string(),
+                )
+            })?;
+
+            // Enter the compensation phase first: a missing saga surfaces as
+            // SagaNotFound from the store's row-count check rather than silently
+            // compensating nothing.
+            store.update_saga_state(saga_id, &SagaState::Compensating).await?;
+
+            let steps = store.load_saga_steps(saga_id).await?;
+            let order = compensation::compensation_order(&steps);
+
+            let overall = std::time::Instant::now();
+            let mut step_results = Vec::with_capacity(order.len());
+            let mut failed_steps = Vec::new();
+
+            for step in order {
+                let result = self.compensate_step_local(mutation_executor, step).await?;
+                if !result.success {
+                    failed_steps.push(result.step_number);
+                }
+                step_results.push(result);
+            }
+
+            let total_duration_ms =
+                u64::try_from(overall.elapsed().as_millis()).unwrap_or(u64::MAX);
+
+            // All completed steps rolled back → Compensated. Any miss (a failed
+            // inverse or an unregistered compensation) → the saga stays Failed and is
+            // reported PartiallyCompensated; never Compensated having undone part.
+            let (status, saga_state, error) = if failed_steps.is_empty() {
+                (CompensationStatus::Compensated, SagaState::Compensated, None)
+            } else {
+                (
+                    CompensationStatus::PartiallyCompensated,
+                    SagaState::Failed,
+                    Some(format!("{} step(s) could not be compensated", failed_steps.len())),
+                )
+            };
+
+            store.update_saga_state(saga_id, &saga_state).await?;
+
+            Ok(CompensationResult {
+                saga_id,
+                status,
+                step_results,
+                failed_steps,
+                total_duration_ms,
+                error,
+            })
+        }
     }
 }
 

--- a/crates/fraiseql-federation/src/saga_compensator/compensation.rs
+++ b/crates/fraiseql-federation/src/saga_compensator/compensation.rs
@@ -1,0 +1,81 @@
+//! Pure compensation-phase decision helpers.
+//!
+//! These functions hold the saga compensation *logic* with no I/O: deciding
+//! whether a step can be compensated, mapping a compensation mutation outcome to
+//! a [`CompensationStepResult`], and ordering the completed steps for reverse
+//! rollback. Keeping them pure lets their unit tests run in the fast `test` leg
+//! on every push, so the "never fabricate a rollback" contract is covered
+//! independently of a live database and of the `unstable-saga` feature — the same
+//! arrangement the forward phase uses in [`crate::saga_executor::forward`].
+//!
+//! They are consumed only by the feature-gated wired compensator, so without
+//! `unstable-saga` they are dead in a non-test build — hence the module-level
+//! `allow(dead_code)` for that configuration (the established `#428` pattern).
+#![cfg_attr(not(feature = "unstable-saga"), allow(dead_code))]
+
+use fraiseql_error::Result;
+use serde_json::Value;
+
+use super::CompensationStepResult;
+use crate::saga_store::{SagaStep, StepState};
+
+/// Whether `step` has a registered compensation (inverse) mutation.
+///
+/// A step is compensatable only when its `compensation_mutation` is present and
+/// non-empty; a `None`/empty value means no rollback was registered and the step
+/// must be skipped rather than silently treated as compensated (best-effort
+/// contract, #429).
+pub(super) fn step_is_compensatable(step: &SagaStep) -> bool {
+    step.compensation_mutation.as_deref().is_some_and(|m| !m.is_empty())
+}
+
+/// Map a single compensation mutation `outcome` to the [`CompensationStepResult`]
+/// reported to callers.
+///
+/// A compensation mutation `Err` is a *legitimate outcome*, not fabricated
+/// success: it becomes `success: false` with the error captured, and no result
+/// data. Compensation never reports a rollback that did not happen (audit H33) —
+/// the true analog of the forward phase's
+/// [`step_result_from`](crate::saga_executor::forward).
+pub(super) fn compensation_result_from(
+    step_number: u32,
+    outcome: &Result<Value>,
+    duration_ms: u64,
+) -> CompensationStepResult {
+    match outcome {
+        Ok(data) => CompensationStepResult {
+            step_number,
+            success: true,
+            data: Some(data.clone()),
+            error: None,
+            duration_ms,
+        },
+        Err(error) => CompensationStepResult {
+            step_number,
+            success: false,
+            data: None,
+            error: Some(error.to_string()),
+            duration_ms,
+        },
+    }
+}
+
+/// Order the steps that must be compensated: only [`StepState::Completed`] steps
+/// were actually executed and therefore need rolling back, in strict reverse
+/// execution order (highest `order` first).
+///
+/// Steps that never completed (Pending/Executing/Failed) are excluded — there is
+/// nothing to undo. Compensatability (a registered compensation mutation) is
+/// decided per step by the caller via [`step_is_compensatable`], so a completed
+/// step with no compensation still appears here and is reported as a best-effort
+/// miss rather than being silently dropped.
+pub(super) fn compensation_order(steps: &[SagaStep]) -> Vec<&SagaStep> {
+    let mut completed: Vec<&SagaStep> =
+        steps.iter().filter(|step| step.state == StepState::Completed).collect();
+    // Reverse execution order: undo the most recently completed step first.
+    completed.sort_by(|a, b| b.order.cmp(&a.order));
+    completed
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-federation/src/saga_compensator/compensation/tests.rs
+++ b/crates/fraiseql-federation/src/saga_compensator/compensation/tests.rs
@@ -1,0 +1,101 @@
+use fraiseql_error::FraiseQLError;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::*;
+use crate::saga_store::MutationType;
+
+/// Build a store `SagaStep` in a given `order`/`state` with an optional
+/// compensation mutation. Only the fields the pure helpers read matter here.
+fn step(order: usize, state: StepState, compensation_mutation: Option<&str>) -> SagaStep {
+    SagaStep {
+        id: Uuid::new_v4(),
+        saga_id: Uuid::new_v4(),
+        order,
+        subgraph: "orders".to_string(),
+        mutation_type: MutationType::Create,
+        typename: "Order".to_string(),
+        variables: json!({"id": "o1"}),
+        state,
+        result: None,
+        started_at: None,
+        completed_at: None,
+        compensation_mutation: compensation_mutation.map(ToString::to_string),
+        compensation_variables: None,
+    }
+}
+
+#[test]
+fn no_compensation_mutation_is_not_compensatable() {
+    assert!(!step_is_compensatable(&step(0, StepState::Completed, None)));
+}
+
+#[test]
+fn empty_compensation_mutation_is_not_compensatable() {
+    assert!(!step_is_compensatable(&step(0, StepState::Completed, Some(""))));
+}
+
+#[test]
+fn registered_compensation_mutation_is_compensatable() {
+    assert!(step_is_compensatable(&step(0, StepState::Completed, Some("deleteOrder"))));
+}
+
+#[test]
+fn ok_outcome_maps_to_success_with_data() {
+    let outcome = Ok(json!({"__typename": "Order", "id": "o1", "deleted": true}));
+    let result = compensation_result_from(2, &outcome, 5);
+
+    assert!(result.success);
+    assert_eq!(result.step_number, 2);
+    assert_eq!(result.data, Some(json!({"__typename": "Order", "id": "o1", "deleted": true})));
+    assert!(result.error.is_none());
+    assert_eq!(result.duration_ms, 5);
+}
+
+#[test]
+fn err_outcome_maps_to_failure_without_fabricating_data() {
+    let outcome: Result<Value> = Err(FraiseQLError::Validation {
+        message: "compensation target not found".to_string(),
+        path:    None,
+    });
+    let result = compensation_result_from(3, &outcome, 9);
+
+    assert!(!result.success, "a failed compensation must never report success");
+    assert!(result.data.is_none(), "a failed compensation must not fabricate rollback data");
+    assert!(
+        result
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("compensation target not found")
+    );
+    assert_eq!(result.duration_ms, 9);
+}
+
+#[test]
+fn compensation_order_keeps_only_completed_in_reverse() {
+    let steps = vec![
+        step(0, StepState::Completed, Some("deleteA")),
+        step(1, StepState::Failed, Some("deleteB")),
+        step(2, StepState::Completed, Some("deleteC")),
+        step(3, StepState::Pending, None),
+    ];
+
+    let ordered = compensation_order(&steps);
+
+    // Only the two Completed steps, most-recent first (order 2 before order 0).
+    let orders: Vec<usize> = ordered.iter().map(|s| s.order).collect();
+    assert_eq!(orders, vec![2, 0], "compensate completed steps in reverse execution order");
+}
+
+#[test]
+fn compensation_order_is_empty_when_no_step_completed() {
+    let steps = vec![
+        step(0, StepState::Failed, Some("deleteA")),
+        step(1, StepState::Pending, None),
+    ];
+    assert!(
+        compensation_order(&steps).is_empty(),
+        "nothing completed → nothing to compensate"
+    );
+}

--- a/crates/fraiseql-federation/src/saga_compensator/tests.rs
+++ b/crates/fraiseql-federation/src/saga_compensator/tests.rs
@@ -105,3 +105,92 @@ async fn get_compensation_status_without_store_is_none() {
 
     assert!(status.is_none(), "no store should yield no status");
 }
+
+/// Wired compensation (`unstable-saga`). The store-backed rollback paths are proven
+/// end-to-end against real PostgreSQL in `tests/saga_integration.rs`; here we pin
+/// the store-absent contract without any external service — a compensator with no
+/// store fails loud (never a silent no-op) before touching the executor. The
+/// executor is an in-memory SQLite one purely to satisfy the type; it is never
+/// reached.
+#[cfg(feature = "unstable-saga")]
+mod wired {
+    use std::sync::Arc;
+
+    use fraiseql_db::sqlite::SqliteAdapter;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use crate::{
+        mutation_executor::FederationMutationExecutor,
+        saga_compensator::SagaCompensator,
+        saga_store::{MutationType, SagaStep, SagaStoreError, StepState},
+        types::{FederatedType, FederationMetadata, KeyDirective},
+    };
+
+    fn order_metadata() -> FederationMetadata {
+        FederationMetadata {
+            enabled: true,
+            version: "v2".to_string(),
+            types: vec![FederatedType {
+                name:                "Order".to_string(),
+                keys:                vec![KeyDirective {
+                    fields:     vec!["id".to_string()],
+                    resolvable: true,
+                }],
+                is_extends:          false,
+                external_fields:     Vec::new(),
+                shareable_fields:    Vec::new(),
+                inaccessible_fields: Vec::new(),
+                field_directives:    std::collections::HashMap::new(),
+                type_shareable:      false,
+            }],
+            remote_subscription_fields: std::collections::HashMap::new(),
+        }
+    }
+
+    async fn order_executor() -> FederationMutationExecutor<SqliteAdapter> {
+        let adapter =
+            Arc::new(SqliteAdapter::with_pool_config("sqlite::memory:", 1, 1).await.unwrap());
+        FederationMutationExecutor::new(adapter, order_metadata(), false)
+    }
+
+    fn completed_step() -> SagaStep {
+        SagaStep {
+            id:                     Uuid::new_v4(),
+            saga_id:                Uuid::new_v4(),
+            order:                  0,
+            subgraph:               "orders".to_string(),
+            mutation_type:          MutationType::Create,
+            typename:               "Order".to_string(),
+            variables:              json!({"id": "o1"}),
+            state:                  StepState::Completed,
+            result:                 None,
+            started_at:             None,
+            completed_at:           None,
+            compensation_mutation:  Some("deleteOrder".to_string()),
+            compensation_variables: Some(json!({"id": "o1"})),
+        }
+    }
+
+    #[tokio::test]
+    async fn compensate_step_local_without_store_fails_loud() {
+        let compensator = SagaCompensator::new();
+        let executor = order_executor().await;
+        let result = compensator.compensate_step_local(&executor, &completed_step()).await;
+        assert!(
+            matches!(result, Err(SagaStoreError::Database(_))),
+            "compensate_step_local without a store must fail loud, never no-op: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn compensate_saga_local_without_store_fails_loud() {
+        let compensator = SagaCompensator::new();
+        let executor = order_executor().await;
+        let result = compensator.compensate_saga_local(Uuid::new_v4(), &executor).await;
+        assert!(
+            matches!(result, Err(SagaStoreError::Database(_))),
+            "compensate_saga_local without a store must fail loud, never no-op: {result:?}"
+        );
+    }
+}

--- a/crates/fraiseql-federation/src/saga_executor/tests.rs
+++ b/crates/fraiseql-federation/src/saga_executor/tests.rs
@@ -161,6 +161,8 @@ mod wired {
             result: None,
             started_at: None,
             completed_at: None,
+            compensation_mutation: None,
+            compensation_variables: None,
         }
     }
 

--- a/crates/fraiseql-federation/src/saga_store.rs
+++ b/crates/fraiseql-federation/src/saga_store.rs
@@ -189,6 +189,12 @@ pub enum StepState {
     Completed,
     /// Step encountered an error.
     Failed,
+    /// Step was rolled back by a successful compensation mutation.
+    ///
+    /// Distinct from `Completed`: the forward mutation ran, then its inverse was
+    /// executed during the compensation phase (#429). A step only reaches this
+    /// state from `Completed`.
+    Compensated,
 }
 
 impl StepState {
@@ -200,6 +206,7 @@ impl StepState {
             StepState::Executing => "executing",
             StepState::Completed => "completed",
             StepState::Failed => "failed",
+            StepState::Compensated => "compensated",
         }
     }
 
@@ -214,6 +221,7 @@ impl StepState {
             "executing" => Some(StepState::Executing),
             "completed" => Some(StepState::Completed),
             "failed" => Some(StepState::Failed),
+            "compensated" => Some(StepState::Compensated),
             _ => None,
         }
     }
@@ -274,27 +282,36 @@ pub struct Saga {
 #[derive(Debug, Clone)]
 pub struct SagaStep {
     /// Unique identifier for this step.
-    pub id:            Uuid,
+    pub id:                     Uuid,
     /// Parent saga this step belongs to.
-    pub saga_id:       Uuid,
+    pub saga_id:                Uuid,
     /// Zero-based execution order within the saga.
-    pub order:         usize,
+    pub order:                  usize,
     /// Subgraph service name that owns this step.
-    pub subgraph:      String,
+    pub subgraph:               String,
     /// Kind of mutation this step performs.
-    pub mutation_type: MutationType,
+    pub mutation_type:          MutationType,
     /// GraphQL type name the mutation targets.
-    pub typename:      String,
+    pub typename:               String,
     /// Input variables for the mutation.
-    pub variables:     Value,
+    pub variables:              Value,
     /// Current lifecycle state of this step.
-    pub state:         StepState,
+    pub state:                  StepState,
     /// Mutation result payload, if the step has completed.
-    pub result:        Option<Value>,
+    pub result:                 Option<Value>,
     /// Timestamp when execution began, if started.
-    pub started_at:    Option<chrono::DateTime<chrono::Utc>>,
+    pub started_at:             Option<chrono::DateTime<chrono::Utc>>,
     /// Timestamp when execution finished, if finished.
-    pub completed_at:  Option<chrono::DateTime<chrono::Utc>>,
+    pub completed_at:           Option<chrono::DateTime<chrono::Utc>>,
+    /// Name of the compensation (inverse) mutation for this step, if one is
+    /// registered. `None`/empty means the step has no rollback and cannot be
+    /// compensated. Distinct from [`crate::saga_coordinator::SagaStep`], whose
+    /// non-optional field carries the same intent at the coordinator layer.
+    pub compensation_mutation:  Option<String>,
+    /// Input variables for the compensation mutation, if registered. When absent
+    /// the compensator falls back to the step's forward `variables` (they carry
+    /// the entity key needed by an inverse delete/update).
+    pub compensation_variables: Option<Value>,
 }
 
 /// A crash-recovery record for a saga that could not complete normally.
@@ -435,6 +452,20 @@ impl PostgresSagaStore {
                 created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
+            ",
+            &[],
+        )
+        .await?;
+
+        // Compensation metadata (nullable): pre-existing step rows predate
+        // compensation, so both columns are added idempotently and may be NULL.
+        // A step with a NULL/empty compensation_mutation has no registered
+        // rollback and is skipped by the compensator (best-effort, #429).
+        conn.execute(
+            "
+            ALTER TABLE tb_federation_saga_steps
+                ADD COLUMN IF NOT EXISTS compensation_mutation TEXT,
+                ADD COLUMN IF NOT EXISTS compensation_variables JSONB
             ",
             &[],
         )
@@ -589,6 +620,8 @@ impl PostgresSagaStore {
             result: row.get(8),
             started_at: row.get(9),
             completed_at: row.get(10),
+            compensation_mutation: row.get(11),
+            compensation_variables: row.get(12),
         })
     }
 
@@ -716,7 +749,7 @@ impl PostgresSagaStore {
 
         let row = conn
             .query_opt(
-                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at
+                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at, fss.compensation_mutation, fss.compensation_variables
                  FROM tb_federation_saga_steps fss
                  INNER JOIN tb_federation_sagas fs ON fss.saga_pk_ = fs.pk_
                  WHERE fss.id = $1",
@@ -737,7 +770,7 @@ impl PostgresSagaStore {
 
         let rows = conn
             .query(
-                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at
+                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at, fss.compensation_mutation, fss.compensation_variables
                  FROM tb_federation_saga_steps fss
                  INNER JOIN tb_federation_sagas fs ON fss.saga_pk_ = fs.pk_
                  WHERE fs.id = $1
@@ -751,7 +784,8 @@ impl PostgresSagaStore {
 
     /// Update saga step state and automatically set completion time for terminal states
     ///
-    /// Terminal states (Completed, Failed) automatically receive `completed_at` timestamp.
+    /// Terminal states (Completed, Failed, Compensated) automatically receive
+    /// `completed_at` timestamp.
     ///
     /// # Errors
     ///
@@ -763,11 +797,12 @@ impl PostgresSagaStore {
         let state_str = state.as_str();
         let now = chrono::Utc::now();
 
-        let completed_at = if matches!(state, StepState::Completed | StepState::Failed) {
-            Some(now)
-        } else {
-            None
-        };
+        let completed_at =
+            if matches!(state, StepState::Completed | StepState::Failed | StepState::Compensated) {
+                Some(now)
+            } else {
+                None
+            };
 
         let affected = conn
             .execute(
@@ -808,10 +843,14 @@ impl PostgresSagaStore {
         let step_number = step.order as i32;
 
         // Use subquery to convert saga natural key (UUID) to surrogate key (BIGINT) for foreign key
+        // compensation_mutation / compensation_variables are part of the immutable
+        // step definition, so — like variables/subgraph — they are written on
+        // INSERT but not touched by the ON CONFLICT update path (which only
+        // advances runtime state/result/completed_at).
         let affected = conn
             .execute(
-                "INSERT INTO tb_federation_saga_steps (id, saga_pk_, step_number, subgraph, mutation_type, typename, variables, state, result, started_at, completed_at, created_at, updated_at)
-             SELECT $1, fs.pk_, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+                "INSERT INTO tb_federation_saga_steps (id, saga_pk_, step_number, subgraph, mutation_type, typename, variables, state, result, started_at, completed_at, created_at, updated_at, compensation_mutation, compensation_variables)
+             SELECT $1, fs.pk_, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
              FROM tb_federation_sagas fs
              WHERE fs.id = $2
              ON CONFLICT (id) DO UPDATE SET state = $8, result = $9, completed_at = $11, updated_at = $13",
@@ -829,6 +868,8 @@ impl PostgresSagaStore {
                     &step.completed_at,
                     &chrono::Utc::now(),
                     &now,
+                    &step.compensation_mutation,
+                    &step.compensation_variables,
                 ],
             )
             .await?;

--- a/crates/fraiseql-federation/tests/saga_integration.rs
+++ b/crates/fraiseql-federation/tests/saga_integration.rs
@@ -81,8 +81,9 @@ mod wired_pg {
 
     use fraiseql_db::{PostgresAdapter, traits::DatabaseAdapter};
     use fraiseql_federation::{
-        FederatedType, FederationMetadata, FederationMutationExecutor, KeyDirective, MutationType,
-        PostgresSagaStore, Saga, SagaExecutor, SagaState, SagaStep, StepState,
+        CompensationStatus, FederatedType, FederationMetadata, FederationMutationExecutor,
+        KeyDirective, MutationType, PostgresSagaStore, Saga, SagaCompensator, SagaExecutor,
+        SagaState, SagaStep, StepState,
     };
     use serde_json::json;
     use uuid::Uuid;
@@ -174,7 +175,72 @@ mod wired_pg {
             result: None,
             started_at: None,
             completed_at: None,
+            compensation_mutation: None,
+            compensation_variables: None,
         }
+    }
+
+    /// Compensation metadata round-trips through the store: a step saved with a
+    /// compensation mutation + variables reloads with both fields intact, and a
+    /// step saved without them reloads as `None` (backwards-compatible with rows
+    /// that predate the compensation columns).
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn saga_step_compensation_metadata_round_trips() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, _executor) = setup(&url, &typename).await;
+
+        let saga_id = Uuid::new_v4();
+        store.save_saga(&new_saga(saga_id)).await.unwrap();
+
+        // Step WITH compensation metadata.
+        let mut step_with = new_step(
+            saga_id,
+            0,
+            MutationType::Create,
+            &typename,
+            json!({"id": "c1", "total": "10"}),
+        );
+        step_with.compensation_mutation = Some("undo_create_order".to_string());
+        step_with.compensation_variables = Some(json!({"id": "c1"}));
+        store.save_saga_step(&step_with).await.unwrap();
+
+        // Step WITHOUT compensation metadata (backwards-compatible None round-trip).
+        let step_without = new_step(
+            saga_id,
+            1,
+            MutationType::Create,
+            &typename,
+            json!({"id": "c2", "total": "20"}),
+        );
+        store.save_saga_step(&step_without).await.unwrap();
+
+        let reloaded_with = store.load_saga_step(step_with.id).await.unwrap().unwrap();
+        assert_eq!(
+            reloaded_with.compensation_mutation.as_deref(),
+            Some("undo_create_order"),
+            "compensation_mutation must round-trip"
+        );
+        assert_eq!(
+            reloaded_with.compensation_variables,
+            Some(json!({"id": "c1"})),
+            "compensation_variables must round-trip"
+        );
+
+        let reloaded_without = store.load_saga_step(step_without.id).await.unwrap().unwrap();
+        assert!(reloaded_without.compensation_mutation.is_none(), "absent compensation → None");
+        assert!(reloaded_without.compensation_variables.is_none(), "absent compensation → None");
+
+        // The list path (load_saga_steps) must carry the metadata too.
+        let steps = store.load_saga_steps(saga_id).await.unwrap();
+        let listed = steps.iter().find(|s| s.id == step_with.id).unwrap();
+        assert_eq!(listed.compensation_mutation.as_deref(), Some("undo_create_order"));
+
+        store.delete_saga(saga_id).await.unwrap();
     }
 
     /// Happy path: every step's real mutation runs, the saga is persisted
@@ -316,5 +382,202 @@ mod wired_pg {
         assert!(state.failed, "execution state reports failure");
         assert_eq!(state.completed_steps, 1, "exactly one step completed");
         assert_eq!(state.total_steps, 3);
+    }
+
+    /// A completed CREATE step is really rolled back by its registered inverse
+    /// (`delete…`) compensation: the row is deleted, the step transitions
+    /// `Compensated`, and the reported result is a real success (never fabricated).
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn compensate_step_local_rolls_back_a_completed_step() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+
+        let saga_id = Uuid::new_v4();
+        store.save_saga(&new_saga(saga_id)).await.unwrap();
+
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let mut step = new_step(
+            saga_id,
+            0,
+            MutationType::Create,
+            &typename,
+            json!({"id": id_a, "total": "10"}),
+        );
+        // Inverse of a create is a delete; the name drives the mutation kind.
+        step.compensation_mutation = Some(format!("delete{typename}"));
+        step.compensation_variables = Some(json!({"id": id_a}));
+        store.save_saga_step(&step).await.unwrap();
+
+        // Run the forward create so the row actually exists, then mark Completed.
+        let forward = SagaExecutor::with_store(Arc::clone(&store));
+        let fwd = forward.execute_step_local(&executor, &step).await;
+        assert!(fwd.success, "forward create must succeed: {fwd:?}");
+        store.update_saga_step_state(step.id, &StepState::Completed).await.unwrap();
+
+        // Compensate the single step.
+        let compensator = SagaCompensator::with_store(Arc::clone(&store));
+        let result = compensator.compensate_step_local(&executor, &step).await.unwrap();
+        assert!(result.success, "compensation must succeed: {result:?}");
+        assert_eq!(result.step_number, 1, "0-based order maps to 1-indexed step number");
+
+        // The step is persisted Compensated and the row is really gone.
+        let reloaded = store.load_saga_step(step.id).await.unwrap().unwrap();
+        assert_eq!(
+            reloaded.state,
+            StepState::Compensated,
+            "a compensated step persists Compensated"
+        );
+        let table = typename.to_lowercase();
+        let rows = PostgresAdapter::new(&url)
+            .await
+            .unwrap()
+            .execute_raw_query(&format!("SELECT id FROM \"{table}\" WHERE id = '{id_a}'"))
+            .await
+            .unwrap();
+        assert!(rows.is_empty(), "the inverse delete really removed the row (not fabricated)");
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+
+    /// Reverse-order rollback: after a saga fails partway, only the *completed*
+    /// step is compensated; the failed step and the never-run step are skipped, and
+    /// the saga ends `Compensated`.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn compensate_saga_local_rolls_back_completed_steps_in_reverse() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+
+        let saga_id = Uuid::new_v4();
+        store.save_saga(&new_saga(saga_id)).await.unwrap();
+
+        // Step 0 creates a row (completes); step 1 updates a missing row (fails);
+        // step 2 never runs. Every step carries a delete compensation.
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let id_c = format!("never-{}", Uuid::new_v4());
+        let mut step0 = new_step(
+            saga_id,
+            0,
+            MutationType::Create,
+            &typename,
+            json!({"id": id_a, "total": "1"}),
+        );
+        step0.compensation_mutation = Some(format!("delete{typename}"));
+        step0.compensation_variables = Some(json!({"id": id_a}));
+        let step1 = new_step(
+            saga_id,
+            1,
+            MutationType::Update,
+            &typename,
+            json!({"id": "missing", "total": "9"}),
+        );
+        let step2 = new_step(
+            saga_id,
+            2,
+            MutationType::Create,
+            &typename,
+            json!({"id": id_c, "total": "3"}),
+        );
+        store.save_saga_step(&step0).await.unwrap();
+        store.save_saga_step(&step1).await.unwrap();
+        store.save_saga_step(&step2).await.unwrap();
+
+        // Forward: step0 Completed, step1 Failed, step2 Pending, saga Failed.
+        SagaExecutor::with_store(Arc::clone(&store))
+            .execute_saga_local(saga_id, &executor)
+            .await
+            .unwrap();
+
+        // Compensate: only the completed step0 rolls back.
+        let comp = SagaCompensator::with_store(Arc::clone(&store))
+            .compensate_saga_local(saga_id, &executor)
+            .await
+            .unwrap();
+        assert_eq!(comp.status, CompensationStatus::Compensated, "all completed steps rolled back");
+        assert_eq!(
+            comp.step_results.len(),
+            1,
+            "only the one completed step is compensated: {comp:?}"
+        );
+        assert!(comp.step_results[0].success, "the completed step compensated: {comp:?}");
+        assert!(comp.failed_steps.is_empty(), "no compensation failures: {comp:?}");
+
+        let mut steps = store.load_saga_steps(saga_id).await.unwrap();
+        steps.sort_by_key(|s| s.order);
+        assert_eq!(steps[0].state, StepState::Compensated, "completed step compensated");
+        assert_eq!(steps[1].state, StepState::Failed, "failed step untouched");
+        assert_eq!(steps[2].state, StepState::Pending, "never-run step untouched");
+        assert_eq!(
+            store.load_saga(saga_id).await.unwrap().unwrap().state,
+            SagaState::Compensated,
+            "saga reaches Compensated"
+        );
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+
+    /// Best-effort: a completed step with *no* registered compensation cannot be
+    /// rolled back — the saga is reported `PartiallyCompensated` and stays `Failed`,
+    /// never marked `Compensated` having undone nothing (audit H33).
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn compensate_saga_local_partial_when_compensation_unregistered() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+
+        let saga_id = Uuid::new_v4();
+        store.save_saga(&new_saga(saga_id)).await.unwrap();
+
+        // A single step that completes but has no compensation registered.
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let step = new_step(
+            saga_id,
+            0,
+            MutationType::Create,
+            &typename,
+            json!({"id": id_a, "total": "5"}),
+        );
+        store.save_saga_step(&step).await.unwrap();
+
+        SagaExecutor::with_store(Arc::clone(&store))
+            .execute_saga_local(saga_id, &executor)
+            .await
+            .unwrap();
+
+        let comp = SagaCompensator::with_store(Arc::clone(&store))
+            .compensate_saga_local(saga_id, &executor)
+            .await
+            .unwrap();
+        assert_eq!(
+            comp.status,
+            CompensationStatus::PartiallyCompensated,
+            "an uncompensatable completed step yields a partial result: {comp:?}"
+        );
+        assert_eq!(comp.failed_steps, vec![1], "step 1 could not be compensated");
+        assert!(comp.error.is_some(), "a partial compensation carries an error summary");
+
+        // The saga stays Failed (never fabricated Compensated) and the completed
+        // step stays Completed (its forward work was not undone).
+        assert_eq!(store.load_saga(saga_id).await.unwrap().unwrap().state, SagaState::Failed);
+        let steps = store.load_saga_steps(saga_id).await.unwrap();
+        assert_eq!(steps[0].state, StepState::Completed, "an uncompensated step stays Completed");
+
+        store.delete_saga(saga_id).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

**Phase 01 of the v2.11.0 saga full round-trip** (#429). Wires the compensation
(rollback) phase: on a saga failure, completed steps are rolled back in strict
reverse execution order by executing each step's registered inverse mutation via
the local SQL adapter. Successor to the v2.9.0 forward-execution slice
(`execute_saga_local`); recovery / coordinator / remote dispatch follow in Phases 02–05.

Everything is gated behind the existing `unstable-saga` Cargo feature. The published
fail-loud placeholders `SagaCompensator::{compensate_saga, compensate_step}` are
**unchanged** — they still return `SagaStoreError::NotImplemented`, and their H33
contract tests stay green.

## Changes

- **`saga_store`** — `tb_federation_saga_steps` gains nullable `compensation_mutation`
  / `compensation_variables` columns (idempotent `ADD COLUMN IF NOT EXISTS`; rows that
  predate them read back `None`); `SagaStep` fields + save/load round-trip; new
  `StepState::Compensated` terminal state.
- **`saga_compensator`** — new always-compiled `compensation.rs` pure helpers
  (`step_is_compensatable`, `compensation_result_from`, `compensation_order`) with the
  `#428` `allow(dead_code)` gate so unit tests run in the fast leg; wired
  `compensate_step_local` / `compensate_saga_local` behind `unstable-saga`, reusing
  `FederationMutationExecutor::execute_local_mutation`.
- **Best-effort semantics** — a failed inverse or a step with no registered
  compensation leaves the saga `Failed` and is reported `PartiallyCompensated`; a saga
  is never marked `Compensated` having undone only part of its work (audit H33).

## House-doctrine compliance

- No new `#[async_trait]` (ratchet held at 188); native async-fn-in-trait.
- Fail loud, never fabricate — no store / no executor returns a hard `Error`.
- Pure logic always compiled; store `SagaStep` and coordinator `SagaStep` kept distinct.
- Unit tests in `tests.rs` siblings (not inline `mod tests {}`); integration tests
  `#[ignore]` + `#[cfg(feature = "unstable-saga")]`, already covered by the
  `.dagger/main.go` integration-postgres `federation` `--include-ignored` entry.

### Naming note (plan-prose drift, resolved the v2.9.0 way)

The plan prose named the wired methods `compensate_step<A>` / `compensate_saga<A>`, but
those cannot coexist with the retained fail-loud `compensate_step` / `compensate_saga`
(Rust has no overloading). They are named `compensate_step_local` /
`compensate_saga_local`, mirroring the forward slice's `execute_saga_local`. Partial
compensation maps to `SagaState::Failed` + `CompensationStatus::PartiallyCompensated`
(no `SagaState::CompensationFailed` exists); no-store returns `SagaStoreError::Database`.

## Verification

- `cargo fmt` (nightly), `cargo clippy --all-targets` with and without `unstable-saga`
- `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, `make preflight` ✅
- 314 lib tests + **11/11 `saga_integration` on live Postgres** (5 unchanged loud-fail
  contract tests + 3 new compensation tests + round-trip + 2 forward)
- async-trait ratchet held (188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)