### PR TITLE
feat(federation): saga step retry-with-backoff + per-step timeout under unstable-saga (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Saga steps can now retry with backoff and time out under `unstable-saga`
+  (#429).** `SagaExecutor` / `WiredSagaCoordinator` gained a `RetryPolicy`
+  (`with_retry_policy`): a transient step failure is retried up to `max_retries`
+  times with exponential backoff — and, when `step_timeout_ms` is set, each attempt
+  is bounded by a per-step timeout — before the saga gives up and its
+  `CompensationStrategy` decides whether to roll back. So a flaky mutation no longer
+  needlessly compensates a whole saga. The default `RetryPolicy::none()` preserves
+  the original one-attempt behaviour. A retried or timed-out attempt is always a real
+  failed attempt (a captured error, never a fabricated success — audit H32). Requires
+  the `unstable-saga` Cargo feature; the API may change without semver guarantees.
+
 - **Saga crash recovery is now concurrency-safe under `unstable-saga` (#429).**
   `SagaRecoveryManager` now claims stuck (`Executing`) sagas via a single atomic
   `UPDATE … WHERE pk_ IN (SELECT … FOR UPDATE SKIP LOCKED)` statement, leasing each

--- a/crates/fraiseql-federation/src/lib.rs
+++ b/crates/fraiseql-federation/src/lib.rs
@@ -14,7 +14,7 @@
 //! |-----------|--------|-------|
 //! | Subgraph mode — `HttpEntityResolver` (`_entities` HTTP resolution) | ✅ Production | SSRF-protected, retry, tracing |
 //! | Composition validation — `CompositionValidator` | ✅ Production | compile-time only |
-//! | Saga forward execution — `SagaExecutor::{execute_step_local, execute_saga_local, execution_state}` | 🚧 Unstable | requires `unstable-saga` feature; dispatches real mutations (local SQL, or over HTTPS to a registered peer subgraph) and persists real step/saga state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). `@requires` pre-fetch is not yet wired. |
+//! | Saga forward execution — `SagaExecutor::{execute_step_local, execute_saga_local, execution_state}` | 🚧 Unstable | requires `unstable-saga` feature; dispatches real mutations (local SQL, or over HTTPS to a registered peer subgraph) and persists real step/saga state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). A `RetryPolicy` retries a transient step failure with exponential backoff (+ optional per-step timeout) before the saga gives up. `@requires` pre-fetch is not yet wired. |
 //! | Saga compensation — `SagaCompensator::{compensate_step_local, compensate_saga_local}` | 🚧 Unstable | requires `unstable-saga` feature; rolls back completed steps in reverse execution order — each on the same transport its forward step used (local SQL adapter, or over HTTPS to a registered peer subgraph) — and persists real `Compensated` state (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). |
 //! | Saga recovery — `SagaRecoveryManager::{run_iteration_local, start_background_loop_local}` | 🚧 Unstable | requires `unstable-saga` feature; re-drives crash-interrupted (`Pending`/`Executing`) sagas to a terminal state by replaying `execute_saga_local`, records recovery attempts, and cleans up stale sagas (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). Stuck sagas are claimed under a lease via `FOR UPDATE SKIP LOCKED`, so concurrent recovery workers never double-drive one. |
 //! | Saga coordination — `WiredSagaCoordinator::{create_saga, execute_saga, get_saga_status, cancel_saga, get_saga_result, list_in_flight_sagas}` | 🚧 Unstable | requires `unstable-saga` feature; ties forward execution + compensation into one handle — persists a saga with compensation metadata, runs the forward phase, and on failure (under `Automatic`) rolls back the completed steps via the local SQL adapter; `cancel_saga` compensates then marks the saga `Cancelled` (see [#429](https://github.com/fraiseql/fraiseql/issues/429)). `with_http_client` + `with_subgraph` route a step to a registered peer subgraph over HTTPS, for both forward execution and compensation (rollback). |
@@ -113,7 +113,7 @@ pub use saga_coordinator::WiredSagaCoordinator;
 pub use saga_coordinator::{
     CompensationStrategy, SagaCoordinator, SagaResult, SagaStatus, SagaStep as SagaCoordinatorStep,
 };
-pub use saga_executor::{ExecutionState, SagaExecutor, StepExecutionResult};
+pub use saga_executor::{ExecutionState, RetryPolicy, SagaExecutor, StepExecutionResult};
 pub use saga_recovery_manager::{RecoveryConfig, RecoveryStats, SagaRecoveryManager};
 pub use saga_store::{
     MutationType, PostgresSagaStore, Saga, SagaRecovery, SagaState, SagaStep, SagaStoreError,

--- a/crates/fraiseql-federation/src/saga_coordinator/wired.rs
+++ b/crates/fraiseql-federation/src/saga_coordinator/wired.rs
@@ -28,7 +28,7 @@ use crate::{
     mutation_executor::FederationMutationExecutor,
     mutation_http_client::{HttpMutationClient, HttpMutationConfig},
     saga_compensator::SagaCompensator,
-    saga_executor::SagaExecutor,
+    saga_executor::{RetryPolicy, SagaExecutor},
     saga_store::{
         PostgresSagaStore, Result as SagaStoreResult, Saga, SagaState, SagaStep as StoreSagaStep,
         SagaStoreError, StepState,
@@ -83,6 +83,19 @@ impl WiredSagaCoordinator {
     #[must_use]
     pub const fn strategy(&self) -> CompensationStrategy {
         self.strategy
+    }
+
+    /// Set the per-step retry/timeout policy for the forward phase (builder).
+    ///
+    /// With a non-default policy a transient step failure is retried (with
+    /// exponential backoff, honouring the optional per-step timeout) before the saga
+    /// gives up and the compensation strategy takes over — so a flaky mutation does
+    /// not needlessly roll back the whole saga. Defaults to
+    /// [`RetryPolicy::none`](crate::saga_executor::RetryPolicy::none) (one attempt).
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.executor = self.executor.with_retry_policy(policy);
+        self
     }
 
     /// Configure the HTTP client used to dispatch saga steps to remote subgraphs.

--- a/crates/fraiseql-federation/src/saga_executor/mod.rs
+++ b/crates/fraiseql-federation/src/saga_executor/mod.rs
@@ -143,14 +143,53 @@ pub struct ExecutionState {
     pub failure_reason:  Option<String>,
 }
 
-/// Saga forward phase executor
+/// Retry + timeout policy for a saga step's forward dispatch.
 ///
+/// A transient step failure (a flaky network call, a momentary lock) should not
+/// immediately roll back an entire saga. With a non-default policy each step is
+/// retried up to `max_retries` times with exponential backoff before it is treated
+/// as failed; only then does the saga's [`crate::saga_coordinator::CompensationStrategy`]
+/// decide whether to compensate. The default [`RetryPolicy::none`] preserves the
+/// original behaviour (one attempt, no timeout).
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    /// Retries attempted *after* the first try (0 = no retry — one attempt only).
+    pub max_retries:     u32,
+    /// Base backoff in milliseconds; attempt `n` (1-indexed retries) waits
+    /// `base_delay_ms * 2^(n-1)` before retrying.
+    pub base_delay_ms:   u64,
+    /// Optional per-attempt dispatch timeout in milliseconds. An attempt that
+    /// exceeds it is a real failed attempt (a timeout error, never a fabricated
+    /// success) and is retried like any other failure. `None` = no timeout.
+    pub step_timeout_ms: Option<u64>,
+}
+
+impl RetryPolicy {
+    /// No retries and no timeout — one attempt per step (the historical behaviour).
+    #[must_use]
+    pub const fn none() -> Self {
+        Self {
+            max_retries:     0,
+            base_delay_ms:   0,
+            step_timeout_ms: None,
+        }
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
 /// Executes saga steps sequentially during the forward phase.
 /// Coordinates with saga store to persist state and handle failures.
 pub struct SagaExecutor {
     /// Saga store for loading/saving saga state
     /// Optional to support testing without database
     pub(super) store: Option<Arc<PostgresSagaStore>>,
+    /// Retry/timeout policy applied to each step's forward dispatch.
+    pub(super) retry: RetryPolicy,
 }
 
 impl SagaExecutor {
@@ -159,7 +198,10 @@ impl SagaExecutor {
     /// This is suitable for testing. For production, use `with_store()`.
     #[must_use]
     pub const fn new() -> Self {
-        Self { store: None }
+        Self {
+            store: None,
+            retry: RetryPolicy::none(),
+        }
     }
 
     /// Create a new saga executor with a saga store
@@ -167,7 +209,17 @@ impl SagaExecutor {
     /// This enables persistence of saga state and recovery from failures.
     #[must_use]
     pub const fn with_store(store: Arc<PostgresSagaStore>) -> Self {
-        Self { store: Some(store) }
+        Self {
+            store: Some(store),
+            retry: RetryPolicy::none(),
+        }
+    }
+
+    /// Set the per-step retry/timeout policy (builder).
+    #[must_use]
+    pub const fn with_retry_policy(mut self, retry: RetryPolicy) -> Self {
+        self.retry = retry;
+        self
     }
 
     /// Check if executor has a saga store configured

--- a/crates/fraiseql-federation/src/saga_executor/orchestrator.rs
+++ b/crates/fraiseql-federation/src/saga_executor/orchestrator.rs
@@ -146,7 +146,10 @@ mod wired {
                     http_client,
                     subgraph_urls,
                 );
-                let (result, state) = Self::dispatch_step(mutation_executor, step, remote).await;
+                // Retry/timeout policy (default: one attempt) wraps the dispatch so a
+                // transient step failure is retried before the saga gives up on it.
+                let (result, state) =
+                    self.dispatch_step_with_retry(mutation_executor, step, remote).await;
 
                 // Persist the real post-mutation entity only on success; a failed
                 // step is marked Failed and carries no fabricated result payload.

--- a/crates/fraiseql-federation/src/saga_executor/step.rs
+++ b/crates/fraiseql-federation/src/saga_executor/step.rs
@@ -60,6 +60,7 @@ impl SagaExecutor {
 /// exposed as the `*_local` methods, gated behind `unstable-saga` until proven.
 #[cfg(feature = "unstable-saga")]
 mod wired {
+    use ::tracing::warn;
     use fraiseql_db::traits::DatabaseAdapter;
     use reqwest::Url;
 
@@ -123,6 +124,74 @@ mod wired {
             forward::step_result_from(step_number, &outcome, duration_ms)
         }
 
+        /// Dispatch a step under the executor's [`crate::saga_executor::RetryPolicy`]:
+        /// retry a failed dispatch up to `max_retries` times with exponential
+        /// backoff, applying the optional per-attempt timeout.
+        ///
+        /// A successful attempt returns immediately. An attempt that fails or times
+        /// out is a real failed attempt — never a fabricated success (audit H32) — and
+        /// once retries are exhausted the last failed result is returned so the saga's
+        /// compensation strategy acts on a genuine failure. With the default
+        /// [`crate::saga_executor::RetryPolicy::none`] this is exactly one attempt,
+        /// identical to [`Self::dispatch_step`].
+        pub(crate) async fn dispatch_step_with_retry<A: DatabaseAdapter>(
+            &self,
+            mutation_executor: &FederationMutationExecutor<A>,
+            step: &SagaStep,
+            remote: Option<(&HttpMutationClient, &Url)>,
+        ) -> (StepExecutionResult, StepState) {
+            let policy = self.retry;
+            let step_number = u32::try_from(step.order).unwrap_or(u32::MAX).saturating_add(1);
+            let mut attempt: u32 = 0;
+            loop {
+                let (result, state) = match policy.step_timeout_ms {
+                    Some(ms) => {
+                        match tokio::time::timeout(
+                            std::time::Duration::from_millis(ms),
+                            Self::dispatch_step(mutation_executor, step, remote),
+                        )
+                        .await
+                        {
+                            Ok(outcome) => outcome,
+                            Err(_) => (
+                                StepExecutionResult {
+                                    step_number,
+                                    success: false,
+                                    data: None,
+                                    error: Some(format!("step dispatch timed out after {ms}ms")),
+                                    duration_ms: ms,
+                                },
+                                StepState::Failed,
+                            ),
+                        }
+                    },
+                    None => Self::dispatch_step(mutation_executor, step, remote).await,
+                };
+
+                // Success, or no retries left → report the genuine outcome.
+                if result.success || attempt >= policy.max_retries {
+                    return (result, state);
+                }
+
+                warn!(
+                    saga_id = %step.saga_id,
+                    step = step_number,
+                    attempt = attempt + 1,
+                    max_retries = policy.max_retries,
+                    error = result.error.as_deref().unwrap_or("<none>"),
+                    "saga step failed; retrying with backoff"
+                );
+
+                // Exponential backoff: base * 2^attempt, saturating (0 base = no wait).
+                let factor = 1u64.checked_shl(attempt).unwrap_or(u64::MAX);
+                let backoff_ms = policy.base_delay_ms.saturating_mul(factor);
+                if backoff_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                }
+                attempt += 1;
+            }
+        }
+
         /// Execute (dispatch) a single saga step's real local mutation and report
         /// the outcome.
         ///
@@ -142,8 +211,9 @@ mod wired {
             step: &SagaStep,
         ) -> StepExecutionResult {
             // Direct single-step dispatch is always local; the remote-routing
-            // registry lives on the coordinator's `execute_saga_local` path.
-            Self::dispatch_step(mutation_executor, step, None).await.0
+            // registry lives on the coordinator's `execute_saga_local` path. The
+            // executor's retry/timeout policy still applies.
+            self.dispatch_step_with_retry(mutation_executor, step, None).await.0
         }
     }
 }

--- a/crates/fraiseql-federation/src/saga_executor/tests.rs
+++ b/crates/fraiseql-federation/src/saga_executor/tests.rs
@@ -122,7 +122,7 @@ mod wired {
 
     use crate::{
         mutation_executor::FederationMutationExecutor,
-        saga_executor::SagaExecutor,
+        saga_executor::{RetryPolicy, SagaExecutor},
         saga_store::{MutationType, SagaStep, StepState},
         types::{FederatedType, FederationMetadata, KeyDirective},
     };
@@ -375,5 +375,187 @@ mod wired {
         assert_eq!(state, StepState::Completed);
         let data = result.data.expect("a successful remote step carries the mock entity");
         assert_eq!(data["id"], "o-verb", "the create response is returned");
+    }
+
+    // ── Retry-with-backoff + per-step timeout (#429 hardening P06) ──────────────
+    //
+    // `dispatch_step_with_retry` retries a failed dispatch under the executor's
+    // `RetryPolicy` before giving up, so a transient step failure does not needlessly
+    // roll back the saga. Store-free (mirrors `dispatch_step`), so these run fast.
+    // The `HttpMutationClient` is built with `max_retries: 1` (no internal retry) so
+    // one dispatch attempt = exactly one HTTP request and the counts are unambiguous.
+
+    fn single_attempt_client() -> HttpMutationClient {
+        HttpMutationClient::new_for_test(HttpMutationConfig {
+            timeout_ms:     5000,
+            max_retries:    1,
+            retry_delay_ms: 1,
+        })
+        .unwrap()
+    }
+
+    /// A step that succeeds on the first try is dispatched exactly once — the retry
+    /// budget is never spent on success.
+    #[tokio::test]
+    async fn dispatch_step_with_retry_succeeds_first_try_no_retry() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "create": { "__typename": "Order", "id": "o-ok" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let (mutation_executor, _adapter) = order_table_executor().await;
+        let client = single_attempt_client();
+        let url = Url::parse(&format!("{}/graphql", server.uri())).unwrap();
+        let step = order_step(MutationType::Create, json!({"id": "o-ok", "total": "1"}));
+        let executor = SagaExecutor::new().with_retry_policy(RetryPolicy {
+            max_retries:     3,
+            base_delay_ms:   1,
+            step_timeout_ms: None,
+        });
+
+        let (result, state) = executor
+            .dispatch_step_with_retry(&mutation_executor, &step, Some((&client, &url)))
+            .await;
+
+        assert!(result.success, "first-try success must not fail: {result:?}");
+        assert_eq!(state, StepState::Completed);
+        let posts = server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .filter(|r| r.url.path() == "/graphql")
+            .count();
+        assert_eq!(posts, 1, "a successful step is dispatched exactly once: {posts}");
+    }
+
+    /// A transient failure is recovered by a retry: the peer returns 500 once, then
+    /// 200; the step ultimately succeeds after exactly two attempts.
+    #[tokio::test]
+    async fn dispatch_step_with_retry_recovers_after_transient_failure() {
+        let server = MockServer::start().await;
+        // Higher-priority 500 fires once, then is exhausted; the default-priority 200
+        // answers the retry.
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "create": { "__typename": "Order", "id": "o-retry" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let (mutation_executor, _adapter) = order_table_executor().await;
+        let client = single_attempt_client();
+        let url = Url::parse(&format!("{}/graphql", server.uri())).unwrap();
+        let step = order_step(MutationType::Create, json!({"id": "o-retry", "total": "1"}));
+        let executor = SagaExecutor::new().with_retry_policy(RetryPolicy {
+            max_retries:     2,
+            base_delay_ms:   1,
+            step_timeout_ms: None,
+        });
+
+        let (result, state) = executor
+            .dispatch_step_with_retry(&mutation_executor, &step, Some((&client, &url)))
+            .await;
+
+        assert!(result.success, "a retry must recover the transient failure: {result:?}");
+        assert_eq!(state, StepState::Completed);
+        let posts = server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .filter(|r| r.url.path() == "/graphql")
+            .count();
+        assert_eq!(posts, 2, "one failed attempt + one successful retry: {posts}");
+    }
+
+    /// A step that keeps failing exhausts its retry budget and is reported failed —
+    /// never a fabricated success. Attempts = `max_retries + 1`.
+    #[tokio::test]
+    async fn dispatch_step_with_retry_exhausts_budget_then_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let (mutation_executor, _adapter) = order_table_executor().await;
+        let client = single_attempt_client();
+        let url = Url::parse(&format!("{}/graphql", server.uri())).unwrap();
+        let step = order_step(MutationType::Create, json!({"id": "o-fail", "total": "1"}));
+        let executor = SagaExecutor::new().with_retry_policy(RetryPolicy {
+            max_retries:     2,
+            base_delay_ms:   1,
+            step_timeout_ms: None,
+        });
+
+        let (result, state) = executor
+            .dispatch_step_with_retry(&mutation_executor, &step, Some((&client, &url)))
+            .await;
+
+        assert!(!result.success, "an exhausted retry budget must report failure: {result:?}");
+        assert_eq!(state, StepState::Failed);
+        assert!(result.data.is_none(), "a failed step fabricates no data");
+        let posts = server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .filter(|r| r.url.path() == "/graphql")
+            .count();
+        assert_eq!(posts, 3, "max_retries=2 → 1 initial + 2 retries = 3 attempts: {posts}");
+    }
+
+    /// A step whose dispatch exceeds the per-step timeout is a real failed attempt
+    /// (a timeout error), never a fabricated success.
+    #[tokio::test]
+    async fn dispatch_step_with_retry_times_out() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(400))
+                    .set_body_json(
+                        json!({ "data": { "create": { "__typename": "Order", "id": "x" } } }),
+                    ),
+            )
+            .mount(&server)
+            .await;
+
+        let (mutation_executor, _adapter) = order_table_executor().await;
+        let client = single_attempt_client();
+        let url = Url::parse(&format!("{}/graphql", server.uri())).unwrap();
+        let step = order_step(MutationType::Create, json!({"id": "o-slow", "total": "1"}));
+        // 50ms step timeout vs a 400ms server delay → the attempt times out.
+        let executor = SagaExecutor::new().with_retry_policy(RetryPolicy {
+            max_retries:     0,
+            base_delay_ms:   0,
+            step_timeout_ms: Some(50),
+        });
+
+        let (result, state) = executor
+            .dispatch_step_with_retry(&mutation_executor, &step, Some((&client, &url)))
+            .await;
+
+        assert!(!result.success, "a timed-out step must report failure: {result:?}");
+        assert_eq!(state, StepState::Failed);
+        assert!(
+            result.error.as_deref().unwrap_or("").contains("timed out"),
+            "the failure must name the timeout: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

**Hardening Phase 06** (strategies core) — saga steps can now **retry a transient failure with exponential backoff** (and an optional **per-step timeout**) before the saga gives up and its `CompensationStrategy` decides whether to roll back. So a flaky mutation no longer needlessly compensates an entire saga.

Chosen as the next phase after Phase 03 (`@requires` pre-fetch) was found to be blocked on out-of-repo SDK metadata.

## Changes

- **`RetryPolicy`** `{max_retries, base_delay_ms, step_timeout_ms}` (Copy, const `none()` default) on `SagaExecutor` — const constructors unchanged, new `with_retry_policy` const builder; exported from lib.rs.
- **`dispatch_step_with_retry`** (store-free, mirrors `dispatch_step`): retries a failed dispatch with exponential backoff, bounds each attempt by the optional timeout (a timeout is a real failed attempt, never fabricated success — audit H32), `tracing::warn`s each retry. `execute_saga_local` + `execute_step_local` route through it; `WiredSagaCoordinator::with_retry_policy` configures it.
- **4 fast wiremock unit tests**: success→1 attempt; transient 500→retry recovers (wiremock priority + `up_to_n_times`); exhausted budget→failure with exact attempt count; per-step timeout→failure.

## Scope / deferrals

Kept tight and fully unit-testable. Deferred (documented in the phase plan): a distinct `ForwardRecovery` deadline strategy (retry already covers "retry before compensating"), a saga metrics-**counter** struct, and a write-capable admin API (read-only status already exists via `get_saga_status` / `list_in_flight_sagas` / `ExecutionState`). Retry lives on the **forward path** (`SagaExecutor`), not as a new `CompensationStrategy` variant — held on the executor to avoid a signature ripple.

## Doctrine

Default `RetryPolicy::none()` → forward path is **byte-for-byte unchanged** (27/27 live-PG suite identical). Additive under `unstable-saga`; loud-fail stubs + all contract tests unchanged. No new `#[async_trait]` (ratchet 188).

## Verification

- ✅ `make preflight` (clippy `--all-targets --all-features -D warnings`, rustdoc, shell gates)
- ✅ 19 `saga_executor` lib tests (incl. 4 new) + **27/27 `saga_integration` on live PostgreSQL**
- ✅ `cargo +nightly fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)