### PR TITLE
chore(deny): pretty-format the async-imap bans.skip entries

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -81,10 +81,6 @@ name = "darling"
 reason = "samael (#381 auth-saml) → derive_builder 0.20 → darling 0.20; workspace on 0.23"
 version = "=0.20.11"
 
-# async-imap (opt-in `inbound-email`, poll-IMAP adapter) pulls stop-token → the
-# async-channel 1.x / event-listener 2.x line; the rest of the workspace is on
-# async-channel 2.x / event-listener 5.x. Pinned to the async-imap-side versions.
-
 [[bans.skip]]
 name = "darling_core"
 reason = "samael (#381 auth-saml) → derive_builder 0.20 → darling_core 0.20; workspace on 0.23"
@@ -119,6 +115,7 @@ version = "=0.24.2"
 name = "tokio-rustls"
 reason = "transitive via rustls 0.21 (aws-sdk)"
 version = "=0.24.1"
+
 [[bans.skip]]
 name = "async-channel"
 reason = "async-imap (inbound-email) → stop-token → async-channel 1.9.0; workspace on 2.x"


### PR DESCRIPTION
Follow-up to #532. The async-imap duplicate-skip added there was not in `pretty-format-toml`'s canonical form, so the pre-commit.ci hook went red on dev. This drops the redundant standalone comment (each entry's `reason` already documents the `async-imap → stop-token → async-channel 1.9.0 / event-listener 2.5.3` origin) and normalizes spacing. **No policy change** — `cargo deny check` stays fully green; audit-lockstep unaffected.

## Verification
- `pre-commit run pretty-format-toml` — Passed (idempotent)
- `cargo deny check` — advisories/bans/licenses/sources all ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)