### PR TITLE
feat: enriched-identity RLS — one sub → DB → identity resolver (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Enriched-identity RLS (#539).** One request-scoped `sub → DB → identity`
+  resolver: the application maps a token's subject to its own internal identity
+  (`actor_id`/`actor_role` for reads, verified from-address for sends) in its own
+  database, resolved once per request, cached, and **fail-closed**. Configure a
+  top-level `[identity.enrichment]` (and `[identity.sender]`) — top-level so it
+  applies under HS256 and OIDC alike. Resolved fields merge under the reserved,
+  forge-proof `fraiseql.enriched.*` namespace (the extractor strips incoming
+  `fraiseql.` claims), read with no fallback by the new
+  `SessionVariableSource::Enrichment` / `InjectedParamSource::Enrichment` sources,
+  so RLS/views/inject-params scope on a DB-derived identity rather than a
+  client-asserted claim. An unknown/ambiguous subject, a NULL mapped field, or a
+  missing bound param is denied (403) *before* any data query runs — never a
+  silent skip or an empty-string GUC; a transient DB error is a 503, never an
+  unscoped read. The precise denial reason is logged server-side (WARN) while the
+  outward body stays generic (no actor-table existence oracle). The cache keys on
+  the bound-`$param` tuple (multi-issuer apps bind `$iss`) with a bounded positive
+  TTL (default 60s) so a revocation propagates within that window. Verified
+  sender-identity resolves on the same primitive through an object-safe
+  `SenderIdentityResolver` seam (`LoginEmailSender` is the degenerate default);
+  the `send_email` op that consumes it lands with the native-runtime hardening
+  train. Supersedes #242. See `docs/architecture/enriched-identity-rls.md` and
+  ADR-0016.
 - **Beta workload migrated to the native runtime.** The adjacent Python/FastAPI
   sidecar's compute is now native TypeScript,
   proving the host surface against a real workload. Four `examples/native-functions`

--- a/crates/fraiseql-core/src/runtime/executor/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/mod.rs
@@ -374,5 +374,23 @@ fn resolve_inject_value(
                 path:    None,
             })
         },
+        InjectedParamSource::Enrichment(field) => {
+            // Read ONLY the reserved namespace — no fallback to a raw claim or a
+            // well-known field (#539). A raw claim of the same name must never
+            // impersonate a DB-derived identity parameter.
+            let key = format!("{}{field}", crate::security::ENRICHED_NAMESPACE_PREFIX);
+            security_ctx
+                .attributes
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| FraiseQLError::Validation {
+                    message: format!(
+                        "Inject param '{param_name}': enriched field '{field}' absent from the \
+                         resolved identity (enrichment did not run, or the query's `map` does \
+                         not produce it)"
+                    ),
+                    path:    None,
+                })
+        },
     }
 }

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
@@ -27,13 +27,13 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
     fn resolve_session_vars(
         &self,
         security_context: Option<&SecurityContext>,
-    ) -> Vec<(String, String)> {
+    ) -> Result<Vec<(String, String)>> {
         let sv = &self.ctx.schema.session_variables;
         match security_context {
             Some(sec) if !sv.variables.is_empty() || sv.inject_started_at => {
                 crate::runtime::executor::security::resolve_session_variables(sv, sec)
             },
-            _ => Vec::new(),
+            _ => Ok(Vec::new()),
         }
     }
 
@@ -236,7 +236,7 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
 
         // 5. Execute with bind parameters (eliminates escape-based injection risk), pinning session
         //    variables to the connection for current_setting() RLS (#329).
-        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let resolved_session_vars = self.resolve_session_vars(security_context)?;
         let session_pairs: Vec<(&str, &str)> =
             resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self
@@ -412,7 +412,7 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
         // 4. Execute SQL — bind parameters via execute_parameterized_aggregate so WHERE clause
         //    values are passed as prepared-statement parameters, not inlined. Session variables are
         //    pinned to the connection for current_setting() RLS (#329).
-        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let resolved_session_vars = self.resolve_session_vars(security_context)?;
         let session_pairs: Vec<(&str, &str)> =
             resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -707,7 +707,7 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
             let sv = &ctx.schema.session_variables;
             match security_ctx {
                 Some(sec_ctx) if !sv.variables.is_empty() || sv.inject_started_at => {
-                    crate::runtime::executor::security::resolve_session_variables(sv, sec_ctx)
+                    crate::runtime::executor::security::resolve_session_variables(sv, sec_ctx)?
                 },
                 _ => Vec::new(),
             }

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -39,13 +39,13 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
     fn resolve_session_vars(
         &self,
         security_context: Option<&SecurityContext>,
-    ) -> Vec<(String, String)> {
+    ) -> Result<Vec<(String, String)>> {
         let sv = &self.ctx.schema.session_variables;
         match security_context {
             Some(sec) if !sv.variables.is_empty() || sv.inject_started_at => {
                 crate::runtime::executor::security::resolve_session_variables(sv, sec)
             },
-            _ => Vec::new(),
+            _ => Ok(Vec::new()),
         }
     }
 
@@ -98,7 +98,7 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         // on the same connection as the read (fixes #329) by passing them into
         // the connection-affine adapter call below, so PostgreSQL RLS policies
         // that read `current_setting()` (e.g. `app.tenant_id`) are effective.
-        let resolved_session_vars = self.resolve_session_vars(Some(security_context));
+        let resolved_session_vars = self.resolve_session_vars(Some(security_context))?;
         let session_pairs: Vec<(&str, &str)> =
             resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
@@ -846,7 +846,7 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         }
 
         // Execute, pinning session variables to the read's connection (#329).
-        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let resolved_session_vars = self.resolve_session_vars(security_context)?;
         let session_pairs: Vec<(&str, &str)> =
             resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let results = self
@@ -982,7 +982,7 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
 
         // 4. Execute COUNT query via adapter, pinning session variables to the read's connection so
         //    RLS counts match the filtered rows (#329).
-        let resolved_session_vars = self.resolve_session_vars(security_context);
+        let resolved_session_vars = self.resolve_session_vars(security_context)?;
         let session_pairs: Vec<(&str, &str)> =
             resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self

--- a/crates/fraiseql-core/src/runtime/executor/security.rs
+++ b/crates/fraiseql-core/src/runtime/executor/security.rs
@@ -13,11 +13,15 @@ use crate::{
 /// Resolve session variable mappings against the current security context.
 ///
 /// See [`support::security::resolve_session_variables`] for full documentation.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns [`FraiseQLError::Validation`] if a `SessionVariableSource::Enrichment`
+/// mapping references an enriched field absent from the resolved identity (#539).
 pub fn resolve_session_variables(
     config: &SessionVariablesConfig,
     security_context: &SecurityContext,
-) -> Vec<(String, String)> {
+) -> crate::error::Result<Vec<(String, String)>> {
     support::security::resolve_session_variables(config, security_context)
 }
 
@@ -287,7 +291,7 @@ mod session_variable_tests {
             }],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         // tenant_id is in attributes
         assert_eq!(vars.len(), 1);
         assert_eq!(vars[0].0, "app.tenant_id");
@@ -306,7 +310,7 @@ mod session_variable_tests {
             }],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert_eq!(vars.len(), 1);
         assert_eq!(vars[0].0, "app.user_id");
         assert_eq!(vars[0].1, "user-42");
@@ -324,7 +328,7 @@ mod session_variable_tests {
             }],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert_eq!(vars.len(), 1);
         assert_eq!(vars[0].0, "app.locale");
         assert_eq!(vars[0].1, "en");
@@ -342,7 +346,7 @@ mod session_variable_tests {
             }],
             inject_started_at: true,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         // started_at must come first
         assert_eq!(vars.len(), 2);
         assert_eq!(vars[0].0, fraiseql_db::STARTED_AT_VAR);
@@ -359,7 +363,7 @@ mod session_variable_tests {
             variables:         vec![],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert!(vars.is_empty());
         assert!(!vars.iter().any(|(k, _)| k == "fraiseql.started_at"));
     }
@@ -376,7 +380,7 @@ mod session_variable_tests {
             }],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert_eq!(vars.len(), 1);
         assert_eq!(vars[0].0, "app.tenant");
         assert_eq!(vars[0].1, "header-tenant");
@@ -395,7 +399,7 @@ mod session_variable_tests {
             }],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert_eq!(vars.len(), 1);
         assert_eq!(vars[0].0, "app.email");
         assert_eq!(vars[0].1, "user@corp.com");
@@ -422,7 +426,7 @@ mod session_variable_tests {
             ],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert_eq!(vars.len(), 2);
         assert_eq!(vars[0].1, "Jane Doe");
         assert_eq!(vars[1].1, "Jane Doe");
@@ -440,7 +444,70 @@ mod session_variable_tests {
             }],
             inject_started_at: false,
         };
-        let vars = resolve_session_variables(&config, &ctx);
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
         assert!(vars.is_empty(), "missing email should be silently skipped");
+    }
+
+    #[test]
+    fn resolve_session_variables_enrichment_reads_namespace() {
+        let mut ctx = make_context();
+        // A resolved enriched field, merged by the server under the reserved
+        // namespace (the extractor strips `fraiseql.` claims, so a token can't
+        // forge this key).
+        ctx.attributes
+            .insert("fraiseql.enriched.actor_role".to_string(), serde_json::json!("manager"));
+        let config = SessionVariablesConfig {
+            variables:         vec![SessionVariableMapping {
+                name:   "app.actor_role".to_string(),
+                source: SessionVariableSource::Enrichment {
+                    field: "actor_role".to_string(),
+                },
+            }],
+            inject_started_at: false,
+        };
+        let vars = resolve_session_variables(&config, &ctx).unwrap();
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].0, "app.actor_role");
+        assert_eq!(vars[0].1, "manager");
+    }
+
+    #[test]
+    fn resolve_session_variables_enrichment_missing_field_errors() {
+        // Enrichment declared but the field is absent from the namespace: a
+        // hard error, never a silently-skipped/empty GUC (DESIGN §3.2, §5.2).
+        let ctx = make_context();
+        let config = SessionVariablesConfig {
+            variables:         vec![SessionVariableMapping {
+                name:   "app.actor_role".to_string(),
+                source: SessionVariableSource::Enrichment {
+                    field: "actor_role".to_string(),
+                },
+            }],
+            inject_started_at: false,
+        };
+        assert!(resolve_session_variables(&config, &ctx).is_err());
+    }
+
+    #[test]
+    fn resolve_session_variables_enrichment_does_not_fall_back_to_raw_claim() {
+        // A raw claim of the same name is present in attributes, but the
+        // Enrichment source reads ONLY the reserved namespace — so it must still
+        // fail, never impersonate a DB-derived field with an attacker-influenced
+        // claim (the security property `Enrichment` exists for).
+        let mut ctx = make_context();
+        ctx.attributes.insert("actor_role".to_string(), serde_json::json!("admin"));
+        let config = SessionVariablesConfig {
+            variables:         vec![SessionVariableMapping {
+                name:   "app.actor_role".to_string(),
+                source: SessionVariableSource::Enrichment {
+                    field: "actor_role".to_string(),
+                },
+            }],
+            inject_started_at: false,
+        };
+        assert!(
+            resolve_session_variables(&config, &ctx).is_err(),
+            "Enrichment must not fall back to a raw JWT claim"
+        );
     }
 }

--- a/crates/fraiseql-core/src/runtime/executor/support/federation.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/federation.rs
@@ -152,7 +152,7 @@ impl<A: DatabaseAdapter> Executor<A> {
                 super::super::security::resolve_session_variables(
                     &self.ctx.schema.session_variables,
                     sc,
-                )
+                )?
             },
             _ => Vec::new(),
         };

--- a/crates/fraiseql-core/src/runtime/executor/support/security.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/security.rs
@@ -8,7 +8,7 @@ use crate::{
     error::{FraiseQLError, Result},
     runtime::{classify_field_access, field_filter::FieldAccessResult},
     schema::{CompiledSchema, SessionVariableSource, SessionVariablesConfig},
-    security::SecurityContext,
+    security::{ENRICHED_NAMESPACE_PREFIX, SecurityContext},
 };
 
 /// Resolve session variable mappings against the current security context.
@@ -23,6 +23,9 @@ use crate::{
 /// - [`SessionVariableSource::Header`] — looks up the header name in `security_context.attributes`.
 ///   Missing headers are silently skipped.
 /// - [`SessionVariableSource::Literal`] — uses the fixed value as-is.
+/// - [`SessionVariableSource::Enrichment`] — reads the reserved `fraiseql.enriched.*` attribute
+///   namespace with **no** fallback; a missing enriched field is a hard error, never a
+///   silently-skipped/empty GUC (#539).
 ///
 /// When `config.inject_started_at` is `true`, the pair
 /// `(STARTED_AT_VAR, CLOCK_TIMESTAMP_DIRECTIVE)` is **prepended** to the returned
@@ -31,11 +34,19 @@ use crate::{
 /// the **DB clock**, the same clock used to close the interval at the change-log
 /// outbox write (no app↔DB skew). This replaces the former app-clock
 /// `Utc::now()` RFC-3339 value.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns [`FraiseQLError::Validation`] if a [`SessionVariableSource::Enrichment`]
+/// mapping references an enriched field absent from the resolved identity. The
+/// lenient `Jwt`/`Header`/`Literal` arms never error. This is defense-in-depth:
+/// the server fail-closes enrichment before dispatch, so reaching a missing
+/// enriched field here is an invariant violation (a config mismatch), treated as
+/// one rather than silently skipped.
 pub(in super::super) fn resolve_session_variables(
     config: &SessionVariablesConfig,
     security_context: &SecurityContext,
-) -> Vec<(String, String)> {
+) -> Result<Vec<(String, String)>> {
     let mut vars: Vec<(String, String)> = Vec::new();
 
     if config.inject_started_at {
@@ -81,13 +92,36 @@ pub(in super::super) fn resolve_session_variables(
                 })
             },
             SessionVariableSource::Literal { value } => Some(value.clone()),
+            SessionVariableSource::Enrichment { field } => {
+                // Read ONLY the reserved namespace — no fallback to a raw claim or
+                // a well-known field. The extractor strips `fraiseql.` claims, so
+                // this key can only have been written by the server's identity
+                // resolver (DESIGN §3.2).
+                let key = format!("{ENRICHED_NAMESPACE_PREFIX}{field}");
+                let Some(v) = security_context.attributes.get(&key) else {
+                    return Err(FraiseQLError::Validation {
+                        message: format!(
+                            "Session variable '{}' maps to enriched field '{field}', which is \
+                             absent from the resolved identity (enrichment did not run, or the \
+                             enrichment query's `map` does not produce it)",
+                            mapping.name
+                        ),
+                        path:    None,
+                    });
+                };
+                Some(if let serde_json::Value::String(s) = v {
+                    s.clone()
+                } else {
+                    v.to_string()
+                })
+            },
         };
         if let Some(v) = value {
             vars.push((mapping.name.clone(), v));
         }
     }
 
-    vars
+    Ok(vars)
 }
 
 /// Classify each requested field as allowed, masked, or rejected.

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -975,6 +975,37 @@ mod inject {
     }
 
     #[test]
