### PR TITLE
feat(federation): persist full saga mutation name for remote dispatch (#429)

### DIFF
--- a/.phases/README.md
+++ b/.phases/README.md
@@ -1,9 +1,30 @@
 # FraiseQL .phases/
 
-**Active:** [2026-05-31-release-train/](2026-05-31-release-train/) — master
-orchestration for everything queued after v2.3.2 (Dagger CI migration as the
-prerequisite, then the v2.4.0 tail, deferred-bug waves, and enhancements), laid
-out for parallel git-worktree execution. **Start there.**
+**Active train (as of 2026-07-01):**
+[v2.11.0-saga-full-roundtrip/](v2.11.0-saga-full-roundtrip/) — closes the round-trip
+half of the #429 saga umbrella (compensation → recovery → coordinator →
+remote-dispatch → finalize). Phases 01–04 are **merged** (dev `176de7ece`); only
+**Phase 05 (Finalize)** remains — it keeps `unstable-saga` gated and adds a
+`# Stability` docs section (promotion is deferred to the hardening train below).
+
+**Queued behind it** (all written, `Not Started`):
+- [v2.14.0-saga-hardening/](v2.14.0-saga-hardening/) — the remaining saga work that
+  v2.11.0 deferred, laid out as 7 phases ending in the `unstable-saga` → stable
+  promotion: remote-mutation-name persistence → remote HTTP compensation → `@requires`
+  pre-fetch → concurrency-safe recovery (`SKIP LOCKED`) → transport hardening (mTLS) →
+  strategies + observability → finalize/promote. (Numbered v2.14.0 as the natural
+  successor to the two trains below; re-prioritise earlier if a consumer needs
+  distributed sagas in production.)
+- [v2.12.0-cdc-and-observer-transports/](v2.12.0-cdc-and-observer-transports/) — Kafka +
+  Kinesis sinks (#382) + observer transports + server auto-mount (#428)
+- [v2.13.0-ai-native/](v2.13.0-ai-native/) — actor model / vector similarity DSL /
+  session-state / MCP resources / Python helpers (renumbered off its dead v2.10.0 label —
+  the v2.10.0 slot shipped as the AX cluster #484–#488)
+
+**Shipped since the release-train era:** v2.9.0 (auth foundation + make-it-real cluster +
+CDC first slice), v2.10.0 (AX feedback cluster #484–#488). The old
+[2026-05-31-release-train/](2026-05-31-release-train/) master orchestration is complete;
+its remaining follow-ups are the three plans above.
 
 ## Archive
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Saga steps now persist their full mutation name for remote dispatch (#429).**
+  `tb_federation_saga_steps` gained a nullable `mutation_name` column (added
+  idempotently by `migrate_schema`) carrying the exact GraphQL operation name
+  (e.g. `createOrder`) alongside the coarse mutation *kind*.
+  `WiredSagaCoordinator::create_saga` persists it, and both local and remote step
+  dispatch now send the full name instead of the reconstructed verb (`create`), so
+  a remote subgraph receives the operation it actually defines. Rows that predate
+  the column (`mutation_name` `NULL`) fall back to the verb, so existing sagas are
+  unaffected. This is the store-schema groundwork for remote saga compensation.
+  Requires the `unstable-saga` Cargo feature; the API may change without semver
+  guarantees.
 - **Saga steps can now be dispatched to remote subgraphs over HTTPS under
   `unstable-saga` (#429).** `WiredSagaCoordinator` gained a subgraph registry:
   `with_http_client(config)` configures an SSRF-protected `HttpMutationClient`, and

--- a/crates/fraiseql-federation/src/saga_compensator/compensation/tests.rs
+++ b/crates/fraiseql-federation/src/saga_compensator/compensation/tests.rs
@@ -14,6 +14,7 @@ fn step(order: usize, state: StepState, compensation_mutation: Option<&str>) -> 
         order,
         subgraph: "orders".to_string(),
         mutation_type: MutationType::Create,
+        mutation_name: None,
         typename: "Order".to_string(),
         variables: json!({"id": "o1"}),
         state,

--- a/crates/fraiseql-federation/src/saga_compensator/tests.rs
+++ b/crates/fraiseql-federation/src/saga_compensator/tests.rs
@@ -161,6 +161,7 @@ mod wired {
             order:                  0,
             subgraph:               "orders".to_string(),
             mutation_type:          MutationType::Create,
+            mutation_name:          Some("createOrder".to_string()),
             typename:               "Order".to_string(),
             variables:              json!({"id": "o1"}),
             state:                  StepState::Completed,

--- a/crates/fraiseql-federation/src/saga_coordinator/wired.rs
+++ b/crates/fraiseql-federation/src/saga_coordinator/wired.rs
@@ -219,6 +219,9 @@ impl WiredSagaCoordinator {
                 order: (step.number as usize).saturating_sub(1),
                 subgraph: step.subgraph.clone(),
                 mutation_type,
+                // Persist the full operation name (e.g. `createOrder`) alongside the
+                // coarse kind so remote dispatch sends the real name, not the verb.
+                mutation_name: Some(step.mutation_name.clone()),
                 typename: step.typename.clone(),
                 variables: step.variables.clone(),
                 state: StepState::Pending,

--- a/crates/fraiseql-federation/src/saga_executor/step.rs
+++ b/crates/fraiseql-federation/src/saga_executor/step.rs
@@ -94,15 +94,17 @@ mod wired {
             remote: Option<(&HttpMutationClient, &Url)>,
         ) -> (StepExecutionResult, StepState) {
             let step_number = u32::try_from(step.order).unwrap_or(u32::MAX).saturating_add(1);
+            // Prefer the full persisted operation name (e.g. `createOrder`) so a
+            // remote subgraph receives the real mutation; pre-migration rows with
+            // no name fall back to the mutation-kind verb (`create`), which the
+            // name-driven `determine_mutation_type` also resolves for the local path.
+            let op_name =
+                step.mutation_name.as_deref().unwrap_or_else(|| step.mutation_type.as_str());
             let started = std::time::Instant::now();
             let outcome = match remote {
                 None => {
                     mutation_executor
-                        .execute_local_mutation(
-                            &step.typename,
-                            step.mutation_type.as_str(),
-                            &step.variables,
-                        )
+                        .execute_local_mutation(&step.typename, op_name, &step.variables)
                         .await
                 },
                 Some((client, url)) => {
@@ -110,7 +112,7 @@ mod wired {
                         .execute_mutation(
                             url.as_str(),
                             &step.typename,
-                            step.mutation_type.as_str(),
+                            op_name,
                             &step.variables,
                             mutation_executor.metadata(),
                         )

--- a/crates/fraiseql-federation/src/saga_executor/tests.rs
+++ b/crates/fraiseql-federation/src/saga_executor/tests.rs
@@ -155,6 +155,7 @@ mod wired {
             order: 0,
             subgraph: "orders".to_string(),
             mutation_type,
+            mutation_name: None,
             typename: "Order".to_string(),
             variables,
             state: StepState::Pending,
@@ -237,7 +238,7 @@ mod wired {
     use reqwest::Url;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{method, path},
+        matchers::{body_string_contains, method, path},
     };
 
     use crate::mutation_http_client::{HttpMutationClient, HttpMutationConfig};
@@ -310,5 +311,69 @@ mod wired {
         assert_eq!(state, StepState::Failed);
         assert!(result.data.is_none(), "a failed remote step fabricates no result data");
         assert!(result.error.is_some(), "a failed remote step carries the error: {result:?}");
+    }
+
+    /// When a step carries a full `mutation_name`, remote dispatch sends THAT as
+    /// the GraphQL operation name — not the coarse mutation-kind verb (#429
+    /// hardening: full remote mutation-name persistence). The mock only matches a
+    /// request body containing `createOrder`, so a request that sent the verb
+    /// `create` would not match and the step would fail.
+    #[tokio::test]
+    async fn dispatch_step_remote_uses_full_mutation_name_when_present() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("createOrder"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "createOrder": { "__typename": "Order", "id": "o-named" } }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (mutation_executor, _adapter) = order_table_executor().await;
+        let client = HttpMutationClient::new_for_test(HttpMutationConfig::default()).unwrap();
+        let url = Url::parse(&format!("{}/graphql", server.uri())).unwrap();
+        let mut step = order_step(MutationType::Create, json!({"id": "o-named", "total": "9"}));
+        step.mutation_name = Some("createOrder".to_string());
+
+        let (result, state) =
+            SagaExecutor::dispatch_step(&mutation_executor, &step, Some((&client, &url))).await;
+
+        assert!(result.success, "the named remote mutation must succeed: {result:?}");
+        assert_eq!(state, StepState::Completed);
+        let data = result.data.expect("a successful remote step carries the mock entity");
+        assert_eq!(data["id"], "o-named", "the createOrder response is returned");
+        // `.expect(1)` on the `createOrder`-body matcher asserts the op name on drop.
+    }
+
+    /// With no `mutation_name` set, remote dispatch falls back to the mutation-kind
+    /// verb (`create`) — backwards-compatible with pre-migration step rows.
+    #[tokio::test]
+    async fn dispatch_step_remote_falls_back_to_verb_when_name_absent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_string_contains("{ create("))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "create": { "__typename": "Order", "id": "o-verb" } }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (mutation_executor, _adapter) = order_table_executor().await;
+        let client = HttpMutationClient::new_for_test(HttpMutationConfig::default()).unwrap();
+        let url = Url::parse(&format!("{}/graphql", server.uri())).unwrap();
+        // mutation_name left None → fall back to the verb.
+        let step = order_step(MutationType::Create, json!({"id": "o-verb", "total": "3"}));
+
+        let (result, state) =
+            SagaExecutor::dispatch_step(&mutation_executor, &step, Some((&client, &url))).await;
+
+        assert!(result.success, "the verb-named remote mutation must succeed: {result:?}");
+        assert_eq!(state, StepState::Completed);
+        let data = result.data.expect("a successful remote step carries the mock entity");
+        assert_eq!(data["id"], "o-verb", "the create response is returned");
     }
 }

--- a/crates/fraiseql-federation/src/saga_store.rs
+++ b/crates/fraiseql-federation/src/saga_store.rs
@@ -296,6 +296,11 @@ pub struct SagaStep {
     pub subgraph:               String,
     /// Kind of mutation this step performs.
     pub mutation_type:          MutationType,
+    /// Full GraphQL mutation operation name (e.g. `createOrder`), if known. The
+    /// store also records the coarse [`MutationType`] *kind*; this carries the
+    /// exact name a remote subgraph expects. `None`/empty (pre-migration rows or
+    /// steps created without a name) falls back to the kind's canonical verb.
+    pub mutation_name:          Option<String>,
     /// GraphQL type name the mutation targets.
     pub typename:               String,
     /// Input variables for the mutation.
@@ -466,11 +471,14 @@ impl PostgresSagaStore {
         // compensation, so both columns are added idempotently and may be NULL.
         // A step with a NULL/empty compensation_mutation has no registered
         // rollback and is skipped by the compensator (best-effort, #429).
+        // `mutation_name` (also nullable, added idempotently) carries the full
+        // remote operation name; NULL rows fall back to the mutation-kind verb.
         conn.execute(
             "
             ALTER TABLE tb_federation_saga_steps
                 ADD COLUMN IF NOT EXISTS compensation_mutation TEXT,
-                ADD COLUMN IF NOT EXISTS compensation_variables JSONB
+                ADD COLUMN IF NOT EXISTS compensation_variables JSONB,
+                ADD COLUMN IF NOT EXISTS mutation_name TEXT
             ",
             &[],
         )
@@ -619,6 +627,7 @@ impl PostgresSagaStore {
             order: row.get::<_, i32>(2) as usize,
             subgraph: row.get(3),
             mutation_type,
+            mutation_name: row.get(13),
             typename: row.get(5),
             variables: row.get(6),
             state,
@@ -758,7 +767,7 @@ impl PostgresSagaStore {
 
         let row = conn
             .query_opt(
-                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at, fss.compensation_mutation, fss.compensation_variables
+                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at, fss.compensation_mutation, fss.compensation_variables, fss.mutation_name
                  FROM tb_federation_saga_steps fss
                  INNER JOIN tb_federation_sagas fs ON fss.saga_pk_ = fs.pk_
                  WHERE fss.id = $1",
@@ -779,7 +788,7 @@ impl PostgresSagaStore {
 
         let rows = conn
             .query(
-                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at, fss.compensation_mutation, fss.compensation_variables
+                "SELECT fss.id, fs.id as saga_id, fss.step_number, fss.subgraph, fss.mutation_type, fss.typename, fss.variables, fss.state, fss.result, fss.started_at, fss.completed_at, fss.compensation_mutation, fss.compensation_variables, fss.mutation_name
                  FROM tb_federation_saga_steps fss
                  INNER JOIN tb_federation_sagas fs ON fss.saga_pk_ = fs.pk_
                  WHERE fs.id = $1
@@ -852,14 +861,14 @@ impl PostgresSagaStore {
         let step_number = step.order as i32;
 
         // Use subquery to convert saga natural key (UUID) to surrogate key (BIGINT) for foreign key
-        // compensation_mutation / compensation_variables are part of the immutable
-        // step definition, so — like variables/subgraph — they are written on
-        // INSERT but not touched by the ON CONFLICT update path (which only
-        // advances runtime state/result/completed_at).
+        // compensation_mutation / compensation_variables / mutation_name are part
+        // of the immutable step definition, so — like variables/subgraph — they are
+        // written on INSERT but not touched by the ON CONFLICT update path (which
+        // only advances runtime state/result/completed_at).
         let affected = conn
             .execute(
-                "INSERT INTO tb_federation_saga_steps (id, saga_pk_, step_number, subgraph, mutation_type, typename, variables, state, result, started_at, completed_at, created_at, updated_at, compensation_mutation, compensation_variables)
-             SELECT $1, fs.pk_, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+                "INSERT INTO tb_federation_saga_steps (id, saga_pk_, step_number, subgraph, mutation_type, typename, variables, state, result, started_at, completed_at, created_at, updated_at, compensation_mutation, compensation_variables, mutation_name)
+             SELECT $1, fs.pk_, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
              FROM tb_federation_sagas fs
              WHERE fs.id = $2
              ON CONFLICT (id) DO UPDATE SET state = $8, result = $9, completed_at = $11, updated_at = $13",
@@ -879,6 +888,7 @@ impl PostgresSagaStore {
                     &now,
                     &step.compensation_mutation,
                     &step.compensation_variables,
+                    &step.mutation_name,
                 ],
             )
             .await?;

--- a/crates/fraiseql-federation/tests/saga_integration.rs
+++ b/crates/fraiseql-federation/tests/saga_integration.rs
@@ -169,6 +169,7 @@ mod wired_pg {
             order,
             subgraph: "orders".to_string(),
             mutation_type: mt,
+            mutation_name: None,
             typename: typename.to_string(),
             variables,
             state: StepState::Pending,
@@ -239,6 +240,51 @@ mod wired_pg {
         let steps = store.load_saga_steps(saga_id).await.unwrap();
         let listed = steps.iter().find(|s| s.id == step_with.id).unwrap();
         assert_eq!(listed.compensation_mutation.as_deref(), Some("undo_create_order"));
+
+        store.delete_saga(saga_id).await.unwrap();
+    }
+
+    /// The full mutation name round-trips through the store: a step saved with a
+    /// `mutation_name` reloads with it intact (both the single-load and list
+    /// paths), and a step saved without one reloads as `None` — backwards
+    /// compatible with rows that predate the `mutation_name` column (#429
+    /// hardening: full remote mutation-name persistence). `setup` runs
+    /// `migrate_schema`, so this also exercises the idempotent ALTER.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL (Postgres saga store)"]
+    async fn saga_step_mutation_name_round_trips() {
+        let Some(url) = database_url() else {
+            eprintln!("DATABASE_URL not set; skipping");
+            return;
+        };
+        let typename = unique_typename();
+        let (store, _executor) = setup(&url, &typename).await;
+
+        let saga_id = Uuid::new_v4();
+        store.save_saga(&new_saga(saga_id)).await.unwrap();
+
+        // Step WITH a full mutation name.
+        let mut named = new_step(saga_id, 0, MutationType::Create, &typename, json!({"id": "n1"}));
+        named.mutation_name = Some("createOrder".to_string());
+        store.save_saga_step(&named).await.unwrap();
+
+        // Step WITHOUT a mutation name (backwards-compatible None round-trip).
+        let unnamed = new_step(saga_id, 1, MutationType::Create, &typename, json!({"id": "n2"}));
+        store.save_saga_step(&unnamed).await.unwrap();
+
+        let reloaded_named = store.load_saga_step(named.id).await.unwrap().unwrap();
+        assert_eq!(
+            reloaded_named.mutation_name.as_deref(),
+            Some("createOrder"),
+            "mutation_name must round-trip through load_saga_step"
+        );
+        let reloaded_unnamed = store.load_saga_step(unnamed.id).await.unwrap().unwrap();
+        assert!(reloaded_unnamed.mutation_name.is_none(), "absent mutation_name → None");
+
+        // The list path (load_saga_steps) must carry the name too.
+        let steps = store.load_saga_steps(saga_id).await.unwrap();
+        let listed = steps.iter().find(|s| s.id == named.id).unwrap();
+        assert_eq!(listed.mutation_name.as_deref(), Some("createOrder"));
 
         store.delete_saga(saga_id).await.unwrap();
     }
@@ -686,6 +732,7 @@ mod recovery_pg {
             order,
             subgraph: "orders".to_string(),
             mutation_type: mt,
+            mutation_name: None,
             typename: typename.to_string(),
             variables,
             state: StepState::Pending,
@@ -1063,6 +1110,12 @@ mod coordinator_pg {
             Some(expected_comp.as_str()),
             "compensation_mutation round-trips through create_saga"
         );
+        let expected_name = format!("create{typename}");
+        assert_eq!(
+            loaded[0].mutation_name.as_deref(),
+            Some(expected_name.as_str()),
+            "the full mutation_name round-trips through create_saga (not just the verb)"
+        );
         assert!(
             loaded.iter().all(|s| s.state == StepState::Pending),
             "created steps start Pending: {loaded:?}"
@@ -1384,14 +1437,23 @@ mod remote_dispatch_pg {
         let store = Arc::new(store);
 
         // A mock peer subgraph returning a create response; must be hit exactly once
-        // (only the remote step, never the local one).
+        // (only the remote step, never the local one). The response is keyed by the
+        // full mutation name the step now sends (`create{typename}`) — the store
+        // persists the real operation name, not the coarse verb.
         let server = MockServer::start().await;
         let remote_id = format!("remote-{}", Uuid::new_v4());
+        let remote_op = format!("create{typename}");
+        let mut entity = serde_json::Map::new();
+        entity.insert("__typename".to_string(), json!(typename));
+        entity.insert("id".to_string(), json!(remote_id));
+        let mut data = serde_json::Map::new();
+        data.insert(remote_op, serde_json::Value::Object(entity));
         Mock::given(method("POST"))
             .and(path("/graphql"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "data": { "create": { "__typename": typename, "id": remote_id } }
-            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "data": serde_json::Value::Object(data) })),
+            )
             .expect(1)
             .mount(&server)
             .await;


### PR DESCRIPTION
## Summary

**Hardening Phase 01** of the saga-hardening train (`v2.14.0-saga-hardening`) — the store-schema groundwork that unblocks remote saga compensation. Saga steps now persist their **full GraphQL operation name** (e.g. `createOrder`) instead of only the coarse mutation *kind*, so remote dispatch sends the operation a peer subgraph actually defines rather than a reconstructed verb (`create`).

This is the successor work to the v2.11.0 saga round-trip (compensation → recovery → coordinator → remote dispatch, all merged). Rather than cut an intermediate gated release, we go straight to hardening; the `unstable-saga` → stable promotion is the final phase of the new train.

## Changes

- **Store** (`saga_store.rs`): nullable `mutation_name` column on `tb_federation_saga_steps` (idempotent `ALTER … ADD COLUMN IF NOT EXISTS`); threaded through store `SagaStep`, both load SELECTs, and the INSERT — kept **out of** the `ON CONFLICT` update set (immutable step definition, like the compensation columns).
- **`create_saga`** (`saga_coordinator/wired.rs`): persists the full operation name alongside the coarse kind.
- **`dispatch_step`** (`saga_executor/step.rs`): prefers the persisted `mutation_name` for **both** local and remote dispatch; falls back to the mutation-kind verb for pre-migration rows (`mutation_name` NULL), which the name-driven `determine_mutation_type` resolves fine locally.
- **Tests**: 2 new fast wiremock dispatch unit tests (full name sent vs. verb fallback), a PG round-trip test, an extended `create_saga` persistence assertion; the P04 remote-dispatch mock now keys its response by the full name (the old `data.create` verb key no longer matches — a correct consequence of the behavior change).

## Doctrine

Additive under `unstable-saga`. The three loud-fail `SagaExecutor` stubs and all 5 loud-fail contract tests are **unchanged and green in both feature builds**. No new `#[async_trait]` (ratchet held 188).

## Verification

- ✅ `make preflight` (clippy `--all-targets --all-features -D warnings`, rustdoc `-D warnings`, shell gates, async-trait ratchet 188)
- ✅ 15 lib tests + **23/23 `saga_integration` on live PostgreSQL** (5 loud-fail contracts intact, zero regressions)
- ✅ `cargo +nightly fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)