### PR TITLE
ci: gate merges on fast Dagger legs via push-triggered checks

### DIFF
--- a/.github/workflows/dagger-preflight.yml
+++ b/.github/workflows/dagger-preflight.yml
@@ -7,12 +7,17 @@ name: Dagger — preflight
 # clippy compile reuses the box's cargo/target/sccache cache volumes (shared with
 # local `dagger call` runs), so warm runs are fast. See .phases/dagger-adoption/.
 #
-# push-only (maintainer-controlled). fraiseql/fraiseql is PUBLIC, so a self-hosted
-# runner must NOT execute fork `pull_request` code — NO pull_request trigger here.
-# Pre-merge remote verification uses workflow_dispatch against the working branch.
+# push-only by design: push events are inherently same-repo (forks cannot push
+# here), so the self-hosted runner never sees fork code — `pull_request` is
+# deliberately absent because those runs execute the PR merge-ref's workflow
+# definition (a fork could edit out any in-workflow guard). Push runs on every
+# in-repo working branch, so this leg's check lands on the PR head SHA and gates the
+# merge via the `dev` ruleset. Fork PRs get no check by design — unblock by pushing
+# the reviewed head commit to an in-repo branch (identical SHA → the check lands).
+# See docs/contributing/branching-model.md.
 on:
   push:
-    branches: [dev]
+    branches-ignore: ['dependabot/**', 'gh-readonly-queue/**']
   workflow_dispatch:
 
 # packages: read lets the runner pull the private ghcr.io/fraiseql/* base-image
@@ -27,7 +32,7 @@ concurrency:
 
 jobs:
   preflight:
-    name: preflight (fmt · clippy · rustdoc · shell gates)
+    name: preflight
     runs-on: [self-hosted, fraiseql-8core]
     timeout-minutes: 45
     steps:

--- a/.github/workflows/dagger-security.yml
+++ b/.github/workflows/dagger-security.yml
@@ -15,11 +15,16 @@ name: Dagger — security
 # Code Scanning), dependency-review (GH Dependency-Graph API). security.yml and
 # security-compliance.yml remain workflow_dispatch as the porting spec / GH-native home.
 #
-# push-only (maintainer-controlled). fraiseql/fraiseql is PUBLIC, so a self-hosted
-# runner must NOT execute fork `pull_request` code — NO pull_request trigger here.
+# push-only by design: push events are inherently same-repo (forks cannot push
+# here), so the self-hosted runner never sees fork code — `pull_request` is
+# deliberately absent because those runs execute the PR merge-ref's workflow
+# definition. Push runs on every in-repo working branch, so this leg's check lands
+# on the PR head SHA and gates the merge via the `dev` ruleset. Fork PRs get no
+# check by design — unblock by pushing the reviewed head commit to an in-repo branch
+# (identical SHA → the check lands). See docs/contributing/branching-model.md.
 on:
   push:
-    branches: [dev]
+    branches-ignore: ['dependabot/**', 'gh-readonly-queue/**']
   workflow_dispatch:
 
 # packages: read lets the runner pull the private ghcr.io/fraiseql/* base-image

--- a/docs/contributing/branching-model.md
+++ b/docs/contributing/branching-model.md
@@ -59,14 +59,44 @@ rather than living on a branch that drifts from the trunk.
 
 ## Keeping the trunk green
 
-- Every push runs the strict gates locally (`make preflight`) and the Dagger CI legs
-  (preflight / test / security / feature-matrix / integration).
-- **Recommended hardening (not yet adopted):** a **GitHub merge queue** with the
-  Dagger legs as **required checks on the PR**, so changes are validated against
-  trunk-HEAD and merged only when green. Today the Dagger legs run *post-merge* on the
-  `dev` push (and must be dispatched manually to validate a PR — see
-  [`.github/workflows/dagger-*.yml`](../../.github/workflows/)), which leaves a window
-  where the trunk can go red between merges. A merge queue closes that window.
+The **fast** Dagger legs — `preflight` (shell gates · fmt · clippy · rustdoc) and
+`security` (`cargo deny`) — run on **push to every in-repo branch**
+(`branches-ignore: [dependabot/**, …]`) on the self-hosted runner, with a warm sccache
+cache. Because **forks cannot push to this repo**, a `push` trigger only ever runs
+trusted in-repo code — so these legs are **fork-safe by construction**, with no
+`pull_request` trigger and no self-hosted exposure to fork code. (A `pull_request` run
+would execute the PR *merge-ref's* workflow definition, which a fork can edit — hence
+its deliberate absence.)
+
+Push-triggered check runs attach to the commit SHA, so they show on any open PR for
+that branch, and the **`dev` ruleset requires `preflight` + `security`** — a PR cannot
+merge until both are green on its head. That is what prevents "merged before CI was
+verified."
+
+The **heavy** legs (`test` / `feature-matrix` / `integration`, which spins up
+PostgreSQL) run **post-merge on the `dev` push** to spare the single runner; dispatch
+them manually (`gh workflow run dagger-<leg>.yml --ref <branch>`) when a change
+warrants full validation before merge. Locally, `make preflight` mirrors the fast gate.
+
+### Fork pull requests
+
+A fork PR produces no `push` event here, so the required checks are **absent** and the
+merge is blocked by design — fork code must never run on the self-hosted runner. To
+land a reviewed fork PR, **push its head commit to an in-repo branch**:
+
+```bash
+git fetch origin pull/<N>/head
+git push origin FETCH_HEAD:refs/heads/review/<slug>
+```
+
+The SHA is identical, so the push fires the legs, the checks land on that SHA, and the
+fork PR's merge box goes green.
+
+### In-flight branches
+
+`push` runs the workflow file from the pushed ref, so branches created before this
+change won't have the new trigger until they are **rebased on `dev`** — otherwise the
+required checks never appear and the ruleset blocks the merge. Rebase once and push.
 
 ## Why we do this
 
@@ -102,8 +132,10 @@ from* it.
 
 These formalize the model further; tracked for follow-up:
 
-- **Single trunk name.** `main`/`dev` are currently kept in sync; the cleanest end
-  state is one trunk (either retire `main` and keep `dev`, or rename the trunk to
-  `main` and retire `dev`). Two branches held in sync is the divergence risk this
-  model exists to remove.
-- **Merge queue + Dagger-on-PR** (see [Keeping the trunk green](#keeping-the-trunk-green)).
+- **Single trunk name.** `main` auto-mirrors `dev` (`.github/workflows/mirror-main.yml`),
+  so divergence can no longer happen silently; the fully-tidy end state is one trunk
+  (retire `main`, or rename the trunk to `main` and retire `dev`) — deferred as churn
+  that isn't worth it right now.
+- **Default workflow token `write` → `read`.** Recommended hardening, but blocked on
+  first giving the ~30 workflows that currently rely on the default an explicit
+  `permissions:` block, so the flip doesn't silently break the ones that need write.


### PR DESCRIPTION
Runs the two fast legs (`preflight`, `security`) on **push to every in-repo branch** instead of dev-only. Push events can only come from write-access, in-repo branches (forks can't push here), so the self-hosted runner never sees fork code — **fork-safe by construction, no `pull_request` trigger**. Push-triggered check runs attach to the head SHA → they show on the PR and can be **required by a `dev` ruleset** (follow-up), which is the actual fix for "merged before CI was verified." Heavy legs stay post-merge on `dev`.

Also documents the fork-PR unblock (push the reviewed head to an in-repo branch) and the in-flight-branch rebase note in `branching-model.md`.

**Heads-up:** after this lands, existing open branches need a rebase on `dev` to pick up the trigger, or the (soon-required) checks won't appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)