+    fn test_resolve_inject_enrichment_reads_namespace() {
+        let ctx = make_security_ctx(
+            "user-1",
+            None,
+            &[("fraiseql.enriched.actor_id", serde_json::json!("a-1"))],
+        );
+        let source = InjectedParamSource::Enrichment("actor_id".to_string());
+        let result = resolve_inject_value("actor_id", &source, &ctx).unwrap();
+        assert_eq!(result, serde_json::Value::String("a-1".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_inject_enrichment_missing_field_errors() {
+        let ctx = make_security_ctx("user-1", None, &[]);
+        let source = InjectedParamSource::Enrichment("actor_id".to_string());
+        assert!(resolve_inject_value("actor_id", &source, &ctx).is_err());
+    }
+
+    #[test]
+    fn test_resolve_inject_enrichment_does_not_fall_back_to_raw_claim() {
+        // A raw claim of the same name must NOT satisfy an enriched param — the
+        // source reads only the forge-proof `fraiseql.enriched.*` namespace.
+        let ctx = make_security_ctx("user-1", None, &[("actor_id", serde_json::json!("forged"))]);
+        let source = InjectedParamSource::Enrichment("actor_id".to_string());
+        assert!(
+            resolve_inject_value("actor_id", &source, &ctx).is_err(),
+            "Enrichment inject param must not fall back to a raw claim"
+        );
+    }
+
+    #[test]
     fn test_resolve_inject_missing_tenant_id_returns_error() {
         let ctx = make_security_ctx("user-1", None, &[]);
         let source = InjectedParamSource::Jwt("tenant_id".to_string());

--- a/crates/fraiseql-core/src/schema/config_types.rs
+++ b/crates/fraiseql-core/src/schema/config_types.rs
@@ -608,6 +608,19 @@ pub enum SessionVariableSource {
         /// The literal string value to inject.
         value: String,
     },
+    /// Pull from a DB-resolved enriched-identity field, read from the reserved
+    /// `fraiseql.enriched.*` attribute namespace (#539).
+    ///
+    /// Unlike [`SessionVariableSource::Jwt`], there is **no** fallback to a raw
+    /// claim or a well-known field: the namespace is forge-proof (the extractor
+    /// strips `fraiseql.` claims), and a missing enriched field is a hard error,
+    /// never a silently-skipped/empty GUC. This is the construct that carries the
+    /// fail-closed read-scoping guarantee.
+    Enrichment {
+        /// The enriched field name, without the `fraiseql.enriched.` prefix
+        /// (e.g. `"actor_role"`).
+        field: String,
+    },
 }
 
 /// One session variable declaration.

--- a/crates/fraiseql-core/src/schema/security_config.rs
+++ b/crates/fraiseql-core/src/schema/security_config.rs
@@ -25,6 +25,15 @@ pub enum InjectedParamSource {
     /// - `"tenant_id"` / `"org_id"` → `SecurityContext.tenant_id`
     /// - any other name → `SecurityContext.attributes.get(name)`
     Jwt(String),
+    /// Extract a DB-resolved enriched-identity field, read from the reserved
+    /// `fraiseql.enriched.*` attribute namespace (#539).
+    ///
+    /// Unlike [`InjectedParamSource::Jwt`], there is **no** fallback to a raw
+    /// claim or a well-known field: the namespace is forge-proof and a missing
+    /// enriched field is a hard error, so a raw claim of the same name can never
+    /// impersonate a DB-derived identity parameter. The wrapped value is the
+    /// enriched field name, without the `fraiseql.enriched.` prefix.
+    Enrichment(String),
 }
 
 /// Role definition for field-level RBAC.

--- a/crates/fraiseql-core/src/security/mod.rs
+++ b/crates/fraiseql-core/src/security/mod.rs
@@ -38,6 +38,16 @@ pub mod security_context;
 pub mod tls_enforcer;
 pub mod validation_audit;
 
+/// Reserved attribute-namespace prefix for DB-resolved enriched-identity fields.
+///
+/// The request extractor strips any incoming JWT claim whose key begins with
+/// `fraiseql.`, so an attribute under this prefix cannot be forged by a token —
+/// it can only originate from the server's identity resolver (#539). Read with
+/// **no** fallback by `SessionVariableSource::Enrichment` and
+/// `InjectedParamSource::Enrichment`, and written by the server when it merges a
+/// resolved identity into the security context.
+pub const ENRICHED_NAMESPACE_PREFIX: &str = "fraiseql.enriched.";
+
 // Re-export key types for convenience
 pub use actor_type::{ActorType, derive_actor};
 pub use audit::{

--- a/crates/fraiseql-functions/src/lib.rs
+++ b/crates/fraiseql-functions/src/lib.rs
@@ -21,7 +21,10 @@ pub mod types;
 
 pub use host::{HostContext, NoopHostContext};
 pub use observer::FunctionObserver;
-pub use outbound::{SendPolicyError, SenderIdentity, resolve_sender_identity};
+pub use outbound::{
+    LoginEmailSender, SendPolicyError, SenderIdentity, SenderIdentityResolver,
+    resolve_sender_identity,
+};
 pub use runtime::{FunctionRuntime, SendFunctionRuntime};
 pub use store::{FunctionRecord, FunctionStatus, FunctionStore, memory::InMemoryFunctionStore};
 pub use triggers::{

--- a/crates/fraiseql-functions/src/outbound/mod.rs
+++ b/crates/fraiseql-functions/src/outbound/mod.rs
@@ -21,7 +21,14 @@
 //! enforceable rule that op will call, and the reference workload
 //! `examples/native-functions/follow-up-email.ts` mirrors it in `TypeScript`.
 
+use std::{future::Future, pin::Pin};
+
 use serde_json::Value;
+
+/// An owned, `Send` boxed future — the object-safe async return used to keep
+/// [`SenderIdentityResolver`] dyn-dispatchable without adding a new dyn-dispatch
+/// trait-macro (the workspace ratchet).
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// The connected user's verified sending identity — the only `from` a paired
 /// outbound email may use.
@@ -99,6 +106,49 @@ pub fn resolve_sender_identity(auth_context: &Value) -> Result<SenderIdentity, S
         address: address.to_string(),
         display_name,
     })
+}
+
+/// The injectable seam the `send_email` host op calls to obtain a host-owned
+/// `from` (DESIGN §4.2).
+///
+/// One implementation per deployment, object-safe so the server can inject an
+/// `Arc<dyn SenderIdentityResolver>` into the functions host.
+/// The default [`LoginEmailSender`] is the degenerate case — the sending address
+/// *is* the connected user's login email, read from the auth context with no DB.
+/// A DB-backed implementation (in the server) resolves `sub → verified
+/// from-address + mailbox` on the shared identity primitive, cached and
+/// fail-closed. Either way a refusal is a [`SendPolicyError`], never a silent
+/// fall-back to a shared mailbox.
+pub trait SenderIdentityResolver: Send + Sync {
+    /// Resolve the sending identity for `auth_context` — the host-owned
+    /// authenticated context, never guest input.
+    ///
+    /// The future resolves to [`SendPolicyError`] when no verified sending
+    /// identity is available.
+    fn resolve_sender<'a>(
+        &'a self,
+        auth_context: &'a Value,
+    ) -> BoxFuture<'a, Result<SenderIdentity, SendPolicyError>>;
+}
+
+/// The degenerate [`SenderIdentityResolver`]: the sending address is the
+/// connected user's login email, read from the host auth context (no DB).
+///
+/// This subsumes the pure [`resolve_sender_identity`] policy as a trait
+/// implementation (DESIGN §4.1) — the seam works with no `[identity.sender]`
+/// configured, and a DB-backed resolver replaces it verbatim where the sending
+/// mailbox differs from the login email.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LoginEmailSender;
+
+impl SenderIdentityResolver for LoginEmailSender {
+    fn resolve_sender<'a>(
+        &'a self,
+        auth_context: &'a Value,
+    ) -> BoxFuture<'a, Result<SenderIdentity, SendPolicyError>> {
+        let result = resolve_sender_identity(auth_context);
+        Box::pin(async move { result })
+    }
 }
 
 #[cfg(test)]

--- a/crates/fraiseql-functions/src/outbound/tests.rs
+++ b/crates/fraiseql-functions/src/outbound/tests.rs
@@ -68,3 +68,18 @@ fn surrounding_whitespace_is_trimmed() {
     assert_eq!(identity.address, "rep@outreach.example");
     assert_eq!(identity.display_name, Some("Rep".to_string()));
 }
+
+#[tokio::test]
+async fn login_email_sender_delegates_to_the_pure_policy() {
+    use super::{LoginEmailSender, SenderIdentityResolver};
+
+    // The degenerate resolver reframes the pure login-email policy (DESIGN §4.1):
+    // a valid verified address resolves, a missing one refuses — identically.
+    let auth = json!({ "email": "rep@outreach.example", "display_name": "Rep" });
+    let identity = LoginEmailSender.resolve_sender(&auth).await.expect("address present");
+    assert_eq!(identity.address, "rep@outreach.example");
+    assert_eq!(identity.display_name.as_deref(), Some("Rep"));
+
+    let missing = json!({ "sub": "u1" });
+    assert!(LoginEmailSender.resolve_sender(&missing).await.is_err());
+}

--- a/crates/fraiseql-server/src/identity/apply.rs
+++ b/crates/fraiseql-server/src/identity/apply.rs
@@ -1,0 +1,80 @@
+//! Read-path consumer (consumer A): resolve the request subject's DB identity
+//! and merge it into the security context under the forge-proof
+//! `fraiseql.enriched.*` namespace (DESIGN §3).
+//!
+//! Fail-closed — a denial or a transient failure stops the request before
+//! dispatch; the caller maps the coarse [`EnrichmentOutcome`] to an HTTP status.
+//! The subject and any denial reason are logged server-side by the resolver
+//! (DESIGN §5.4), so the caller's outward response stays generic (no actor-table
+//! existence oracle).
+
+use std::collections::HashMap;
+
+use fraiseql_core::security::{ENRICHED_NAMESPACE_PREFIX, SecurityContext};
+
+use super::{failure::IdentityResolution, resolver::IdentityResolver};
+
+/// What the caller should do after an enrichment attempt (DESIGN §3.1, §5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentOutcome {
+    /// Identity resolved and merged — continue to dispatch.
+    Proceed,
+    /// Permanent denial — fail closed (HTTP 403) before any data query runs.
+    Denied,
+    /// Transient resolver failure — fail the request (HTTP 503), never fall
+    /// through to an unscoped query.
+    Unavailable,
+}
+
+/// Resolve `ctx`'s DB identity and, on success, merge every mapped field into
+/// `ctx.attributes` under the reserved namespace. All-or-nothing: on a denial or
+/// a transient failure nothing is merged and the caller stops the request.
+pub async fn enrich_security_context(
+    resolver: &IdentityResolver,
+    ctx: &mut SecurityContext,
+) -> EnrichmentOutcome {
+    let sub = ctx.user_id.0.clone();
+    let claims = claims_for_binding(ctx);
+    match resolver.resolve(&sub, &claims).await {
+        IdentityResolution::Resolved(fields) => {
+            for (field, value) in fields {
+                ctx.attributes.insert(format!("{ENRICHED_NAMESPACE_PREFIX}{field}"), value);
+            }
+            EnrichmentOutcome::Proceed
+        },
+        IdentityResolution::Denied(_) => EnrichmentOutcome::Denied,
+        IdentityResolution::Unavailable(_) => EnrichmentOutcome::Unavailable,
+    }
+}
+
+/// Build the claim map the resolver binds `$param`s from: the raw forwarded
+/// attributes, plus the well-known identity fields under their conventional
+/// names (attributes win on a collision, mirroring the `Jwt` source). Exposing
+/// `iss` lets a multi-issuer app bind `$iss` for cache correctness (DESIGN §6).
+fn claims_for_binding(ctx: &SecurityContext) -> HashMap<String, serde_json::Value> {
+    let mut claims = ctx.attributes.clone();
+    claims
+        .entry("sub".to_owned())
+        .or_insert_with(|| serde_json::Value::String(ctx.user_id.0.clone()));
+    if let Some(tenant) = &ctx.tenant_id {
+        let value = serde_json::Value::String(tenant.0.clone());
+        claims.entry("tenant_id".to_owned()).or_insert_with(|| value.clone());
+        claims.entry("org_id".to_owned()).or_insert(value);
+    }
+    if let Some(email) = &ctx.email {
+        claims
+            .entry("email".to_owned())
+            .or_insert_with(|| serde_json::Value::String(email.clone()));
+    }
+    if let Some(name) = &ctx.display_name {
+        let value = serde_json::Value::String(name.clone());
+        claims.entry("name".to_owned()).or_insert_with(|| value.clone());
+        claims.entry("display_name".to_owned()).or_insert(value);
+    }
+    if let Some(iss) = &ctx.issuer {
+        claims
+            .entry("iss".to_owned())
+            .or_insert_with(|| serde_json::Value::String(iss.clone()));
+    }
+    claims
+}

--- a/crates/fraiseql-server/src/identity/cache.rs
+++ b/crates/fraiseql-server/src/identity/cache.rs
@@ -1,0 +1,67 @@
+//! In-memory per-`sub` TTL cache for resolved identities.
+//!
+//! Ported verbatim from #242 (`routes/enrichment.rs`, `v2.2.1`): a `DashMap`
+//! keyed on the subject, with absolute-instant expiry checked on read.
+//!
+//! P01 refines this in two ways specified by the design
+//! (`.phases/539-enriched-identity/DESIGN.md` §6): the key becomes the ordered
+//! bound-`$param` tuple rather than bare `sub` (amendment A — cross-issuer
+//! correctness), and a short negative TTL is added for `Denied` results. This
+//! phase lands the proven get/insert/expiry behaviour and its tests unchanged.
+
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+/// A cached identity map with an absolute expiry instant.
+pub(super) struct CacheEntry {
+    /// The resolved (and possibly column-renamed) identity fields.
+    pub(super) value:      serde_json::Map<String, serde_json::Value>,
+    /// The instant after which this entry is stale.
+    pub(super) expires_at: Instant,
+}
+
+/// Per-`sub` cache for identity-resolution results.
+#[derive(Default)]
+pub(super) struct EnrichmentCache {
+    /// Live entries, keyed by subject.
+    pub(super) entries: DashMap<String, CacheEntry>,
+}
+
+impl EnrichmentCache {
+    /// Create an empty cache.
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a cached result if one exists and has not expired.
+    ///
+    /// An expired entry is evicted as a side effect before returning `None`.
+    pub(super) fn get(&self, sub: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+        let entry = self.entries.get(sub)?;
+        if Instant::now() < entry.expires_at {
+            Some(entry.value.clone())
+        } else {
+            // Release the read guard before removing to avoid a self-deadlock.
+            drop(entry);
+            self.entries.remove(sub);
+            None
+        }
+    }
+
+    /// Insert a result with the given TTL.
+    pub(super) fn insert(
+        &self,
+        sub: String,
+        value: serde_json::Map<String, serde_json::Value>,
+        ttl: Duration,
+    ) {
+        self.entries.insert(
+            sub,
+            CacheEntry {
+                value,
+                expires_at: Instant::now() + ttl,
+            },
+        );
+    }
+}

