### PR TITLE
feat: admin identity-cache flush endpoint (#539 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unscoped read. The precise denial reason is logged server-side (WARN) while the
   outward body stays generic (no actor-table existence oracle). The cache keys on
   the bound-`$param` tuple (multi-issuer apps bind `$iss`) with a bounded positive
-  TTL (default 60s) so a revocation propagates within that window. Verified
+  TTL (default 60s) so a revocation propagates within that window — or immediately
+  via the admin `POST /api/identity/flush[-all]` (behind the admin bearer token).
+  Verified
   sender-identity resolves on the same primitive through an object-safe
   `SenderIdentityResolver` seam (`LoginEmailSender` is the degenerate default);
   the `send_email` op that consumes it lands with the native-runtime hardening

--- a/crates/fraiseql-server/src/identity/admin.rs
+++ b/crates/fraiseql-server/src/identity/admin.rs
@@ -1,0 +1,44 @@
+//! Admin surface for the identity cache — `flush(sub)` / `flush_all`.
+//!
+//! Lets an operator propagate a revocation or a fresh provision **immediately**
+//! rather than waiting out `cache_ttl_secs` (DESIGN §6, §6.1). Mounted under the
+//! admin bearer token alongside the RBAC-management API, and only when an
+//! enrichment resolver exists (`[identity.enrichment]` enabled).
+
+use std::sync::Arc;
+
+use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::post};
+use serde::Deserialize;
+
+use super::resolver::IdentityResolver;
+
+/// Body of `POST /api/identity/flush`.
+#[derive(Debug, Deserialize)]
+struct FlushRequest {
+    /// The subject whose cached identity — across every bound-parameter tuple —
+    /// is evicted.
+    sub: String,
+}
+
+/// Build the identity-cache admin router over a resolver instance.
+pub fn identity_admin_router(resolver: Arc<IdentityResolver>) -> Router {
+    Router::new()
+        .route("/api/identity/flush", post(flush_subject))
+        .route("/api/identity/flush-all", post(flush_all))
+        .with_state(resolver)
+}
+
+/// Evict every cache entry for one subject — propagates a revoke/provision now.
+async fn flush_subject(
+    State(resolver): State<Arc<IdentityResolver>>,
+    Json(request): Json<FlushRequest>,
+) -> impl IntoResponse {
+    resolver.flush(&request.sub);
+    (StatusCode::OK, Json(serde_json::json!({ "flushed": request.sub })))
+}
+
+/// Evict the entire identity cache.
+async fn flush_all(State(resolver): State<Arc<IdentityResolver>>) -> impl IntoResponse {
+    resolver.flush_all();
+    (StatusCode::OK, Json(serde_json::json!({ "flushed_all": true })))
+}

