### PR TITLE
fix(runtime): recase native-column WHERE to the snake_case SQL column

### DIFF
--- a/crates/fraiseql-core/src/runtime/executor/runners/query_params.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_params.rs
@@ -22,7 +22,11 @@ pub fn inject_param_where_clause(
 ) -> WhereClause {
     if let Some(pg_type) = native_columns.get(col) {
         WhereClause::NativeField {
-            column: col.to_string(),
+            // `native_columns` is keyed by the GraphQL-surface name (camelCase
+            // under `naming_convention = "camelCase"`); the SQL column it was
+            // resolved from is snake_case. Recase like the JSONB path below —
+            // idempotent for as-authored snake_case names.
+            column: crate::utils::to_snake_case(col),
             pg_cast: pg_type_to_cast(pg_type).to_string(),
             operator: WhereOperator::Eq,
             value,
@@ -103,7 +107,11 @@ pub fn combine_explicit_arg_where(
             provided_args.get(&arg.name).map(|value| {
                 if let Some(pg_type) = native_columns.get(&arg.name) {
                     WhereClause::NativeField {
-                        column:   arg.name.clone(),
+                        // Same recasing as the JSONB branch below: the map key is
+                        // the GraphQL argument name, not the SQL column name.
+                        // `comments(postId: …)` must emit `WHERE post_id = …`,
+                        // never `WHERE "postId" = …` (column does not exist).
+                        column:   crate::utils::to_snake_case(&arg.name),
                         pg_cast:  pg_type_to_cast(pg_type).to_string(),
                         operator: WhereOperator::Eq,
                         value:    value.clone(),

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_params_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_params_tests.rs
@@ -174,3 +174,50 @@ fn empty_fact_metadata() -> crate::compiler::fact_table::FactTableMetadata {
     }))
     .expect("valid empty fact-table metadata")
 }
+
+// ── Native-column path: camelCase arg → snake_case SQL column ────────────────
+
+/// Build a one-argument explicit-arg WHERE clause whose arg resolves to a
+/// native column, and return the emitted SQL column name.
+fn explicit_native_arg_column(arg_name: &str) -> String {
+    let args = [ArgumentDefinition::new(arg_name, FieldType::Id)];
+    let mut provided = HashMap::new();
+    provided.insert(arg_name.to_string(), serde_json::json!("x"));
+    let mut native = HashMap::new();
+    native.insert(arg_name.to_string(), "uuid".to_string());
+    let clause = combine_explicit_arg_where(None, &args, &provided, &native)
+        .expect("single explicit arg yields a clause");
+    match clause {
+        WhereClause::NativeField { column, .. } => column,
+        other => panic!("expected WhereClause::NativeField, got {other:?}"),
+    }
+}
+
+#[test]
+fn explicit_native_arg_multiword_camel_is_recased_to_snake_column() {
+    // `native_columns` is keyed by the GraphQL argument name (camelCase under
+    // `naming_convention = "camelCase"`), but the SQL column it resolved from is
+    // snake_case (`post_id`). Emitting the key verbatim produces
+    // `WHERE "postId" = …` → `column does not exist` → 500 on every filtered
+    // query. The column name must be recased exactly like the JSONB path (#486).
+    assert_eq!(explicit_native_arg_column("postId"), "post_id");
+    assert_eq!(explicit_native_arg_column("authorId"), "author_id");
+}
+
+#[test]
+fn explicit_native_arg_snake_is_unchanged() {
+    // Idempotent for as-authored snake_case (`naming_convention = "preserve"`).
+    assert_eq!(explicit_native_arg_column("post_id"), "post_id");
+    assert_eq!(explicit_native_arg_column("status"), "status");
+}
+
+#[test]
+fn inject_param_native_camel_is_recased_to_snake_column() {
+    let mut native = HashMap::new();
+    native.insert("tenantId".to_string(), "uuid".to_string());
+    let clause = inject_param_where_clause("tenantId", serde_json::json!("t"), &native);
+    match clause {
+        WhereClause::NativeField { column, .. } => assert_eq!(column, "tenant_id"),
+        other => panic!("expected WhereClause::NativeField, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Native-column WHERE filters emitted the camelCase GraphQL argument name verbatim as the SQL column, so `comments(postId: …)` produced `WHERE "postId" = …` (column does not exist → 500), and the sibling JSONB path had already been recased so the bug hid in plain sight. This applies `to_snake_case` to the emitted column in both `inject_param_where_clause` and `combine_explicit_arg_where`, matching the adjacent JSONB branch. Present on both `main` and the `dev` line (not a regression from a stranded fix).

Tests: `multiword_camel_arg_filters_on_snake_column`, `test_inject_params_respects_native_columns` pass on the dev base; core compiles.

**Deferred (follow-up):** the same-class `aggregate_parser` native-column emission (`aggregate_parser.rs:198-201`) and federation injects — their `native_columns` keying differs, so the correct fix there is not identical; tracked for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)