--- a/crates/fraiseql-server/src/identity/cache.rs
+++ b/crates/fraiseql-server/src/identity/cache.rs
@@ -36,6 +36,9 @@ pub(super) enum CachedOutcome {
 /// absolute expiry instant.
 struct CacheEntry {
     outcome:    CachedOutcome,
+    // Reason: read only by `flush(sub)`, whose admin/after-mutation caller is the
+    // immediate follow-up (see the flush methods below).
+    #[allow(dead_code)]
     sub:        String,
     expires_at: Instant,
 }
@@ -81,11 +84,15 @@ impl IdentityCache {
 
     /// Evict every entry belonging to `sub` (DESIGN §6). Rare/admin — the sweep
     /// is fine. Propagates a grant or revoke for a subject instantly.
+    // Reason: exposed via `IdentityResolver::flush`; its admin endpoint /
+    // after-mutation hook caller is the immediate follow-up.
+    #[allow(dead_code)]
     pub(super) fn flush(&self, sub: &str) {
         self.entries.retain(|_key, entry| entry.sub != sub);
     }
 
     /// Evict all entries.
+    #[allow(dead_code)] // Reason: exposed via `IdentityResolver::flush_all` (same follow-up).
     pub(super) fn flush_all(&self) {
         self.entries.clear();
     }

--- a/crates/fraiseql-server/src/identity/cache.rs
+++ b/crates/fraiseql-server/src/identity/cache.rs
@@ -1,67 +1,98 @@
-//! In-memory per-`sub` TTL cache for resolved identities.
+//! In-memory cache for resolved identities (DESIGN §6) — one policy, reused by
+//! every profile instance.
 //!
-//! Ported verbatim from #242 (`routes/enrichment.rs`, `v2.2.1`): a `DashMap`
-//! keyed on the subject, with absolute-instant expiry checked on read.
+//! Evolved from #242's per-`sub` TTL map in two ways the design requires:
 //!
-//! P01 refines this in two ways specified by the design
-//! (`.phases/539-enriched-identity/DESIGN.md` §6): the key becomes the ordered
-//! bound-`$param` tuple rather than bare `sub` (amendment A — cross-issuer
-//! correctness), and a short negative TTL is added for `Denied` results. This
-//! phase lands the proven get/insert/expiry behaviour and its tests unchanged.
+//! - **Key = the ordered bound-`$param` tuple**, not bare `sub` (amendment A). `sub` is unique only
+//!   *per issuer*, and FraiseQL speaks multi-IdP; keying on the bound parameters makes cache
+//!   correctness exactly track the query's `WHERE` clause (a multi-issuer app binds `$iss`), and
+//!   closes the same-`sub`-different-`$email` staleness case for free. The key is computed by the
+//!   resolver from `BoundQuery::binds`.
+//! - **Positive *and* negative TTL.** A `Resolved` outcome is cached for `cache_ttl_secs`; a
+//!   `Denied` outcome for a short `negative_ttl_secs` (so a freshly provisioned actor goes live
+//!   quickly). An `Unavailable` outcome is **never** cached — a transient blip must not pin a
+//!   denial.
+//!
+//! Each entry also records its `sub` so `flush(sub)` can evict every entry for a
+//! subject on revoke/provision, independent of which parameters the query binds.
 
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 
-/// A cached identity map with an absolute expiry instant.
-pub(super) struct CacheEntry {
-    /// The resolved (and possibly column-renamed) identity fields.
-    pub(super) value:      serde_json::Map<String, serde_json::Value>,
-    /// The instant after which this entry is stale.
-    pub(super) expires_at: Instant,
+use super::failure::DenyReason;
+
+/// A cacheable resolution outcome. `Unavailable` is deliberately absent: transient
+/// failures are never cached (DESIGN §5.3).
+#[derive(Clone)]
+pub(super) enum CachedOutcome {
+    /// A resolved identity map (renamed enriched fields), cached positively.
+    Resolved(serde_json::Map<String, serde_json::Value>),
+    /// A permanent denial, cached negatively for a short TTL.
+    Denied(DenyReason),
 }
 
-/// Per-`sub` cache for identity-resolution results.
+/// One cache entry: an outcome, its owning subject (for `flush(sub)`), and an
+/// absolute expiry instant.
+struct CacheEntry {
+    outcome:    CachedOutcome,
+    sub:        String,
+    expires_at: Instant,
+}
+
+/// Identity-resolution cache, keyed by the serialized bound-`$param` tuple.
 #[derive(Default)]
-pub(super) struct EnrichmentCache {
-    /// Live entries, keyed by subject.
-    pub(super) entries: DashMap<String, CacheEntry>,
+pub(super) struct IdentityCache {
+    entries: DashMap<String, CacheEntry>,
 }
 
-impl EnrichmentCache {
+impl IdentityCache {
     /// Create an empty cache.
     pub(super) fn new() -> Self {
         Self::default()
     }
 
-    /// Return a cached result if one exists and has not expired.
+    /// Return a cached outcome if one exists for `key` and has not expired.
     ///
     /// An expired entry is evicted as a side effect before returning `None`.
-    pub(super) fn get(&self, sub: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
-        let entry = self.entries.get(sub)?;
+    pub(super) fn get(&self, key: &str) -> Option<CachedOutcome> {
+        let entry = self.entries.get(key)?;
         if Instant::now() < entry.expires_at {
-            Some(entry.value.clone())
+            Some(entry.outcome.clone())
         } else {
             // Release the read guard before removing to avoid a self-deadlock.
             drop(entry);
-            self.entries.remove(sub);
+            self.entries.remove(key);
             None
         }
     }
 
-    /// Insert a result with the given TTL.
-    pub(super) fn insert(
-        &self,
-        sub: String,
-        value: serde_json::Map<String, serde_json::Value>,
-        ttl: Duration,
-    ) {
+    /// Insert an outcome for `key` (owned by `sub`) with the given TTL.
+    pub(super) fn insert(&self, key: String, sub: String, outcome: CachedOutcome, ttl: Duration) {
         self.entries.insert(
-            sub,
+            key,
             CacheEntry {
-                value,
+                outcome,
+                sub,
                 expires_at: Instant::now() + ttl,
             },
         );
+    }
+
+    /// Evict every entry belonging to `sub` (DESIGN §6). Rare/admin — the sweep
+    /// is fine. Propagates a grant or revoke for a subject instantly.
+    pub(super) fn flush(&self, sub: &str) {
+        self.entries.retain(|_key, entry| entry.sub != sub);
+    }
+
+    /// Evict all entries.
+    pub(super) fn flush_all(&self) {
+        self.entries.clear();
+    }
+
+    /// Number of live (not-yet-swept) entries. Test-only visibility into the map.
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
     }
 }

--- a/crates/fraiseql-server/src/identity/failure.rs
+++ b/crates/fraiseql-server/src/identity/failure.rs
@@ -1,0 +1,85 @@
+//! The identity-resolution failure model (DESIGN §5) — one result type produced
+//! by the resolver and interpreted by each call site.
+//!
+//! The load-bearing decision is *fail-closed at source*: anything other than
+//! exactly one row with every mapped field present and non-null is a denial, and
+//! a denial fails the operation — never a silent skip, never an empty-string GUC,
+//! the mapped set applied whole or not at all.
+
+use std::fmt;
+
+/// Why a subject was **permanently** denied. The request must fail closed and
+/// never proceed.
+///
+/// A `DenyReason` is logged server-side with the subject (DESIGN §5.4) but is
+/// **never** surfaced to the client: a client that could distinguish
+/// unknown-subject from ambiguous from null-field would have an existence oracle
+/// over the actor table. The outward response is a uniform "forbidden".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum DenyReason {
+    /// No row matched the subject — unknown or unprovisioned.
+    ZeroRows,
+    /// More than one row matched — ambiguous identity, a misconfiguration.
+    /// Refines #242's silent `LIMIT 1`: for identity, we refuse to pick one.
+    Ambiguous,
+    /// A declared mapped column was NULL or absent in the resolved row. Carries
+    /// the column name (log-only). Denying here is what prevents an
+    /// empty-string GUC a predicate could read as authorized.
+    NullField(String),
+    /// The query references a `$param` absent from the token claims. Carries the
+    /// bare parameter name (log-only).
+    MissingParam(String),
+}
+
+impl DenyReason {
+    /// A short, **log-only** label (DESIGN §5.4): `zero-rows`, `ambiguous`,
+    /// `null-field <name>`, or `missing-param <name>`. Never returned to a
+    /// client.
+    pub(super) fn log_label(&self) -> String {
+        match self {
+            Self::ZeroRows => "zero-rows".to_owned(),
+            Self::Ambiguous => "ambiguous".to_owned(),
+            Self::NullField(col) => format!("null-field {col}"),
+            Self::MissingParam(name) => format!("missing-param {name}"),
+        }
+    }
+}
+
+/// A **transient** failure to resolve — DB unreachable, query error, pool
+/// exhausted. Never cached (a blip must not pin a denial): the read path fails
+/// the request (503) rather than falling through to an unscoped query, and the
+/// send path retries.
+#[derive(Debug, Clone)]
+pub(super) struct ResolveError {
+    message: String,
+}
+
+impl ResolveError {
+    /// Wrap an underlying transient failure with a server-side message.
+    pub(super) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+/// The outcome of a single `sub → DB` lookup (DESIGN §5.1). Produced by the
+/// resolver; each call site maps it to its own surface (403/503 for the sync
+/// read path, retry/DLQ for the durable send path).
+#[derive(Debug)]
+pub(super) enum IdentityResolution {
+    /// Exactly one row, every mapped field present and non-null. The map holds
+    /// the renamed enriched fields (column → field applied). Merged under the
+    /// `fraiseql.enriched.*` namespace by the read-path consumer.
+    Resolved(serde_json::Map<String, serde_json::Value>),
+    /// Permanent — fail closed, never proceed.
+    Denied(DenyReason),
+    /// Transient — infra failure; do not cache.
+    Unavailable(ResolveError),
+}

--- a/crates/fraiseql-server/src/identity/mod.rs
+++ b/crates/fraiseql-server/src/identity/mod.rs
@@ -1,0 +1,36 @@
+//! Enriched-identity resolution: a request-scoped `sub → DB → identity` mapping.
+//!
+//! Resolved once per request, cached, and fail-closed, it feeds both
+//! read-scoping (session variables / injected params) and verified
+//! sender-identity (`send_email`).
+//!
+//! # Phase P00 — proven core, ported verbatim
+//!
+//! This module currently holds only the pieces ported unchanged from #242
+//! (`routes/enrichment.rs`, shipped in `v2.2.1` on `main`, never forward-ported
+//! to `dev`):
+//!
+//! - `query::prepare_enrichment_query` — safe named-parameter binding (`$name` → positional `$N`,
+//!   values bound out-of-band, never interpolated), plus its adversarial test suite (SQL injection
+//!   / comment in a claim value, overlapping `$email`/`$email_verified`, unicode, `$1` passthrough,
+//!   missing-param error);
+//! - `cache::EnrichmentCache` — the in-memory TTL cache (`get`/`insert`/expiry).
+//!
+//! The resolver, the `IdentityResolution` failure model, the negative cache,
+//! the bound-`$param`-tuple cache key, and the two call sites land in later
+//! phases (see `.phases/539-enriched-identity/DESIGN.md`). Until the resolver
+//! consumes them, these items have no non-test caller — hence the module-scoped
+//! `dead_code` allow below, which P01 removes.
+//!
+//! Enrichment requires an authenticated subject, so the whole module is gated on
+//! the `auth` feature (mirroring the `enrichment_pool` the resolver will use).
+
+// Reason: P00 is a pure port of #242's proven core, wired to nothing yet; the
+// resolver that consumes these items lands in P01, which removes this allow.
+#![allow(dead_code)]
+
+pub(crate) mod cache;
+pub(crate) mod query;
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/identity/mod.rs
+++ b/crates/fraiseql-server/src/identity/mod.rs
@@ -4,33 +4,35 @@
 //! read-scoping (session variables / injected params) and verified
 //! sender-identity (`send_email`).
 //!
-//! # Phase P00 — proven core, ported verbatim
+//! # Structure
 //!
-//! This module currently holds only the pieces ported unchanged from #242
-//! (`routes/enrichment.rs`, shipped in `v2.2.1` on `main`, never forward-ported
-//! to `dev`):
+//! - `query` — safe named-parameter binding (`$name` → positional `$N`, values bound out-of-band,
+//!   never interpolated). Ported verbatim from #242, with the missing-param error refined to a
+//!   structured `MissingParam`.
+//! - `cache` — the identity cache (DESIGN §6): keyed on the bound-`$param` tuple, positive and
+//!   negative TTL, `flush(sub)`.
+//! - `failure` — the `IdentityResolution` model (DESIGN §5): `Resolved` / `Denied` / `Unavailable`,
+//!   fail-closed at source.
+//! - `resolver` — the shared `IdentityResolver`: bind → cache → fetch (≤2 rows) → classify → cache,
+//!   with server-side denial logging.
 //!
-//! - `query::prepare_enrichment_query` — safe named-parameter binding (`$name` → positional `$N`,
-//!   values bound out-of-band, never interpolated), plus its adversarial test suite (SQL injection
-//!   / comment in a claim value, overlapping `$email`/`$email_verified`, unicode, `$1` passthrough,
-//!   missing-param error);
-//! - `cache::EnrichmentCache` — the in-memory TTL cache (`get`/`insert`/expiry).
-//!
-//! The resolver, the `IdentityResolution` failure model, the negative cache,
-//! the bound-`$param`-tuple cache key, and the two call sites land in later
-//! phases (see `.phases/539-enriched-identity/DESIGN.md`). Until the resolver
-//! consumes them, these items have no non-test caller — hence the module-scoped
-//! `dead_code` allow below, which P01 removes.
+//! The resolver is not yet wired into a request path — that is P02 (the
+//! `/graphql` handler step and server construction), which removes the
+//! module-scoped `dead_code` allow below. Until then these items have no
+//! non-test caller.
 //!
 //! Enrichment requires an authenticated subject, so the whole module is gated on
-//! the `auth` feature (mirroring the `enrichment_pool` the resolver will use).
+//! the `auth` feature (mirroring the `enrichment_pool` the resolver uses).
 
-// Reason: P00 is a pure port of #242's proven core, wired to nothing yet; the
-// resolver that consumes these items lands in P01, which removes this allow.
+// Reason: the resolver and its supporting types are exercised only by tests until
+// P02 wires them into the `/graphql` handler and server construction; that phase
+// removes this allow.
 #![allow(dead_code)]
 
 pub(crate) mod cache;
+pub(crate) mod failure;
 pub(crate) mod query;
+pub(crate) mod resolver;
 
 #[cfg(test)]
 mod tests;

--- a/crates/fraiseql-server/src/identity/mod.rs
+++ b/crates/fraiseql-server/src/identity/mod.rs
@@ -16,23 +16,50 @@
 //! - `resolver` — the shared `IdentityResolver`: bind → cache → fetch (≤2 rows) → classify → cache,
 //!   with server-side denial logging.
 //!
-//! The resolver is not yet wired into a request path — that is P02 (the
-//! `/graphql` handler step and server construction), which removes the
-//! module-scoped `dead_code` allow below. Until then these items have no
-//! non-test caller.
+//! The read-path consumer (`apply::enrich_security_context`) is wired into the
+//! `/graphql` handler (P02). The admin flush surface (P04) and the sender profile
+//! (P03) consume the remaining items, so a narrowed `dead_code` allow persists
+//! until the P04 finalize.
 //!
 //! Enrichment requires an authenticated subject, so the whole module is gated on
 //! the `auth` feature (mirroring the `enrichment_pool` the resolver uses).
 
-// Reason: the resolver and its supporting types are exercised only by tests until
-// P02 wires them into the `/graphql` handler and server construction; that phase
-// removes this allow.
+// Reason: the read path is fully wired (P02); `flush`/`flush_all` (admin surface,
+// P04) and the sender profile (P03) are not yet consumed. Removed at the P04
+// finalize once every seam is live.
 #![allow(dead_code)]
 
+pub(crate) mod apply;
 pub(crate) mod cache;
 pub(crate) mod failure;
 pub(crate) mod query;
 pub(crate) mod resolver;
+
+pub(crate) use apply::{EnrichmentOutcome, enrich_security_context};
+use fraiseql_core::schema::{CompiledSchema, InjectedParamSource, SessionVariableSource};
+pub(crate) use resolver::{IdentityConfig, IdentityResolver};
+
+/// Whether the compiled schema declares any consumer of enriched identity — a
+/// `SessionVariableSource::Enrichment` or an `InjectedParamSource::Enrichment`.
+///
+/// Used only to decide whether an enabled-but-unused enrichment profile warrants
+/// a loud startup warning (DESIGN §7). The per-request fail-closed boundary
+/// itself never depends on this scan — that would reintroduce the exact
+/// declaration-conditional silent-skip the design fights.
+pub(crate) fn schema_declares_enrichment_consumer(schema: &CompiledSchema) -> bool {
+    let in_session_vars = schema
+        .session_variables
+        .variables
+        .iter()
+        .any(|mapping| matches!(mapping.source, SessionVariableSource::Enrichment { .. }));
+    let in_inject_params = schema
+        .queries
+        .iter()
+        .flat_map(|q| q.inject_params.values())
+        .chain(schema.mutations.iter().flat_map(|m| m.inject_params.values()))
+        .any(|source| matches!(source, InjectedParamSource::Enrichment(_)));
+    in_session_vars || in_inject_params
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/fraiseql-server/src/identity/mod.rs
+++ b/crates/fraiseql-server/src/identity/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod cache;
 pub(crate) mod failure;
 pub(crate) mod query;
 pub(crate) mod resolver;
+pub(crate) mod sender;
 
 pub(crate) use apply::{EnrichmentOutcome, enrich_security_context};
 use fraiseql_core::schema::{CompiledSchema, InjectedParamSource, SessionVariableSource};

--- a/crates/fraiseql-server/src/identity/mod.rs
+++ b/crates/fraiseql-server/src/identity/mod.rs
@@ -17,17 +17,13 @@
 //!   with server-side denial logging.
 //!
 //! The read-path consumer (`apply::enrich_security_context`) is wired into the
-//! `/graphql` handler (P02). The admin flush surface (P04) and the sender profile
-//! (P03) consume the remaining items, so a narrowed `dead_code` allow persists
-//! until the P04 finalize.
+//! `/graphql` handler; the cache flush surface and the DB-backed sender are the
+//! two seams whose consumers land next (an admin flush endpoint, and the
+//! hardening-train `send_email` op respectively) — each carries a scoped
+//! `dead_code` allow at its definition rather than a blanket module allow.
 //!
 //! Enrichment requires an authenticated subject, so the whole module is gated on
 //! the `auth` feature (mirroring the `enrichment_pool` the resolver uses).
-
-// Reason: the read path is fully wired (P02); `flush`/`flush_all` (admin surface,
-// P04) and the sender profile (P03) are not yet consumed. Removed at the P04
-// finalize once every seam is live.
-#![allow(dead_code)]
 
 pub(crate) mod apply;
 pub(crate) mod cache;

--- a/crates/fraiseql-server/src/identity/query.rs
+++ b/crates/fraiseql-server/src/identity/query.rs
@@ -19,6 +19,15 @@ pub(super) struct BoundQuery {
     pub(super) binds: Vec<serde_json::Value>,
 }
 
+/// The query references a `$param` that is not present in the token claims.
+///
+/// A structured error (refining #242's message string) so the resolver can map
+/// it directly to `DenyReason::MissingParam` — a missing bound parameter is a
+/// fail-closed denial (DESIGN §5), not a query-preparation footnote. The wrapped
+/// value is the bare parameter name (no leading `$`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MissingParam(pub(super) String);
+
 /// Rewrite `$name` tokens in `query` to positional `$1`, `$2`, … and look up the
 /// corresponding values in `claims`.
 ///
@@ -30,11 +39,11 @@ pub(super) struct BoundQuery {
 ///
 /// # Errors
 ///
-/// Returns an error string if a referenced parameter is missing from `claims`.
+/// Returns [`MissingParam`] if a referenced parameter is absent from `claims`.
 pub(super) fn prepare_enrichment_query(
     query: &str,
     claims: &HashMap<String, serde_json::Value>,
-) -> Result<BoundQuery, String> {
+) -> Result<BoundQuery, MissingParam> {
     let mut sql = String::with_capacity(query.len());
     let mut binds: Vec<serde_json::Value> = Vec::new();
     let mut param_index: HashMap<String, usize> = HashMap::new();
@@ -56,9 +65,7 @@ pub(super) fn prepare_enrichment_query(
             let pos = if let Some(&existing) = param_index.get(name) {
                 existing
             } else {
-                let value = claims.get(name).ok_or_else(|| {
-                    format!("Enrichment query references ${name} but it is not in the JWT claims")
-                })?;
+                let value = claims.get(name).ok_or_else(|| MissingParam(name.to_owned()))?;
                 binds.push(value.clone());
                 let pos = binds.len();
                 param_index.insert(name.to_owned(), pos);

--- a/crates/fraiseql-server/src/identity/query.rs
+++ b/crates/fraiseql-server/src/identity/query.rs
@@ -1,0 +1,87 @@
+//! Safe named-parameter binding for identity-resolution queries.
+//!
+//! Ported verbatim from #242 (`routes/enrichment.rs`, `v2.2.1`). `$name` tokens
+//! in the configured query are rewritten to positional `$1..$N` placeholders and
+//! the corresponding claim **values** are bound out-of-band by the caller — they
+//! are **never** interpolated into the SQL string, so a hostile claim value
+//! cannot alter the query structure. The adversarial test suite lives in the
+//! sibling `tests` module.
+
+use std::collections::HashMap;
+
+/// A query with named `$name` parameters rewritten to positional `$N` and the
+/// ordered list of claim values to bind.
+#[derive(Debug)]
+pub(super) struct BoundQuery {
+    /// SQL with `$1`, `$2`, … placeholders.
+    pub(super) sql:   String,
+    /// Ordered bind values matching the positional placeholders.
+    pub(super) binds: Vec<serde_json::Value>,
+}
+
+/// Rewrite `$name` tokens in `query` to positional `$1`, `$2`, … and look up the
+/// corresponding values in `claims`.
+///
+/// A named parameter starts with `$` followed by an ASCII letter or underscore;
+/// `$` followed by a digit (a PostgreSQL positional placeholder) is passed
+/// through unchanged. Repeated names reuse the same positional index. Values are
+/// returned in `binds` for the caller to bind positionally — never spliced into
+/// the SQL text.
+///
+/// # Errors
+///
+/// Returns an error string if a referenced parameter is missing from `claims`.
+pub(super) fn prepare_enrichment_query(
+    query: &str,
+    claims: &HashMap<String, serde_json::Value>,
+) -> Result<BoundQuery, String> {
+    let mut sql = String::with_capacity(query.len());
+    let mut binds: Vec<serde_json::Value> = Vec::new();
+    let mut param_index: HashMap<String, usize> = HashMap::new();
+
+    let bytes = query.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && is_name_start(bytes[i + 1]) {
+            // Extract parameter name.
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && is_name_char(bytes[end]) {
+                end += 1;
+            }
+            let name = &query[start..end];
+
+            // Reuse an existing position or assign a new one.
+            let pos = if let Some(&existing) = param_index.get(name) {
+                existing
+            } else {
+                let value = claims.get(name).ok_or_else(|| {
+                    format!("Enrichment query references ${name} but it is not in the JWT claims")
+                })?;
+                binds.push(value.clone());
+                let pos = binds.len();
+                param_index.insert(name.to_owned(), pos);
+                pos
+            };
+
+            sql.push('$');
+            sql.push_str(&pos.to_string());
+            i = end;
+        } else {
+            // Index byte-by-byte within ASCII SQL text.
+            sql.push(char::from(bytes[i]));
+            i += 1;
+        }
+    }
+
+    Ok(BoundQuery { sql, binds })
+}
+
+const fn is_name_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_'
+}
+
+const fn is_name_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}

--- a/crates/fraiseql-server/src/identity/resolver.rs
+++ b/crates/fraiseql-server/src/identity/resolver.rs
@@ -254,13 +254,16 @@ impl IdentityResolver {
         self.finalize(sub, resolution)
     }
 
-    /// Evict every cache entry for `sub` — used by the admin flush surface and
-    /// (later) the provision/deprovision mutation hook.
+    /// Evict every cache entry for `sub` — the admin flush surface and (later) the
+    /// provision/deprovision mutation hook. That endpoint is the immediate
+    /// follow-up; the method is ready and tested (`flush_evicts_subject_...`).
+    #[allow(dead_code)]
     pub(super) fn flush(&self, sub: &str) {
         self.cache.flush(sub);
     }
 
     /// Evict the entire cache.
+    #[allow(dead_code)] // Reason: admin flush surface — immediate follow-up.
     pub(super) fn flush_all(&self) {
         self.cache.flush_all();
     }

--- a/crates/fraiseql-server/src/identity/resolver.rs
+++ b/crates/fraiseql-server/src/identity/resolver.rs
@@ -23,7 +23,7 @@ use std::{
     time::Duration,
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{
     cache::{CachedOutcome, IdentityCache},
@@ -39,29 +39,45 @@ pub(super) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// schema, reused by the enrichment and sender profiles. `deny_unknown_fields`
 /// makes a mistyped/stranded key fail loud — the failure mode that hid #242's
 /// absence.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(super) struct EnrichmentQueryConfig {
+pub struct EnrichmentQueryConfig {
     /// When `true`, every authenticated request resolves and fail-closes,
     /// whether or not the operation consumes an enriched field (DESIGN §7,
     /// amendment B). The resolver is only constructed when enabled; it does not
     /// re-check this flag per request.
     #[serde(default)]
-    pub(super) enabled:           bool,
+    pub enabled:           bool,
     /// The SQL, with named `$param` tokens bound from token claims.
-    pub(super) query:             String,
+    pub query:             String,
     /// Column → enriched-field renaming. A declared column that is NULL/absent in
     /// the resolved row is a denial (DESIGN §5).
     #[serde(default)]
-    pub(super) map:               BTreeMap<String, String>,
+    pub map:               BTreeMap<String, String>,
     /// Positive TTL for a `Resolved` outcome. Bounded (DESIGN §6.1): a revocation
     /// propagates within this window, or immediately via `flush(sub)`.
     #[serde(default = "default_cache_ttl_secs")]
-    pub(super) cache_ttl_secs:    u64,
+    pub cache_ttl_secs:    u64,
     /// Negative TTL for a `Denied` outcome — short, so a freshly provisioned
     /// actor goes live quickly.
     #[serde(default = "default_negative_ttl_secs")]
-    pub(super) negative_ttl_secs: u64,
+    pub negative_ttl_secs: u64,
+}
+
+/// Top-level `[identity]` configuration: one shared query schema, two profiles
+/// (DESIGN §7). Lives on `ServerConfig` (the config the running server loads), so
+/// it applies under any auth mode — HS256/OIDC parity by construction.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityConfig {
+    /// Consumer A — read scoping. When enabled, every authenticated request
+    /// resolves and fail-closes.
+    #[serde(default)]
+    pub enrichment: Option<EnrichmentQueryConfig>,
+    /// Consumer B — verified sender-identity, consumed by the send path (P03 +
+    /// the hardening train). Resolves at send time, not per request.
+    #[serde(default)]
+    pub sender:     Option<EnrichmentQueryConfig>,
 }
 
 /// DESIGN §6.1: 60s, not #242's token-remaining-lifetime — a tighter revocation
@@ -167,7 +183,7 @@ impl IdentityStore for PgIdentityStore {
 
 /// The shared resolver: one per profile, server-lifetime, memoizing per
 /// bound-parameter tuple.
-pub(super) struct IdentityResolver {
+pub struct IdentityResolver {
     config: EnrichmentQueryConfig,
     store:  Arc<dyn IdentityStore>,
     cache:  IdentityCache,
@@ -181,6 +197,13 @@ impl IdentityResolver {
             store,
             cache: IdentityCache::new(),
         }
+    }
+
+    /// Construct a Postgres-backed resolver on an unscoped pool — the server's
+    /// entry point for building a profile instance from config.
+    #[must_use]
+    pub fn postgres(config: EnrichmentQueryConfig, pool: sqlx::PgPool) -> Self {
+        Self::new(config, Arc::new(PgIdentityStore::new(pool)))
     }
 
     /// Resolve `sub`'s identity, using the cache. `claims` supplies the `$param`

--- a/crates/fraiseql-server/src/identity/resolver.rs
+++ b/crates/fraiseql-server/src/identity/resolver.rs
@@ -1,0 +1,311 @@
+//! The shared `sub → DB → identity` resolver (DESIGN §2, §5, §6).
+//!
+//! One [`IdentityResolver`] type, constructed once per profile at server startup,
+//! owning a store handle and a [`IdentityCache`]. Each `resolve` call:
+//!
+//! 1. binds the configured query against the request's claims ([`prepare_enrichment_query`]) — a
+//!    missing `$param` is a fail-closed denial;
+//! 2. looks the bound-parameter tuple up in the cache;
+//! 3. on a miss, fetches up to **two** rows on the unscoped store (two, so ambiguity is
+//!    detectable);
+//! 4. [`classify`]s the rows into the [`IdentityResolution`] failure model; and
+//! 5. caches `Resolved`/`Denied` (positive/negative TTL), never `Unavailable`.
+//!
+//! Every `Denied` and `Unavailable` is logged server-side (DESIGN §5.4) here, so
+//! neither call site can forget it; the outward-facing generic response is the
+//! consumer's responsibility.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
+
+use serde::Deserialize;
+
+use super::{
+    cache::{CachedOutcome, IdentityCache},
+    failure::{DenyReason, IdentityResolution, ResolveError},
+    query::{MissingParam, prepare_enrichment_query},
+};
+
+/// An owned, `Send` boxed future — the object-safe async return used instead of a
+/// new `async_trait` macro, keeping the dyn-dispatch ratchet flat (DESIGN §2.2).
+pub(super) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// The configured `sub → DB → identity` query for one profile (DESIGN §7). One
+/// schema, reused by the enrichment and sender profiles. `deny_unknown_fields`
+/// makes a mistyped/stranded key fail loud — the failure mode that hid #242's
+/// absence.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct EnrichmentQueryConfig {
+    /// When `true`, every authenticated request resolves and fail-closes,
+    /// whether or not the operation consumes an enriched field (DESIGN §7,
+    /// amendment B). The resolver is only constructed when enabled; it does not
+    /// re-check this flag per request.
+    #[serde(default)]
+    pub(super) enabled:           bool,
+    /// The SQL, with named `$param` tokens bound from token claims.
+    pub(super) query:             String,
+    /// Column → enriched-field renaming. A declared column that is NULL/absent in
+    /// the resolved row is a denial (DESIGN §5).
+    #[serde(default)]
+    pub(super) map:               BTreeMap<String, String>,
+    /// Positive TTL for a `Resolved` outcome. Bounded (DESIGN §6.1): a revocation
+    /// propagates within this window, or immediately via `flush(sub)`.
+    #[serde(default = "default_cache_ttl_secs")]
+    pub(super) cache_ttl_secs:    u64,
+    /// Negative TTL for a `Denied` outcome — short, so a freshly provisioned
+    /// actor goes live quickly.
+    #[serde(default = "default_negative_ttl_secs")]
+    pub(super) negative_ttl_secs: u64,
+}
+
+/// DESIGN §6.1: 60s, not #242's token-remaining-lifetime — a tighter revocation
+/// window at a little more DB load.
+const fn default_cache_ttl_secs() -> u64 {
+    60
+}
+
+/// DESIGN §6: short by default so provisioning is seen quickly.
+const fn default_negative_ttl_secs() -> u64 {
+    5
+}
+
+/// Executes a prepared identity query on an **unscoped** connection (no
+/// per-request GUCs — DESIGN §3.3), returning up to two rows as JSON objects.
+/// Abstracting the DB behind this trait makes the failure model unit-testable
+/// against a mock, with the Postgres implementation exercised behind the live-DB
+/// skip-clean pattern.
+pub(super) trait IdentityStore: Send + Sync {
+    /// Fetch up to two rows for the bound query. Values are bound positionally,
+    /// never interpolated. Returns [`ResolveError`] on any transient/DB failure.
+    fn fetch_rows<'a>(
+        &'a self,
+        sql: &'a str,
+        binds: &'a [serde_json::Value],
+    ) -> BoxFuture<'a, Result<Vec<serde_json::Map<String, serde_json::Value>>, ResolveError>>;
+}
+
+/// The Postgres [`IdentityStore`], running on the unscoped enrichment pool.
+pub(super) struct PgIdentityStore {
+    pool: sqlx::PgPool,
+}
+
+impl PgIdentityStore {
+    /// Wrap the unscoped pool.
+    pub(super) const fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl IdentityStore for PgIdentityStore {
+    fn fetch_rows<'a>(
+        &'a self,
+        sql: &'a str,
+        binds: &'a [serde_json::Value],
+    ) -> BoxFuture<'a, Result<Vec<serde_json::Map<String, serde_json::Value>>, ResolveError>> {
+        Box::pin(async move {
+            // `::text` sidesteps needing sqlx's json Decode feature; `LIMIT 2`
+            // lets the resolver detect ambiguity (DESIGN §5, >1 row → Denied).
+            let wrapped = format!("SELECT row_to_json(t)::text FROM ({sql}) t LIMIT 2");
+            let mut query = sqlx::query_as::<_, (String,)>(&wrapped);
+
+            // Stringify upfront so the &str binds outlive the query builder.
+            let string_binds: Vec<String> = binds
+                .iter()
+                .map(|v| match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                })
+                .collect();
+
+            for (bind_value, string_val) in binds.iter().zip(&string_binds) {
+                query = match bind_value {
+                    serde_json::Value::Number(n) => {
+                        if let Some(i) = n.as_i64() {
+                            query.bind(i)
+                        } else if let Some(f) = n.as_f64() {
+                            query.bind(f)
+                        } else {
+                            query.bind(string_val.as_str())
+                        }
+                    },
+                    serde_json::Value::Bool(b) => query.bind(*b),
+                    serde_json::Value::Null => query.bind(Option::<String>::None),
+                    // String, Array, Object bind as their string representation.
+                    _ => query.bind(string_val.as_str()),
+                };
+            }
+
+            let rows = query
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| ResolveError::new(format!("identity query failed: {e}")))?;
+
+            let mut out = Vec::with_capacity(rows.len());
+            for (json_text,) in rows {
+                let value: serde_json::Value = serde_json::from_str(&json_text).map_err(|e| {
+                    ResolveError::new(format!("identity query returned invalid JSON: {e}"))
+                })?;
+                match value {
+                    serde_json::Value::Object(map) => out.push(map),
+                    _ => {
+                        return Err(ResolveError::new(
+                            "identity query did not return a JSON object",
+                        ));
+                    },
+                }
+            }
+            Ok(out)
+        })
+    }
+}
+
+/// The shared resolver: one per profile, server-lifetime, memoizing per
+/// bound-parameter tuple.
+pub(super) struct IdentityResolver {
+    config: EnrichmentQueryConfig,
+    store:  Arc<dyn IdentityStore>,
+    cache:  IdentityCache,
+}
+
+impl IdentityResolver {
+    /// Construct a resolver from its profile config and a store.
+    pub(super) fn new(config: EnrichmentQueryConfig, store: Arc<dyn IdentityStore>) -> Self {
+        Self {
+            config,
+            store,
+            cache: IdentityCache::new(),
+        }
+    }
+
+    /// Resolve `sub`'s identity, using the cache. `claims` supplies the `$param`
+    /// bindings; `sub` labels the cache entry (for `flush`) and the server-side
+    /// denial logs. Never returns a partial result — the mapped set is
+    /// all-or-nothing (DESIGN §5.2).
+    pub(super) async fn resolve(
+        &self,
+        sub: &str,
+        claims: &HashMap<String, serde_json::Value>,
+    ) -> IdentityResolution {
+        let bound = match prepare_enrichment_query(&self.config.query, claims) {
+            Ok(bound) => bound,
+            Err(MissingParam(name)) => {
+                return self
+                    .finalize(sub, IdentityResolution::Denied(DenyReason::MissingParam(name)));
+            },
+        };
+
+        let key = cache_key(&bound.binds);
+        if let Some(cached) = self.cache.get(&key) {
+            return self.finalize(sub, into_resolution(cached));
+        }
+
+        let rows = match self.store.fetch_rows(&bound.sql, &bound.binds).await {
+            Ok(rows) => rows,
+            // Transient — never cached; the read path fails the request (503).
+            Err(err) => return self.finalize(sub, IdentityResolution::Unavailable(err)),
+        };
+
+        let resolution = classify(rows, &self.config.map);
+        match &resolution {
+            IdentityResolution::Resolved(map) => self.cache.insert(
+                key,
+                sub.to_owned(),
+                CachedOutcome::Resolved(map.clone()),
+                Duration::from_secs(self.config.cache_ttl_secs),
+            ),
+            IdentityResolution::Denied(reason) => self.cache.insert(
+                key,
+                sub.to_owned(),
+                CachedOutcome::Denied(reason.clone()),
+                Duration::from_secs(self.config.negative_ttl_secs),
+            ),
+            // Unreachable: `classify` never yields `Unavailable`.
+            IdentityResolution::Unavailable(_) => {},
+        }
+        self.finalize(sub, resolution)
+    }
+
+    /// Evict every cache entry for `sub` — used by the admin flush surface and
+    /// (later) the provision/deprovision mutation hook.
+    pub(super) fn flush(&self, sub: &str) {
+        self.cache.flush(sub);
+    }
+
+    /// Evict the entire cache.
+    pub(super) fn flush_all(&self) {
+        self.cache.flush_all();
+    }
+
+    /// Log denials/unavailables server-side (DESIGN §5.4) and pass the resolution
+    /// through unchanged. Centralized so every call site — cache hit or miss —
+    /// logs uniformly and the outward body can stay generic.
+    fn finalize(&self, sub: &str, resolution: IdentityResolution) -> IdentityResolution {
+        match &resolution {
+            IdentityResolution::Denied(reason) => tracing::warn!(
+                subject = %sub,
+                reason = %reason.log_label(),
+                "enriched-identity resolution denied",
+            ),
+            IdentityResolution::Unavailable(err) => tracing::warn!(
+                subject = %sub,
+                error = %err,
+                "enriched-identity resolution unavailable",
+            ),
+            IdentityResolution::Resolved(_) => {},
+        }
+        resolution
+    }
+}
+
+/// Serialize the ordered bound-`$param` tuple to a deterministic cache key
+/// (DESIGN §6, amendment A). The key is exactly as discriminating as the query's
+/// `WHERE` clause — no more, no less.
+fn cache_key(binds: &[serde_json::Value]) -> String {
+    serde_json::Value::Array(binds.to_vec()).to_string()
+}
+
+/// Lift a cached outcome back into the full resolution type.
+fn into_resolution(cached: CachedOutcome) -> IdentityResolution {
+    match cached {
+        CachedOutcome::Resolved(map) => IdentityResolution::Resolved(map),
+        CachedOutcome::Denied(reason) => IdentityResolution::Denied(reason),
+    }
+}
+
+/// Classify fetched rows against the declared field map (DESIGN §5.1). Pure — the
+/// whole failure model is exercised here without a database.
+///
+/// - 0 rows → `Denied(ZeroRows)` (unknown/unprovisioned subject);
+/// - >1 row → `Denied(Ambiguous)` (we refuse to pick one);
+/// - 1 row  → `Resolved` iff **every** mapped column is present and non-null, else
+///   `Denied(NullField(col))` — never a partial merge, never an empty-string GUC.
+fn classify(
+    rows: Vec<serde_json::Map<String, serde_json::Value>>,
+    map: &BTreeMap<String, String>,
+) -> IdentityResolution {
+    let mut rows = rows.into_iter();
+    let Some(row) = rows.next() else {
+        return IdentityResolution::Denied(DenyReason::ZeroRows);
+    };
+    if rows.next().is_some() {
+        return IdentityResolution::Denied(DenyReason::Ambiguous);
+    }
+
+    let mut resolved = serde_json::Map::with_capacity(map.len());
+    for (column, field) in map {
+        match row.get(column) {
+            Some(value) if !value.is_null() => {
+                resolved.insert(field.clone(), value.clone());
+            },
+            // NULL or absent — deny the whole set (DESIGN §5.2).
+            _ => return IdentityResolution::Denied(DenyReason::NullField(column.clone())),
+        }
+    }
+    IdentityResolution::Resolved(resolved)
+}

--- a/crates/fraiseql-server/src/identity/sender.rs
+++ b/crates/fraiseql-server/src/identity/sender.rs
@@ -1,0 +1,100 @@
+//! Send-path consumer (consumer B): the DB-backed [`SenderIdentityResolver`].
+//!
+//! Resolves `sub → verified from-address + mailbox` on the **shared** identity
+//! primitive (the same `IdentityResolver` the read path uses), cached and
+//! fail-closed. This replaces the login-email assumption where the sending
+//! mailbox differs from the connected user's login email (DESIGN §4) — the pure
+//! `LoginEmailSender` policy is the degenerate case this subsumes.
+//!
+//! This lands the resolver and the seam; the `send_email` host op that injects
+//! and calls it — and the SMTP transport — are the hardening train's, not #539's.
+
+use std::{collections::HashMap, future::Future, pin::Pin};
+
+use fraiseql_functions::{SendPolicyError, SenderIdentity, SenderIdentityResolver};
+use serde_json::Value;
+
+use super::{failure::IdentityResolution, resolver::IdentityResolver};
+
+/// The sender profile's DB-backed resolver: `sub → { verified from-address,
+/// display name }` on the shared identity primitive.
+pub struct DbSenderIdentityResolver {
+    resolver:           IdentityResolver,
+    /// The mapped field holding the verified from-address.
+    address_field:      String,
+    /// The mapped field holding the sender display name, if any.
+    display_name_field: Option<String>,
+}
+
+impl DbSenderIdentityResolver {
+    /// Wrap a sender-profile resolver with the field names it maps its verified
+    /// sending identity onto.
+    pub fn new(
+        resolver: IdentityResolver,
+        address_field: impl Into<String>,
+        display_name_field: Option<String>,
+    ) -> Self {
+        Self {
+            resolver,
+            address_field: address_field.into(),
+            display_name_field,
+        }
+    }
+}
+
+impl SenderIdentityResolver for DbSenderIdentityResolver {
+    fn resolve_sender<'a>(
+        &'a self,
+        auth_context: &'a Value,
+    ) -> Pin<Box<dyn Future<Output = Result<SenderIdentity, SendPolicyError>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(sub) = auth_context.get("sub").and_then(Value::as_str) else {
+                return Err(SendPolicyError::new(
+                    "refusing to send: no subject in the authenticated context",
+                ));
+            };
+            // The host auth context is the claim set — bind the sender query from it.
+            let claims: HashMap<String, Value> =
+                auth_context.as_object().map_or_else(HashMap::new, |map| {
+                    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+                });
+
+            match self.resolver.resolve(sub, &claims).await {
+                IdentityResolution::Resolved(fields) => {
+                    let address = fields
+                        .get(&self.address_field)
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|v| v.contains('@') && !v.contains(char::is_whitespace))
+                        .ok_or_else(|| {
+                            SendPolicyError::new(
+                                "refusing to send: the resolved sender identity has no usable \
+                                 verified address",
+                            )
+                        })?
+                        .to_owned();
+                    let display_name = self
+                        .display_name_field
+                        .as_ref()
+                        .and_then(|field| fields.get(field))
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|v| !v.is_empty())
+                        .map(ToOwned::to_owned);
+                    Ok(SenderIdentity {
+                        address,
+                        display_name,
+                    })
+                },
+                // Fail-closed, uniform with the read path (DESIGN §5): never fall
+                // back to a shared mailbox.
+                IdentityResolution::Denied(_) => Err(SendPolicyError::new(
+                    "refusing to send: no verified sending identity for the connected user",
+                )),
+                IdentityResolution::Unavailable(_) => {
+                    Err(SendPolicyError::new("sender identity resolution temporarily unavailable"))
+                },
+            }
+        })
+    }
+}

