### PR TITLE
feat(federation): wire saga coordinator under unstable-saga (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Saga coordinator facade is now wired under `unstable-saga` (#429).** A new
+  `WiredSagaCoordinator` ties forward execution and compensation into a single handle over
+  a `PostgresSagaStore`: `create_saga` validates and persists a saga (`Pending`) with each
+  step's compensation metadata; `execute_saga` runs the forward phase and, on a step failure
+  under the default `Automatic` strategy, rolls back the completed steps via
+  `SagaCompensator::compensate_saga_local` (returning `Failed` + `compensated: true`), while
+  the `Manual` strategy leaves the saga `Failed` for an operator; `cancel_saga` refuses a
+  terminal saga, compensates any completed steps, then marks the saga `Cancelled` (a new
+  terminal `SagaState`); and `get_saga_status` / `get_saga_result` / `list_in_flight_sagas`
+  report real persisted state. The wiring is additive — the published fail-loud
+  `SagaCoordinator::{create_saga, execute_saga, get_saga_status, cancel_saga, get_saga_result,
+  list_in_flight_sagas}` placeholders are unchanged and still return
+  `SagaStoreError::NotImplemented` in every build. Remote (HTTP) step dispatch remains
+  unwired. Requires the `unstable-saga` Cargo feature; the API may change without semver
+  guarantees.
 - **Saga crash recovery is now wired under `unstable-saga` (#429).** A
   `SagaRecoveryManager` background loop re-drives sagas that a crash or restart left
   in-flight: each tick finds stuck (`Executing`) and pending (never-started) sagas, records

--- a/crates/fraiseql-federation/src/lib.rs
+++ b/crates/fraiseql-federation/src/lib.rs
@@ -17,7 +17,8 @@
 //! | Saga forward execution — `SagaExecutor::{execute_step_local, execute_saga_local, execution_state}` | 🚧 Unstable | requires `unstable-saga` feature; dispatches real local mutations and persists real step/saga state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Remote (HTTP) dispatch and `@requires` pre-fetch are not yet wired. |
 //! | Saga compensation — `SagaCompensator::{compensate_step_local, compensate_saga_local}` | 🚧 Unstable | requires `unstable-saga` feature; rolls back completed steps in reverse execution order via the local SQL adapter and persists real `Compensated` state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Remote (HTTP) compensation is not yet wired. |
 //! | Saga recovery — `SagaRecoveryManager::{run_iteration_local, start_background_loop_local}` | 🚧 Unstable | requires `unstable-saga` feature; re-drives crash-interrupted (`Pending`/`Executing`) sagas to a terminal state by replaying `execute_saga_local`, records recovery attempts, and cleans up stale sagas (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Remote saga recovery rides on Phase 04's remote dispatch. |
-//! | Saga placeholders — `SagaExecutor::{execute_step, execute_saga, get_execution_state}` + `SagaCompensator::{compensate_step, compensate_saga}` + `SagaRecoveryManager::{run_iteration, start_background_loop}` + coordination | 🚧 Not implemented | return `SagaStoreError::NotImplemented` in every build (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). `PostgresSagaStore` persistence is real. |
+//! | Saga coordination — `WiredSagaCoordinator::{create_saga, execute_saga, get_saga_status, cancel_saga, get_saga_result, list_in_flight_sagas}` | 🚧 Unstable | requires `unstable-saga` feature; ties forward execution + compensation into one handle — persists a saga with compensation metadata, runs the forward phase, and on failure (under `Automatic`) rolls back the completed steps via the local SQL adapter; `cancel_saga` compensates then marks the saga `Cancelled` (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Remote (HTTP) dispatch is not yet wired. |
+//! | Saga placeholders — `SagaExecutor::{execute_step, execute_saga, get_execution_state}` + `SagaCompensator::{compensate_step, compensate_saga}` + `SagaRecoveryManager::{run_iteration, start_background_loop}` + `SagaCoordinator::{create_saga, execute_saga, get_saga_status, cancel_saga, get_saga_result, list_in_flight_sagas}` | 🚧 Not implemented | return `SagaStoreError::NotImplemented` in every build (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). `PostgresSagaStore` persistence is real. |
 //! | HTTP mutation propagation — `HttpMutationClient` | ✅ Production | SSRF-protected |
 //! | Gateway mode — `ConnectionManager::get_or_create_connection` | 🚧 Unstable | requires `unstable` feature |
 //! | Direct-DB federation — `DirectDbResolver` | 🚧 Unstable | stub only; not yet implemented |
@@ -107,6 +108,8 @@ pub use requires_provides_validator::{
 pub use saga_compensator::{
     CompensationResult, CompensationStatus, CompensationStepResult, SagaCompensator,
 };
+#[cfg(feature = "unstable-saga")]
+pub use saga_coordinator::WiredSagaCoordinator;
 pub use saga_coordinator::{
     CompensationStrategy, SagaCoordinator, SagaResult, SagaStatus, SagaStep as SagaCoordinatorStep,
 };

--- a/crates/fraiseql-federation/src/saga_coordinator.rs
+++ b/crates/fraiseql-federation/src/saga_coordinator.rs
@@ -81,6 +81,18 @@ use uuid::Uuid;
 
 use crate::saga_store::{Result as SagaStoreResult, SagaState};
 
+/// Pure coordinator decision helpers (always compiled; see the module docs for why
+/// the logic lives outside the feature gate).
+mod coordination;
+
+/// Wired coordinator that ties forward execution, compensation, and recovery into
+/// a single handle (the `unstable-saga` feature). Additive: the loud-fail
+/// [`SagaCoordinator`] below keeps its signatures and behaviour in every build.
+#[cfg(feature = "unstable-saga")]
+mod wired;
+#[cfg(feature = "unstable-saga")]
+pub use wired::WiredSagaCoordinator;
+
 /// Represents a saga step mutation to execute
 ///
 /// Each step defines:
@@ -192,6 +204,43 @@ pub struct SagaResult {
     pub compensated:     bool,
 }
 
+/// Validate that a saga's steps are present and sequentially ordered (1..N).
+///
+/// Shared by the loud-fail [`SagaCoordinator::create_saga`] and the wired
+/// [`WiredSagaCoordinator`](crate::saga_coordinator::WiredSagaCoordinator)::`create_saga`:
+/// a saga must have at least one step and its steps must be numbered 1, 2, 3, … in
+/// order before any persistence is attempted.
+///
+/// # Errors
+///
+/// Returns [`SagaStoreError::Database`](crate::saga_store::SagaStoreError::Database)
+/// if the steps are empty or not in sequential order.
+fn validate_step_sequence(steps: &[SagaStep]) -> SagaStoreResult<()> {
+    // Validate at least one step
+    if steps.is_empty() {
+        warn!("Saga creation failed: saga must have at least one step");
+        return Err(crate::saga_store::SagaStoreError::Database(
+            "saga must have at least one step".to_string(),
+        ));
+    }
+
+    // Validate step order
+    for (i, step) in steps.iter().enumerate() {
+        if step.number as usize != i + 1 {
+            warn!(
+                expected = i + 1,
+                actual = step.number,
+                "Saga creation failed: steps must be in sequential order"
+            );
+            return Err(crate::saga_store::SagaStoreError::Database(
+                "steps must be in sequential order".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Saga coordinator for distributed transaction orchestration.
 ///
 /// **Not implemented.** Every operational method fails loud with
@@ -251,27 +300,7 @@ impl SagaCoordinator {
     /// let saga_id = coordinator.create_saga(steps).await?;
     /// ```
     pub async fn create_saga(&self, steps: Vec<SagaStep>) -> SagaStoreResult<Uuid> {
-        // Validate at least one step
-        if steps.is_empty() {
-            warn!("Saga creation failed: saga must have at least one step");
-            return Err(crate::saga_store::SagaStoreError::Database(
-                "saga must have at least one step".to_string(),
-            ));
-        }
-
-        // Validate step order
-        for (i, step) in steps.iter().enumerate() {
-            if step.number as usize != i + 1 {
-                warn!(
-                    expected = i + 1,
-                    actual = step.number,
-                    "Saga creation failed: steps must be in sequential order"
-                );
-                return Err(crate::saga_store::SagaStoreError::Database(
-                    "steps must be in sequential order".to_string(),
-                ));
-            }
-        }
+        validate_step_sequence(&steps)?;
 
         // Input validation above is real; persistence is not. The previous body
         // generated a UUID and returned it WITHOUT writing anything to the store

--- a/crates/fraiseql-federation/src/saga_coordinator/coordination.rs
+++ b/crates/fraiseql-federation/src/saga_coordinator/coordination.rs
@@ -1,0 +1,67 @@
+//! Pure coordinator decision helpers.
+//!
+//! These functions hold the saga *coordination* logic with no I/O: deriving the
+//! persisted [`MutationType`] a forward mutation name implies, deciding whether a
+//! saga state is terminal (so a cancel is refused), and computing progress as a
+//! percentage. Keeping them pure lets their unit tests run in the fast `test` leg
+//! on every push, independently of a live database and of the `unstable-saga`
+//! feature — the same arrangement the forward and compensation phases use in
+//! [`crate::saga_executor::forward`] and [`crate::saga_compensator::compensation`].
+//!
+//! They are consumed only by the feature-gated wired coordinator, so without
+//! `unstable-saga` they are dead in a non-test build — hence the module-level
+//! `allow(dead_code)` for that configuration (the established `#428` pattern).
+#![cfg_attr(not(feature = "unstable-saga"), allow(dead_code))]
+
+use crate::saga_store::{MutationType, SagaState};
+
+/// Map a forward mutation operation name to the [`MutationType`] to persist for a
+/// saga step.
+///
+/// Mirrors the runtime `determine_mutation_type` verb-prefix rule so a saga step
+/// created from a coordinator `mutation_name` (e.g. `createOrder`) stores the same
+/// kind the executor will dispatch. Returns `None` when the name begins with no
+/// recognised verb — the coordinator then refuses to persist a step whose mutation
+/// kind is unknowable rather than defaulting it (the M-fed-mut-executor trap, where
+/// an unrecognised name silently became an `UPDATE`).
+pub(super) fn mutation_type_for(mutation_name: &str) -> Option<MutationType> {
+    let lower = mutation_name.to_lowercase();
+    if lower.starts_with("create") || lower.starts_with("add") {
+        Some(MutationType::Create)
+    } else if lower.starts_with("update") || lower.starts_with("modify") {
+        Some(MutationType::Update)
+    } else if lower.starts_with("delete") || lower.starts_with("remove") {
+        Some(MutationType::Delete)
+    } else {
+        None
+    }
+}
+
+/// Whether `state` is a terminal saga state that can no longer be cancelled.
+///
+/// A saga that has already `Completed`, `Failed`, `Compensated`, or been
+/// `Cancelled` has reached an outcome; a second cancel must fail loud rather than
+/// re-drive it. `Pending`/`Executing`/`Compensating` are in-flight and cancellable.
+pub(super) const fn saga_state_is_terminal(state: &SagaState) -> bool {
+    match state {
+        SagaState::Completed
+        | SagaState::Failed
+        | SagaState::Compensated
+        | SagaState::Cancelled => true,
+        SagaState::Pending | SagaState::Executing | SagaState::Compensating => false,
+    }
+}
+
+/// Progress of a saga as a percentage of completed steps.
+///
+/// A saga with no steps is reported `0.0` rather than dividing by zero. Uses exact
+/// `u32`→`f64` widening, so a fully-completed saga reports exactly `100.0`.
+pub(super) fn progress_percentage(completed: u32, total: u32) -> f64 {
+    if total == 0 {
+        return 0.0;
+    }
+    f64::from(completed) / f64::from(total) * 100.0
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-federation/src/saga_coordinator/coordination/tests.rs
+++ b/crates/fraiseql-federation/src/saga_coordinator/coordination/tests.rs
@@ -1,0 +1,69 @@
+//! Unit tests for the pure coordinator decision helpers.
+//!
+//! These run in the fast `test` leg on every push (no database, feature-agnostic),
+//! covering the tricky bits — verb→kind mapping, terminal-state classification, and
+//! the divide-by-zero-safe percentage — that the wired coordinator relies on.
+
+use super::{mutation_type_for, progress_percentage, saga_state_is_terminal};
+use crate::saga_store::{MutationType, SagaState};
+
+#[test]
+fn mutation_type_for_maps_create_verbs() {
+    assert_eq!(mutation_type_for("createOrder"), Some(MutationType::Create));
+    assert_eq!(mutation_type_for("addItem"), Some(MutationType::Create));
+    // Case-insensitive, mirroring the runtime resolver.
+    assert_eq!(mutation_type_for("CreateOrder"), Some(MutationType::Create));
+}
+
+#[test]
+fn mutation_type_for_maps_update_verbs() {
+    assert_eq!(mutation_type_for("updateOrder"), Some(MutationType::Update));
+    assert_eq!(mutation_type_for("modifyOrder"), Some(MutationType::Update));
+}
+
+#[test]
+fn mutation_type_for_maps_delete_verbs() {
+    assert_eq!(mutation_type_for("deleteOrder"), Some(MutationType::Delete));
+    assert_eq!(mutation_type_for("removeOrder"), Some(MutationType::Delete));
+}
+
+#[test]
+fn mutation_type_for_rejects_unknown_verb() {
+    // An unrecognised name must not default to a kind (M-fed-mut-executor): the
+    // coordinator refuses to persist a step whose mutation kind is unknowable.
+    assert_eq!(mutation_type_for("frobnicateOrder"), None);
+    assert_eq!(mutation_type_for(""), None);
+}
+
+#[test]
+fn terminal_states_are_terminal() {
+    assert!(saga_state_is_terminal(&SagaState::Completed));
+    assert!(saga_state_is_terminal(&SagaState::Failed));
+    assert!(saga_state_is_terminal(&SagaState::Compensated));
+    assert!(saga_state_is_terminal(&SagaState::Cancelled));
+}
+
+#[test]
+fn in_flight_states_are_not_terminal() {
+    assert!(!saga_state_is_terminal(&SagaState::Pending));
+    assert!(!saga_state_is_terminal(&SagaState::Executing));
+    assert!(!saga_state_is_terminal(&SagaState::Compensating));
+}
+
+#[test]
+fn progress_percentage_is_zero_for_no_steps() {
+    // No steps must not divide by zero.
+    assert!((progress_percentage(0, 0) - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn progress_percentage_full_is_exactly_100() {
+    assert!((progress_percentage(2, 2) - 100.0).abs() < f64::EPSILON);
+    assert!((progress_percentage(3, 3) - 100.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn progress_percentage_partial() {
+    assert!((progress_percentage(1, 4) - 25.0).abs() < f64::EPSILON);
+    assert!((progress_percentage(0, 3) - 0.0).abs() < f64::EPSILON);
+}

--- a/crates/fraiseql-federation/src/saga_coordinator/wired.rs
+++ b/crates/fraiseql-federation/src/saga_coordinator/wired.rs
@@ -1,0 +1,366 @@
+//! Wired saga coordinator (the `unstable-saga` feature).
+//!
+//! Ties the three already-wired subsystems — forward execution
+//! ([`SagaExecutor::execute_saga_local`]), compensation
+//! ([`SagaCompensator::compensate_saga_local`]), and the store — into a single
+//! public handle. A caller can create a saga with compensation metadata, execute
+//! it end-to-end (forward + automatic rollback on failure), cancel it, and query
+//! its status through one type.
+//!
+//! Additive by design: the loud-fail [`SagaCoordinator`](super::SagaCoordinator)
+//! and its contract tests are untouched. This type carries the `store`, `executor`,
+//! and `compensator` the loud-fail coordinator never had, so its methods are the
+//! real thing — no stub shares their names. Remote (HTTP) step dispatch is Phase 04;
+//! every mutation here runs against the local SQL adapter.
+
+use std::sync::Arc;
+
+use ::tracing::{info, warn};
+use fraiseql_db::traits::DatabaseAdapter;
+use uuid::Uuid;
+
+use super::{
+    CompensationStrategy, SagaResult, SagaStatus, SagaStep, coordination, validate_step_sequence,
+};
+use crate::{
+    mutation_executor::FederationMutationExecutor,
+    saga_compensator::SagaCompensator,
+    saga_executor::SagaExecutor,
+    saga_store::{
+        PostgresSagaStore, Result as SagaStoreResult, Saga, SagaState, SagaStep as StoreSagaStep,
+        SagaStoreError, StepState,
+    },
+};
+
+/// A fully-wired saga coordinator over a Postgres saga store.
+///
+/// Owns the store plus a [`SagaExecutor`] and [`SagaCompensator`] built over the
+/// same store, and delegates each lifecycle operation to them. Unlike the loud-fail
+/// [`SagaCoordinator`](super::SagaCoordinator), every method here performs real work
+/// and persists real state.
+pub struct WiredSagaCoordinator {
+    /// How a failed saga is rolled back.
+    strategy:    CompensationStrategy,
+    /// Persistent saga store (shared with `executor`/`compensator`).
+    store:       Arc<PostgresSagaStore>,
+    /// Forward-phase executor over `store`.
+    executor:    SagaExecutor,
+    /// Compensation-phase executor over `store`.
+    compensator: SagaCompensator,
+}
+
+impl WiredSagaCoordinator {
+    /// Create a coordinator over `store` with the given compensation `strategy`.
+    ///
+    /// The forward executor and compensator are constructed over clones of the same
+    /// store handle, so all three share one connection pool.
+    #[must_use]
+    pub fn new(store: Arc<PostgresSagaStore>, strategy: CompensationStrategy) -> Self {
+        let executor = SagaExecutor::with_store(Arc::clone(&store));
+        let compensator = SagaCompensator::with_store(Arc::clone(&store));
+        Self {
+            strategy,
+            store,
+            executor,
+            compensator,
+        }
+    }
+
+    /// The compensation strategy this coordinator applies on failure.
+    #[must_use]
+    pub const fn strategy(&self) -> CompensationStrategy {
+        self.strategy
+    }
+
+    /// Create and persist a new saga from ordered `steps`, in state `Pending`.
+    ///
+    /// Validates the steps (present, sequentially numbered 1..N) before any write,
+    /// then persists the saga and each step — including its compensation mutation +
+    /// variables so a later rollback can find them. Each step's forward
+    /// `mutation_name` is mapped to the persisted mutation kind
+    /// (`coordination::mutation_type_for`); a name with no recognised verb is
+    /// rejected rather than defaulted, so a saga whose steps cannot be dispatched is
+    /// never created.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SagaStoreError::Database`] if the steps are empty, out of order, or
+    /// carry a forward mutation name whose kind cannot be determined; or any store
+    /// error encountered while persisting the saga or its steps.
+    pub async fn create_saga(&self, steps: Vec<SagaStep>) -> SagaStoreResult<Uuid> {
+        validate_step_sequence(&steps)?;
+
+        let saga_id = Uuid::new_v4();
+        let saga = Saga {
+            id:           saga_id,
+            state:        SagaState::Pending,
+            created_at:   chrono::Utc::now(),
+            completed_at: None,
+            metadata:     None,
+        };
+        self.store.save_saga(&saga).await?;
+
+        for step in &steps {
+            let mutation_type =
+                coordination::mutation_type_for(&step.mutation_name).ok_or_else(|| {
+                    SagaStoreError::Database(format!(
+                        "cannot determine mutation type for step {} operation '{}': expected a \
+                         name beginning with create/add, update/modify, or delete/remove",
+                        step.number, step.mutation_name
+                    ))
+                })?;
+
+            // An empty compensation mutation means the step has no registered
+            // rollback → store None so the compensator skips it (best-effort, #429).
+            let (compensation_mutation, compensation_variables) =
+                if step.compensation_mutation.is_empty() {
+                    (None, None)
+                } else {
+                    (
+                        Some(step.compensation_mutation.clone()),
+                        Some(step.compensation_variables.clone()),
+                    )
+                };
+
+            let store_step = StoreSagaStep {
+                id: step.id,
+                saga_id,
+                // Coordinator steps are 1-indexed (validated); the store is 0-based.
+                order: (step.number as usize).saturating_sub(1),
+                subgraph: step.subgraph.clone(),
+                mutation_type,
+                typename: step.typename.clone(),
+                variables: step.variables.clone(),
+                state: StepState::Pending,
+                result: None,
+                started_at: None,
+                completed_at: None,
+                compensation_mutation,
+                compensation_variables,
+            };
+            self.store.save_saga_step(&store_step).await?;
+        }
+
+        info!(saga_id = %saga_id, steps = steps.len(), "Saga created and persisted (Pending)");
+        Ok(saga_id)
+    }
+
+    /// Execute a saga end-to-end: run the forward phase, then — on any step failure
+    /// under the `Automatic` strategy — roll back the completed steps.
+    ///
+    /// On full success the saga is `Completed` and `compensated` is false. On a step
+    /// failure the returned result is `Failed`; under
+    /// [`CompensationStrategy::Automatic`] the completed steps are compensated and
+    /// `compensated` is true, while under [`CompensationStrategy::Manual`] the saga
+    /// is left `Failed` for an operator to compensate explicitly (`compensated` is
+    /// false). `completed_steps` counts the steps whose forward mutation succeeded.
+    ///
+    /// # Errors
+    ///
+    /// Returns any store error from the forward or compensation phase — e.g.
+    /// [`SagaStoreError::SagaNotFound`] if `saga_id` does not exist.
+    pub async fn execute_saga<A: DatabaseAdapter>(
+        &self,
+        saga_id: Uuid,
+        mutation_executor: &FederationMutationExecutor<A>,
+    ) -> SagaStoreResult<SagaResult> {
+        let results = self.executor.execute_saga_local(saga_id, mutation_executor).await?;
+
+        let total_steps =
+            u32::try_from(self.store.load_saga_steps(saga_id).await?.len()).unwrap_or(u32::MAX);
+        let completed_steps =
+            u32::try_from(results.iter().filter(|r| r.success).count()).unwrap_or(u32::MAX);
+
+        if results.iter().all(|r| r.success) {
+            info!(saga_id = %saga_id, "Saga completed: every step succeeded");
+            return Ok(SagaResult {
+                saga_id,
+                state: SagaState::Completed,
+                completed_steps,
+                total_steps,
+                error: None,
+                compensated: false,
+            });
+        }
+
+        let error = results.iter().find(|r| !r.success).and_then(|r| r.error.clone());
+
+        // The strategy governs rollback: Automatic compensates the completed steps
+        // immediately; Manual leaves the saga Failed for an operator to trigger
+        // compensation explicitly. A rollback that did not run is never reported.
+        let compensated = match self.strategy {
+            CompensationStrategy::Automatic => {
+                warn!(saga_id = %saga_id, "Saga failed; compensating completed steps");
+                self.compensator.compensate_saga_local(saga_id, mutation_executor).await?;
+                true
+            },
+            CompensationStrategy::Manual => {
+                warn!(
+                    saga_id = %saga_id,
+                    "Saga failed; Manual strategy leaves compensation to an operator"
+                );
+                false
+            },
+        };
+
+        Ok(SagaResult {
+            saga_id,
+            state: SagaState::Failed,
+            completed_steps,
+            total_steps,
+            error,
+            compensated,
+        })
+    }
+
+    /// Query the live status of a saga.
+    ///
+    /// Reports the persisted state, total and completed step counts, the currently
+    /// executing step (if any, as a 1-indexed number), and progress as a percentage
+    /// of completed steps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SagaStoreError::SagaNotFound`] if `saga_id` does not exist, or any
+    /// store error while loading the saga or its steps.
+    pub async fn get_saga_status(&self, saga_id: Uuid) -> SagaStoreResult<SagaStatus> {
+        let saga = self
+            .store
+            .load_saga(saga_id)
+            .await?
+            .ok_or(SagaStoreError::SagaNotFound(saga_id))?;
+        let steps = self.store.load_saga_steps(saga_id).await?;
+
+        let step_count = u32::try_from(steps.len()).unwrap_or(u32::MAX);
+        let completed_steps =
+            u32::try_from(steps.iter().filter(|s| s.state == StepState::Completed).count())
+                .unwrap_or(u32::MAX);
+        let current_step = steps
+            .iter()
+            .find(|s| s.state == StepState::Executing)
+            .map(|s| u32::try_from(s.order).unwrap_or(u32::MAX).saturating_add(1));
+        let progress_percentage = coordination::progress_percentage(completed_steps, step_count);
+
+        Ok(SagaStatus {
+            saga_id,
+            state: saga.state,
+            step_count,
+            completed_steps,
+            current_step,
+            progress_percentage,
+        })
+    }
+
+    /// Cancel an in-flight saga, rolling back any completed steps first.
+    ///
+    /// Refuses to cancel a saga already in a terminal state
+    /// (`coordination::saga_state_is_terminal`). Any completed steps are
+    /// compensated *before* the saga is marked `Cancelled`, so the `Cancelled`
+    /// transition is the last, authoritative write; `compensated` reflects whether a
+    /// rollback actually ran (a saga with nothing completed reports false, never a
+    /// fabricated rollback).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SagaStoreError::SagaNotFound`] if `saga_id` does not exist,
+    /// [`SagaStoreError::InvalidStateTransition`] if the saga is already terminal, or
+    /// any store/compensation error encountered while cancelling.
+    pub async fn cancel_saga<A: DatabaseAdapter>(
+        &self,
+        saga_id: Uuid,
+        mutation_executor: &FederationMutationExecutor<A>,
+    ) -> SagaStoreResult<SagaResult> {
+        let saga = self
+            .store
+            .load_saga(saga_id)
+            .await?
+            .ok_or(SagaStoreError::SagaNotFound(saga_id))?;
+
+        if coordination::saga_state_is_terminal(&saga.state) {
+            warn!(
+                saga_id = %saga_id,
+                state = saga.state.as_str(),
+                "Refusing to cancel a saga already in a terminal state"
+            );
+            return Err(SagaStoreError::InvalidStateTransition {
+                from: saga.state.as_str().to_string(),
+                to:   SagaState::Cancelled.as_str().to_string(),
+            });
+        }
+
+        let steps = self.store.load_saga_steps(saga_id).await?;
+        let total_steps = u32::try_from(steps.len()).unwrap_or(u32::MAX);
+        let completed_steps =
+            u32::try_from(steps.iter().filter(|s| s.state == StepState::Completed).count())
+                .unwrap_or(u32::MAX);
+
+        // Roll back completed work before the Cancelled transition: the compensator
+        // drives the saga through Compensating, so Cancelled must be written last.
+        let compensated = if completed_steps > 0 {
+            self.compensator.compensate_saga_local(saga_id, mutation_executor).await?;
+            true
+        } else {
+            false
+        };
+
+        self.store.update_saga_state(saga_id, &SagaState::Cancelled).await?;
+        info!(saga_id = %saga_id, compensated, "Saga cancelled");
+
+        Ok(SagaResult {
+            saga_id,
+            state: SagaState::Cancelled,
+            completed_steps,
+            total_steps,
+            error: None,
+            compensated,
+        })
+    }
+
+    /// Assemble the final result of a saga from its persisted saga + step rows.
+    ///
+    /// `compensated` is true when the saga reached `Compensated` or any step was
+    /// rolled back to `Compensated`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SagaStoreError::SagaNotFound`] if `saga_id` does not exist, or any
+    /// store error while loading the saga or its steps.
+    pub async fn get_saga_result(&self, saga_id: Uuid) -> SagaStoreResult<SagaResult> {
+        let saga = self
+            .store
+            .load_saga(saga_id)
+            .await?
+            .ok_or(SagaStoreError::SagaNotFound(saga_id))?;
+        let steps = self.store.load_saga_steps(saga_id).await?;
+
+        let total_steps = u32::try_from(steps.len()).unwrap_or(u32::MAX);
+        let completed_steps =
+            u32::try_from(steps.iter().filter(|s| s.state == StepState::Completed).count())
+                .unwrap_or(u32::MAX);
+        let compensated = saga.state == SagaState::Compensated
+            || steps.iter().any(|s| s.state == StepState::Compensated);
+
+        Ok(SagaResult {
+            saga_id,
+            state: saga.state,
+            completed_steps,
+            total_steps,
+            error: None,
+            compensated,
+        })
+    }
+
+    /// List the ids of all in-flight sagas (`Executing` or `Pending`).
+    ///
+    /// # Errors
+    ///
+    /// Returns any store error encountered while querying by state.
+    pub async fn list_in_flight_sagas(&self) -> SagaStoreResult<Vec<Uuid>> {
+        let mut ids = Vec::new();
+        for state in [SagaState::Executing, SagaState::Pending] {
+            let sagas = self.store.load_sagas_by_state(&state).await?;
+            ids.extend(sagas.into_iter().map(|saga| saga.id));
+        }
+        Ok(ids)
+    }
+}

--- a/crates/fraiseql-federation/src/saga_store.rs
+++ b/crates/fraiseql-federation/src/saga_store.rs
@@ -143,6 +143,9 @@ pub enum SagaState {
     Compensating,
     /// All compensation steps have finished.
     Compensated,
+    /// The saga was cancelled by an operator; any completed steps were rolled
+    /// back before it reached this terminal state (#429).
+    Cancelled,
 }
 
 impl SagaState {
@@ -156,6 +159,7 @@ impl SagaState {
             SagaState::Failed => "failed",
             SagaState::Compensating => "compensating",
             SagaState::Compensated => "compensated",
+            SagaState::Cancelled => "cancelled",
         }
     }
 
@@ -172,6 +176,7 @@ impl SagaState {
             "failed" => Some(SagaState::Failed),
             "compensating" => Some(SagaState::Compensating),
             "compensated" => Some(SagaState::Compensated),
+            "cancelled" => Some(SagaState::Cancelled),
             _ => None,
         }
     }
@@ -707,7 +712,8 @@ impl PostgresSagaStore {
 
     /// Update saga state and automatically set completion time for terminal states
     ///
-    /// Terminal states (Completed, Compensated) automatically receive `completed_at` timestamp.
+    /// Terminal states (Completed, Compensated, Cancelled) automatically receive a
+    /// `completed_at` timestamp.
     ///
     /// # Errors
     ///
@@ -719,7 +725,10 @@ impl PostgresSagaStore {
         let state_str = state.as_str();
         let now = chrono::Utc::now();
 
-        let completed_at = if matches!(state, SagaState::Completed | SagaState::Compensated) {
+        let completed_at = if matches!(
+            state,
+            SagaState::Completed | SagaState::Compensated | SagaState::Cancelled
+        ) {
             Some(now)
         } else {
             None

--- a/crates/fraiseql-federation/tests/saga_integration.rs
+++ b/crates/fraiseql-federation/tests/saga_integration.rs
@@ -927,3 +927,331 @@ mod recovery_pg {
         assert!(!manager.is_running());
     }
 }
+
+// ── Wired coordinator end-to-end against real PostgreSQL (unstable-saga) ──────
+//
+// Ignored by default — these require a live PostgreSQL reachable via
+// `DATABASE_URL` (the saga store is Postgres-only). The CI integration leg runs
+// them with `--features unstable-saga --include-ignored` against the bound
+// service. They exercise the additive `WiredSagaCoordinator`, which ties forward
+// execution + compensation into one handle; the loud-fail `SagaCoordinator`
+// entry points are unchanged and covered by its own unit tests.
+
+#[cfg(feature = "unstable-saga")]
+mod coordinator_pg {
+    use std::sync::Arc;
+
+    use fraiseql_db::{PostgresAdapter, traits::DatabaseAdapter};
+    use fraiseql_federation::{
+        CompensationStrategy, FederatedType, FederationMetadata, FederationMutationExecutor,
+        KeyDirective, PostgresSagaStore, SagaCoordinatorStep, SagaState, SagaStoreError, StepState,
+        WiredSagaCoordinator,
+    };
+    use serde_json::json;
+    use uuid::Uuid;
+
+    fn database_url() -> Option<String> {
+        std::env::var("DATABASE_URL").ok()
+    }
+
+    /// A unique, all-lowercase, identifier-safe entity type name per test run.
+    /// `execute_local_mutation` targets `lowercase(typename)` as the table, so a
+    /// unique name isolates each test from other tests sharing the database.
+    fn unique_typename() -> String {
+        format!("sagacoord{}", Uuid::new_v4().simple())
+    }
+
+    fn entity_metadata(typename: &str) -> FederationMetadata {
+        FederationMetadata {
+            enabled: true,
+            version: "v2".to_string(),
+            types: vec![FederatedType {
+                name:                typename.to_string(),
+                keys:                vec![KeyDirective {
+                    fields:     vec!["id".to_string()],
+                    resolvable: true,
+                }],
+                is_extends:          false,
+                external_fields:     Vec::new(),
+                shareable_fields:    Vec::new(),
+                inaccessible_fields: Vec::new(),
+                field_directives:    std::collections::HashMap::new(),
+                type_shareable:      false,
+            }],
+            remote_subscription_fields: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Build a saga store + a mutation executor over a freshly-created entity
+    /// table named after `typename`.
+    async fn setup(
+        url: &str,
+        typename: &str,
+    ) -> (PostgresSagaStore, FederationMutationExecutor<PostgresAdapter>) {
+        let store = PostgresSagaStore::new(url).await.unwrap();
+        store.migrate_schema().await.unwrap();
+        let adapter = PostgresAdapter::new(url).await.unwrap();
+        let table = typename.to_lowercase();
+        adapter
+            .execute_raw_query(&format!("DROP TABLE IF EXISTS \"{table}\""))
+            .await
+            .unwrap();
+        adapter
+            .execute_raw_query(&format!(
+                "CREATE TABLE \"{table}\" (id TEXT PRIMARY KEY, total TEXT)"
+            ))
+            .await
+            .unwrap();
+        let executor =
+            FederationMutationExecutor::new(Arc::new(adapter), entity_metadata(typename), false);
+        (store, executor)
+    }
+
+    /// A create step whose forward `create…` mutation writes a row and whose
+    /// `delete…` compensation undoes it.
+    fn create_step(number: u32, typename: &str, id: &str, total: &str) -> SagaCoordinatorStep {
+        SagaCoordinatorStep::new(
+            number,
+            "orders",
+            typename,
+            format!("create{typename}"),
+            json!({"id": id, "total": total}),
+            format!("delete{typename}"),
+            json!({"id": id}),
+        )
+    }
+
+    /// Cycle 1: `create_saga` persists the saga (`Pending`) and every step, carrying
+    /// the compensation metadata through to the store.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn create_saga_persists_saga_and_steps() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, _executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+        let coordinator =
+            WiredSagaCoordinator::new(Arc::clone(&store), CompensationStrategy::Automatic);
+
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let id_b = format!("b-{}", Uuid::new_v4());
+        let id_c = format!("c-{}", Uuid::new_v4());
+        let steps = vec![
+            create_step(1, &typename, &id_a, "1"),
+            create_step(2, &typename, &id_b, "2"),
+            create_step(3, &typename, &id_c, "3"),
+        ];
+
+        let saga_id = coordinator.create_saga(steps).await.unwrap();
+
+        // The saga is persisted Pending.
+        assert_eq!(
+            store.load_saga(saga_id).await.unwrap().unwrap().state,
+            SagaState::Pending,
+            "a created saga starts Pending"
+        );
+
+        // All three steps are loadable (ordered) with compensation metadata intact.
+        let loaded = store.load_saga_steps(saga_id).await.unwrap();
+        assert_eq!(loaded.len(), 3, "every step persisted: {loaded:?}");
+        let expected_comp = format!("delete{typename}");
+        assert_eq!(
+            loaded[0].compensation_mutation.as_deref(),
+            Some(expected_comp.as_str()),
+            "compensation_mutation round-trips through create_saga"
+        );
+        assert!(
+            loaded.iter().all(|s| s.state == StepState::Pending),
+            "created steps start Pending: {loaded:?}"
+        );
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+
+    /// Cycle 1 (validation): `create_saga` rejects empty and out-of-order steps
+    /// before touching the store.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn create_saga_rejects_invalid_steps() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, _executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+        let coordinator =
+            WiredSagaCoordinator::new(Arc::clone(&store), CompensationStrategy::Automatic);
+
+        let empty = coordinator.create_saga(vec![]).await;
+        assert!(
+            matches!(empty, Err(SagaStoreError::Database(_))),
+            "empty steps rejected before persistence: {empty:?}"
+        );
+
+        // A single step numbered 2 is out of sequence (must start at 1).
+        let out_of_order = coordinator.create_saga(vec![create_step(2, &typename, "x", "1")]).await;
+        assert!(
+            matches!(out_of_order, Err(SagaStoreError::Database(_))),
+            "non-sequential steps rejected: {out_of_order:?}"
+        );
+    }
+
+    /// Cycle 2: `execute_saga` happy path — every step's real mutation runs, the
+    /// saga completes with no compensation, and status/result reflect completion.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn execute_saga_completes_all_steps() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+        let coordinator =
+            WiredSagaCoordinator::new(Arc::clone(&store), CompensationStrategy::Automatic);
+
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let id_b = format!("b-{}", Uuid::new_v4());
+        let saga_id = coordinator
+            .create_saga(vec![
+                create_step(1, &typename, &id_a, "10"),
+                create_step(2, &typename, &id_b, "20"),
+            ])
+            .await
+            .unwrap();
+
+        let result = coordinator.execute_saga(saga_id, &executor).await.unwrap();
+        assert_eq!(result.state, SagaState::Completed, "all steps succeed: {result:?}");
+        assert!(!result.compensated, "no compensation on success: {result:?}");
+        assert_eq!(result.completed_steps, 2, "both steps completed: {result:?}");
+
+        let status = coordinator.get_saga_status(saga_id).await.unwrap();
+        assert!(
+            (status.progress_percentage - 100.0).abs() < 1e-9,
+            "a fully-executed saga is 100% complete: {status:?}"
+        );
+
+        let final_result = coordinator.get_saga_result(saga_id).await.unwrap();
+        assert_eq!(final_result.completed_steps, 2, "result reports two completed steps");
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+
+    /// Cycle 3: `execute_saga` failure path — a failing step fails the saga and, under
+    /// `Automatic`, the completed steps are really rolled back.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn execute_saga_failure_triggers_compensation() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+        let coordinator =
+            WiredSagaCoordinator::new(Arc::clone(&store), CompensationStrategy::Automatic);
+
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let id_b = format!("b-{}", Uuid::new_v4());
+        // Steps 1–2 create rows (each with a delete compensation); step 3 updates a
+        // row that does not exist → fails at execution, triggering rollback. Step 3
+        // has no compensation (it never completes, so nothing to undo).
+        let step3 = SagaCoordinatorStep::new(
+            3,
+            "orders",
+            typename.as_str(),
+            format!("update{typename}"),
+            json!({"id": "missing", "total": "9"}),
+            String::new(),
+            json!({}),
+        );
+        let saga_id = coordinator
+            .create_saga(vec![
+                create_step(1, &typename, &id_a, "1"),
+                create_step(2, &typename, &id_b, "2"),
+                step3,
+            ])
+            .await
+            .unwrap();
+
+        let result = coordinator.execute_saga(saga_id, &executor).await.unwrap();
+        assert_eq!(result.state, SagaState::Failed, "a failed step fails the saga: {result:?}");
+        assert!(result.compensated, "Automatic strategy rolls back on failure: {result:?}");
+
+        let mut steps = store.load_saga_steps(saga_id).await.unwrap();
+        steps.sort_by_key(|s| s.order);
+        assert_eq!(steps[0].state, StepState::Compensated, "step 1 rolled back");
+        assert_eq!(steps[1].state, StepState::Compensated, "step 2 rolled back");
+        assert_eq!(
+            steps[2].state,
+            StepState::Failed,
+            "the failed step never completed → not compensated"
+        );
+
+        // The compensations really removed the created rows (not fabricated).
+        let table = typename.to_lowercase();
+        let rows = PostgresAdapter::new(&url)
+            .await
+            .unwrap()
+            .execute_raw_query(&format!(
+                "SELECT id FROM \"{table}\" WHERE id IN ('{id_a}', '{id_b}')"
+            ))
+            .await
+            .unwrap();
+        assert!(rows.is_empty(), "both created rows were rolled back: {rows:?}");
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+
+    /// Cycle 4: `cancel_saga` on a `Pending` saga + `list_in_flight_sagas` membership.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn cancel_pending_saga_and_list_in_flight() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, executor) = setup(&url, &typename).await;
+        let store = Arc::new(store);
+        let coordinator =
+            WiredSagaCoordinator::new(Arc::clone(&store), CompensationStrategy::Automatic);
+
+        let id_a = format!("a-{}", Uuid::new_v4());
+        let id_b = format!("b-{}", Uuid::new_v4());
+        let saga_id = coordinator
+            .create_saga(vec![
+                create_step(1, &typename, &id_a, "1"),
+                create_step(2, &typename, &id_b, "2"),
+            ])
+            .await
+            .unwrap();
+
+        // A never-executed saga is in-flight (Pending).
+        let in_flight = coordinator.list_in_flight_sagas().await.unwrap();
+        assert!(in_flight.contains(&saga_id), "a Pending saga is in-flight: {in_flight:?}");
+
+        // Cancel it: nothing completed → nothing to compensate.
+        let result = coordinator.cancel_saga(saga_id, &executor).await.unwrap();
+        assert_eq!(result.state, SagaState::Cancelled, "cancel yields Cancelled: {result:?}");
+
+        // No longer in-flight.
+        let after = coordinator.list_in_flight_sagas().await.unwrap();
+        assert!(!after.contains(&saga_id), "a cancelled saga is not in-flight: {after:?}");
+
+        // Cancelling an already-terminal saga fails loud.
+        let second = coordinator.cancel_saga(saga_id, &executor).await;
+        assert!(
+            matches!(second, Err(SagaStoreError::InvalidStateTransition { .. })),
+            "a second cancel on a terminal saga is rejected: {second:?}"
+        );
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+}


### PR DESCRIPTION
Phase 03 of the v2.11.0 saga full round-trip (#429 umbrella). Ties forward execution + compensation into a single public handle: create → execute (forward + automatic rollback on failure) → cancel → query, all through one type.

## What this wires

A new **`WiredSagaCoordinator`** (feature-gated `unstable-saga`) over a `PostgresSagaStore`, holding an internal `SagaExecutor` + `SagaCompensator`:

- **`create_saga`** — validates (non-empty, sequential 1..N) and persists a saga (`Pending`) plus each step with its compensation metadata. Forward `mutation_name` → persisted mutation kind via a pure verb-prefix helper; an unrecognised verb fails loud rather than defaulting (the M-fed-mut-executor trap).
- **`execute_saga`** — runs the forward phase; on any step failure under the default `Automatic` strategy it rolls back the completed steps via `SagaCompensator::compensate_saga_local` (`Failed` + `compensated: true`). `Manual` leaves the saga `Failed` for an operator.
- **`cancel_saga`** — refuses an already-terminal saga, compensates any completed steps, then marks the saga `Cancelled`.
- **`get_saga_status` / `get_saga_result` / `list_in_flight_sagas`** — report real persisted state.

## Doctrine (consistent with Phase 01/02)

- **Additive.** The loud-fail `SagaCoordinator` and its six contract tests are **untouched**. The new type carries the `store` the loud-fail coordinator never had, so no stub shares a method name — no rename needed on the loud-fail side.
- **No new `#[async_trait]`** — ratchet held **188**.
- **Pure logic always compiled** — `saga_coordinator/coordination.rs` (`mutation_type_for`, `saga_state_is_terminal`, `progress_percentage`) with `#![cfg_attr(not(feature = \"unstable-saga\"), allow(dead_code))]`; each helper is called from the wired path.

## Plan drift resolved the P01/P02 way

1. Plan replaced `SagaCoordinator`'s struct/`new` — impossible without breaking the loud-fail contract tests (they run in **both** feature builds). Resolved with an **additive gated type** (struct-level analog of the `*_local` rename).
2. Plan called `compensator.compensate_saga(...)` — the wired method is `compensate_saga_local` (bare name stays loud-fail).
3. `SagaState::Cancelled` didn't exist — added additively (terminal; `as_str`/`from_str`/`completed_at` ripple only). Plan's `SagaResult.failed_steps` field doesn't exist; `error` is populated instead. Plan's `OnFirstFailure`/`BestEffort` strategy names are actually `Automatic`/`Manual`.

Cycle 5's `.dagger/main.go` edit is a no-op — `main.go:636` already runs the whole `saga_integration.rs` `--include-ignored` and `:410` runs `--lib --features unstable-saga`.

## Verification

- ✅ `make preflight` — fmt, clippy `--all-targets --all-features -D warnings`, rustdoc `--all-features`, shell gates (async-trait 188, tests-layout, unwrap 1/3, audit-lockstep)
- ✅ 22 federation lib tests incl. 9 new pure-helper + 13 loud-fail contract tests (feature on & off)
- ✅ 20/20 `saga_integration` on live Postgres (5 new `coordinator_pg` cycles + zero regressions in `wired_pg`/`recovery_pg`/loud-fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)