### PR TITLE
ci: declare PR-comment scope on the two blockless benchmark workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,12 @@ name: Benchmarks
 on:
   workflow_dispatch:
 
+# Repo default is least-privilege (contents: read). This workflow posts benchmark
+# results as a PR comment, so it declares the extra scope explicitly.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   bench:
     name: Criterion benchmarks

--- a/.github/workflows/benchmark-velocity.yml
+++ b/.github/workflows/benchmark-velocity.yml
@@ -24,6 +24,12 @@ name: Velocitybench Regression Gate
 on:
   workflow_dispatch:
 
+# Repo default is least-privilege (contents: read). This workflow posts its
+# regression report as a PR comment, so it declares the extra scope explicitly.
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"

--- a/docs/contributing/branching-model.md
+++ b/docs/contributing/branching-model.md
@@ -114,6 +114,15 @@ category (`cargo`) with the best track record of catching a real problem at the 
 change won't have the new trigger until they are **rebased on `dev`** — otherwise the
 required checks never appear and the ruleset blocks the merge. Rebase once and push.
 
+### Workflow token permissions
+
+The repository's default `GITHUB_TOKEN` permission is **`read`** (least-privilege). A
+workflow (or a single job) that needs to write — comment on a PR, push a commit, create
+a release, publish a package — must **declare that scope explicitly** in a `permissions:`
+block. A workflow that needs write and forgets fails **closed and loud** (a `403` on first
+run), never silently holding a scope it didn't ask for. Declare permissions at the *job*
+level when only some jobs need write.
+
 ## Why we do this
 
 Trunk-based development is not an aesthetic preference here — it is the direct fix for


### PR DESCRIPTION
Explicit-exceptions half of moving the repo to least-privilege `GITHUB_TOKEN`. Per-job audit: every write-ish workflow already declares a `permissions:` block; the only zero-block workflows doing anything privileged are `bench` + `benchmark-velocity` (PR comments), now declared. Plus a doc note recording the default-read posture.

**After merge — flip the default (my gate → yours):**
```
gh api -X PUT repos/fraiseql/fraiseql/actions/permissions/workflow -f default_workflow_permissions=read
```
**One-line revert if anything 403s:**
```
gh api -X PUT repos/fraiseql/fraiseql/actions/permissions/workflow -f default_workflow_permissions=write
```
**Free live test:** merging this pushes to `dev`, which fires `mirror-main.yml` (declares `contents: write`) and the heavy legs — so the highest-value write path runs minutes after the flip. Eyeball the next `bench`/`benchmark-velocity` dispatch too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)