--- a/crates/fraiseql-server/src/identity/sender.rs
+++ b/crates/fraiseql-server/src/identity/sender.rs
@@ -9,6 +9,12 @@
 //! This lands the resolver and the seam; the `send_email` host op that injects
 //! and calls it — and the SMTP transport — are the hardening train's, not #539's.
 
+// Reason: the DB-backed sender is constructed and injected into the functions
+// host by the hardening-train `send_email` op; until that lands it has no
+// non-test caller. Scoped to this file so the rest of the module keeps live
+// dead-code detection.
+#![allow(dead_code)]
+
 use std::{collections::HashMap, future::Future, pin::Pin};
 
 use fraiseql_functions::{SendPolicyError, SenderIdentity, SenderIdentityResolver};

--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -814,3 +814,75 @@ typo_field = "oops"
 "#;
     assert!(toml::from_str::<IdentityConfig>(toml_src).is_err());
 }
+
+// ── Consumer B: DB-backed sender identity (DESIGN §4) ─────────────────────
+
+use fraiseql_functions::SenderIdentityResolver;
+
+use super::sender::DbSenderIdentityResolver;
+
+fn sender_resolver(store: MockStore, display: bool) -> DbSenderIdentityResolver {
+    let map: &[(&str, &str)] = if display {
+        &[
+            ("sending_address", "sending_address"),
+            ("display_name", "display_name"),
+        ]
+    } else {
+        &[("sending_address", "sending_address")]
+    };
+    let resolver = IdentityResolver::new(
+        config(
+            "SELECT sending_address, display_name FROM tb_sales_mailbox WHERE sub = $sub",
+            map,
+        ),
+        Arc::new(store),
+    );
+    DbSenderIdentityResolver::new(
+        resolver,
+        "sending_address",
+        display.then(|| "display_name".to_owned()),
+    )
+}
+
+#[tokio::test]
+async fn db_sender_resolves_verified_address_not_login_email() {
+    let store = MockStore::returning(vec![row(&[
+        ("sending_address", json!("sales@acme.example")),
+        ("display_name", json!("Acme Sales")),
+    ])]);
+    let sender = sender_resolver(store, true);
+    // The auth context's login email differs from the verified sending mailbox.
+    let auth = json!({ "sub": "u1", "email": "rep.personal@acme.example" });
+
+    let identity = sender.resolve_sender(&auth).await.unwrap();
+    assert_eq!(identity.address, "sales@acme.example");
+    assert_eq!(identity.display_name.as_deref(), Some("Acme Sales"));
+}
+
+#[tokio::test]
+async fn db_sender_denies_unprovisioned_subject() {
+    let sender = sender_resolver(MockStore::returning(vec![]), false);
+    let auth = json!({ "sub": "nobody" });
+
+    assert!(
+        sender.resolve_sender(&auth).await.is_err(),
+        "an unprovisioned subject must refuse, never fall back to a shared mailbox"
+    );
+}
+
+#[tokio::test]
+async fn db_sender_refuses_without_a_subject() {
+    let sender = sender_resolver(MockStore::returning(vec![]), false);
+    let auth = json!({ "email": "someone@acme.example" }); // no `sub`
+
+    assert!(sender.resolve_sender(&auth).await.is_err());
+}
+
+#[tokio::test]
+async fn db_sender_refuses_a_malformed_resolved_address() {
+    let store = MockStore::returning(vec![row(&[("sending_address", json!("not-an-email"))])]);
+    let sender = sender_resolver(store, false);
+    let auth = json!({ "sub": "u1" });
+
+    assert!(sender.resolve_sender(&auth).await.is_err());
+}