--- a/crates/fraiseql-server/src/identity/cache.rs
+++ b/crates/fraiseql-server/src/identity/cache.rs
@@ -36,9 +36,6 @@ pub(super) enum CachedOutcome {
 /// absolute expiry instant.
 struct CacheEntry {
     outcome:    CachedOutcome,
-    // Reason: read only by `flush(sub)`, whose admin/after-mutation caller is the
-    // immediate follow-up (see the flush methods below).
-    #[allow(dead_code)]
     sub:        String,
     expires_at: Instant,
 }
@@ -84,15 +81,11 @@ impl IdentityCache {
 
     /// Evict every entry belonging to `sub` (DESIGN §6). Rare/admin — the sweep
     /// is fine. Propagates a grant or revoke for a subject instantly.
-    // Reason: exposed via `IdentityResolver::flush`; its admin endpoint /
-    // after-mutation hook caller is the immediate follow-up.
-    #[allow(dead_code)]
     pub(super) fn flush(&self, sub: &str) {
         self.entries.retain(|_key, entry| entry.sub != sub);
     }
 
     /// Evict all entries.
-    #[allow(dead_code)] // Reason: exposed via `IdentityResolver::flush_all` (same follow-up).
     pub(super) fn flush_all(&self) {
         self.entries.clear();
     }

--- a/crates/fraiseql-server/src/identity/mod.rs
+++ b/crates/fraiseql-server/src/identity/mod.rs
@@ -17,14 +17,15 @@
 //!   with server-side denial logging.
 //!
 //! The read-path consumer (`apply::enrich_security_context`) is wired into the
-//! `/graphql` handler; the cache flush surface and the DB-backed sender are the
-//! two seams whose consumers land next (an admin flush endpoint, and the
-//! hardening-train `send_email` op respectively) — each carries a scoped
+//! `/graphql` handler, and the cache flush surface (`admin::identity_admin_router`)
+//! into the admin API. The DB-backed sender is the one seam whose consumer lands
+//! elsewhere (the hardening-train `send_email` op), so it carries a scoped
 //! `dead_code` allow at its definition rather than a blanket module allow.
 //!
 //! Enrichment requires an authenticated subject, so the whole module is gated on
 //! the `auth` feature (mirroring the `enrichment_pool` the resolver uses).
 
+pub(crate) mod admin;
 pub(crate) mod apply;
 pub(crate) mod cache;
 pub(crate) mod failure;
@@ -32,6 +33,7 @@ pub(crate) mod query;
 pub(crate) mod resolver;
 pub(crate) mod sender;
 
+pub(crate) use admin::identity_admin_router;
 pub(crate) use apply::{EnrichmentOutcome, enrich_security_context};
 use fraiseql_core::schema::{CompiledSchema, InjectedParamSource, SessionVariableSource};
 pub(crate) use resolver::{IdentityConfig, IdentityResolver};

--- a/crates/fraiseql-server/src/identity/resolver.rs
+++ b/crates/fraiseql-server/src/identity/resolver.rs
@@ -254,16 +254,14 @@ impl IdentityResolver {
         self.finalize(sub, resolution)
     }
 
-    /// Evict every cache entry for `sub` — the admin flush surface and (later) the
-    /// provision/deprovision mutation hook. That endpoint is the immediate
-    /// follow-up; the method is ready and tested (`flush_evicts_subject_...`).
-    #[allow(dead_code)]
+    /// Evict every cache entry for `sub` — the admin flush surface
+    /// (`admin::identity_admin_router`) and (later) the provision/deprovision
+    /// mutation hook. Propagates a revoke or a fresh provision immediately.
     pub(super) fn flush(&self, sub: &str) {
         self.cache.flush(sub);
     }
 
     /// Evict the entire cache.
-    #[allow(dead_code)] // Reason: admin flush surface — immediate follow-up.
     pub(super) fn flush_all(&self) {
         self.cache.flush_all();
     }

--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -19,14 +19,20 @@ use std::{
     time::Duration,
 };
 
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
 use chrono::Utc;
 use fraiseql_core::{
     security::{ENRICHED_NAMESPACE_PREFIX, SecurityContext},
     types::UserId,
 };
 use serde_json::{Value, json};
+use tower::ServiceExt;
 
 use super::{
+    admin::identity_admin_router,
     apply::{EnrichmentOutcome, enrich_security_context},
     cache::{CachedOutcome, IdentityCache},
     failure::{DenyReason, IdentityResolution, ResolveError},
@@ -1012,4 +1018,85 @@ async fn acceptance_two_role_read_boundary() {
     sqlx::query(&format!("DROP VIEW {view}")).execute(&pool).await.unwrap();
     sqlx::query(&format!("DROP TABLE {item}")).execute(&pool).await.unwrap();
     sqlx::query(&format!("DROP TABLE {actor}")).execute(&pool).await.unwrap();
+}
+
+// ── Admin flush endpoint (the immediate #539 follow-up) ────────────────────
+
+fn actor_resolver_arc() -> std::sync::Arc<IdentityResolver> {
+    std::sync::Arc::new(IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        Arc::new(MockStore::returning(vec![actor_row()])),
+    ))
+}
+
+#[tokio::test]
+async fn identity_admin_router_constructs() {
+    // axum validates path-capture syntax inside `Router::route`, so a bad literal
+    // would panic here at build time (issue #316 prevention).
+    let _ = identity_admin_router(actor_resolver_arc());
+}
+
+#[tokio::test]
+async fn flush_endpoint_evicts_the_subject() {
+    let store = Arc::new(MockStore::returning(vec![actor_row()]));
+    let resolver = Arc::new(IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        store.clone(),
+    ));
+
+    // Warm the cache, then flush the subject through the HTTP handler.
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+    assert_eq!(store.calls(), 1);
+
+    let response = identity_admin_router(resolver.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/identity/flush")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"sub":"u1"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The next resolve re-hits the store — the entry was evicted.
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+    assert_eq!(store.calls(), 2, "flush must evict the subject's cache entry");
+}
+
+#[tokio::test]
+async fn flush_all_endpoint_clears_the_cache() {
+    let store = Arc::new(MockStore::returning(vec![actor_row()]));
+    let resolver = Arc::new(IdentityResolver::new(
+        config(
+            "SELECT actor_id, actor_role FROM tb_actor WHERE sub = $sub",
+            &[("actor_id", "actor_id"), ("actor_role", "actor_role")],
+        ),
+        store.clone(),
+    ));
+
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+
+    let response = identity_admin_router(resolver.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/identity/flush-all")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _ = resolver.resolve("u1", &sub_claims()).await;
+    assert_eq!(store.calls(), 2, "flush-all must clear the cache");
 }

--- a/crates/fraiseql-server/src/server/routing/extensions.rs
+++ b/crates/fraiseql-server/src/server/routing/extensions.rs
@@ -30,6 +30,26 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             app = self.mount_rbac(app, db_pool);
         }
 
+        // Identity-cache admin API (flush) — same admin bearer gate as RBAC,
+        // mounted only when an enrichment resolver exists (#539). Lets an operator
+        // propagate a revoke/provision immediately instead of waiting out the TTL.
+        #[cfg(feature = "auth")]
+        if let (Some(resolver), Some(token)) =
+            (state.identity_resolver.as_ref(), self.config.admin_token.as_ref())
+        {
+            let auth_state = BearerAuthState::with_max_failures(
+                token.clone(),
+                self.config.admin_auth_max_failures,
+            );
+            let identity_router = crate::identity::identity_admin_router(resolver.clone())
+                .route_layer(middleware::from_fn_with_state(auth_state, bearer_auth_middleware));
+            app = app.merge(identity_router);
+            info!(
+                "Identity-cache admin API enabled (POST /api/identity/flush[-all]; admin bearer \
+                 token required)"
+            );
+        }
+
         // Observer routes (if enabled and compiled with feature)
         #[cfg(feature = "observers")]
         {

--- a/docs/architecture/enriched-identity-rls.md
+++ b/docs/architecture/enriched-identity-rls.md
@@ -135,6 +135,9 @@ an existence oracle over the actor table.
 - **Invariant:** *a revocation or role change propagates within `cache_ttl_secs`,
   or immediately via `flush(sub)`.* Raising `cache_ttl_secs` widens that window —
   do it with open eyes.
+- **Manual flush** is exposed on the admin API, behind the admin bearer token,
+  when enrichment is enabled: `POST /api/identity/flush` with `{"sub": "..."}`
+  evicts one subject; `POST /api/identity/flush-all` clears the cache.
 
 ---
 


### PR DESCRIPTION
Follow-up to #539 (merged in #546). Completes the enriched-identity admin
surface — the partner's "flush from day one" ask, the one item the #539 P04
finalize deferred.

Lets an operator propagate a revoke or a fresh provision **immediately** instead
of waiting out `cache_ttl_secs` (default 60s), per DESIGN §6.1.

## Changes

- `identity::admin::identity_admin_router` — `POST /api/identity/flush`
  (`{"sub": "..."}`) evicts one subject across every bound-parameter tuple;
  `POST /api/identity/flush-all` clears the cache.
- Mounted in `mount_extensions` under the **same admin bearer token** as the
  RBAC-management API, and only when an enrichment resolver exists
  (`[identity.enrichment]` enabled).
- `IdentityResolver::flush` / `flush_all` (and the cache's) are now consumed, so
  their scoped `dead_code` allows are removed — only the DB-backed sender (whose
  consumer is the native-runtime hardening train) still carries one.

## Verification

- `identity_admin_router_constructs` extends the axum route-syntax construction
  gate (issue #316 prevention); `flush_endpoint_evicts_the_subject` /
  `flush_all_endpoint_clears_the_cache` drive the handler via `oneshot` and assert
  the store is re-hit after eviction.
- `make preflight` (fmt, rustdoc `-D`, clippy `--all-targets --all-features -D`,
  `lint-routes`); `cargo nextest -p fraiseql-server --lib` — 1197 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)