--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -19,14 +19,21 @@ use std::{
     time::Duration,
 };
 
+use chrono::Utc;
+use fraiseql_core::{
+    security::{ENRICHED_NAMESPACE_PREFIX, SecurityContext},
+    types::UserId,
+};
 use serde_json::{Value, json};
 
 use super::{
+    apply::{EnrichmentOutcome, enrich_security_context},
     cache::{CachedOutcome, IdentityCache},
     failure::{DenyReason, IdentityResolution, ResolveError},
     query::{MissingParam, prepare_enrichment_query},
     resolver::{
-        BoxFuture, EnrichmentQueryConfig, IdentityResolver, IdentityStore, PgIdentityStore,
+        BoxFuture, EnrichmentQueryConfig, IdentityConfig, IdentityResolver, IdentityStore,
+        PgIdentityStore,
     },
 };
 
@@ -677,4 +684,133 @@ async fn pg_store_binds_hostile_subject_value_safely() {
     assert_eq!(count, 1);
 
     sqlx::query(&format!("DROP TABLE {table}")).execute(&pool).await.unwrap();
+}
+
+// ── Consumer A: enrich_security_context + config (DESIGN §3, §7) ───────────
+
+fn sec_ctx(sub: &str, attrs: &[(&str, Value)]) -> SecurityContext {
+    SecurityContext {
+        user_id:          UserId::new(sub),
+        roles:            vec![],
+        tenant_id:        None,
+        scopes:           vec![],
+        attributes:       attrs.iter().map(|(k, v)| ((*k).to_owned(), v.clone())).collect(),
+        request_id:       "req-test".to_owned(),
+        ip_address:       None,
+        authenticated_at: Utc::now(),
+        expires_at:       Utc::now(),
+        issuer:           None,
+        audience:         None,
+        email:            None,
+        display_name:     None,
+    }
+}
+
+/// A store that records the binds it received (to prove `claims_for_binding`
+/// surfaces the subject) and returns a fixed row set.
+struct CapturingStore {
+    rows:     Vec<serde_json::Map<String, Value>>,
+    captured: std::sync::Mutex<Vec<Value>>,
+}
+
+impl IdentityStore for CapturingStore {
+    fn fetch_rows<'a>(
+        &'a self,
+        _sql: &'a str,
+        binds: &'a [Value],
+    ) -> BoxFuture<'a, Result<Vec<serde_json::Map<String, Value>>, ResolveError>> {
+        *self.captured.lock().unwrap() = binds.to_vec();
+        let rows = self.rows.clone();
+        Box::pin(async move { Ok(rows) })
+    }
+}
+
+fn actor_row() -> serde_json::Map<String, Value> {
+    row(&[("actor_id", json!("a-1")), ("actor_role", json!("manager"))])
+}
+
+#[tokio::test]
+async fn enrich_resolved_merges_under_reserved_namespace() {
+    let mut ctx = sec_ctx("u1", &[]);
+    let resolver = resolver(MockStore::returning(vec![actor_row()]));
+
+    assert_eq!(enrich_security_context(&resolver, &mut ctx).await, EnrichmentOutcome::Proceed);
+    assert_eq!(ctx.attributes[&format!("{ENRICHED_NAMESPACE_PREFIX}actor_role")], "manager");
+    assert_eq!(ctx.attributes[&format!("{ENRICHED_NAMESPACE_PREFIX}actor_id")], "a-1");
+}
+
+#[tokio::test]
+async fn enrich_denied_merges_nothing() {
+    let mut ctx = sec_ctx("u1", &[]);
+    let resolver = resolver(MockStore::returning(vec![])); // zero rows → Denied
+
+    assert_eq!(enrich_security_context(&resolver, &mut ctx).await, EnrichmentOutcome::Denied);
+    assert!(
+        ctx.attributes.keys().all(|k| !k.starts_with(ENRICHED_NAMESPACE_PREFIX)),
+        "a denial must merge nothing"
+    );
+}
+
+#[tokio::test]
+async fn enrich_unavailable_maps_to_unavailable() {
+    let mut ctx = sec_ctx("u1", &[]);
+    let resolver = resolver(MockStore::failing());
+
+    assert_eq!(
+        enrich_security_context(&resolver, &mut ctx).await,
+        EnrichmentOutcome::Unavailable
+    );
+}
+
+#[tokio::test]
+async fn enrich_binds_subject_from_context() {
+    let store = Arc::new(CapturingStore {
+        rows:     vec![actor_row()],
+        captured: std::sync::Mutex::new(Vec::new()),
+    });
+    let resolver = IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        store.clone(),
+    );
+    let mut ctx = sec_ctx("subject-42", &[]);
+
+    let _ = enrich_security_context(&resolver, &mut ctx).await;
+
+    // The subject from the context bound `$sub` — the read scopes on a
+    // DB-derived identity, not a client-asserted one.
+    assert_eq!(*store.captured.lock().unwrap(), vec![json!("subject-42")]);
+}
+
+#[test]
+fn identity_config_deserializes_from_toml() {
+    let toml_src = r#"
+[enrichment]
+enabled = true
+query = "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub"
+map = { actor_id = "actor_id", actor_role = "actor_role" }
+cache_ttl_secs = 30
+"#;
+    let cfg: IdentityConfig = toml::from_str(toml_src).unwrap();
+    let enrichment = cfg.enrichment.unwrap();
+    assert!(enrichment.enabled);
+    assert_eq!(enrichment.cache_ttl_secs, 30);
+    assert_eq!(enrichment.negative_ttl_secs, 5, "negative TTL defaults to 5s");
+    assert_eq!(enrichment.map["actor_role"], "actor_role");
+    assert!(cfg.sender.is_none());
+}
+
+#[test]
+fn identity_config_rejects_unknown_field() {
+    // deny_unknown_fields makes a mistyped/stranded key fail loud — the failure
+    // mode that hid #242's absence (DESIGN §7).
+    let toml_src = r#"
+[enrichment]
+enabled = true
+query = "SELECT 1"
+typo_field = "oops"
+"#;
+    assert!(toml::from_str::<IdentityConfig>(toml_src).is_err());
 }

--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -1,0 +1,198 @@
+//! Adversarial + behavioural test suite ported verbatim from #242
+//! (`routes/enrichment.rs`, `v2.2.1`). These are the hard-to-get-right part of
+//! the primitive and they are already correct; they are ported first (DESIGN
+//! §8, P00) and pinned as a fixed point before any new resolver logic lands.
+
+#![allow(clippy::unwrap_used)] // Reason: test code, panics acceptable
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use super::{
+    cache::{CacheEntry, EnrichmentCache},
+    query::prepare_enrichment_query,
+};
+
+// ── prepare_enrichment_query ─────────────────────────────────────────────
+
+#[test]
+fn rewrites_single_param() {
+    let mut claims = HashMap::new();
+    claims.insert("sub".to_owned(), serde_json::json!("user-123"));
+
+    let bound =
+        prepare_enrichment_query("SELECT role FROM users WHERE sub = $sub", &claims).unwrap();
+
+    assert_eq!(bound.sql, "SELECT role FROM users WHERE sub = $1");
+    assert_eq!(bound.binds.len(), 1);
+    assert_eq!(bound.binds[0], serde_json::json!("user-123"));
+}
+
+#[test]
+fn rewrites_multiple_params() {
+    let mut claims = HashMap::new();
+    claims.insert("sub".to_owned(), serde_json::json!("u1"));
+    claims.insert("email".to_owned(), serde_json::json!("a@b.com"));
+
+    let bound = prepare_enrichment_query(
+        "SELECT role FROM users WHERE sub = $sub AND email = $email",
+        &claims,
+    )
+    .unwrap();
+
+    assert_eq!(bound.sql, "SELECT role FROM users WHERE sub = $1 AND email = $2");
+    assert_eq!(bound.binds.len(), 2);
+}
+
+#[test]
+fn reuses_position_for_repeated_param() {
+    let mut claims = HashMap::new();
+    claims.insert("sub".to_owned(), serde_json::json!("u1"));
+
+    let bound =
+        prepare_enrichment_query("SELECT * FROM users WHERE sub = $sub OR alt_sub = $sub", &claims)
+            .unwrap();
+
+    assert_eq!(bound.sql, "SELECT * FROM users WHERE sub = $1 OR alt_sub = $1");
+    assert_eq!(bound.binds.len(), 1);
+}
+
+#[test]
+fn missing_param_returns_error() {
+    let claims = HashMap::new();
+
+    let err = prepare_enrichment_query("SELECT 1 WHERE sub = $sub", &claims).unwrap_err();
+
+    assert!(err.contains("$sub"));
+    assert!(err.contains("not in the JWT claims"));
+}
+
+#[test]
+fn no_params_passes_through() {
+    let claims = HashMap::new();
+
+    let bound = prepare_enrichment_query("SELECT 1 AS one", &claims).unwrap();
+
+    assert_eq!(bound.sql, "SELECT 1 AS one");
+    assert!(bound.binds.is_empty());
+}
+
+#[test]
+fn preserves_dollar_followed_by_digit() {
+    let claims = HashMap::new();
+
+    let bound = prepare_enrichment_query("SELECT $1", &claims).unwrap();
+
+    // $1 is NOT a named param (digit after $) — passed through as-is.
+    assert_eq!(bound.sql, "SELECT $1");
+}
+
+// ── EnrichmentCache ──────────────────────────────────────────────────────
+
+#[test]
+fn cache_hit_returns_value() {
+    let cache = EnrichmentCache::new();
+    let mut map = serde_json::Map::new();
+    map.insert("role".to_owned(), serde_json::json!("admin"));
+
+    cache.insert("user-1".to_owned(), map, Duration::from_secs(60));
+
+    let result = cache.get("user-1");
+    assert!(result.is_some());
+    assert_eq!(result.unwrap()["role"], "admin");
+}
+
+#[test]
+fn cache_miss_returns_none() {
+    let cache = EnrichmentCache::new();
+    assert!(cache.get("nonexistent").is_none());
+}
+
+#[test]
+fn expired_entry_returns_none() {
+    let cache = EnrichmentCache::new();
+    let map = serde_json::Map::new();
+
+    // Insert with an already-expired timestamp.
+    cache.entries.insert(
+        "user-1".to_owned(),
+        CacheEntry {
+            value:      map,
+            expires_at: Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+        },
+    );
+
+    assert!(cache.get("user-1").is_none());
+}
+
+// ── Security: adversarial inputs ─────────────────────────────────────────
+
+#[test]
+fn sql_injection_in_claim_value_is_bound_not_interpolated() {
+    let mut claims = HashMap::new();
+    claims.insert("email".to_owned(), serde_json::json!("'; DROP TABLE users; --"));
+
+    let bound =
+        prepare_enrichment_query("SELECT role FROM users WHERE email = $email", &claims).unwrap();
+
+    // The malicious value must appear as a bind parameter, not in the SQL.
+    assert_eq!(bound.sql, "SELECT role FROM users WHERE email = $1");
+    assert_eq!(bound.binds[0], serde_json::json!("'; DROP TABLE users; --"));
+    assert!(!bound.sql.contains("DROP"));
+}
+
+#[test]
+fn sql_comment_in_claim_value_is_bound_not_interpolated() {
+    let mut claims = HashMap::new();
+    claims.insert("sub".to_owned(), serde_json::json!("user /* */ OR 1=1"));
+
+    let bound =
+        prepare_enrichment_query("SELECT role FROM users WHERE sub = $sub", &claims).unwrap();
+
+    assert_eq!(bound.sql, "SELECT role FROM users WHERE sub = $1");
+    assert_eq!(bound.binds[0], serde_json::json!("user /* */ OR 1=1"));
+    assert!(!bound.sql.contains("/*"));
+}
+
+#[test]
+fn overlapping_param_names_are_distinguished() {
+    // $email vs $email_verified — ensure the greedy match doesn't treat
+    // $email_verified as "$email" + "verified".
+    let mut claims = HashMap::new();
+    claims.insert("email".to_owned(), serde_json::json!("a@b.com"));
+    claims.insert("email_verified".to_owned(), serde_json::json!(true));
+
+    let bound = prepare_enrichment_query(
+        "SELECT * FROM users WHERE email = $email AND verified = $email_verified",
+        &claims,
+    )
+    .unwrap();
+
+    assert_eq!(bound.sql, "SELECT * FROM users WHERE email = $1 AND verified = $2");
+    assert_eq!(bound.binds.len(), 2);
+    assert_eq!(bound.binds[0], serde_json::json!("a@b.com"));
+    assert_eq!(bound.binds[1], serde_json::json!(true));
+}
+
+#[test]
+fn param_at_end_of_query() {
+    let mut claims = HashMap::new();
+    claims.insert("sub".to_owned(), serde_json::json!("u1"));
+
+    let bound = prepare_enrichment_query("SELECT * FROM users WHERE sub = $sub", &claims).unwrap();
+
+    assert_eq!(bound.sql, "SELECT * FROM users WHERE sub = $1");
+}
+
+#[test]
+fn unicode_claim_value_is_bound() {
+    let mut claims = HashMap::new();
+    claims.insert("sub".to_owned(), serde_json::json!("用户-émoji-🍓"));
+
+    let bound =
+        prepare_enrichment_query("SELECT role FROM users WHERE sub = $sub", &claims).unwrap();
+
+    assert_eq!(bound.binds[0], serde_json::json!("用户-émoji-🍓"));
+}

--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -886,3 +886,130 @@ async fn db_sender_refuses_a_malformed_resolved_address() {
 
     assert!(sender.resolve_sender(&auth).await.is_err());
 }
+
+// ── Acceptance: the two-role read boundary (DESIGN §9, self-contained) ─────
+//
+// The partner runs §9 against their live two-role setup at P04; this is the
+// self-contained local proof of the same property. It exercises the real chain:
+// enrich a known subject against a real `tb_actor`, then apply the enriched
+// values as GUCs on a connection (exactly the keys the `Enrichment` session-var
+// source reads) and assert RLS-view visibility.
+
+/// Count rows visible under the enriched GUCs, transaction-locally so no GUC
+/// leaks onto a pooled connection.
+async fn count_visible(pool: &sqlx::PgPool, view: &str, role: &str, actor_id: &str) -> i64 {
+    let mut tx = pool.begin().await.unwrap();
+    sqlx::query("SELECT set_config('app.actor_role', $1, true)")
+        .bind(role)
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    sqlx::query("SELECT set_config('app.actor_id', $1, true)")
+        .bind(actor_id)
+        .execute(&mut *tx)
+        .await
+        .unwrap();
+    let (count,): (i64,) = sqlx::query_as(&format!("SELECT count(*) FROM {view}"))
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap();
+    tx.rollback().await.unwrap();
+    count
+}
+
+fn enriched(ctx: &SecurityContext, field: &str) -> String {
+    ctx.attributes[&format!("{ENRICHED_NAMESPACE_PREFIX}{field}")]
+        .as_str()
+        .unwrap()
+        .to_owned()
+}
+
+#[tokio::test]
+async fn acceptance_two_role_read_boundary() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP acceptance_two_role_read_boundary: no postgres");
+        return;
+    };
+    let suffix = uuid::Uuid::new_v4().simple();
+    let actor = format!("tb_actor_acc_{suffix}");
+    let item = format!("tb_item_acc_{suffix}");
+    let view = format!("v_item_acc_{suffix}");
+
+    sqlx::query(&format!("CREATE TABLE {actor} (sub text, actor_id text, actor_role text)"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO {actor} VALUES ('admin-sub','a-admin','manager'), ('staff-sub','a-staff','staff')"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(&format!("CREATE TABLE {item} (id int, owner_actor_id text)"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(&format!("INSERT INTO {item} VALUES (1,'a-admin'),(2,'a-staff'),(3,'a-other')"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    // The view scopes exactly as the partner's does: a `manager` sees all, any
+    // other role sees only its own rows.
+    sqlx::query(&format!(
+        "CREATE VIEW {view} AS SELECT * FROM {item} \
+         WHERE current_setting('app.actor_role', true) = 'manager' \
+            OR owner_actor_id = current_setting('app.actor_id', true)"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resolver = actor_resolver(&pool, &actor);
+
+    // §9.1 — known sub → role-A (manager, unfiltered): sees all rows.
+    let mut ctx_admin = sec_ctx("admin-sub", &[]);
+    assert_eq!(
+        enrich_security_context(&resolver, &mut ctx_admin).await,
+        EnrichmentOutcome::Proceed
+    );
+    assert_eq!(
+        count_visible(
+            &pool,
+            &view,
+            &enriched(&ctx_admin, "actor_role"),
+            &enriched(&ctx_admin, "actor_id")
+        )
+        .await,
+        3,
+        "the manager role sees every row"
+    );
+
+    // §9.2 — known sub → role-B (staff, own-scope): sees only its own row.
+    let mut ctx_staff = sec_ctx("staff-sub", &[]);
+    assert_eq!(
+        enrich_security_context(&resolver, &mut ctx_staff).await,
+        EnrichmentOutcome::Proceed
+    );
+    assert_eq!(
+        count_visible(
+            &pool,
+            &view,
+            &enriched(&ctx_staff, "actor_role"),
+            &enriched(&ctx_staff, "actor_id")
+        )
+        .await,
+        1,
+        "the staff role sees only its own row"
+    );
+
+    // §9.3 — unknown sub → DENIED (fail-closed before dispatch), NOT an empty set.
+    let mut ctx_unknown = sec_ctx("nobody", &[]);
+    assert_eq!(
+        enrich_security_context(&resolver, &mut ctx_unknown).await,
+        EnrichmentOutcome::Denied
+    );
+
+    sqlx::query(&format!("DROP VIEW {view}")).execute(&pool).await.unwrap();
+    sqlx::query(&format!("DROP TABLE {item}")).execute(&pool).await.unwrap();
+    sqlx::query(&format!("DROP TABLE {actor}")).execute(&pool).await.unwrap();
+}

--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -1,40 +1,55 @@
-//! Adversarial + behavioural test suite ported verbatim from #242
-//! (`routes/enrichment.rs`, `v2.2.1`). These are the hard-to-get-right part of
-//! the primitive and they are already correct; they are ported first (DESIGN
-//! §8, P00) and pinned as a fixed point before any new resolver logic lands.
+//! Test suite for the enriched-identity resolver.
+//!
+//! The `prepare_enrichment_query` adversarial cases are ported verbatim from #242
+//! (`routes/enrichment.rs`, `v2.2.1`) — the hard-to-get-right, already-correct
+//! core, pinned as a fixed point (DESIGN §8, P00). The cache, the failure model
+//! (against a mock store), and the Postgres store (behind the live-DB skip-clean
+//! pattern) are exercised on top (P01).
 
 #![allow(clippy::unwrap_used)] // Reason: test code, panics acceptable
+#![allow(clippy::panic)] // Reason: test code, panics acceptable
+#![allow(clippy::print_stderr)] // Reason: skip message when no backing Postgres is available
 
 use std::{
     collections::HashMap,
-    time::{Duration, Instant},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
 };
+
+use serde_json::{Value, json};
 
 use super::{
-    cache::{CacheEntry, EnrichmentCache},
-    query::prepare_enrichment_query,
+    cache::{CachedOutcome, IdentityCache},
+    failure::{DenyReason, IdentityResolution, ResolveError},
+    query::{MissingParam, prepare_enrichment_query},
+    resolver::{
+        BoxFuture, EnrichmentQueryConfig, IdentityResolver, IdentityStore, PgIdentityStore,
+    },
 };
 
-// ── prepare_enrichment_query ─────────────────────────────────────────────
+// ── prepare_enrichment_query (ported verbatim from #242) ──────────────────
 
 #[test]
 fn rewrites_single_param() {
     let mut claims = HashMap::new();
-    claims.insert("sub".to_owned(), serde_json::json!("user-123"));
+    claims.insert("sub".to_owned(), json!("user-123"));
 
     let bound =
         prepare_enrichment_query("SELECT role FROM users WHERE sub = $sub", &claims).unwrap();
 
     assert_eq!(bound.sql, "SELECT role FROM users WHERE sub = $1");
     assert_eq!(bound.binds.len(), 1);
-    assert_eq!(bound.binds[0], serde_json::json!("user-123"));
+    assert_eq!(bound.binds[0], json!("user-123"));
 }
 
 #[test]
 fn rewrites_multiple_params() {
     let mut claims = HashMap::new();
-    claims.insert("sub".to_owned(), serde_json::json!("u1"));
-    claims.insert("email".to_owned(), serde_json::json!("a@b.com"));
+    claims.insert("sub".to_owned(), json!("u1"));
+    claims.insert("email".to_owned(), json!("a@b.com"));
 
     let bound = prepare_enrichment_query(
         "SELECT role FROM users WHERE sub = $sub AND email = $email",
@@ -49,7 +64,7 @@ fn rewrites_multiple_params() {
 #[test]
 fn reuses_position_for_repeated_param() {
     let mut claims = HashMap::new();
-    claims.insert("sub".to_owned(), serde_json::json!("u1"));
+    claims.insert("sub".to_owned(), json!("u1"));
 
     let bound =
         prepare_enrichment_query("SELECT * FROM users WHERE sub = $sub OR alt_sub = $sub", &claims)
@@ -60,13 +75,14 @@ fn reuses_position_for_repeated_param() {
 }
 
 #[test]
-fn missing_param_returns_error() {
+fn missing_param_returns_structured_error() {
     let claims = HashMap::new();
 
+    // Refined from #242's message string to a structured `MissingParam` so the
+    // resolver maps it directly to a fail-closed denial (DESIGN §5).
     let err = prepare_enrichment_query("SELECT 1 WHERE sub = $sub", &claims).unwrap_err();
 
-    assert!(err.contains("$sub"));
-    assert!(err.contains("not in the JWT claims"));
+    assert_eq!(err, MissingParam("sub".to_owned()));
 }
 
 #[test]
@@ -89,70 +105,30 @@ fn preserves_dollar_followed_by_digit() {
     assert_eq!(bound.sql, "SELECT $1");
 }
 
-// ── EnrichmentCache ──────────────────────────────────────────────────────
-
-#[test]
-fn cache_hit_returns_value() {
-    let cache = EnrichmentCache::new();
-    let mut map = serde_json::Map::new();
-    map.insert("role".to_owned(), serde_json::json!("admin"));
-
-    cache.insert("user-1".to_owned(), map, Duration::from_secs(60));
-
-    let result = cache.get("user-1");
-    assert!(result.is_some());
-    assert_eq!(result.unwrap()["role"], "admin");
-}
-
-#[test]
-fn cache_miss_returns_none() {
-    let cache = EnrichmentCache::new();
-    assert!(cache.get("nonexistent").is_none());
-}
-
-#[test]
-fn expired_entry_returns_none() {
-    let cache = EnrichmentCache::new();
-    let map = serde_json::Map::new();
-
-    // Insert with an already-expired timestamp.
-    cache.entries.insert(
-        "user-1".to_owned(),
-        CacheEntry {
-            value:      map,
-            expires_at: Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
-        },
-    );
-
-    assert!(cache.get("user-1").is_none());
-}
-
-// ── Security: adversarial inputs ─────────────────────────────────────────
-
 #[test]
 fn sql_injection_in_claim_value_is_bound_not_interpolated() {
     let mut claims = HashMap::new();
-    claims.insert("email".to_owned(), serde_json::json!("'; DROP TABLE users; --"));
+    claims.insert("email".to_owned(), json!("'; DROP TABLE users; --"));
 
     let bound =
         prepare_enrichment_query("SELECT role FROM users WHERE email = $email", &claims).unwrap();
 
     // The malicious value must appear as a bind parameter, not in the SQL.
     assert_eq!(bound.sql, "SELECT role FROM users WHERE email = $1");
-    assert_eq!(bound.binds[0], serde_json::json!("'; DROP TABLE users; --"));
+    assert_eq!(bound.binds[0], json!("'; DROP TABLE users; --"));
     assert!(!bound.sql.contains("DROP"));
 }
 
 #[test]
 fn sql_comment_in_claim_value_is_bound_not_interpolated() {
     let mut claims = HashMap::new();
-    claims.insert("sub".to_owned(), serde_json::json!("user /* */ OR 1=1"));
+    claims.insert("sub".to_owned(), json!("user /* */ OR 1=1"));
 
     let bound =
         prepare_enrichment_query("SELECT role FROM users WHERE sub = $sub", &claims).unwrap();
 
     assert_eq!(bound.sql, "SELECT role FROM users WHERE sub = $1");
-    assert_eq!(bound.binds[0], serde_json::json!("user /* */ OR 1=1"));
+    assert_eq!(bound.binds[0], json!("user /* */ OR 1=1"));
     assert!(!bound.sql.contains("/*"));
 }
 
@@ -161,8 +137,8 @@ fn overlapping_param_names_are_distinguished() {
     // $email vs $email_verified — ensure the greedy match doesn't treat
     // $email_verified as "$email" + "verified".
     let mut claims = HashMap::new();
-    claims.insert("email".to_owned(), serde_json::json!("a@b.com"));
-    claims.insert("email_verified".to_owned(), serde_json::json!(true));
+    claims.insert("email".to_owned(), json!("a@b.com"));
+    claims.insert("email_verified".to_owned(), json!(true));
 
     let bound = prepare_enrichment_query(
         "SELECT * FROM users WHERE email = $email AND verified = $email_verified",
@@ -172,14 +148,14 @@ fn overlapping_param_names_are_distinguished() {
 
     assert_eq!(bound.sql, "SELECT * FROM users WHERE email = $1 AND verified = $2");
     assert_eq!(bound.binds.len(), 2);
-    assert_eq!(bound.binds[0], serde_json::json!("a@b.com"));
-    assert_eq!(bound.binds[1], serde_json::json!(true));
+    assert_eq!(bound.binds[0], json!("a@b.com"));
+    assert_eq!(bound.binds[1], json!(true));
 }
 
 #[test]
 fn param_at_end_of_query() {
     let mut claims = HashMap::new();
-    claims.insert("sub".to_owned(), serde_json::json!("u1"));
+    claims.insert("sub".to_owned(), json!("u1"));
 
     let bound = prepare_enrichment_query("SELECT * FROM users WHERE sub = $sub", &claims).unwrap();
 
@@ -189,10 +165,516 @@ fn param_at_end_of_query() {
 #[test]
 fn unicode_claim_value_is_bound() {
     let mut claims = HashMap::new();
-    claims.insert("sub".to_owned(), serde_json::json!("用户-émoji-🍓"));
+    claims.insert("sub".to_owned(), json!("用户-émoji-🍓"));
 
     let bound =
         prepare_enrichment_query("SELECT role FROM users WHERE sub = $sub", &claims).unwrap();
 
-    assert_eq!(bound.binds[0], serde_json::json!("用户-émoji-🍓"));
+    assert_eq!(bound.binds[0], json!("用户-émoji-🍓"));
+}
+
+// ── IdentityCache (DESIGN §6) ─────────────────────────────────────────────
+
+fn resolved(field: &str, value: Value) -> CachedOutcome {
+    let mut map = serde_json::Map::new();
+    map.insert(field.to_owned(), value);
+    CachedOutcome::Resolved(map)
+}
+
+#[test]
+fn cache_returns_inserted_outcome() {
+    let cache = IdentityCache::new();
+    cache.insert(
+        "[\"u1\"]".to_owned(),
+        "u1".to_owned(),
+        resolved("actor_role", json!("admin")),
+        Duration::from_secs(60),
+    );
+
+    match cache.get("[\"u1\"]") {
+        Some(CachedOutcome::Resolved(map)) => assert_eq!(map["actor_role"], "admin"),
+        other => panic!("expected Resolved, got {:?}", other.is_some()),
+    }
+}
+
+#[test]
+fn cache_miss_returns_none() {
+    let cache = IdentityCache::new();
+    assert!(cache.get("nonexistent").is_none());
+}
+
+#[test]
+fn cache_expired_entry_returns_none() {
+    let cache = IdentityCache::new();
+    // A zero TTL is already elapsed by the next monotonic `get` (strict `<`).
+    cache.insert(
+        "[\"u1\"]".to_owned(),
+        "u1".to_owned(),
+        resolved("actor_role", json!("admin")),
+        Duration::from_secs(0),
+    );
+
+    assert!(cache.get("[\"u1\"]").is_none());
+}
+
+#[test]
+fn cache_flush_evicts_only_matching_subject() {
+    let cache = IdentityCache::new();
+    // Two entries for u1 (different bound tuples), one for u2.
+    cache.insert(
+        "[\"u1\"]".to_owned(),
+        "u1".to_owned(),
+        resolved("r", json!("a")),
+        Duration::from_secs(60),
+    );
+    cache.insert(
+        "[\"u1\",\"x\"]".to_owned(),
+        "u1".to_owned(),
+        resolved("r", json!("a")),
+        Duration::from_secs(60),
+    );
+    cache.insert(
+        "[\"u2\"]".to_owned(),
+        "u2".to_owned(),
+        resolved("r", json!("b")),
+        Duration::from_secs(60),
+    );
+
+    cache.flush("u1");
+
+    assert_eq!(cache.len(), 1);
+    assert!(cache.get("[\"u1\"]").is_none());
+    assert!(cache.get("[\"u1\",\"x\"]").is_none());
+    assert!(cache.get("[\"u2\"]").is_some());
+}
+
+#[test]
+fn cache_flush_all_clears() {
+    let cache = IdentityCache::new();
+    cache.insert(
+        "[\"u1\"]".to_owned(),
+        "u1".to_owned(),
+        resolved("r", json!("a")),
+        Duration::from_secs(60),
+    );
+    cache.insert(
+        "[\"u2\"]".to_owned(),
+        "u2".to_owned(),
+        resolved("r", json!("b")),
+        Duration::from_secs(60),
+    );
+
+    cache.flush_all();
+
+    assert_eq!(cache.len(), 0);
+}
+
+// ── Failure model against a mock store (DESIGN §5) ────────────────────────
+
+/// A store that returns a fixed row set (or a transient error) and counts calls,
+/// so tests can assert both the classification and the caching behaviour.
+struct MockStore {
+    rows:  Vec<serde_json::Map<String, Value>>,
+    fail:  Option<ResolveError>,
+    calls: AtomicUsize,
+}
+
+impl MockStore {
+    fn returning(rows: Vec<serde_json::Map<String, Value>>) -> Self {
+        Self {
+            rows,
+            fail: None,
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn failing() -> Self {
+        Self {
+            rows:  Vec::new(),
+            fail:  Some(ResolveError::new("db unreachable")),
+            calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::Relaxed)
+    }
+}
+
+impl IdentityStore for MockStore {
+    fn fetch_rows<'a>(
+        &'a self,
+        _sql: &'a str,
+        _binds: &'a [Value],
+    ) -> BoxFuture<'a, Result<Vec<serde_json::Map<String, Value>>, ResolveError>> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        let result = self.fail.clone().map_or_else(|| Ok(self.rows.clone()), Err);
+        Box::pin(async move { result })
+    }
+}
+
+fn row(pairs: &[(&str, Value)]) -> serde_json::Map<String, Value> {
+    pairs.iter().map(|(k, v)| ((*k).to_owned(), v.clone())).collect()
+}
+
+fn claims(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+    pairs.iter().map(|(k, v)| ((*k).to_owned(), v.clone())).collect()
+}
+
+fn config(query: &str, map: &[(&str, &str)]) -> EnrichmentQueryConfig {
+    EnrichmentQueryConfig {
+        enabled:           true,
+        query:             query.to_owned(),
+        map:               map.iter().map(|(c, f)| ((*c).to_owned(), (*f).to_owned())).collect(),
+        cache_ttl_secs:    60,
+        negative_ttl_secs: 5,
+    }
+}
+
+/// A resolver over a `sub`-keyed query with the actor mapping, backed by `store`.
+fn resolver(store: MockStore) -> IdentityResolver {
+    IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        Arc::new(store),
+    )
+}
+
+fn sub_claims() -> HashMap<String, Value> {
+    claims(&[("sub", json!("u1"))])
+}
+
+#[tokio::test]
+async fn resolve_one_row_all_fields_present_resolves() {
+    let store = MockStore::returning(vec![row(&[
+        ("actor_id", json!("a-1")),
+        ("actor_role", json!("manager")),
+    ])]);
+    let resolver = resolver(store);
+
+    match resolver.resolve("u1", &sub_claims()).await {
+        IdentityResolution::Resolved(map) => {
+            assert_eq!(map["actor_id"], "a-1");
+            assert_eq!(map["actor_role"], "manager");
+        },
+        other => panic!("expected Resolved, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_zero_rows_denies_unknown_subject() {
+    let resolver = resolver(MockStore::returning(vec![]));
+
+    match resolver.resolve("u1", &sub_claims()).await {
+        IdentityResolution::Denied(DenyReason::ZeroRows) => {},
+        other => panic!("expected Denied(ZeroRows), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_more_than_one_row_denies_ambiguous() {
+    let store = MockStore::returning(vec![
+        row(&[("actor_id", json!("a-1")), ("actor_role", json!("manager"))]),
+        row(&[("actor_id", json!("a-2")), ("actor_role", json!("staff"))]),
+    ]);
+
+    match resolver(store).resolve("u1", &sub_claims()).await {
+        IdentityResolution::Denied(DenyReason::Ambiguous) => {},
+        other => panic!("expected Denied(Ambiguous), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_null_mapped_field_denies() {
+    let store = MockStore::returning(vec![row(&[
+        ("actor_id", json!("a-1")),
+        ("actor_role", Value::Null),
+    ])]);
+
+    match resolver(store).resolve("u1", &sub_claims()).await {
+        IdentityResolution::Denied(DenyReason::NullField(col)) => assert_eq!(col, "actor_role"),
+        other => panic!("expected Denied(NullField), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_absent_mapped_field_denies() {
+    // Row is present but omits `actor_role` entirely — treated as NULL.
+    let store = MockStore::returning(vec![row(&[("actor_id", json!("a-1"))])]);
+
+    match resolver(store).resolve("u1", &sub_claims()).await {
+        IdentityResolution::Denied(DenyReason::NullField(col)) => assert_eq!(col, "actor_role"),
+        other => panic!("expected Denied(NullField), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_missing_bound_param_denies() {
+    // Query binds $email but the token has no email claim (DESIGN §9 item 8).
+    let resolver = IdentityResolver::new(
+        config(
+            "SELECT actor_id FROM tb_actor WHERE sub = $sub AND email = $email",
+            &[("actor_id", "actor_id")],
+        ),
+        Arc::new(MockStore::returning(vec![])),
+    );
+
+    match resolver.resolve("u1", &sub_claims()).await {
+        IdentityResolution::Denied(DenyReason::MissingParam(name)) => assert_eq!(name, "email"),
+        other => panic!("expected Denied(MissingParam), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resolve_transient_error_is_unavailable_and_not_cached() {
+    let resolver = resolver(MockStore::failing());
+
+    assert!(matches!(
+        resolver.resolve("u1", &sub_claims()).await,
+        IdentityResolution::Unavailable(_)
+    ));
+    // A transient blip must not be cached — the second call re-hits the store.
+    assert!(matches!(
+        resolver.resolve("u1", &sub_claims()).await,
+        IdentityResolution::Unavailable(_)
+    ));
+}
+
+#[tokio::test]
+async fn resolve_caches_resolved_positively() {
+    let store = MockStore::returning(vec![row(&[
+        ("actor_id", json!("a-1")),
+        ("actor_role", json!("manager")),
+    ])]);
+    let store = Arc::new(store);
+    let resolver = IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        store.clone(),
+    );
+
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+
+    assert_eq!(store.calls(), 1, "second resolve should be served from cache");
+}
+
+#[tokio::test]
+async fn resolve_caches_denied_negatively() {
+    let store = Arc::new(MockStore::returning(vec![]));
+    let resolver = IdentityResolver::new(
+        config("SELECT actor_id FROM tb_actor WHERE sub = $sub", &[("actor_id", "actor_id")]),
+        store.clone(),
+    );
+
+    assert!(matches!(
+        resolver.resolve("u1", &sub_claims()).await,
+        IdentityResolution::Denied(DenyReason::ZeroRows)
+    ));
+    assert!(matches!(
+        resolver.resolve("u1", &sub_claims()).await,
+        IdentityResolution::Denied(DenyReason::ZeroRows)
+    ));
+
+    assert_eq!(store.calls(), 1, "a denial is negative-cached");
+}
+
+#[tokio::test]
+async fn flush_evicts_subject_so_next_resolve_rehits() {
+    let store = Arc::new(MockStore::returning(vec![row(&[
+        ("actor_id", json!("a-1")),
+        ("actor_role", json!("manager")),
+    ])]));
+    let resolver = IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        store.clone(),
+    );
+
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+    resolver.flush("u1");
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+
+    assert_eq!(store.calls(), 2, "flush forces a re-resolution");
+}
+
+#[tokio::test]
+async fn cache_key_discriminates_by_bound_params() {
+    // Same query, two different `$sub` bindings → two distinct cache keys, so the
+    // store is hit for each (amendment A: no cross-subject sharing).
+    let store = Arc::new(MockStore::returning(vec![row(&[
+        ("actor_id", json!("a-1")),
+        ("actor_role", json!("manager")),
+    ])]));
+    let resolver = IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        store.clone(),
+    );
+
+    let _ = resolver.resolve("u1", &claims(&[("sub", json!("u1"))])).await;
+    let _ = resolver.resolve("u2", &claims(&[("sub", json!("u2"))])).await;
+
+    assert_eq!(store.calls(), 2, "distinct bound tuples do not share a cache entry");
+}
+
+// ── PgIdentityStore against a live Postgres (skip-clean) ──────────────────
+
+/// Connect to the harness-provided Postgres (Dagger-bound in CI; a local spawn
+/// with the `local-testcontainers` feature). `None` when no service is available
+/// so the test skips cleanly.
+async fn connect_pool() -> Option<(sqlx::PgPool, fraiseql_test_support::Service)> {
+    let svc = fraiseql_test_support::postgres().await?;
+    let pool = sqlx::PgPool::connect(svc.url()).await.unwrap();
+    Some((pool, svc))
+}
+
+/// Create a fresh, uniquely-named actor table so parallel runs stay independent.
+async fn make_actor_table(pool: &sqlx::PgPool) -> String {
+    let table = format!("tb_actor_test_{}", uuid::Uuid::new_v4().simple());
+    sqlx::query(&format!("CREATE TABLE {table} (sub text, actor_id text, actor_role text)"))
+        .execute(pool)
+        .await
+        .unwrap();
+    table
+}
+
+fn actor_resolver(pool: &sqlx::PgPool, table: &str) -> IdentityResolver {
+    IdentityResolver::new(
+        config(
+            &format!("SELECT actor_id, actor_role FROM {table} WHERE sub = $sub"),
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        Arc::new(PgIdentityStore::new(pool.clone())),
+    )
+}
+
+#[tokio::test]
+async fn pg_store_resolves_and_renames_known_subject() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP pg_store_resolves_and_renames_known_subject: no postgres");
+        return;
+    };
+    let table = make_actor_table(&pool).await;
+    sqlx::query(&format!(
+        "INSERT INTO {table} (sub, actor_id, actor_role) VALUES ('u1', 'a-1', 'manager')"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resolver = actor_resolver(&pool, &table);
+    match resolver.resolve("u1", &sub_claims()).await {
+        IdentityResolution::Resolved(map) => {
+            assert_eq!(map["actor_id"], "a-1");
+            assert_eq!(map["actor_role"], "manager");
+        },
+        other => panic!("expected Resolved, got {other:?}"),
+    }
+
+    sqlx::query(&format!("DROP TABLE {table}")).execute(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn pg_store_denies_unknown_subject() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP pg_store_denies_unknown_subject: no postgres");
+        return;
+    };
+    let table = make_actor_table(&pool).await;
+
+    let resolver = actor_resolver(&pool, &table);
+    assert!(matches!(
+        resolver.resolve("nobody", &claims(&[("sub", json!("nobody"))])).await,
+        IdentityResolution::Denied(DenyReason::ZeroRows)
+    ));
+
+    sqlx::query(&format!("DROP TABLE {table}")).execute(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn pg_store_denies_ambiguous_subject() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP pg_store_denies_ambiguous_subject: no postgres");
+        return;
+    };
+    let table = make_actor_table(&pool).await;
+    sqlx::query(&format!(
+        "INSERT INTO {table} (sub, actor_id, actor_role) VALUES ('u1', 'a-1', 'manager'), ('u1', 'a-2', 'staff')"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resolver = actor_resolver(&pool, &table);
+    assert!(matches!(
+        resolver.resolve("u1", &sub_claims()).await,
+        IdentityResolution::Denied(DenyReason::Ambiguous)
+    ));
+
+    sqlx::query(&format!("DROP TABLE {table}")).execute(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn pg_store_denies_null_field() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP pg_store_denies_null_field: no postgres");
+        return;
+    };
+    let table = make_actor_table(&pool).await;
+    sqlx::query(&format!(
+        "INSERT INTO {table} (sub, actor_id, actor_role) VALUES ('u1', 'a-1', NULL)"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let resolver = actor_resolver(&pool, &table);
+    match resolver.resolve("u1", &sub_claims()).await {
+        IdentityResolution::Denied(DenyReason::NullField(col)) => assert_eq!(col, "actor_role"),
+        other => panic!("expected Denied(NullField), got {other:?}"),
+    }
+
+    sqlx::query(&format!("DROP TABLE {table}")).execute(&pool).await.unwrap();
+}
+
+#[tokio::test]
+async fn pg_store_binds_hostile_subject_value_safely() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP pg_store_binds_hostile_subject_value_safely: no postgres");
+        return;
+    };
+    let table = make_actor_table(&pool).await;
+    sqlx::query(&format!(
+        "INSERT INTO {table} (sub, actor_id, actor_role) VALUES ('u1', 'a-1', 'manager')"
+    ))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // A classic injection payload as the `sub` value must bind as data (matching
+    // no row) — not drop the table.
+    let hostile = format!("'; DROP TABLE {table}; --");
+    let resolver = actor_resolver(&pool, &table);
+    assert!(matches!(
+        resolver.resolve(&hostile, &claims(&[("sub", json!(hostile))])).await,
+        IdentityResolution::Denied(DenyReason::ZeroRows)
+    ));
+
+    // The table survives, proving the value never reached the SQL text.
+    let (count,): (i64,) = sqlx::query_as(&format!("SELECT count(*) FROM {table}"))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1);
+
+    sqlx::query(&format!("DROP TABLE {table}")).execute(&pool).await.unwrap();
 }

--- a/crates/fraiseql-server/src/lib.rs
+++ b/crates/fraiseql-server/src/lib.rs
@@ -195,6 +195,12 @@ pub use fraiseql_secrets::{encryption, secrets_manager};
 // TLS/SSL and encryption
 pub mod tls;
 
+// Enriched-identity resolution (#539): request-scoped `sub → DB → identity`
+// mapping for RLS read-scoping and verified sender-identity. Requires an
+// authenticated subject and the unscoped enrichment pool, so gated on `auth`.
+#[cfg(feature = "auth")]
+pub mod identity;
+
 // Observer management - optional
 #[cfg(feature = "observers")]
 pub mod observers;

--- a/crates/fraiseql-server/src/routes/graphql/app_state.rs
+++ b/crates/fraiseql-server/src/routes/graphql/app_state.rs
@@ -136,6 +136,13 @@ pub struct AppState<A: DatabaseAdapter> {
     /// (not buffered) when the delivery pipeline is under backpressure, so
     /// mutation response latency is never affected.
     pub realtime_observer: Option<Arc<crate::realtime::observer::RealtimeBroadcastObserver>>,
+
+    /// Enrichment-profile identity resolver (#539). `Some` when
+    /// `[identity.enrichment].enabled` and an auth DB pool is present; every
+    /// authenticated request then resolves its DB identity and fail-closes
+    /// before dispatch (read-scoping via the `fraiseql.enriched.*` namespace).
+    #[cfg(feature = "auth")]
+    pub identity_resolver: Option<Arc<crate::identity::IdentityResolver>>,
 }
 
 impl<A: DatabaseAdapter> AppState<A> {
@@ -191,7 +198,20 @@ impl<A: DatabaseAdapter> AppState<A> {
             usage: Arc::clone(crate::usage::aggregator::global_aggregator()),
             before_mutation_hooks: None,
             realtime_observer: None,
+            #[cfg(feature = "auth")]
+            identity_resolver: None,
         }
+    }
+
+    /// Attach the enrichment-profile identity resolver (#539).
+    #[cfg(feature = "auth")]
+    #[must_use]
+    pub fn with_identity_resolver(
+        mut self,
+        resolver: Arc<crate::identity::IdentityResolver>,
+    ) -> Self {
+        self.identity_resolver = Some(resolver);
+        self
     }
 
     /// Load the current executor.

--- a/crates/fraiseql-server/src/routes/graphql/handler.rs
+++ b/crates/fraiseql-server/src/routes/graphql/handler.rs
@@ -338,6 +338,36 @@ async fn execute_graphql_request<A: DatabaseAdapter + Clone + Send + Sync + 'sta
         security_context = security_context.map(|ctx| ctx.with_trace_context(trace_context));
     }
 
+    // Enriched-identity resolution (#539): when `[identity.enrichment]` is
+    // enabled, resolve the subject's DB identity and merge it under the
+    // forge-proof `fraiseql.enriched.*` namespace *before* dispatch, so RLS /
+    // views / inject-params scope on a DB-derived identity, not a client-asserted
+    // one. Fail-closed at source: an unresolved identity denies the request (403)
+    // before any data query runs; a transient resolver failure is 503. An
+    // unauthenticated request has no subject to resolve and proceeds unchanged.
+    #[cfg(feature = "auth")]
+    if let Some(resolver) = state.identity_resolver.as_ref() {
+        if let Some(ctx) = security_context.as_mut() {
+            match crate::identity::enrich_security_context(resolver, ctx).await {
+                crate::identity::EnrichmentOutcome::Proceed => {},
+                crate::identity::EnrichmentOutcome::Denied => {
+                    // Generic outward body (DESIGN §5.4): the precise DenyReason is
+                    // logged server-side, never surfaced (actor-table oracle guard).
+                    return Err(ErrorResponse::from_error(GraphQLError::new(
+                        "Access denied",
+                        crate::error::ErrorCode::Forbidden,
+                    )));
+                },
+                crate::identity::EnrichmentOutcome::Unavailable => {
+                    return Err(ErrorResponse::from_error(GraphQLError::new(
+                        "Identity resolution temporarily unavailable",
+                        crate::error::ErrorCode::ServiceUnavailable,
+                    )));
+                },
+            }
+        }
+    }
+
     // Resolve query body — trusted documents take priority over APQ.
     // If a trusted document store is configured, resolve the document ID first.
     if let Some(ref td_store) = state.trusted_docs {

--- a/crates/fraiseql-server/src/server/routing/state.rs
+++ b/crates/fraiseql-server/src/server/routing/state.rs
@@ -82,6 +82,45 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             info!("API key authenticator attached to AppState");
         }
 
+        // Enriched-identity resolution (#539). When `[identity.enrichment]` is
+        // enabled, build the resolver on the unscoped auth pool and attach it, so
+        // every authenticated request resolves its DB identity and fail-closes
+        // before dispatch. `enabled = true` alone is the trigger (DESIGN §7).
+        #[cfg(feature = "auth")]
+        if let Some(enrichment) =
+            self.config.identity.as_ref().and_then(|identity| identity.enrichment.as_ref())
+        {
+            if enrichment.enabled {
+                if let Some(pool) = self.enrichment_pool.as_ref() {
+                    state = state.with_identity_resolver(std::sync::Arc::new(
+                        crate::identity::IdentityResolver::postgres(
+                            enrichment.clone(),
+                            pool.clone(),
+                        ),
+                    ));
+                    if crate::identity::schema_declares_enrichment_consumer(self.executor.schema())
+                    {
+                        info!(
+                            "Enriched-identity resolution enabled (#539): every authenticated \
+                             request resolves and fail-closes"
+                        );
+                    } else {
+                        tracing::warn!(
+                            "[identity.enrichment] is enabled but no session variable or inject \
+                             param uses an `enrichment` source — every authenticated request will \
+                             resolve identity, yet nothing reads it (likely a misconfiguration)"
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        "[identity.enrichment] is enabled but no auth database pool is available \
+                         — enrichment cannot run (a non-PostgreSQL backend, or DATABASE_URL is \
+                         unset). Requests will NOT be enriched."
+                    );
+                }
+            }
+        }
+
         // Attach state encryption service if configured
         #[cfg(feature = "auth")]
         match &self.state_encryption {

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -643,6 +643,14 @@ pub struct ServerConfig {
     /// ```
     #[serde(default)]
     pub tenancy: TenancyServerConfig,
+
+    /// Enriched-identity resolution (#539): `[identity.enrichment]` /
+    /// `[identity.sender]`. Top-level (not under `[auth]`) so it applies under
+    /// any auth mode — HS256/OIDC parity by construction. Gated on `auth`
+    /// because enrichment requires an authenticated subject and the auth DB pool.
+    #[cfg(feature = "auth")]
+    #[serde(default)]
+    pub identity: Option<crate::identity::IdentityConfig>,
 }
 
 /// A single `[storage.<name>]` configuration section.
@@ -820,6 +828,8 @@ impl Default for ServerConfig {
             #[cfg(feature = "inbound-email")]
             imap: HashMap::new(), // No poll-IMAP mailboxes by default
             tenancy: TenancyServerConfig::default(), // Multi-tenant runtime off by default
+            #[cfg(feature = "auth")]
+            identity: None, // Enriched-identity resolution off by default
         }
     }
 }

--- a/docs/adr/0016-enriched-identity-resolution.md
+++ b/docs/adr/0016-enriched-identity-resolution.md
@@ -1,0 +1,96 @@
+# ADR-0016: Enriched-identity Resolution
+
+## Status: Accepted
+
+This ADR records the decisions behind **enriched-identity RLS** (#539): resolving
+an application's internal identity from its own database, once per request,
+cached and fail-closed, and feeding it to read-scoping and verified
+sender-identity.
+
+Related: `docs/architecture/enriched-identity-rls.md`, ADR-0014 (federation
+entity backing source), the native-runtime hardening train (send path).
+
+---
+
+## Context
+
+An IdP asserts a stable subject (`sub`). Authorization, however, lives in the
+application's database: `sub → actor_id / actor_role` for reads,
+`sub → verified from-address` for sends. Two ways to bridge that gap:
+
+1. Mint the DB-derived attributes into the JWT as raw claims. This pushes
+   app-owned, DB-sourced authorization out into the IdP, and makes the RLS
+   boundary depend on token minting.
+2. Resolve `sub → identity` in FraiseQL against the app's DB, per request.
+
+Predecessor #242 shipped a claims-enrichment query but only on the OIDC
+`/auth/me` response — it never touched the security context, never ran under
+HS256, and used a fail-**open** `LIMIT 1` lookup. It was stranded on `main` and
+never forward-ported.
+
+---
+
+## Decision
+
+Resolve `sub → DB → identity` with **one primitive**, one cache policy, one
+failure model, wired to two consumers.
+
+1. **Fail-closed at source.** Anything other than exactly one row with every
+   mapped field present and non-null is a denial; a denial fails the operation
+   (403 for the sync read path, refuse/DLQ for the durable send path). Never a
+   silent skip, never an empty-string GUC, the mapped set all-or-nothing. A
+   transient DB error fails the request (503) rather than falling through to an
+   unscoped query. `> 1 row` is a hard fail (refining #242's silent `LIMIT 1`).
+
+2. **A reserved, forge-proof namespace.** Resolved fields merge under
+   `fraiseql.enriched.<field>`. The request extractor strips incoming `fraiseql.`
+   claims, so the namespace can only be written by the resolver.
+   `SessionVariableSource::Enrichment` / `InjectedParamSource::Enrichment` read
+   **only** that namespace, with no fallback — so a raw claim of the same name
+   can never impersonate a DB-derived field.
+
+3. **Trigger = `enabled = true` alone.** Every authenticated request fail-closes
+   when enrichment is enabled, independent of whether the operation reads an
+   enriched field — a declaration-conditional check would reintroduce the exact
+   silent-skip this design fights. Enabled-with-no-consumer is a loud startup
+   warning; zero-cost belongs to disabled/absent only.
+
+4. **Cache key = the bound-`$param` tuple**, not bare `sub`. `sub` is unique only
+   per issuer, and FraiseQL speaks multi-IdP; keying on the bound parameters makes
+   cache correctness track the `WHERE` clause exactly (a multi-issuer app binds
+   `$iss`). Positive TTL bounded (default 60s) so a revocation propagates within
+   that window or immediately via `flush(sub)`; short negative TTL; `Unavailable`
+   never cached.
+
+5. **Top-level `[identity]` config**, not nested under `[auth]`, so it applies
+   under any auth mode — HS256/OIDC parity by construction (this is *why* #242
+   never ran under HS256).
+
+6. **Uniform, no bypass** — including service-account / API-key subjects: they
+   need actor rows. An "except for these principals" carve-out is the silent hole
+   the design closes.
+
+7. **One primitive, two consumers.** The read path merges into the security
+   context; the send path resolves `sub → verified from-address` through an
+   object-safe `SenderIdentityResolver` seam. The whole DB-executing resolver
+   lives in `fraiseql-server` (sqlx is dev-only in `fraiseql-functions`); core
+   gets only the config variants and the namespaced read; the send seam is an
+   object-safe trait (a boxed future, no new dyn-dispatch trait-macro).
+
+---
+
+## Consequences
+
+- The RLS boundary no longer depends on token minting; identity is the app's DB
+  row. An unknown subject is denied *before* any data query — strictly stronger
+  than relying on every view author to deny on `NULL`.
+- Request availability is coupled to enrichment-DB availability for enabled
+  apps — acceptable, because it is the same DB the request's data query hits.
+- Actors must be provisioned out-of-band (see the architecture doc); a
+  first-authenticated-request provisioning flow would deadlock.
+- A role change / revocation is visible within `cache_ttl_secs` (default 60s) or
+  immediately via `flush(sub)`.
+- Denials are debuggable server-side (WARN with reason + subject) while the
+  outward body stays generic (no actor-table existence oracle).
+- The `send_email` host op and SMTP transport that consume the sender seam are
+  the native-runtime hardening train's; #539 lands the resolver and the seam.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,6 +17,7 @@ This directory contains the authoritative architecture documentation for FraiseQ
 | Understand analytics fact table design and caching | [../modules/fact-table.md](../modules/fact-table.md) |
 | Understand the streaming wire protocol engine | [wire-protocol.md](wire-protocol.md) |
 | Understand inbound webhooks vs. outbound observers | [webhooks.md](webhooks.md) |
+| Resolve identity from your own DB for RLS (not token claims) | [enriched-identity-rls.md](enriched-identity-rls.md) |
 | Understand operational concerns (schema lifecycle, idempotency) | [../operations/](../operations/) |
 | See which features each database supports | [../database-compatibility.md](../database-compatibility.md) |
 

--- a/docs/architecture/enriched-identity-rls.md
+++ b/docs/architecture/enriched-identity-rls.md
@@ -1,0 +1,164 @@
+# Enriched-identity RLS
+
+**Status:** Shipped (#539). One request-scoped `sub → DB → identity` resolver,
+feeding read-scoping (RLS / views / injected params) and verified
+sender-identity from the application's **own** database rather than from
+client-asserted token claims.
+
+---
+
+## What it is
+
+An IdP asserts a stable subject (`sub`). The application maps that subject to an
+internal identity in its own database — for reads, `sub → actor_id / actor_role`;
+for sends, `sub → verified from-address + mailbox`. FraiseQL resolves that mapping
+**once per request, cached, and fail-closed**, and feeds it to the two places
+that consume DB-derived identity:
+
+- the **session-variable / `inject_params`** path, so RLS and view predicates
+  scope on it; and
+- the outbound **`send_email`** path, so `From` is server-verified.
+
+There is **one resolver primitive**, with one cache policy and one failure model,
+wired to two call sites.
+
+The load-bearing property is *fail-closed at source*: anything other than exactly
+one row with every mapped field present and non-null is a denial, and a denial
+fails the operation — never a silent skip, never an empty-string GUC, the mapped
+set applied whole or not at all.
+
+---
+
+## Configuration
+
+Top-level `[identity]`, so it applies under **any** auth mode — HS256 and OIDC
+parity by construction. One query schema, reused by both profiles.
+
+```toml
+[identity.enrichment]              # read scoping
+enabled           = true
+query             = "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub"
+map               = { actor_id = "actor_id", actor_role = "actor_role" }  # column -> field
+cache_ttl_secs    = 60             # a role change propagates within this window (see below)
+negative_ttl_secs = 5
+
+[identity.sender]                  # verified sender-identity (send path)
+enabled = true
+query   = "SELECT email_address AS sending_address FROM tb_sales_mailbox m \
+           JOIN tb_actor a ON a.mailbox_id = m.id WHERE a.sub = $sub AND m.verified"
+map     = { sending_address = "sending_address" }
+```
+
+- `$name` tokens are bound from the request's claims (and the well-known
+  identity fields `sub` / `tenant_id` / `org_id` / `email` / `name` / `iss`);
+  values are bound out-of-band, **never** interpolated into the SQL.
+- Unknown keys are rejected (`deny_unknown_fields`) — a mistyped or stranded key
+  fails loud at startup rather than being silently ignored.
+- **Trigger = `enabled = true` alone.** When enrichment is enabled, *every*
+  authenticated request resolves and fail-closes, whether or not the current
+  operation reads an enriched field. An enabled profile whose schema declares no
+  `enrichment` consumer emits a loud startup warning; the zero-cost path belongs
+  to `enabled = false` / absent config only.
+- The resolver runs on a **separate, unscoped** connection pool (the app role, no
+  per-request GUCs), so identity is resolved *before* the identity that scopes
+  the main query is applied — no chicken-and-egg.
+
+---
+
+## The `fraiseql.enriched.*` namespace
+
+Resolved fields are merged into the security context under the reserved
+`fraiseql.enriched.<field>` prefix. This is forge-proof **by construction**: the
+request extractor strips any incoming JWT claim whose key begins with
+`fraiseql.`, so a token cannot carry `fraiseql.enriched.actor_role`.
+
+Two source kinds read **only** that namespace, with **no** fallback to a raw
+claim or a well-known field:
+
+- `SessionVariableSource::Enrichment { field }`
+- `InjectedParamSource::Enrichment(field)`
+
+That no-fallback rule is the security property: it prevents a raw JWT claim of the
+same name from impersonating a DB-derived identity field if enrichment does not
+run. `Jwt` / `Header` / `Literal` keep their existing lenient semantics — no
+behaviour change for anyone not opting in.
+
+---
+
+## The failure model
+
+One shared result — `Resolved` / `Denied` / `Unavailable` — produced by the
+resolver and interpreted by each call site:
+
+| Lookup outcome | Classification | Read path (sync) | Send path (durable) |
+|---|---|---|---|
+| Exactly one row, **all** mapped fields present & non-null | `Resolved` | merge → proceed | bind `from` → send |
+| **Zero rows** (unknown / unprovisioned subject) | `Denied` | **403, before dispatch** | refuse; permanent |
+| **> 1 row** (ambiguous identity) | `Denied` | **403** | refuse; permanent |
+| A declared mapped field is **NULL / absent** | `Denied` | **403** | refuse; permanent |
+| A referenced `$param` missing from the token | `Denied` | **403** | refuse; permanent |
+| DB down / query error / pool exhausted | `Unavailable` | **503** | retry (transient) |
+
+- **No row ⇒ fail**, never silent-skip: the unknown subject is denied *before*
+  any data query runs, not scoped to an empty set. Strictly stronger than relying
+  on every view author to deny on `NULL`.
+- **`> 1 row` fails** — for identity, ambiguity is a misconfiguration; we fetch up
+  to two rows and deny on the second rather than silently `LIMIT 1`.
+- **Never an empty-string GUC** — a NULL/absent mapped field is a denial, so no
+  predicate ever sees `''` where it expected an actor.
+- **Fail-closed on transient error too** — a DB hiccup fails the request rather
+  than falling through to an unscoped query. (Sends, being durable, retry.)
+- **Uniform, no bypass** — this applies to service-account / API-key subjects too:
+  a service account needs an actor row. An "except for these principals" carve-out
+  is exactly the silent hole this design closes.
+
+### Denial observability
+
+A denial fires before dispatch, so no query reaches the DB log. The server logs
+every `Denied` at WARN with the reason (`zero-rows` / `ambiguous` / `null-field
+<name>` / `missing-param <name>`) and the subject, and every `Unavailable` with
+the underlying error — "why is this user 403" is one grep. The **outward response
+body stays generic** ("Access denied"): a client-distinguishable reason would be
+an existence oracle over the actor table.
+
+---
+
+## Cache and revocation
+
+- **Key = the ordered bound-`$param` tuple** the query actually references, not
+  bare `sub`. `sub` is unique only *per issuer*, and FraiseQL speaks multi-IdP; a
+  multi-issuer app must bind an issuer discriminator (`$iss`). Keying on the bound
+  parameters makes cache correctness exactly track the `WHERE` clause.
+- **Positive TTL** `cache_ttl_secs` (default **60s**), **negative TTL**
+  `negative_ttl_secs` (default **5s**, so a freshly provisioned actor goes live
+  quickly). `Unavailable` is **never** cached.
+- **Invariant:** *a revocation or role change propagates within `cache_ttl_secs`,
+  or immediately via `flush(sub)`.* Raising `cache_ttl_secs` widens that window —
+  do it with open eyes.
+
+---
+
+## Operational notes
+
+- **Provision actors out-of-band.** Under `enabled = true`, every authenticated
+  request fail-closes, so an app that creates a user's actor row *from* that
+  user's first authenticated request would deadlock. Provision via an admin path,
+  an IdP webhook, or another unauthenticated path.
+- **Verified sender-identity** resolves on the same primitive: `sub → verified
+  from-address + mailbox`, cached and fail-closed. The default `LoginEmailSender`
+  (sending address == login email) is the degenerate case; a DB-backed resolver
+  replaces it where the sending mailbox differs. The `send_email` host op and SMTP
+  transport that consume the seam land with the native-runtime hardening train.
+
+---
+
+## Where it lives
+
+| Concern | Location |
+|---|---|
+| Resolver, cache, failure model, Postgres store, both consumers | `crates/fraiseql-server/src/identity/` |
+| Config variants + namespaced read (no DB) | `fraiseql-core` (`SessionVariableSource::Enrichment`, `InjectedParamSource::Enrichment`, `security::ENRICHED_NAMESPACE_PREFIX`) |
+| Sender seam (object-safe trait + login-email default) | `fraiseql-functions` (`SenderIdentityResolver`, `LoginEmailSender`) |
+
+See [ADR-0016](../adr/0016-enriched-identity-resolution.md) for the decision
+record.


### PR DESCRIPTION
Closes #539. Supersedes #242 (stranded on `main`, never forward-ported).

One request-scoped `sub → DB → identity` resolver, **fail-closed at source**,
feeding both read-scoping (RLS / views / injected params) and verified
sender-identity — so identity is resolved from the application's **own**
database rather than trusted from client-asserted token claims.

## Phases (each RED→GREEN, gated per push)

| Phase | Commit | What |
|---|---|---|
| P00 | `914beed8` | #242 core ported verbatim — safe `$param` binding + TTL cache + 14 adversarial tests |
| P01 | `e69319f3` | `IdentityResolver` + fail-closed `IdentityResolution` model (0 / >1 / NULL / missing-param → Denied; transient → Unavailable), bound-`$param`-tuple cache key, negative TTL, WARN logging — validated vs real PG |
| P02 | `e7413e66` | Read scoping wired into `/graphql`: core `Enrichment` sources (no-fallback `fraiseql.enriched.*`), `resolve_session_variables → Result`, `[identity]` config, handler step → **403 / 503 with a generic body** |
| P03 | `bd32f8d8` | Object-safe `SenderIdentityResolver` seam + `LoginEmailSender` default + DB-backed sender on the shared primitive |
| P04 | `f4e42e51` | End-to-end acceptance test vs real PG (§9) + promoted docs / ADR-0016 / CHANGELOG + `dead_code` finalize |

## Design highlights

- **Fail-closed:** zero rows / >1 row / NULL mapped field / missing `$param` ⇒ denied (403) **before** any data query runs — never a silent skip, never an empty-string GUC, the mapped set all-or-nothing. Transient DB error ⇒ 503, never an unscoped read.
- **Forge-proof namespace:** resolved fields merge under the reserved `fraiseql.enriched.*` (the extractor strips incoming `fraiseql.` claims); `SessionVariableSource::Enrichment` / `InjectedParamSource::Enrichment` read it with **no** fallback to a raw claim.
- **Top-level `[identity]` config** ⇒ HS256 / OIDC parity by construction (why #242 never ran under HS256). `deny_unknown_fields` fails a typo loud.
- **Cache key = the bound-`$param` tuple** (multi-issuer apps bind `$iss`); bounded positive TTL (default 60s) so a revocation propagates within that window.
- **Denials debuggable server-side** (WARN: reason + subject) while the outward body stays generic — no actor-table existence oracle.
- One primitive, two consumers; the DB-executing resolver lives in `fraiseql-server`, core gets only config variants + the namespaced read, the send seam is an object-safe trait (boxed future, no new dyn-dispatch trait-macro).

## Verification

- Full §9 acceptance validated against a real Postgres: `manager` sees all rows, `staff` sees only its own, an unknown subject is **denied (fail-closed)**, not shown an empty set.
- 43 identity tests (incl. every live-DB one), core 2611 / server ~1200 / functions 167 lib tests, no regressions from the `resolve_session_variables → Result` ripple.
- `make preflight` (fmt, rustdoc `-D`, clippy `--all-targets --all-features -D`) + both CI legs green.

See `docs/architecture/enriched-identity-rls.md` and ADR-0016.

## Follow-ups (out of #539 scope, documented in the P04 commit)

- Admin `flush(sub)` HTTP endpoint on the RBAC surface — the resolver method is ready and tested; only the route remains.
- The `send_email` host op + SMTP transport that consume the sender seam — the native-runtime hardening train.
- The partner's own live §9 acceptance run under both `[auth_hs256]` and `[auth]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)