### PR TITLE
feat: send_email host op + native functions in the binary (#539 hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `send_email` op that consumes it lands with the native-runtime hardening
   train. Supersedes #242. See `docs/architecture/enriched-identity-rls.md` and
   ADR-0016.
+- **`send_email` host op with a host-owned `from` (native-runtime hardening).**
+  Functions can now send email through a first-class `send_email` host op (WASM +
+  Deno): the guest supplies only `to`/`subject`/body, and the host injects the
+  `from` from the resolved sender identity (the #539 seam — `LoginEmailSender` by
+  default, a DB-backed resolver where the sending mailbox differs). A guest cannot
+  send from another address (a `from` in the request is dropped at the type level).
+  The transport is **per-connected-account SMTP** (`[mailbox.<name>.smtp]`,
+  STARTTLS, secrets read server-side by mailbox, the account selected by the
+  verified sending address — never a shared mailbox), with a **send-warming daily
+  cap** that ramps 10/day → 200/day → unlimited. Failures classify onto durable
+  dispatch: a permanent refusal (denied identity, bad recipient, SMTP 5xx,
+  over-cap) is a 4xx → dead-letter; a transient one (SMTP timeout/greylist,
+  identity store momentarily down) is a 5xx → retry. Attach it via
+  `BeforeMutationHooks::with_email`. **Note:** the stock server binary does not yet
+  populate `before_mutation_hooks`, so after:mutation functions (this op included)
+  run only where the functions-runtime hooks are built — a separate pre-existing
+  gap. The DB-backed `SendCounter` (over the app's mailbox table) is the remaining
+  warming piece. See `docs/architecture/native-runtime-ergonomics.md`.
 - **Beta workload migrated to the native runtime.** The adjacent Python/FastAPI
   sidecar's compute is now native TypeScript,
   proving the host surface against a real workload. Four `examples/native-functions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Inbound email config renamed: `[imap.<name>]` → `[mailbox.<name>.imap]` (breaking).**
+  A connected mail account now has one section, `[mailbox.<name>]`, carrying both its
+  poll-IMAP *receive* half (`[mailbox.<name>.imap]`) and its SMTP *send* half
+  (`[mailbox.<name>.smtp]`, consumed by the new `send_email` host op). Either half is
+  optional. **Migration:** move each `[imap.foo]` section to `[mailbox.foo.imap]` and each
+  `[[imap.foo.routing]]` to `[[mailbox.foo.imap.routing]]`. Only affects the opt-in
+  `inbound-email` feature. See `docs/architecture/inbound-email.md`.
+
 - **The distributed saga subsystem is now stable (#429).** The `unstable-saga`
   Cargo feature has been renamed to **`saga`** and its API is now covered by semver
   (it will not change without a major version bump). It remains an opt-in feature so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cap** that ramps 10/day → 200/day → unlimited. Failures classify onto durable
   dispatch: a permanent refusal (denied identity, bad recipient, SMTP 5xx,
   over-cap) is a 4xx → dead-letter; a transient one (SMTP timeout/greylist,
-  identity store momentarily down) is a 5xx → retry. Attach it via
-  `BeforeMutationHooks::with_email`. **Note:** the stock server binary does not yet
-  populate `before_mutation_hooks`, so after:mutation functions (this op included)
-  run only where the functions-runtime hooks are built — a separate pre-existing
-  gap. The DB-backed `SendCounter` (over the app's mailbox table) is the remaining
-  warming piece. See `docs/architecture/native-runtime-ergonomics.md`.
+  identity store momentarily down) is a 5xx → retry. The DB-backed `SendCounter`
+  (over the app's mailbox table) is the remaining warming piece. See
+  `docs/architecture/native-runtime-ergonomics.md`.
+- **After:mutation functions now run in the stock server binary.** The server loads
+  each declared function's module from the compiled schema's `module_dir`
+  (`<module_dir>/<name>.<ext>` — `.wasm` for WASM, `.js`/`.ts` for Deno), registers
+  the compiled-in runtimes, and mounts the before-mutation dispatch hooks at serve
+  time, so `after:mutation` functions (and the `send_email` op) fire on the
+  I/O-capable live host. Previously the runtime + dispatch machinery existed and was
+  unit-tested but was never wired into the binary. A declared function whose module
+  file is missing or unreadable, or whose runtime is not compiled in, **fails server
+  startup** (a declared function that can never run is a misconfiguration, surfaced
+  loudly rather than silently never firing).
 - **Permanent-error tagging for durable functions.** A function can now signal that
   a failure is permanent so durable dispatch dead-letters it on the first attempt
   instead of exhausting retries: a guest throws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   run only where the functions-runtime hooks are built — a separate pre-existing
   gap. The DB-backed `SendCounter` (over the app's mailbox table) is the remaining
   warming piece. See `docs/architecture/native-runtime-ergonomics.md`.
+- **Permanent-error tagging for durable functions.** A function can now signal that
+  a failure is permanent so durable dispatch dead-letters it on the first attempt
+  instead of exhausting retries: a guest throws
+  `Object.assign(new Error(msg), { fraiseqlPermanent: true })` (or a message carrying
+  the `[fraiseql:permanent]` marker), which the runtime maps to a 4xx `FraiseQLError`.
+  Host ops auto-tag — any op returning a 4xx (client) error is permanent by default,
+  so e.g. a `send_email` refusal (denied identity, rejected recipient, over-cap)
+  dead-letters immediately while a transient one still retries. Untagged errors are
+  unchanged (transient). Works on both the Deno and WASM runtimes.
 - **Beta workload migrated to the native runtime.** The adjacent Python/FastAPI
   sidecar's compute is now native TypeScript,
   proving the host surface against a real workload. Four `examples/native-functions`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,7 @@ dependencies = [
  "http-body-util",
  "ipnet",
  "jsonwebtoken",
+ "lettre",
  "metrics",
  "metrics-exporter-prometheus",
  "opentelemetry",

--- a/crates/fraiseql-functions/src/host/dyn_context.rs
+++ b/crates/fraiseql-functions/src/host/dyn_context.rs
@@ -59,6 +59,12 @@ pub trait DynHostContext: Send + Sync {
         content_type: &str,
     ) -> BoxFuture<'_, Result<()>>;
 
+    /// Send an email (host-owned `from`).
+    fn send_email<'a>(
+        &'a self,
+        request: &'a crate::outbound::SendEmailRequest,
+    ) -> BoxFuture<'a, Result<crate::outbound::SendEmailResponse>>;
+
     /// Get the current auth context.
     ///
     /// # Errors
@@ -138,6 +144,14 @@ impl<T: crate::HostContext + Send + Sync> DynHostContext for T {
         Box::pin(async move {
             crate::HostContext::storage_put(self, &bucket, &key, &body, &content_type).await
         })
+    }
+
+    fn send_email<'a>(
+        &'a self,
+        request: &'a crate::outbound::SendEmailRequest,
+    ) -> BoxFuture<'a, Result<crate::outbound::SendEmailResponse>> {
+        let request = request.clone();
+        Box::pin(async move { crate::HostContext::send_email(self, &request).await })
     }
 
     fn auth_context(&self) -> Result<serde_json::Value> {

--- a/crates/fraiseql-functions/src/host/live/mod.rs
+++ b/crates/fraiseql-functions/src/host/live/mod.rs
@@ -97,6 +97,14 @@ pub struct LiveHostContext {
 
     /// Security context for the authenticated user.
     pub security_context: SecurityContext,
+
+    /// Sender-identity resolver for `send_email` — resolves the host-owned `from`
+    /// from the authenticated context. `None` → `send_email` is unconfigured and
+    /// fails loud (mirrors the `sql_query` fail-loud-until-wired stance).
+    sender_resolver: Option<Arc<dyn crate::outbound::SenderIdentityResolver>>,
+
+    /// Email transport for `send_email`. `None` → `send_email` fails loud.
+    email_transport: Option<Arc<dyn crate::outbound::EmailTransport>>,
 }
 
 impl LiveHostContext {
@@ -111,6 +119,8 @@ impl LiveHostContext {
             http_client: None,
             storage_backend: None,
             security_context: Self::default_security_context(),
+            sender_resolver: None,
+            email_transport: None,
         }
     }
 
@@ -128,6 +138,8 @@ impl LiveHostContext {
             http_client: None,
             storage_backend: None,
             security_context: Self::default_security_context(),
+            sender_resolver: None,
+            email_transport: None,
         }
     }
 
@@ -146,6 +158,8 @@ impl LiveHostContext {
             http_client: Some(http_client),
             storage_backend: None,
             security_context: Self::default_security_context(),
+            sender_resolver: None,
+            email_transport: None,
         }
     }
 
@@ -180,6 +194,24 @@ impl LiveHostContext {
     #[must_use]
     pub fn captured_logs(&self) -> Vec<LogEntry> {
         self.logs.lock().expect("log mutex poisoned").clone()
+    }
+
+    /// Attach a sender-identity resolver and email transport, enabling
+    /// [`send_email`](HostContext::send_email).
+    ///
+    /// The resolver produces the host-owned `from` from the authenticated context
+    /// (the #539 seam — `LoginEmailSender` by default, a DB-backed resolver where
+    /// the sending mailbox differs from the login email); the transport relays the
+    /// message. Without both, `send_email` fails loud.
+    #[must_use]
+    pub fn with_email(
+        mut self,
+        sender_resolver: Arc<dyn crate::outbound::SenderIdentityResolver>,
+        email_transport: Arc<dyn crate::outbound::EmailTransport>,
+    ) -> Self {
+        self.sender_resolver = Some(sender_resolver);
+        self.email_transport = Some(email_transport);
+        self
     }
 }
 
@@ -370,6 +402,50 @@ impl HostContext for LiveHostContext {
         })?;
 
         backend.put(bucket, key, body, content_type).await
+    }
+
+    async fn send_email(
+        &self,
+        request: &crate::outbound::SendEmailRequest,
+    ) -> Result<crate::outbound::SendEmailResponse> {
+        // Fail loud, not silent, when the op is unconfigured — mirror `sql_query`.
+        let resolver = self.sender_resolver.as_ref().ok_or_else(|| {
+            fraiseql_error::FraiseQLError::Unsupported {
+                message: "send_email is not configured: no sender-identity resolver is wired \
+                          (configure a mailbox with an SMTP send half)"
+                    .to_string(),
+            }
+        })?;
+        let transport = self.email_transport.as_ref().ok_or_else(|| {
+            fraiseql_error::FraiseQLError::Unsupported {
+                message: "send_email is not configured: no email transport is wired (configure a \
+                          mailbox with an SMTP send half)"
+                    .to_string(),
+            }
+        })?;
+
+        // The `from` is host-owned: resolve it from the authenticated context, not
+        // from the guest request. A refusal is fail-closed and never falls back to
+        // a shared mailbox. Map the refusal's permanence onto the error status
+        // durable dispatch classifies by: permanent → 403 (dead-letter), transient
+        // → 503 (retry).
+        let auth = self.auth_context()?;
+        let sender = resolver.resolve_sender(&auth).await.map_err(|error| {
+            if error.retryable {
+                fraiseql_error::FraiseQLError::ServiceUnavailable {
+                    message:     error.message,
+                    retry_after: None,
+                }
+            } else {
+                fraiseql_error::FraiseQLError::Authorization {
+                    message:  error.message,
+                    action:   Some("send_email".to_string()),
+                    resource: None,
+                }
+            }
+        })?;
+
+        transport.send(&sender, request).await
     }
 
     fn auth_context(&self) -> Result<serde_json::Value> {

--- a/crates/fraiseql-functions/src/host/live/tests.rs
+++ b/crates/fraiseql-functions/src/host/live/tests.rs
@@ -964,3 +964,144 @@ async fn test_host_event_payload_returns_trigger_data() {
     assert_eq!(returned_payload.event_kind, "created");
     assert_eq!(returned_payload.data, event_data);
 }
+
+// ── send_email host op (host-owned `from`) ──────────────────────────────────────
+
+use crate::outbound::{
+    BoxFuture, EmailTransport, LoginEmailSender, SendEmailRequest, SendEmailResponse,
+    SendPolicyError, SenderIdentity, SenderIdentityResolver,
+};
+
+/// A transport that records the `(sender, request)` it was last asked to send and
+/// returns success — so a test can assert on the host-owned `from` the op bound.
+#[derive(Default)]
+struct RecordingTransport {
+    last: std::sync::Mutex<Option<(SenderIdentity, SendEmailRequest)>>,
+}
+
+impl EmailTransport for RecordingTransport {
+    fn send<'a>(
+        &'a self,
+        sender: &'a SenderIdentity,
+        request: &'a SendEmailRequest,
+    ) -> BoxFuture<'a, Result<SendEmailResponse>> {
+        *self.last.lock().unwrap() = Some((sender.clone(), request.clone()));
+        Box::pin(async {
+            Ok(SendEmailResponse {
+                message_id: Some("recorded".to_string()),
+                accepted:   true,
+            })
+        })
+    }
+}
+
+/// A resolver that fails **transiently** (a retry may succeed) — models the
+/// identity store being momentarily unavailable.
+struct TransientResolver;
+
+impl SenderIdentityResolver for TransientResolver {
+    fn resolve_sender<'a>(
+        &'a self,
+        _auth_context: &'a serde_json::Value,
+    ) -> BoxFuture<'a, std::result::Result<SenderIdentity, SendPolicyError>> {
+        Box::pin(async { Err(SendPolicyError::transient("identity store unavailable")) })
+    }
+}
+
+fn send_email_payload() -> EventPayload {
+    EventPayload {
+        trigger_type: "after:mutation:Deal:update".to_string(),
+        entity:       "Deal".to_string(),
+        event_kind:   "updated".to_string(),
+        data:         serde_json::json!({}),
+        timestamp:    chrono::Utc::now(),
+    }
+}
+
+#[tokio::test]
+async fn test_send_email_from_is_host_owned_not_guest_supplied() {
+    let mut host = LiveHostContext::new(send_email_payload(), HostContextConfig::default());
+    host.security_context.email = Some("alice@example.com".to_string());
+    let transport = Arc::new(RecordingTransport::default());
+    let host = host.with_email(Arc::new(LoginEmailSender), transport.clone());
+
+    // A guest request that *tries* to set `from`. `SendEmailRequest` has no `from`
+    // field, so the attempted value is dropped on deserialization; the op binds
+    // `from` from the auth context regardless.
+    let request: SendEmailRequest = serde_json::from_str(
+        r#"{"from":"attacker@evil.example","to":"bob@example.com","subject":"hi","text":"b"}"#,
+    )
+    .unwrap();
+
+    let response = host.send_email(&request).await.unwrap();
+    assert!(response.accepted);
+
+    let (sender, sent) = transport.last.lock().unwrap().clone().unwrap();
+    // The transport was handed the connected user's verified address, never the
+    // guest's attempted `from`.
+    assert_eq!(sender.address, "alice@example.com");
+    assert_eq!(sent.to, "bob@example.com");
+}
+
+#[tokio::test]
+async fn test_send_email_fails_closed_without_verified_identity() {
+    let mut host = LiveHostContext::new(send_email_payload(), HostContextConfig::default());
+    host.security_context.email = None; // no verified sending address
+    let transport = Arc::new(RecordingTransport::default());
+    let host = host.with_email(Arc::new(LoginEmailSender), transport.clone());
+
+    let request = SendEmailRequest {
+        to:       "bob@example.com".to_string(),
+        subject:  "hi".to_string(),
+        text:     Some("b".to_string()),
+        html:     None,
+        reply_to: None,
+    };
+
+    let error = host.send_email(&request).await.unwrap_err();
+    // Permanent policy denial → 403 (durable dispatch dead-letters, does not retry).
+    assert_eq!(error.status_code(), 403);
+    // Never attempted a send.
+    assert!(transport.last.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_send_email_transient_identity_failure_is_retryable() {
+    let mut host = LiveHostContext::new(send_email_payload(), HostContextConfig::default());
+    host.security_context.email = Some("alice@example.com".to_string());
+    let transport = Arc::new(RecordingTransport::default());
+    let host = host.with_email(Arc::new(TransientResolver), transport.clone());
+
+    let request = SendEmailRequest {
+        to:       "bob@example.com".to_string(),
+        subject:  "hi".to_string(),
+        text:     Some("b".to_string()),
+        html:     None,
+        reply_to: None,
+    };
+
+    let error = host.send_email(&request).await.unwrap_err();
+    // Transient failure → 503 (durable dispatch retries rather than dead-letters).
+    assert_eq!(error.status_code(), 503);
+    assert!(transport.last.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_send_email_unconfigured_fails_loud() {
+    let mut host = LiveHostContext::new(send_email_payload(), HostContextConfig::default());
+    host.security_context.email = Some("alice@example.com".to_string());
+    // No `.with_email(...)` → resolver + transport absent.
+
+    let request = SendEmailRequest {
+        to:       "bob@example.com".to_string(),
+        subject:  "hi".to_string(),
+        text:     Some("b".to_string()),
+        html:     None,
+        reply_to: None,
+    };
+
+    let error = host.send_email(&request).await.unwrap_err();
+    // Fail loud (Unsupported / 501), never a silent phantom success — mirror
+    // `sql_query`.
+    assert_eq!(error.status_code(), 501);
+}

--- a/crates/fraiseql-functions/src/host/mod.rs
+++ b/crates/fraiseql-functions/src/host/mod.rs
@@ -91,6 +91,22 @@ pub trait HostContext: Send + Sync {
         content_type: &str,
     ) -> impl Future<Output = Result<()>> + Send;
 
+    /// Send an email.
+    ///
+    /// The `from` is **host-owned**: it is resolved by the host from the
+    /// authenticated identity, never supplied by the guest (a `from` field in the
+    /// guest request is ignored). The request carries only `to`/`subject`/body.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if no sender-identity resolver or transport is configured, the
+    /// sender identity cannot be resolved (fail-closed), or the relay rejects the
+    /// message.
+    fn send_email(
+        &self,
+        request: &crate::outbound::SendEmailRequest,
+    ) -> impl Future<Output = Result<crate::outbound::SendEmailResponse>> + Send;
+
     /// Get the current authenticated user's context.
     ///
     /// # Errors
@@ -191,6 +207,15 @@ impl HostContext for NoopHostContext {
     ) -> Result<()> {
         Err(fraiseql_error::FraiseQLError::Unsupported {
             message: "HostContext::storage_put not implemented".to_string(),
+        })
+    }
+
+    async fn send_email(
+        &self,
+        _request: &crate::outbound::SendEmailRequest,
+    ) -> Result<crate::outbound::SendEmailResponse> {
+        Err(fraiseql_error::FraiseQLError::Unsupported {
+            message: "HostContext::send_email not implemented".to_string(),
         })
     }
 

--- a/crates/fraiseql-functions/src/lib.rs
+++ b/crates/fraiseql-functions/src/lib.rs
@@ -22,8 +22,8 @@ pub mod types;
 pub use host::{HostContext, NoopHostContext};
 pub use observer::FunctionObserver;
 pub use outbound::{
-    LoginEmailSender, SendPolicyError, SenderIdentity, SenderIdentityResolver,
-    resolve_sender_identity,
+    EmailTransport, LoginEmailSender, SendEmailRequest, SendEmailResponse, SendPolicyError,
+    SenderIdentity, SenderIdentityResolver, resolve_sender_identity,
 };
 pub use runtime::{FunctionRuntime, SendFunctionRuntime};
 pub use store::{FunctionRecord, FunctionStatus, FunctionStore, memory::InMemoryFunctionStore};

--- a/crates/fraiseql-functions/src/outbound/mod.rs
+++ b/crates/fraiseql-functions/src/outbound/mod.rs
@@ -47,15 +47,34 @@ pub struct SenderIdentity {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendPolicyError {
     /// Human-readable reason the send is refused.
-    pub message: String,
+    pub message:   String,
+    /// Whether a retry might succeed. A **permanent** refusal (`false`, the
+    /// default) — no verified identity, an ambiguous subject — will not succeed
+    /// on retry and should be dead-lettered immediately. A **transient** refusal
+    /// (`true`) — the identity store is momentarily unavailable — is eligible for
+    /// retry. The `send_email` host op maps this onto the error status durable
+    /// dispatch classifies by (permanent → 403, transient → 503).
+    pub retryable: bool,
 }
 
 impl SendPolicyError {
-    /// Build a refusal from a reason.
+    /// Build a **permanent** refusal from a reason (the default: a retry will not
+    /// help — e.g. no verified sending identity).
     #[must_use]
     pub fn new(message: impl Into<String>) -> Self {
         Self {
-            message: message.into(),
+            message:   message.into(),
+            retryable: false,
+        }
+    }
+
+    /// Build a **transient** refusal from a reason (a retry may succeed — e.g. the
+    /// identity store is momentarily unavailable).
+    #[must_use]
+    pub fn transient(message: impl Into<String>) -> Self {
+        Self {
+            message:   message.into(),
+            retryable: true,
         }
     }
 }
@@ -149,6 +168,60 @@ impl SenderIdentityResolver for LoginEmailSender {
         let result = resolve_sender_identity(auth_context);
         Box::pin(async move { result })
     }
+}
+
+/// A guest's request to send an email via the `send_email` host op.
+///
+/// The `from` is **not** part of this request: it is host-owned and injected by
+/// the op from the resolved [`SenderIdentity`], so a guest can never send from
+/// another address. A `from` field in the guest's JSON is silently ignored (it
+/// maps to no field here), which is the enforcement — the guest cannot override
+/// the sender.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SendEmailRequest {
+    /// The recipient address.
+    pub to:       String,
+    /// The message subject.
+    pub subject:  String,
+    /// The plain-text body, if any. At least one of `text`/`html` should be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text:     Option<String>,
+    /// The HTML body, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub html:     Option<String>,
+    /// An optional `Reply-To` address.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+}
+
+/// The result of a successful [`send_email`](crate::HostContext::send_email).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SendEmailResponse {
+    /// The relay/provider message id, when one was returned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    /// Always `true` on a returned response — the relay accepted the message.
+    pub accepted:   bool,
+}
+
+/// The transport seam the `send_email` host op relays through, once the op has
+/// resolved the host-owned `from` from the [`SenderIdentityResolver`].
+///
+/// Object-safe so the server can inject an `Arc<dyn EmailTransport>` into the
+/// functions host; the concrete per-connected-account SMTP transport lives in
+/// `fraiseql-server` (the runtime-SMTP owner), mirroring the resolver split.
+///
+/// The returned [`FraiseQLError`](fraiseql_error::FraiseQLError) carries the status
+/// that durable dispatch classifies by: a **4xx** (e.g. `Validation`/403) is a
+/// permanent failure routed straight to the dead-letter queue, a **5xx** (e.g.
+/// `ServiceUnavailable`) is transient and retried.
+pub trait EmailTransport: Send + Sync {
+    /// Send `request` from the resolved verified `sender` identity.
+    fn send<'a>(
+        &'a self,
+        sender: &'a SenderIdentity,
+        request: &'a SendEmailRequest,
+    ) -> BoxFuture<'a, fraiseql_error::Result<SendEmailResponse>>;
 }
 
 #[cfg(test)]

--- a/crates/fraiseql-functions/src/outbound/tests.rs
+++ b/crates/fraiseql-functions/src/outbound/tests.rs
@@ -83,3 +83,43 @@ async fn login_email_sender_delegates_to_the_pure_policy() {
     let missing = json!({ "sub": "u1" });
     assert!(LoginEmailSender.resolve_sender(&missing).await.is_err());
 }
+
+#[test]
+fn a_guest_supplied_from_is_dropped_on_deserialization() {
+    use super::SendEmailRequest;
+
+    // The op's `from` is host-owned. `SendEmailRequest` has no `from` field, so a
+    // guest that tries to set one has it silently dropped — the enforcement is at
+    // the type level, before the op even runs.
+    let request: SendEmailRequest = serde_json::from_str(
+        r#"{"from":"attacker@evil.example","to":"bob@example.com","subject":"hi","text":"body"}"#,
+    )
+    .expect("valid request JSON");
+    assert_eq!(request.to, "bob@example.com");
+    assert_eq!(request.subject, "hi");
+    assert_eq!(request.text.as_deref(), Some("body"));
+    // Round-trip carries no `from` key.
+    let serialized = serde_json::to_string(&request).expect("serializes");
+    assert!(!serialized.contains("from"), "serialized request must not carry a `from`");
+}
+
+#[test]
+fn send_policy_error_permanence() {
+    use super::SendPolicyError;
+
+    // `new` is a permanent refusal (default); `transient` is retryable.
+    assert!(!SendPolicyError::new("no identity").retryable);
+    assert!(SendPolicyError::transient("store down").retryable);
+}
+
+#[test]
+fn send_email_response_omits_absent_message_id() {
+    use super::SendEmailResponse;
+
+    let response = SendEmailResponse {
+        message_id: None,
+        accepted:   true,
+    };
+    let serialized = serde_json::to_string(&response).expect("serializes");
+    assert_eq!(serialized, r#"{"accepted":true}"#);
+}

--- a/crates/fraiseql-functions/src/runtime/deno/executor.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/executor.rs
@@ -112,8 +112,13 @@ fn wrap_source(source: &str, event_json: &str) -> String {
         .replace("export default function", "const __fn = function")
         .replace("export default", "const __fn =");
 
+    // Injected so a guest can mark a thrown error permanent structurally
+    // (`throw Object.assign(new Error(msg), {{ fraiseqlPermanent: true }})`) and the
+    // runtime dead-letters it immediately. Host-op errors already carry the marker
+    // in their message; this folds the property form into the same signal.
+    let marker = crate::types::PERMANENT_ERROR_MARKER;
     format!(
-        r"
+        r#"
 {inner}
 (async () => {{
     try {{
@@ -123,10 +128,11 @@ fn wrap_source(source: &str, event_json: &str) -> String {
         globalThis.__fraiseql_error = null;
     }} catch (e) {{
         globalThis.__fraiseql_result = null;
-        globalThis.__fraiseql_error = String(e);
+        const __permanent = e && e.fraiseqlPermanent === true;
+        globalThis.__fraiseql_error = (__permanent ? "{marker} " : "") + String(e);
     }}
 }})();
-"
+"#
     )
 }
 

--- a/crates/fraiseql-functions/src/runtime/deno/executor.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/executor.rs
@@ -79,6 +79,7 @@ fn make_fraiseql_extension(
             ops::fraiseql_http_request(),
             ops::fraiseql_storage_get(),
             ops::fraiseql_storage_put(),
+            ops::fraiseql_send_email(),
             ops::fraiseql_auth_context(),
             ops::fraiseql_env_var(),
         ]),

--- a/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
@@ -179,6 +179,14 @@ async fn test_follow_up_sends_via_the_host_op() {
 
 /// A host refusal (no verified sending identity) propagates as a failure — the
 /// guest does not swallow it or fall back to another sender.
+///
+/// It also pins a known boundary property: the host refusal is *permanent* (a 403
+/// from `send_email`), but a guest exception flattens to `Unsupported` (501) at the
+/// Deno runtime boundary, so durable dispatch currently sees it as **transient**
+/// (retries, then dead-letters) rather than dead-lettering immediately. Closing
+/// that — letting a guest tag a thrown error as permanent — is the hardening
+/// train's permanent-error-tagging phase (P05); this assertion will flag the day
+/// that lands.
 #[tokio::test]
 async fn test_follow_up_propagates_a_host_refusal() {
     let recorded = Arc::new(Mutex::new(Recorded::default()));
@@ -191,7 +199,10 @@ async fn test_follow_up_propagates_a_host_refusal() {
     )
     .await;
 
-    assert!(result.is_err(), "a host refusal must fail loud, not send");
+    let error = result.expect_err("a host refusal must fail loud, not send");
+    // Documents the boundary: a permanent (403) refusal is seen as 501 (transient)
+    // once it crosses the guest exception boundary. See the doc comment above.
+    assert_eq!(error.status_code(), 501);
     assert!(recorded.lock().unwrap().sends.is_empty(), "nothing was sent");
 }
 

--- a/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
@@ -1,10 +1,12 @@
 //! The per-user follow-up-send demonstrator.
 //!
 //! Drives the real `examples/native-functions/follow-up-email.ts` through
-//! `invoke_with_context`, proving the banked per-user send constraint: the `from`
-//! is the connected user's verified address from the host auth context and
-//! nothing else, and a missing verified address fails loud rather than falling
-//! back to a shared or default mailbox.
+//! `invoke_with_context`. The example now delegates the send to the `send_email`
+//! host op: the guest supplies only `to`/`subject`/body, and the host injects the
+//! host-owned `from`. So these tests prove the guest calls the op correctly and
+//! that a host refusal (no verified sending identity) propagates as a failure —
+//! the `from`-resolution enforcement itself is host-side, covered by the
+//! `LiveHostContext::send_email` tests.
 
 #![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code
 
@@ -15,30 +17,25 @@ use chrono::Utc;
 use crate::{
     EventPayload, FunctionModule, ResourceLimits, RuntimeType,
     host::{HttpResponse, dyn_context::DynHostContext},
+    outbound::{SendEmailRequest, SendEmailResponse},
     runtime::deno::{DenoConfig, DenoRuntime},
 };
 
 const FOLLOW_UP_TS: &str =
     include_str!("../../../../../examples/native-functions/follow-up-email.ts");
 
-/// One recorded send, with the parsed JSON body so the test can read `from`.
-#[derive(Clone)]
-struct SendCall {
-    url:  String,
-    body: serde_json::Value,
-}
-
 #[derive(Default)]
 struct Recorded {
-    sends: Vec<SendCall>,
+    sends: Vec<SendEmailRequest>,
 }
 
-/// A mock host with a configurable auth context (the per-user identity) that
-/// fakes the mail provider's send endpoint.
+/// A mock host that records `send_email` requests and either accepts them or, when
+/// `refuse` is set, emulates the host refusing (no verified sending identity) so a
+/// test can prove the refusal propagates through the guest.
 struct SendHost {
     event:    EventPayload,
     recorded: Arc<Mutex<Recorded>>,
-    auth:     serde_json::Value,
+    refuse:   bool,
 }
 
 impl crate::HostContext for SendHost {
@@ -61,21 +58,14 @@ impl crate::HostContext for SendHost {
     async fn http_request(
         &self,
         _method: &str,
-        url: &str,
+        _url: &str,
         _headers: &[(String, String)],
-        body: Option<&[u8]>,
+        _body: Option<&[u8]>,
     ) -> fraiseql_error::Result<HttpResponse> {
-        let parsed = body
-            .and_then(|bytes| serde_json::from_slice(bytes).ok())
-            .unwrap_or(serde_json::Value::Null);
-        self.recorded.lock().unwrap().sends.push(SendCall {
-            url:  url.to_string(),
-            body: parsed,
-        });
         Ok(HttpResponse {
             status:  200,
-            headers: vec![("content-type".to_string(), "application/json".to_string())],
-            body:    serde_json::to_vec(&serde_json::json!({ "id": "msg-1" })).unwrap(),
+            headers: vec![],
+            body:    vec![],
         })
     }
 
@@ -95,24 +85,31 @@ impl crate::HostContext for SendHost {
 
     async fn send_email(
         &self,
-        _request: &crate::outbound::SendEmailRequest,
-    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
-        Ok(crate::outbound::SendEmailResponse {
-            message_id: None,
+        request: &SendEmailRequest,
+    ) -> fraiseql_error::Result<SendEmailResponse> {
+        // A host refusal happens before any send — the identity is resolved first
+        // and fails closed, so nothing is recorded.
+        if self.refuse {
+            return Err(fraiseql_error::FraiseQLError::Authorization {
+                message:  "no verified sending identity for the connected user".to_string(),
+                action:   Some("send_email".to_string()),
+                resource: None,
+            });
+        }
+        self.recorded.lock().unwrap().sends.push(request.clone());
+        Ok(SendEmailResponse {
+            message_id: Some("msg-1".to_string()),
             accepted:   true,
         })
     }
 
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
-        Ok(self.auth.clone())
+        // The guest no longer reads this — the host op owns the `from`.
+        Ok(serde_json::json!({}))
     }
 
-    fn env_var(&self, name: &str) -> fraiseql_error::Result<Option<String>> {
-        if name == "MAIL_API_KEY" {
-            Ok(Some("mail-live-test".to_string()))
-        } else {
-            Ok(None)
-        }
+    fn env_var(&self, _name: &str) -> fraiseql_error::Result<Option<String>> {
+        Ok(None)
     }
 
     fn event_payload(&self) -> &EventPayload {
@@ -134,14 +131,14 @@ fn deal_event(deal: serde_json::Value) -> EventPayload {
 
 async fn run_follow_up(
     deal: serde_json::Value,
-    auth: serde_json::Value,
+    refuse: bool,
     recorded: &Arc<Mutex<Recorded>>,
 ) -> fraiseql_error::Result<serde_json::Value> {
     let event = deal_event(deal);
     let host: Arc<dyn DynHostContext> = Arc::new(SendHost {
         event: event.clone(),
         recorded: Arc::clone(recorded),
-        auth,
+        refuse,
     });
     let module = FunctionModule::from_source(
         "follow-up-email".to_string(),
@@ -156,47 +153,45 @@ async fn run_follow_up(
 }
 
 #[tokio::test]
-async fn test_follow_up_sends_from_the_connected_users_address() {
+async fn test_follow_up_sends_via_the_host_op() {
     let recorded = Arc::new(Mutex::new(Recorded::default()));
     let value = run_follow_up(
         serde_json::json!({
             "id": "deal-1", "next_action": "send_follow_up",
             "name": "Acme rollout", "contact_email": "jane@acme.example"
         }),
-        serde_json::json!({ "user_id": "u1", "email": "rep@outreach.example" }),
+        false,
         &recorded,
     )
     .await
     .expect("send should run");
 
-    assert_eq!(value["sent_from"], "rep@outreach.example");
     assert_eq!(value["sent_to"], "jane@acme.example");
     assert_eq!(value["message_id"], "msg-1");
+    assert_eq!(value["accepted"], true);
 
     let rec = recorded.lock().unwrap();
     assert_eq!(rec.sends.len(), 1, "exactly one send");
-    assert_eq!(rec.sends[0].url, "https://mail.provider.test/v1/send");
-    // The critical enforcement: `from` is the connected user's address, verbatim.
-    assert_eq!(rec.sends[0].body["from"], "rep@outreach.example");
-    assert_eq!(rec.sends[0].body["to"], "jane@acme.example");
+    // The guest supplies only recipient/subject/body — never a `from` (host-owned).
+    assert_eq!(rec.sends[0].to, "jane@acme.example");
+    assert!(rec.sends[0].subject.contains("Acme rollout"));
 }
 
-/// No verified sending address in the auth context → refuse to send (fail loud),
-/// never fall back to a shared or default mailbox.
+/// A host refusal (no verified sending identity) propagates as a failure — the
+/// guest does not swallow it or fall back to another sender.
 #[tokio::test]
-async fn test_follow_up_refuses_without_a_verified_sender() {
+async fn test_follow_up_propagates_a_host_refusal() {
     let recorded = Arc::new(Mutex::new(Recorded::default()));
     let result = run_follow_up(
         serde_json::json!({
             "id": "deal-2", "next_action": "send_follow_up", "contact_email": "jane@acme.example"
         }),
-        // Authenticated, but no verified sending address.
-        serde_json::json!({ "user_id": "u1", "roles": ["rep"] }),
+        true, // host refuses to resolve a sending identity
         &recorded,
     )
     .await;
 
-    assert!(result.is_err(), "a missing sender identity must fail loud, not send");
+    assert!(result.is_err(), "a host refusal must fail loud, not send");
     assert!(recorded.lock().unwrap().sends.is_empty(), "nothing was sent");
 }
 
@@ -207,7 +202,7 @@ async fn test_follow_up_skips_when_action_is_not_send() {
         serde_json::json!({
             "id": "deal-3", "next_action": "wait", "contact_email": "jane@acme.example"
         }),
-        serde_json::json!({ "email": "rep@outreach.example" }),
+        false,
         &recorded,
     )
     .await
@@ -225,7 +220,7 @@ async fn test_follow_up_skips_when_no_contact() {
     let recorded = Arc::new(Mutex::new(Recorded::default()));
     let value = run_follow_up(
         serde_json::json!({ "id": "deal-4", "next_action": "send_follow_up" }),
-        serde_json::json!({ "email": "rep@outreach.example" }),
+        false,
         &recorded,
     )
     .await

--- a/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
@@ -93,6 +93,16 @@ impl crate::HostContext for SendHost {
         Ok(())
     }
 
+    async fn send_email(
+        &self,
+        _request: &crate::outbound::SendEmailRequest,
+    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
+        Ok(crate::outbound::SendEmailResponse {
+            message_id: None,
+            accepted:   true,
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         Ok(self.auth.clone())
     }

--- a/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/follow_up_tests.rs
@@ -178,17 +178,12 @@ async fn test_follow_up_sends_via_the_host_op() {
 }
 
 /// A host refusal (no verified sending identity) propagates as a failure — the
-/// guest does not swallow it or fall back to another sender.
-///
-/// It also pins a known boundary property: the host refusal is *permanent* (a 403
-/// from `send_email`), but a guest exception flattens to `Unsupported` (501) at the
-/// Deno runtime boundary, so durable dispatch currently sees it as **transient**
-/// (retries, then dead-letters) rather than dead-lettering immediately. Closing
-/// that — letting a guest tag a thrown error as permanent — is the hardening
-/// train's permanent-error-tagging phase (P05); this assertion will flag the day
-/// that lands.
+/// guest does not swallow it or fall back to another sender — and, because the
+/// refusal is *permanent* (a 4xx from `send_email`), it is tagged permanent across
+/// the guest exception boundary so durable dispatch dead-letters it immediately
+/// rather than exhausting retries (the permanent-error-tagging fix).
 #[tokio::test]
-async fn test_follow_up_propagates_a_host_refusal() {
+async fn test_follow_up_propagates_a_host_refusal_as_permanent() {
     let recorded = Arc::new(Mutex::new(Recorded::default()));
     let result = run_follow_up(
         serde_json::json!({
@@ -200,9 +195,9 @@ async fn test_follow_up_propagates_a_host_refusal() {
     .await;
 
     let error = result.expect_err("a host refusal must fail loud, not send");
-    // Documents the boundary: a permanent (403) refusal is seen as 501 (transient)
-    // once it crosses the guest exception boundary. See the doc comment above.
-    assert_eq!(error.status_code(), 501);
+    // The op's permanent (403) refusal survives the boundary as a 4xx client error,
+    // so durable dispatch dead-letters on the first attempt (no retry loop).
+    assert!(error.is_client_error(), "a permanent refusal stays permanent → immediate DLQ");
     assert!(recorded.lock().unwrap().sends.is_empty(), "nothing was sent");
 }
 

--- a/crates/fraiseql-functions/src/runtime/deno/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/mod.rs
@@ -234,6 +234,16 @@ fn run_guest(
                     path:    None,
                 })
             },
+            // A permanent-tagged failure (a host op that returned a 4xx, or a guest
+            // that tagged its throw) maps to a 4xx so durable dispatch dead-letters
+            // immediately instead of retrying. Untagged failures stay `Unsupported`
+            // (501, transient).
+            Err(e) if e.contains(crate::types::PERMANENT_ERROR_MARKER) => {
+                Err(fraiseql_error::FraiseQLError::Validation {
+                    message: e,
+                    path:    None,
+                })
+            },
             Err(e) => Err(fraiseql_error::FraiseQLError::Unsupported { message: e }),
         }
     }

--- a/crates/fraiseql-functions/src/runtime/deno/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/mod.rs
@@ -90,6 +90,12 @@ async function fraiseql_storage_put(
   content_type: string,
 ): Promise<void>;
 
+// Send an email. The `from` is host-owned (resolved from the auth context),
+// never supplied by the guest. The request carries only to/subject/body.
+async function fraiseql_send_email(
+  request: string, // JSON: { to, subject, text?, html?, reply_to? }
+): Promise<string>; // JSON: { message_id?, accepted }
+
 // Get the current authenticated user's context
 function fraiseql_auth_context(): string; // JSON string
 

--- a/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
@@ -54,6 +54,20 @@ fn require_host_rc(state: &Rc<RefCell<OpState>>) -> Result<Arc<dyn DynHostContex
     require_host(&state.borrow())
 }
 
+/// Convert a host-op error into an `AnyError`, tagging it **permanent** when it is
+/// a client error (4xx) — a failure that will not succeed on retry (a denied
+/// identity, a rejected recipient, a validation error). The marker travels in the
+/// message so the runtime maps it to a 4xx `FraiseQLError`, which durable dispatch
+/// dead-letters immediately rather than exhausting retries. A 5xx stays untagged
+/// (transient, retried).
+fn op_error(error: fraiseql_error::FraiseQLError) -> AnyError {
+    if error.is_client_error() {
+        deno_core::anyhow::anyhow!("{} {error}", crate::types::PERMANENT_ERROR_MARKER)
+    } else {
+        AnyError::new(error)
+    }
+}
+
 /// Serialised HTTP response handed back to the guest.
 ///
 /// `body` is a [`ToJsBuffer`] so it serialises to a `Uint8Array` in JS, matching
@@ -77,7 +91,7 @@ pub(crate) async fn fraiseql_query(
 ) -> Result<String, AnyError> {
     let host = require_host_rc(&state)?;
     let vars = parse_json_arg(&variables, "variables")?;
-    let result = host.query(&graphql, vars).await.map_err(AnyError::new)?;
+    let result = host.query(&graphql, vars).await.map_err(op_error)?;
     serde_json::to_string(&result)
         .map_err(|e| deno_core::anyhow::anyhow!("failed to serialise query result: {e}"))
 }
@@ -99,7 +113,7 @@ pub(crate) async fn fraiseql_sql_query(
         serde_json::Value::Null => Vec::new(),
         other => vec![other],
     };
-    let rows = host.sql_query(&sql, &params_vec).await.map_err(AnyError::new)?;
+    let rows = host.sql_query(&sql, &params_vec).await.map_err(op_error)?;
     serde_json::to_string(&rows)
         .map_err(|e| deno_core::anyhow::anyhow!("failed to serialise sql result: {e}"))
 }
@@ -121,7 +135,7 @@ pub(crate) async fn fraiseql_http_request(
     let resp = host
         .http_request(&method, &url, &headers, body_vec.as_deref())
         .await
-        .map_err(AnyError::new)?;
+        .map_err(op_error)?;
     Ok(HttpResponseJs {
         status:  resp.status,
         headers: resp.headers,
@@ -140,7 +154,7 @@ pub(crate) async fn fraiseql_storage_get(
     #[string] key: String,
 ) -> Result<Vec<u8>, AnyError> {
     let host = require_host_rc(&state)?;
-    host.storage_get(&bucket, &key).await.map_err(AnyError::new)
+    host.storage_get(&bucket, &key).await.map_err(op_error)
 }
 
 /// Store an object to storage on behalf of the guest.
@@ -156,9 +170,7 @@ pub(crate) async fn fraiseql_storage_put(
 ) -> Result<(), AnyError> {
     let host = require_host_rc(&state)?;
     let body = body.to_vec();
-    host.storage_put(&bucket, &key, &body, &content_type)
-        .await
-        .map_err(AnyError::new)
+    host.storage_put(&bucket, &key, &body, &content_type).await.map_err(op_error)
 }
 
 /// Send an email on behalf of the guest (the `from` is host-owned).
@@ -173,7 +185,7 @@ pub(crate) async fn fraiseql_send_email(
     let host = require_host_rc(&state)?;
     let req: crate::outbound::SendEmailRequest = serde_json::from_str(&request)
         .map_err(|e| deno_core::anyhow::anyhow!("invalid send_email request JSON: {e}"))?;
-    let response = host.send_email(&req).await.map_err(AnyError::new)?;
+    let response = host.send_email(&req).await.map_err(op_error)?;
     serde_json::to_string(&response)
         .map_err(|e| deno_core::anyhow::anyhow!("failed to serialise send_email response: {e}"))
 }
@@ -185,7 +197,7 @@ pub(crate) async fn fraiseql_send_email(
 #[string]
 pub(crate) fn fraiseql_auth_context(state: &OpState) -> Result<String, AnyError> {
     let host = require_host(state)?;
-    let ctx = host.auth_context().map_err(AnyError::new)?;
+    let ctx = host.auth_context().map_err(op_error)?;
     serde_json::to_string(&ctx)
         .map_err(|e| deno_core::anyhow::anyhow!("failed to serialise auth context: {e}"))
 }
@@ -200,7 +212,7 @@ pub(crate) fn fraiseql_env_var(
     #[string] name: String,
 ) -> Result<Option<String>, AnyError> {
     let host = require_host(state)?;
-    host.env_var(&name).map_err(AnyError::new)
+    host.env_var(&name).map_err(op_error)
 }
 
 /// Parse a JSON-string op argument, treating an empty string as an empty object.

--- a/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
@@ -161,6 +161,23 @@ pub(crate) async fn fraiseql_storage_put(
         .map_err(AnyError::new)
 }
 
+/// Send an email on behalf of the guest (the `from` is host-owned).
+///
+/// `Deno.core.ops.fraiseql_send_email(requestJson) -> responseJson`
+#[op2(async)]
+#[string]
+pub(crate) async fn fraiseql_send_email(
+    state: Rc<RefCell<OpState>>,
+    #[string] request: String,
+) -> Result<String, AnyError> {
+    let host = require_host_rc(&state)?;
+    let req: crate::outbound::SendEmailRequest = serde_json::from_str(&request)
+        .map_err(|e| deno_core::anyhow::anyhow!("invalid send_email request JSON: {e}"))?;
+    let response = host.send_email(&req).await.map_err(AnyError::new)?;
+    serde_json::to_string(&response)
+        .map_err(|e| deno_core::anyhow::anyhow!("failed to serialise send_email response: {e}"))
+}
+
 /// Return the current auth context as a JSON string (sync).
 ///
 /// `Deno.core.ops.fraiseql_auth_context() -> authJson`

--- a/crates/fraiseql-functions/src/runtime/deno/qonto_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/qonto_tests.rs
@@ -110,6 +110,16 @@ impl crate::HostContext for QontoHost {
         Ok(())
     }
 
+    async fn send_email(
+        &self,
+        _request: &crate::outbound::SendEmailRequest,
+    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
+        Ok(crate::outbound::SendEmailResponse {
+            message_id: None,
+            accepted:   true,
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         Ok(serde_json::json!({ "user_id": "u123" }))
     }

--- a/crates/fraiseql-functions/src/runtime/deno/reply_awareness_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/reply_awareness_tests.rs
@@ -101,6 +101,16 @@ impl crate::HostContext for ReplyHost {
         Ok(())
     }
 
+    async fn send_email(
+        &self,
+        _request: &crate::outbound::SendEmailRequest,
+    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
+        Ok(crate::outbound::SendEmailResponse {
+            message_id: None,
+            accepted:   true,
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         Ok(serde_json::json!({ "user_id": "u123" }))
     }

--- a/crates/fraiseql-functions/src/runtime/deno/scoring_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/scoring_tests.rs
@@ -102,6 +102,16 @@ impl crate::HostContext for ScoringHost {
         Ok(())
     }
 
+    async fn send_email(
+        &self,
+        _request: &crate::outbound::SendEmailRequest,
+    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
+        Ok(crate::outbound::SendEmailResponse {
+            message_id: None,
+            accepted:   true,
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         Ok(serde_json::json!({ "user_id": "u123" }))
     }

--- a/crates/fraiseql-functions/src/runtime/deno/tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/tests.rs
@@ -741,6 +741,36 @@ export default async () => {
 }
 
 #[tokio::test]
+async fn test_deno_guest_can_tag_an_error_permanent() {
+    // A guest that structurally tags its throw as permanent crosses the exception
+    // boundary as a 4xx client error → durable dispatch dead-letters immediately.
+    let error = run_with_mock(
+        r"
+export default async () => {
+    throw Object.assign(new Error('nope'), { fraiseqlPermanent: true });
+};
+",
+    )
+    .await
+    .expect_err("guest threw");
+    assert!(error.is_client_error(), "a permanent-tagged guest error is a 4xx");
+}
+
+#[tokio::test]
+async fn test_deno_untagged_guest_error_stays_transient() {
+    // Default behaviour is unchanged: an untagged throw is transient (501), retried.
+    let error = run_with_mock(
+        r"
+export default async () => { throw new Error('boom'); };
+",
+    )
+    .await
+    .expect_err("guest threw");
+    assert!(!error.is_client_error(), "an untagged guest error stays transient");
+    assert_eq!(error.status_code(), 501);
+}
+
+#[tokio::test]
 async fn test_deno_op_auth_context_and_env_var() {
     let value = run_with_mock(
         r"

--- a/crates/fraiseql-functions/src/runtime/deno/tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/tests.rs
@@ -602,6 +602,18 @@ impl crate::HostContext for MockHostContext {
         Ok(())
     }
 
+    async fn send_email(
+        &self,
+        request: &crate::outbound::SendEmailRequest,
+    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
+        // Echo the recipient so a guest test can prove the request JSON marshaled
+        // through the op intact.
+        Ok(crate::outbound::SendEmailResponse {
+            message_id: Some(format!("sent:{}", request.to)),
+            accepted:   true,
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         Ok(serde_json::json!({ "user_id": "u123", "roles": ["admin"] }))
     }
@@ -706,6 +718,26 @@ export default async () => {
     .expect("storage ops should succeed");
 
     assert_eq!(value["got"], "stored:bucket/key");
+}
+
+#[tokio::test]
+async fn test_deno_op_send_email_reaches_host() {
+    let value = run_with_mock(
+        r"
+export default async () => {
+    const raw = await Deno.core.ops.fraiseql_send_email(
+        JSON.stringify({ to: 'bob@example.com', subject: 'hi', text: 'body' }),
+    );
+    return JSON.parse(raw);
+};
+",
+    )
+    .await
+    .expect("send_email op should succeed");
+
+    // The op reached the host and the request JSON marshaled through intact.
+    assert_eq!(value["accepted"], true);
+    assert_eq!(value["message_id"], "sent:bob@example.com");
 }
 
 #[tokio::test]

--- a/crates/fraiseql-functions/src/runtime/parity_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/parity_tests.rs
@@ -77,6 +77,16 @@ impl crate::HostContext for ParityHost {
         Ok(())
     }
 
+    async fn send_email(
+        &self,
+        _request: &crate::outbound::SendEmailRequest,
+    ) -> fraiseql_error::Result<crate::outbound::SendEmailResponse> {
+        Ok(crate::outbound::SendEmailResponse {
+            message_id: None,
+            accepted:   true,
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         Ok(serde_json::json!({ "user_id": "u123" }))
     }

--- a/crates/fraiseql-functions/src/runtime/wasm/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/wasm/mod.rs
@@ -478,8 +478,9 @@ impl DynHostContext for HostContextSnapshot {
         _request: &'a crate::outbound::SendEmailRequest,
     ) -> std::pin::Pin<
         Box<
-            dyn std::future::Future<Output = fraiseql_error::Result<crate::outbound::SendEmailResponse>>
-                + Send
+            dyn std::future::Future<
+                    Output = fraiseql_error::Result<crate::outbound::SendEmailResponse>,
+                > + Send
                 + 'a,
         >,
     > {

--- a/crates/fraiseql-functions/src/runtime/wasm/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/wasm/mod.rs
@@ -473,6 +473,23 @@ impl DynHostContext for HostContextSnapshot {
         })
     }
 
+    fn send_email<'a>(
+        &'a self,
+        _request: &'a crate::outbound::SendEmailRequest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = fraiseql_error::Result<crate::outbound::SendEmailResponse>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async {
+            Err(fraiseql_error::FraiseQLError::Unsupported {
+                message: "send_email not available in snapshot context".to_string(),
+            })
+        })
+    }
+
     fn auth_context(&self) -> fraiseql_error::Result<serde_json::Value> {
         self.auth_context
             .clone()

--- a/crates/fraiseql-functions/src/runtime/wasm/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/wasm/mod.rs
@@ -304,6 +304,18 @@ fn map_guest_outcome(outcome: GuestOutcome) -> Result<Option<serde_json::Value>>
             );
             Ok(Some(value))
         },
+        // A permanent-tagged guest error (a host op that returned a 4xx, or a guest
+        // that tagged its `Err`) maps to a 4xx so durable dispatch dead-letters
+        // immediately; untagged errors stay `Unsupported` (501, transient). Parity
+        // with the Deno runtime.
+        GuestOutcome::GuestError(message)
+            if message.contains(crate::types::PERMANENT_ERROR_MARKER) =>
+        {
+            Err(fraiseql_error::FraiseQLError::Validation {
+                message,
+                path: None,
+            })
+        },
         GuestOutcome::GuestError(message) => {
             Err(fraiseql_error::FraiseQLError::Unsupported { message })
         },

--- a/crates/fraiseql-functions/src/runtime/wasm/store/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/wasm/store/mod.rs
@@ -152,12 +152,24 @@ impl context::Host for StoreData {
     }
 }
 
+/// Stringify a host error for the WIT `result<_, string>` boundary, tagging a
+/// client error (4xx) as permanent so the runtime dead-letters it immediately
+/// instead of retrying (parity with the Deno op path).
+#[allow(clippy::needless_pass_by_value)] // Reason: consumed via `.map_err` at each WIT call site
+fn host_err_string(error: fraiseql_error::FraiseQLError) -> String {
+    if error.is_client_error() {
+        format!("{} {error}", crate::types::PERMANENT_ERROR_MARKER)
+    } else {
+        error.to_string()
+    }
+}
+
 impl io::Host for StoreData {
     async fn query(&mut self, graphql: String, variables: String) -> Result<String, String> {
         let host = self.require_host_context()?;
         let vars: serde_json::Value =
             serde_json::from_str(&variables).map_err(|e| e.to_string())?;
-        let result = host.query(&graphql, vars).await.map_err(|e| e.to_string())?;
+        let result = host.query(&graphql, vars).await.map_err(host_err_string)?;
         serde_json::to_string(&result).map_err(|e| e.to_string())
     }
 
@@ -165,7 +177,7 @@ impl io::Host for StoreData {
         let host = self.require_host_context()?;
         let params_vec: Vec<serde_json::Value> =
             serde_json::from_str(&params).map_err(|e| e.to_string())?;
-        let result = host.sql_query(&sql, &params_vec).await.map_err(|e| e.to_string())?;
+        let result = host.sql_query(&sql, &params_vec).await.map_err(host_err_string)?;
         serde_json::to_string(&result).map_err(|e| e.to_string())
     }
 
@@ -180,7 +192,7 @@ impl io::Host for StoreData {
         let response = host
             .http_request(&method, &url, &headers, body.as_deref())
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(host_err_string)?;
         Ok(io::HttpResponse {
             status:  response.status,
             headers: response.headers,
@@ -190,7 +202,7 @@ impl io::Host for StoreData {
 
     async fn storage_get(&mut self, bucket: String, key: String) -> Result<Vec<u8>, String> {
         let host = self.require_host_context()?;
-        host.storage_get(&bucket, &key).await.map_err(|e| e.to_string())
+        host.storage_get(&bucket, &key).await.map_err(host_err_string)
     }
 
     async fn storage_put(
@@ -203,14 +215,14 @@ impl io::Host for StoreData {
         let host = self.require_host_context()?;
         host.storage_put(&bucket, &key, &body, &content_type)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(host_err_string)
     }
 
     async fn send_email(&mut self, request: String) -> Result<String, String> {
         let host = self.require_host_context()?;
         let req: crate::outbound::SendEmailRequest =
             serde_json::from_str(&request).map_err(|e| e.to_string())?;
-        let response = host.send_email(&req).await.map_err(|e| e.to_string())?;
+        let response = host.send_email(&req).await.map_err(host_err_string)?;
         serde_json::to_string(&response).map_err(|e| e.to_string())
     }
 }

--- a/crates/fraiseql-functions/src/runtime/wasm/store/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/wasm/store/mod.rs
@@ -205,6 +205,14 @@ impl io::Host for StoreData {
             .await
             .map_err(|e| e.to_string())
     }
+
+    async fn send_email(&mut self, request: String) -> Result<String, String> {
+        let host = self.require_host_context()?;
+        let req: crate::outbound::SendEmailRequest =
+            serde_json::from_str(&request).map_err(|e| e.to_string())?;
+        let response = host.send_email(&req).await.map_err(|e| e.to_string())?;
+        serde_json::to_string(&response).map_err(|e| e.to_string())
+    }
 }
 
 impl wasmtime::ResourceLimiter for StoreData {

--- a/crates/fraiseql-functions/src/types.rs
+++ b/crates/fraiseql-functions/src/types.rs
@@ -5,6 +5,20 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
+/// Marker a function (or a host op) puts in a thrown error's message to signal the
+/// failure is **permanent** — do not retry, dead-letter immediately.
+///
+/// Both runtimes surface a guest failure as a string, so permanence travels as this
+/// sentinel substring: when the error message contains it, the runtime classifies
+/// the failure as a client error (4xx) — which the durable dispatcher dead-letters
+/// on the first attempt — rather than the default transient `Unsupported` (501).
+///
+/// A guest can also throw `Object.assign(new Error(msg), { fraiseqlPermanent: true })`
+/// (Deno); the wrapper folds that into this marker. Host ops that already know a
+/// failure is permanent (e.g. `send_email` on a denied identity or a rejected
+/// recipient) prepend it automatically.
+pub const PERMANENT_ERROR_MARKER: &str = "[fraiseql:permanent]";
+
 /// Supported runtime types for serverless functions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]

--- a/crates/fraiseql-functions/wit/fraiseql-host.wit
+++ b/crates/fraiseql-functions/wit/fraiseql-host.wit
@@ -23,6 +23,9 @@ interface io {
     http-request: func(method: string, url: string, headers: list<tuple<string, string>>, body: option<list<u8>>) -> result<http-response, string>;
     storage-get: func(bucket: string, key: string) -> result<list<u8>, string>;
     storage-put: func(bucket: string, key: string, body: list<u8>, content-type: string) -> result<_, string>;
+    // Host-owned `from`: the request JSON carries only to/subject/body; the host
+    // resolves and injects the sender address. JSON in, JSON out.
+    send-email: func(request: string) -> result<string, string>;
 }
 
 world fraiseql-function {

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -115,6 +115,10 @@ async-imap = {version = "0.11", default-features = false, features = ["runtime-t
 # avoids the rustls process-default-provider ambiguity panic).
 tokio-rustls = {version = "0.26", default-features = false, features = ["ring", "tls12", "logging"], optional = true}
 webpki-roots = {version = "0.26", optional = true}
+# SMTP send transport for the `send_email` host op (opt-in `inbound-email`). Same
+# lettre config as fraiseql-observers' email action: async SMTP over rustls,
+# STARTTLS. The per-connected-account transport keyed by verified sending address.
+lettre = {version = "0.11", default-features = false, features = ["builder", "smtp-transport", "tokio1", "tokio1-rustls-tls"], optional = true}
 # Database
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio", "uuid", "chrono"]}
 # Constant-time comparison (timing attack prevention)
@@ -228,6 +232,7 @@ inbound-email = [
     "dep:async-imap",
     "dep:tokio-rustls",
     "dep:webpki-roots",
+    "dep:lettre",
 ]
 # auth is included by default because auth middleware is wired into the core request pipeline.
 # secrets and webhooks are opt-in: add them to your dependency features when needed.

--- a/crates/fraiseql-server/src/identity/sender.rs
+++ b/crates/fraiseql-server/src/identity/sender.rs
@@ -9,13 +9,10 @@
 //! This lands the resolver and the seam; the `send_email` host op that injects
 //! and calls it — and the SMTP transport — are the hardening train's, not #539's.
 
-// Reason: the DB-backed sender is composed into the `send_email` wiring
-// (`BeforeMutationHooks::with_email`) by whoever builds the functions-runtime
-// hooks. The `send_email` op + transport now exist, but the stock server binary
-// does not yet populate `before_mutation_hooks` (a separate pre-existing gap from
-// the beta native-runtime train), so this resolver has no production caller until
-// that binary wiring lands. Scoped to this file so the rest of the module keeps
-// live dead-code detection.
+// Reason: the DB-backed sender is constructed by the `send_email` wiring
+// (`Server::build_sender_resolver`), which is gated on `inbound-email`. Under an
+// `auth`-only build (no `inbound-email`) it has no caller, so the file keeps this
+// allow; the rest of the module keeps live dead-code detection.
 #![allow(dead_code)]
 
 use std::{collections::HashMap, future::Future, pin::Pin};

--- a/crates/fraiseql-server/src/identity/sender.rs
+++ b/crates/fraiseql-server/src/identity/sender.rs
@@ -9,10 +9,13 @@
 //! This lands the resolver and the seam; the `send_email` host op that injects
 //! and calls it — and the SMTP transport — are the hardening train's, not #539's.
 
-// Reason: the DB-backed sender is constructed and injected into the functions
-// host by the hardening-train `send_email` op; until that lands it has no
-// non-test caller. Scoped to this file so the rest of the module keeps live
-// dead-code detection.
+// Reason: the DB-backed sender is composed into the `send_email` wiring
+// (`BeforeMutationHooks::with_email`) by whoever builds the functions-runtime
+// hooks. The `send_email` op + transport now exist, but the stock server binary
+// does not yet populate `before_mutation_hooks` (a separate pre-existing gap from
+// the beta native-runtime train), so this resolver has no production caller until
+// that binary wiring lands. Scoped to this file so the rest of the module keeps
+// live dead-code detection.
 #![allow(dead_code)]
 
 use std::{collections::HashMap, future::Future, pin::Pin};

--- a/crates/fraiseql-server/src/identity/sender.rs
+++ b/crates/fraiseql-server/src/identity/sender.rs
@@ -97,9 +97,9 @@ impl SenderIdentityResolver for DbSenderIdentityResolver {
                 IdentityResolution::Denied(_) => Err(SendPolicyError::new(
                     "refusing to send: no verified sending identity for the connected user",
                 )),
-                IdentityResolution::Unavailable(_) => {
-                    Err(SendPolicyError::new("sender identity resolution temporarily unavailable"))
-                },
+                IdentityResolution::Unavailable(_) => Err(SendPolicyError::transient(
+                    "sender identity resolution temporarily unavailable",
+                )),
             }
         })
     }

--- a/crates/fraiseql-server/src/inbound/email/config.rs
+++ b/crates/fraiseql-server/src/inbound/email/config.rs
@@ -40,6 +40,10 @@ pub struct MailboxConfig {
     /// is send-only and starts no poll worker.
     #[serde(default)]
     pub imap: Option<ImapConfig>,
+    /// The SMTP send half (`[mailbox.<name>.smtp]`) the `send_email` host op relays
+    /// through. Absent → this account is receive-only.
+    #[serde(default)]
+    pub smtp: Option<MailboxSmtpConfig>,
 }
 
 /// The poll-IMAP receive configuration for a mailbox (`[mailbox.<name>.imap]`).
@@ -79,6 +83,62 @@ pub struct ImapConfig {
     pub routing:            Vec<RoutingRuleConfig>,
 }
 
+/// Default SMTP submission port (STARTTLS).
+const fn default_smtp_port() -> u16 {
+    587
+}
+
+/// Default SMTP connect/send timeout.
+const fn default_smtp_timeout_secs() -> u64 {
+    30
+}
+
+/// Transport security for the SMTP send connection.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SmtpTlsMode {
+    /// STARTTLS upgrade on the submission port (default; typically port 587).
+    #[default]
+    StartTls,
+    /// Implicit TLS / SMTPS (typically port 465).
+    Tls,
+    /// No transport security — plaintext. Local relays / development only.
+    None,
+}
+
+/// The SMTP send half of a connected mailbox (`[mailbox.<name>.smtp]`).
+///
+/// Strict (`deny_unknown_fields`): a mistyped key in this security-relevant block
+/// fails the parse rather than being silently ignored. The password is read from
+/// the environment at [`password_env`](Self::password_env), never stored in config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MailboxSmtpConfig {
+    /// SMTP server hostname (also the TLS SNI / certificate name).
+    pub host:         String,
+    /// SMTP submission port; defaults to 587 (STARTTLS).
+    #[serde(default = "default_smtp_port")]
+    pub port:         u16,
+    /// The verified sending address this account relays for. The `send_email` op
+    /// selects the account whose `address` equals the resolved sender identity's
+    /// address, so this must match what the sender resolver returns — guest input
+    /// never selects the account.
+    pub address:      String,
+    /// SMTP auth username (often the mailbox address itself).
+    pub username:     String,
+    /// Name of the environment variable holding the SMTP password. An account whose
+    /// password env is unset is skipped with a warning rather than relaying
+    /// unauthenticated.
+    pub password_env: String,
+    /// Transport security; defaults to STARTTLS.
+    #[serde(default)]
+    pub tls:          SmtpTlsMode,
+    /// Connection/send timeout in seconds; defaults to 30.
+    #[serde(default = "default_smtp_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
 /// A declared `[[mailbox.<name>.imap.routing]]` rule: a dedicated address that maps
 /// to an entity type (the recipient's plus-tag becomes the entity id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -99,3 +159,6 @@ impl RoutingRuleConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/config.rs
+++ b/crates/fraiseql-server/src/inbound/email/config.rs
@@ -1,4 +1,10 @@
-//! Configuration for the poll-IMAP email adapter (`[imap.<name>]`).
+//! Configuration for one connected mailbox account (`[mailbox.<name>]`).
+//!
+//! A mailbox account has two optional halves: the poll-IMAP *receive* half
+//! (`[mailbox.<name>.imap]`, [`ImapConfig`]) that the inbound adapter watches, and
+//! the SMTP *send* half (`[mailbox.<name>.smtp]`) the outbound `send_email` host op
+//! relays through. One connected account carries both, so they share one section
+//! name — the mailbox's stable identity.
 
 use serde::{Deserialize, Serialize};
 
@@ -21,14 +27,28 @@ const fn default_batch_size() -> u32 {
     50
 }
 
-/// One `[imap.<name>]` mailbox the poll-IMAP adapter watches.
+/// One connected mailbox account (`[mailbox.<name>]`).
 ///
-/// The section key is the mailbox's stable identity — it names the cursor row, so
-/// it must not change once a mailbox is in production. Connection is over implicit
-/// TLS (IMAPS) on [`port`](Self::port); the password is read from the environment
-/// at [`password_env`](Self::password_env), never stored in the config.
+/// The section key is the account's stable identity — it names the inbound cursor
+/// row, so it must not change once a mailbox is in production. An account has two
+/// optional halves: [`imap`](Self::imap) (poll-receive) and its SMTP send half
+/// (added by the hardening `send_email` transport). At least one half must be
+/// present for the account to do anything.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImapMailboxConfig {
+pub struct MailboxConfig {
+    /// The poll-IMAP receive half (`[mailbox.<name>.imap]`). Absent → this account
+    /// is send-only and starts no poll worker.
+    #[serde(default)]
+    pub imap: Option<ImapConfig>,
+}
+
+/// The poll-IMAP receive configuration for a mailbox (`[mailbox.<name>.imap]`).
+///
+/// Connection is over implicit TLS (IMAPS) on [`port`](Self::port); the password
+/// is read from the environment at [`password_env`](Self::password_env), never
+/// stored in the config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImapConfig {
     /// IMAP server hostname (also the TLS SNI / certificate name).
     pub host:               String,
     /// IMAPS port; defaults to 993.
@@ -59,8 +79,8 @@ pub struct ImapMailboxConfig {
     pub routing:            Vec<RoutingRuleConfig>,
 }
 
-/// A declared `[[imap.<name>.routing]]` rule: a dedicated address that maps to an
-/// entity type (the recipient's plus-tag becomes the entity id).
+/// A declared `[[mailbox.<name>.imap.routing]]` rule: a dedicated address that maps
+/// to an entity type (the recipient's plus-tag becomes the entity id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoutingRuleConfig {
     /// The dedicated base address this rule matches (`support@example.com`).

--- a/crates/fraiseql-server/src/inbound/email/config/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/config/tests.rs
@@ -1,0 +1,66 @@
+//! Parse tests for the unified `[mailbox.<name>]` config (both halves).
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use super::{MailboxConfig, SmtpTlsMode};
+
+#[test]
+fn parses_both_halves_with_defaults() {
+    // One connected account carries both its IMAP receive half and its SMTP send
+    // half under one section; unspecified fields take their defaults.
+    let toml = r#"
+[imap]
+host = "imap.example.com"
+username = "sales@example.com"
+password_env = "SALES_IMAP_PW"
+
+[smtp]
+host = "smtp.example.com"
+address = "sales@example.com"
+username = "sales@example.com"
+password_env = "SALES_SMTP_PW"
+"#;
+    let mailbox: MailboxConfig = toml::from_str(toml).unwrap();
+
+    let imap = mailbox.imap.expect("imap half");
+    assert_eq!(imap.host, "imap.example.com");
+    assert_eq!(imap.port, 993, "IMAPS default");
+    assert_eq!(imap.mailbox, "INBOX", "default folder");
+
+    let smtp = mailbox.smtp.expect("smtp half");
+    assert_eq!(smtp.host, "smtp.example.com");
+    assert_eq!(smtp.address, "sales@example.com");
+    assert_eq!(smtp.port, 587, "STARTTLS submission default");
+    assert_eq!(smtp.tls, SmtpTlsMode::StartTls, "default TLS mode");
+    assert_eq!(smtp.timeout_secs, 30);
+}
+
+#[test]
+fn a_send_only_mailbox_has_no_imap_half() {
+    let toml = r#"
+[smtp]
+host = "smtp.example.com"
+address = "sales@example.com"
+username = "sales@example.com"
+password_env = "SALES_SMTP_PW"
+tls = "tls"
+"#;
+    let mailbox: MailboxConfig = toml::from_str(toml).unwrap();
+    assert!(mailbox.imap.is_none(), "send-only: no poll worker");
+    assert_eq!(mailbox.smtp.unwrap().tls, SmtpTlsMode::Tls);
+}
+
+#[test]
+fn an_unknown_smtp_key_fails_the_parse() {
+    // The SMTP block is strict (deny_unknown_fields): a typo fails at boot rather
+    // than being silently ignored.
+    let toml = r#"
+[smtp]
+host = "smtp.example.com"
+address = "sales@example.com"
+username = "sales@example.com"
+password_env = "SALES_SMTP_PW"
+frmo = "typo@example.com"
+"#;
+    assert!(toml::from_str::<MailboxConfig>(toml).is_err());
+}

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -32,10 +32,12 @@ use tracing::{info, warn};
 pub mod config;
 pub mod cursor;
 pub mod imap;
+pub mod smtp;
 pub mod store;
 pub mod worker;
 
-pub use config::{ImapConfig, MailboxConfig, RoutingRuleConfig};
+pub use config::{ImapConfig, MailboxConfig, MailboxSmtpConfig, RoutingRuleConfig, SmtpTlsMode};
+pub use smtp::SmtpMailboxTransport;
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
 pub use store::PostgresEmailCursorStore;

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -34,10 +34,12 @@ pub mod cursor;
 pub mod imap;
 pub mod smtp;
 pub mod store;
+pub mod warming;
 pub mod worker;
 
 pub use config::{ImapConfig, MailboxConfig, MailboxSmtpConfig, RoutingRuleConfig, SmtpTlsMode};
 pub use smtp::SmtpMailboxTransport;
+pub use warming::{SendCounter, WarmingState, warming_daily_limit};
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
 pub use store::PostgresEmailCursorStore;

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -35,7 +35,7 @@ pub mod imap;
 pub mod store;
 pub mod worker;
 
-pub use config::{ImapMailboxConfig, RoutingRuleConfig};
+pub use config::{ImapConfig, MailboxConfig, RoutingRuleConfig};
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
 pub use store::PostgresEmailCursorStore;
@@ -53,37 +53,42 @@ pub async fn init_cursor_store(pool: &sqlx::PgPool) -> fraiseql_error::Result<()
     PostgresEmailCursorStore::new(pool.clone()).init().await
 }
 
-/// Build a poll worker (and its interval) for each configured mailbox.
+/// Build a poll worker (and its interval) for each mailbox with an IMAP half.
 ///
-/// A mailbox whose `password_env` is unset, or whose TLS connector cannot be
-/// built, is skipped with a warning rather than started without credentials.
-/// `get_env` resolves the password env (in production, [`std::env::var`]); `sink`
-/// is the storage backend attachments stream into (`None` drops attachments);
-/// `hooks` fire `after:ingest:email` (`None` ingests without dispatch).
+/// A mailbox with no `[mailbox.<name>.imap]` half is skipped (send-only). A mailbox
+/// whose `password_env` is unset, or whose TLS connector cannot be built, is
+/// skipped with a warning rather than started without credentials. `get_env`
+/// resolves the password env (in production, [`std::env::var`]); `sink` is the
+/// storage backend attachments stream into (`None` drops attachments); `hooks`
+/// fire `after:ingest:email` (`None` ingests without dispatch).
 #[must_use]
 pub fn build_workers<S: std::hash::BuildHasher>(
-    mailboxes: &HashMap<String, ImapMailboxConfig, S>,
+    mailboxes: &HashMap<String, MailboxConfig, S>,
     pool: &sqlx::PgPool,
     hooks: Option<&Arc<BeforeMutationHooks>>,
     sink: Option<&Arc<dyn StorageBackend>>,
     get_env: impl Fn(&str) -> Option<String>,
 ) -> Vec<(EmailPollWorker, Duration)> {
     let mut workers = Vec::new();
-    for (name, config) in mailboxes {
-        let Some(password) = get_env(&config.password_env) else {
+    for (name, mailbox) in mailboxes {
+        // Send-only mailboxes have no IMAP half — nothing to poll.
+        let Some(imap) = mailbox.imap.as_ref() else {
+            continue;
+        };
+        let Some(password) = get_env(&imap.password_env) else {
             warn!(
                 mailbox = %name,
-                password_env = %config.password_env,
+                password_env = %imap.password_env,
                 "poll-IMAP mailbox not started: password env is unset"
             );
             continue;
         };
         let fetcher = match ImapMailboxFetcher::new(
-            &config.host,
-            config.port,
-            &config.username,
+            &imap.host,
+            imap.port,
+            &imap.username,
             password,
-            &config.mailbox,
+            &imap.mailbox,
         ) {
             Ok(fetcher) => Arc::new(fetcher),
             Err(error) => {
@@ -91,22 +96,22 @@ pub fn build_workers<S: std::hash::BuildHasher>(
                 continue;
             },
         };
-        let routing_rules = config.routing.iter().map(RoutingRuleConfig::to_rule).collect();
+        let routing_rules = imap.routing.iter().map(RoutingRuleConfig::to_rule).collect();
         let worker = EmailPollWorker::new(
             name.clone(),
             fetcher,
             pool.clone(),
             routing_rules,
-            config.batch_size,
-            config.attachment_bucket.clone(),
+            imap.batch_size,
+            imap.attachment_bucket.clone(),
             sink.cloned(),
             hooks.cloned(),
         );
-        let interval = Duration::from_secs(config.poll_interval_secs.max(1));
+        let interval = Duration::from_secs(imap.poll_interval_secs.max(1));
         info!(
             mailbox = %name,
-            host = %config.host,
-            folder = %config.mailbox,
+            host = %imap.host,
+            folder = %imap.mailbox,
             "poll-IMAP mailbox configured"
         );
         workers.push((worker, interval));

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -40,7 +40,7 @@ pub mod worker;
 pub use config::{ImapConfig, MailboxConfig, MailboxSmtpConfig, RoutingRuleConfig, SmtpTlsMode};
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
-pub use smtp::SmtpMailboxTransport;
+pub use smtp::{SmtpMailboxTransport, build_email_transport};
 pub use store::PostgresEmailCursorStore;
 pub use warming::{SendCounter, WarmingState, warming_daily_limit};
 pub use worker::EmailPollWorker;

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -38,11 +38,11 @@ pub mod warming;
 pub mod worker;
 
 pub use config::{ImapConfig, MailboxConfig, MailboxSmtpConfig, RoutingRuleConfig, SmtpTlsMode};
-pub use smtp::SmtpMailboxTransport;
-pub use warming::{SendCounter, WarmingState, warming_daily_limit};
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
+pub use smtp::SmtpMailboxTransport;
 pub use store::PostgresEmailCursorStore;
+pub use warming::{SendCounter, WarmingState, warming_daily_limit};
 pub use worker::EmailPollWorker;
 
 use crate::subsystems::BeforeMutationHooks;

--- a/crates/fraiseql-server/src/inbound/email/smtp.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp.rs
@@ -1,0 +1,212 @@
+//! Per-connected-account SMTP send transport for the `send_email` host op.
+//!
+//! Consumes the `[mailbox.<name>.smtp]` halves: one pooled `lettre` transport per
+//! connected account, keyed by the account's verified sending address. The op
+//! resolves the host-owned `from` (the #539 sender seam), then this transport
+//! routes the send to the account whose address matches — never falling back to a
+//! different mailbox. Secrets (the SMTP password) are read server-side from the
+//! account's `password_env`, never from the DB row or guest input.
+//!
+//! Failures are classified onto the error status durable dispatch reads: a
+//! permanent SMTP error (5xx, unknown account, malformed recipient) is a 4xx
+//! `FraiseQLError` (dead-lettered), a transient one (connection refused, timeout,
+//! greylisting) is a 5xx (retried).
+
+use std::{collections::HashMap, future::Future, pin::Pin, time::Duration};
+
+use fraiseql_error::{FraiseQLError, Result};
+use fraiseql_functions::{EmailTransport, SendEmailRequest, SendEmailResponse, SenderIdentity};
+use lettre::{
+    Address, AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+    message::{Mailbox, MultiPart, SinglePart},
+    transport::smtp::authentication::Credentials,
+};
+use tracing::warn;
+
+use super::config::{MailboxSmtpConfig, SmtpTlsMode};
+
+/// Build the `send_email` transport from the SMTP halves of the configured mailboxes.
+///
+/// Returns an `Arc<dyn EmailTransport>` ready to attach via
+/// [`BeforeMutationHooks::with_email`](crate::subsystems::BeforeMutationHooks::with_email).
+/// Returns `None` when no `[mailbox.<name>.smtp]` account was successfully built —
+/// the caller then leaves `send_email` unconfigured (fail-loud). `get_env` resolves
+/// each account's password env (in production, [`std::env::var`]).
+#[must_use]
+pub fn build_email_transport<S: std::hash::BuildHasher>(
+    mailboxes: &HashMap<String, super::MailboxConfig, S>,
+    get_env: impl Fn(&str) -> Option<String>,
+) -> Option<std::sync::Arc<dyn EmailTransport>> {
+    let accounts = mailboxes
+        .iter()
+        .filter_map(|(name, mailbox)| mailbox.smtp.as_ref().map(|smtp| (name.as_str(), smtp)));
+    SmtpMailboxTransport::build(accounts, get_env)
+        .map(|transport| std::sync::Arc::new(transport) as std::sync::Arc<dyn EmailTransport>)
+}
+
+/// One connected SMTP account: a pooled `lettre` transport, keyed in the parent
+/// map by its verified sending address.
+struct SmtpAccount {
+    transport: AsyncSmtpTransport<Tokio1Executor>,
+}
+
+/// The `send_email` transport: routes each send to the connected account whose
+/// verified sending address matches the resolved sender identity.
+pub struct SmtpMailboxTransport {
+    accounts: HashMap<String, SmtpAccount>,
+}
+
+impl SmtpMailboxTransport {
+    /// Build a transport from the SMTP halves of the configured mailboxes.
+    ///
+    /// Each `[mailbox.<name>.smtp]` account becomes one pooled `lettre` transport,
+    /// keyed by its `address`. `get_env` resolves the password env (in production,
+    /// [`std::env::var`]). An account whose password env is unset, or whose relay
+    /// cannot be built, is skipped with a warning (never relays unauthenticated).
+    /// Returns `None` when no account was successfully built — the caller then
+    /// leaves `send_email` unconfigured (fail-loud), never a phantom transport.
+    #[must_use]
+    pub fn build<'a>(
+        mailboxes: impl Iterator<Item = (&'a str, &'a MailboxSmtpConfig)>,
+        get_env: impl Fn(&str) -> Option<String>,
+    ) -> Option<Self> {
+        let mut accounts = HashMap::new();
+        for (name, cfg) in mailboxes {
+            let Some(password) = get_env(&cfg.password_env) else {
+                warn!(
+                    mailbox = %name,
+                    password_env = %cfg.password_env,
+                    "SMTP send not enabled for mailbox: password env is unset"
+                );
+                continue;
+            };
+            match build_account_transport(cfg, password) {
+                Ok(transport) => {
+                    accounts.insert(cfg.address.clone(), SmtpAccount { transport });
+                },
+                Err(error) => warn!(
+                    mailbox = %name,
+                    %error,
+                    "SMTP send not enabled for mailbox: relay build failed"
+                ),
+            }
+        }
+        if accounts.is_empty() {
+            None
+        } else {
+            Some(Self { accounts })
+        }
+    }
+
+    /// Number of connected send accounts (for diagnostics/tests).
+    #[must_use]
+    pub fn account_count(&self) -> usize {
+        self.accounts.len()
+    }
+}
+
+impl EmailTransport for SmtpMailboxTransport {
+    fn send<'a>(
+        &'a self,
+        sender: &'a SenderIdentity,
+        request: &'a SendEmailRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<SendEmailResponse>> + Send + 'a>> {
+        Box::pin(async move {
+            // Select the account by the verified sending address — never fall back
+            // to a different mailbox (uniform with the read path's fail-closed).
+            let Some(account) = self.accounts.get(&sender.address) else {
+                return Err(FraiseQLError::Validation {
+                    message: format!(
+                        "no connected SMTP account for sending address {:?}",
+                        sender.address
+                    ),
+                    path:    None,
+                });
+            };
+
+            let message = build_message(sender, request)?;
+
+            match account.transport.send(message).await {
+                Ok(response) => Ok(SendEmailResponse {
+                    message_id: response.first_line().map(ToString::to_string),
+                    accepted:   true,
+                }),
+                // A permanent SMTP failure (5xx: auth rejected, bad recipient) must
+                // NOT retry — map to a 4xx so durable dispatch dead-letters it.
+                Err(error) if error.is_permanent() => Err(FraiseQLError::Validation {
+                    message: format!("SMTP permanent error: {error}"),
+                    path:    None,
+                }),
+                // Everything else (connection refused, timeout, 4xx greylisting) is
+                // transient — a 5xx so durable dispatch retries.
+                Err(error) => Err(FraiseQLError::ServiceUnavailable {
+                    message:     format!("SMTP transient error: {error}"),
+                    retry_after: None,
+                }),
+            }
+        })
+    }
+}
+
+/// Build one account's pooled SMTP transport from its config + resolved password.
+fn build_account_transport(
+    cfg: &MailboxSmtpConfig,
+    password: String,
+) -> Result<AsyncSmtpTransport<Tokio1Executor>> {
+    let mut builder = match cfg.tls {
+        SmtpTlsMode::StartTls => AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.host)
+            .map_err(|error| FraiseQLError::Configuration {
+                message: format!("cannot build STARTTLS relay to {}: {error}", cfg.host),
+            })?,
+        SmtpTlsMode::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.host).map_err(
+            |error| FraiseQLError::Configuration {
+                message: format!("cannot build TLS relay to {}: {error}", cfg.host),
+            },
+        )?,
+        SmtpTlsMode::None => AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&cfg.host),
+    };
+    builder = builder
+        .port(cfg.port)
+        .timeout(Some(Duration::from_secs(cfg.timeout_secs)))
+        .credentials(Credentials::new(cfg.username.clone(), password));
+    Ok(builder.build())
+}
+
+/// Build the `lettre` message: host-owned `from`, guest-supplied recipient/body.
+fn build_message(sender: &SenderIdentity, request: &SendEmailRequest) -> Result<Message> {
+    let from = mailbox(&sender.address, sender.display_name.as_deref())?;
+    let to = mailbox(&request.to, None)?;
+
+    let mut builder = Message::builder().from(from).to(to).subject(request.subject.clone());
+    if let Some(reply_to) = request.reply_to.as_deref() {
+        builder = builder.reply_to(mailbox(reply_to, None)?);
+    }
+
+    let built = match (request.text.as_deref(), request.html.as_deref()) {
+        (Some(text), Some(html)) => builder.multipart(MultiPart::alternative_plain_html(
+            text.to_owned(),
+            html.to_owned(),
+        )),
+        (Some(text), None) => builder.singlepart(SinglePart::plain(text.to_owned())),
+        (None, Some(html)) => builder.singlepart(SinglePart::html(html.to_owned())),
+        // No body: a valid, empty plain-text part rather than an error.
+        (None, None) => builder.singlepart(SinglePart::plain(String::new())),
+    };
+
+    built.map_err(|error| FraiseQLError::Validation {
+        message: format!("failed to build email message: {error}"),
+        path:    None,
+    })
+}
+
+/// Parse an address into a `lettre` [`Mailbox`] with an optional display name.
+fn mailbox(address: &str, display_name: Option<&str>) -> Result<Mailbox> {
+    let parsed = address.parse::<Address>().map_err(|error| FraiseQLError::Validation {
+        message: format!("invalid email address {address:?}: {error}"),
+        path:    None,
+    })?;
+    Ok(Mailbox::new(display_name.map(ToOwned::to_owned), parsed))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/smtp.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp.rs
@@ -54,6 +54,9 @@ struct SmtpAccount {
 /// verified sending address matches the resolved sender identity.
 pub struct SmtpMailboxTransport {
     accounts: HashMap<String, SmtpAccount>,
+    /// Optional per-mailbox send-warming counter. `None` → no daily cap is
+    /// enforced (see [`with_send_counter`](Self::with_send_counter)).
+    counter:  Option<std::sync::Arc<dyn super::warming::SendCounter>>,
 }
 
 impl SmtpMailboxTransport {
@@ -94,8 +97,22 @@ impl SmtpMailboxTransport {
         if accounts.is_empty() {
             None
         } else {
-            Some(Self { accounts })
+            Some(Self {
+                accounts,
+                counter: None,
+            })
         }
+    }
+
+    /// Attach a per-mailbox send-warming counter that caps daily volume during a
+    /// mailbox's warming period. Without one, no daily cap is enforced.
+    #[must_use]
+    pub fn with_send_counter(
+        mut self,
+        counter: std::sync::Arc<dyn super::warming::SendCounter>,
+    ) -> Self {
+        self.counter = Some(counter);
+        self
     }
 
     /// Number of connected send accounts (for diagnostics/tests).
@@ -124,13 +141,40 @@ impl EmailTransport for SmtpMailboxTransport {
                 });
             };
 
+            // Warming cap: refuse when the mailbox is at its daily limit. A daily
+            // cap will not clear on a seconds-scale retry, so this is a permanent
+            // failure for this dispatch (429 → dead-letter → replay next day),
+            // not a transient one.
+            if let Some(counter) = self.counter.as_ref() {
+                if let Some(state) = counter.state(&sender.address).await? {
+                    if !state.within_cap() {
+                        return Err(FraiseQLError::RateLimited {
+                            message:          format!(
+                                "sending address {:?} is at its warming daily cap",
+                                sender.address
+                            ),
+                            retry_after_secs: 86_400,
+                        });
+                    }
+                }
+            }
+
             let message = build_message(sender, request)?;
 
             match account.transport.send(message).await {
-                Ok(response) => Ok(SendEmailResponse {
-                    message_id: response.first_line().map(ToString::to_string),
-                    accepted:   true,
-                }),
+                Ok(response) => {
+                    // Best-effort accounting: the message is already sent, so a
+                    // counter error is logged, not surfaced (it must not un-send).
+                    if let Some(counter) = self.counter.as_ref() {
+                        if let Err(error) = counter.record_send(&sender.address).await {
+                            warn!(address = %sender.address, %error, "failed to record send for warming");
+                        }
+                    }
+                    Ok(SendEmailResponse {
+                        message_id: response.first_line().map(ToString::to_string),
+                        accepted:   true,
+                    })
+                },
                 // A permanent SMTP failure (5xx: auth rejected, bad recipient) must
                 // NOT retry — map to a 4xx so durable dispatch dead-letters it.
                 Err(error) if error.is_permanent() => Err(FraiseQLError::Validation {

--- a/crates/fraiseql-server/src/inbound/email/smtp.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp.rs
@@ -202,11 +202,13 @@ fn build_account_transport(
             .map_err(|error| FraiseQLError::Configuration {
                 message: format!("cannot build STARTTLS relay to {}: {error}", cfg.host),
             })?,
-        SmtpTlsMode::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.host).map_err(
-            |error| FraiseQLError::Configuration {
-                message: format!("cannot build TLS relay to {}: {error}", cfg.host),
-            },
-        )?,
+        SmtpTlsMode::Tls => {
+            AsyncSmtpTransport::<Tokio1Executor>::relay(&cfg.host).map_err(|error| {
+                FraiseQLError::Configuration {
+                    message: format!("cannot build TLS relay to {}: {error}", cfg.host),
+                }
+            })?
+        },
         SmtpTlsMode::None => AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&cfg.host),
     };
     builder = builder
@@ -227,10 +229,9 @@ fn build_message(sender: &SenderIdentity, request: &SendEmailRequest) -> Result<
     }
 
     let built = match (request.text.as_deref(), request.html.as_deref()) {
-        (Some(text), Some(html)) => builder.multipart(MultiPart::alternative_plain_html(
-            text.to_owned(),
-            html.to_owned(),
-        )),
+        (Some(text), Some(html)) => {
+            builder.multipart(MultiPart::alternative_plain_html(text.to_owned(), html.to_owned()))
+        },
         (Some(text), None) => builder.singlepart(SinglePart::plain(text.to_owned())),
         (None, Some(html)) => builder.singlepart(SinglePart::html(html.to_owned())),
         // No body: a valid, empty plain-text part rather than an error.

--- a/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
@@ -1,0 +1,143 @@
+//! Unit tests for the per-account SMTP send transport.
+//!
+//! These exercise account building and mailbox selection without a live SMTP
+//! server — the paths that return before any connection is opened. Actually
+//! relaying a message needs an SMTP server and is covered by the skip-clean live
+//! pattern elsewhere.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use fraiseql_functions::{EmailTransport, SendEmailRequest, SenderIdentity};
+
+use std::collections::HashMap;
+
+use super::{
+    MailboxSmtpConfig, SmtpMailboxTransport, SmtpTlsMode, build_email_transport, build_message,
+};
+use crate::inbound::email::MailboxConfig;
+
+fn smtp_cfg(address: &str) -> MailboxSmtpConfig {
+    MailboxSmtpConfig {
+        host:         "smtp.example.com".to_string(),
+        port:         587,
+        address:      address.to_string(),
+        username:     address.to_string(),
+        password_env: "TEST_SMTP_PW".to_string(),
+        // No TLS: the builder is constructed without connecting; no send happens
+        // in these tests, so no network is touched.
+        tls:          SmtpTlsMode::None,
+        timeout_secs: 5,
+    }
+}
+
+fn request(to: &str) -> SendEmailRequest {
+    SendEmailRequest {
+        to:       to.to_string(),
+        subject:  "hi".to_string(),
+        text:     Some("body".to_string()),
+        html:     None,
+        reply_to: None,
+    }
+}
+
+#[test]
+fn build_skips_accounts_with_unset_password_env() {
+    let cfg = smtp_cfg("sales@example.com");
+    let transport = SmtpMailboxTransport::build(std::iter::once(("sales", &cfg)), |_| None);
+    // No account could be built without credentials → no phantom transport.
+    assert!(transport.is_none());
+}
+
+#[test]
+fn build_creates_one_account_per_configured_mailbox() {
+    let a = smtp_cfg("sales@example.com");
+    let b = smtp_cfg("support@example.com");
+    let transport =
+        SmtpMailboxTransport::build([("sales", &a), ("support", &b)].into_iter(), |_| {
+            Some("pw".to_string())
+        })
+        .expect("accounts built");
+    assert_eq!(transport.account_count(), 2);
+}
+
+#[tokio::test]
+async fn send_from_an_unconnected_address_is_a_permanent_refusal() {
+    let cfg = smtp_cfg("sales@example.com");
+    let transport =
+        SmtpMailboxTransport::build(std::iter::once(("sales", &cfg)), |_| Some("pw".to_string()))
+            .unwrap();
+
+    // The resolved sender's address has no connected account → refuse (never fall
+    // back to a different mailbox). Returns before any connection is attempted.
+    let sender = SenderIdentity {
+        address:      "stranger@example.com".to_string(),
+        display_name: None,
+    };
+    let error = transport.send(&sender, &request("bob@example.com")).await.unwrap_err();
+    // Permanent (400) → durable dispatch dead-letters rather than retries.
+    assert_eq!(error.status_code(), 400);
+}
+
+#[test]
+fn build_email_transport_from_mailbox_config() {
+    // A mailbox with an SMTP half yields a transport; one with only IMAP (or none)
+    // does not contribute a send account.
+    let mut mailboxes: HashMap<String, MailboxConfig> = HashMap::new();
+    mailboxes.insert(
+        "sales".to_string(),
+        MailboxConfig {
+            imap: None,
+            smtp: Some(smtp_cfg("sales@example.com")),
+        },
+    );
+    mailboxes.insert("receive_only".to_string(), MailboxConfig {
+        imap: None,
+        smtp: None,
+    });
+
+    let transport = build_email_transport(&mailboxes, |_| Some("pw".to_string()));
+    assert!(transport.is_some(), "an SMTP half yields a transport");
+
+    // No SMTP halves at all → no transport (send_email stays fail-loud).
+    let receive_only: HashMap<String, MailboxConfig> = std::iter::once((
+        "r".to_string(),
+        MailboxConfig {
+            imap: None,
+            smtp: None,
+        },
+    ))
+    .collect();
+    assert!(build_email_transport(&receive_only, |_| Some("pw".to_string())).is_none());
+}
+
+#[test]
+fn build_message_rejects_a_malformed_recipient() {
+    let sender = SenderIdentity {
+        address:      "sales@example.com".to_string(),
+        display_name: Some("Sales".to_string()),
+    };
+    assert!(build_message(&sender, &request("not-an-email")).is_err());
+}
+
+#[test]
+fn build_message_supports_text_html_and_multipart_bodies() {
+    let sender = SenderIdentity {
+        address:      "sales@example.com".to_string(),
+        display_name: Some("Sales".to_string()),
+    };
+    for (text, html) in [
+        (Some("t"), None),
+        (None, Some("<b>h</b>")),
+        (Some("t"), Some("<b>h</b>")),
+        (None, None),
+    ] {
+        let req = SendEmailRequest {
+            to:       "bob@example.com".to_string(),
+            subject:  "hi".to_string(),
+            text:     text.map(ToString::to_string),
+            html:     html.map(ToString::to_string),
+            reply_to: None,
+        };
+        assert!(build_message(&sender, &req).is_ok(), "text={text:?} html={html:?}");
+    }
+}

--- a/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
@@ -9,12 +9,14 @@
 
 use fraiseql_functions::{EmailTransport, SendEmailRequest, SenderIdentity};
 
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+
+use fraiseql_error::Result;
 
 use super::{
     MailboxSmtpConfig, SmtpMailboxTransport, SmtpTlsMode, build_email_transport, build_message,
 };
-use crate::inbound::email::MailboxConfig;
+use crate::inbound::email::{MailboxConfig, SendCounter, WarmingState};
 
 fn smtp_cfg(address: &str) -> MailboxSmtpConfig {
     MailboxSmtpConfig {
@@ -108,6 +110,53 @@ fn build_email_transport_from_mailbox_config() {
     ))
     .collect();
     assert!(build_email_transport(&receive_only, |_| Some("pw".to_string())).is_none());
+}
+
+/// A counter reporting a fixed warming state, for cap-enforcement tests.
+struct FixedCounter {
+    state: Option<WarmingState>,
+}
+
+impl SendCounter for FixedCounter {
+    fn state<'a>(
+        &'a self,
+        _address: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<WarmingState>>> + Send + 'a>> {
+        let state = self.state;
+        Box::pin(async move { Ok(state) })
+    }
+
+    fn record_send<'a>(
+        &'a self,
+        _address: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn send_is_refused_at_the_warming_daily_cap() {
+    let cfg = smtp_cfg("sales@example.com");
+    // Day 0 → cap 10; already 10 sent today → over cap.
+    let counter = Arc::new(FixedCounter {
+        state: Some(WarmingState {
+            days_since_start: 0,
+            sends_today:      10,
+        }),
+    });
+    let transport =
+        SmtpMailboxTransport::build(std::iter::once(("sales", &cfg)), |_| Some("pw".to_string()))
+            .unwrap()
+            .with_send_counter(counter);
+
+    let sender = SenderIdentity {
+        address:      "sales@example.com".to_string(),
+        display_name: None,
+    };
+    // The cap gate refuses BEFORE any SMTP connection is attempted.
+    let error = transport.send(&sender, &request("bob@example.com")).await.unwrap_err();
+    // 429 → a client error → durable dispatch dead-letters (replay next day).
+    assert_eq!(error.status_code(), 429);
 }
 
 #[test]

--- a/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
@@ -7,11 +7,10 @@
 
 #![allow(clippy::unwrap_used)] // Reason: test code
 
-use fraiseql_functions::{EmailTransport, SendEmailRequest, SenderIdentity};
-
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use fraiseql_error::Result;
+use fraiseql_functions::{EmailTransport, SendEmailRequest, SenderIdentity};
 
 use super::{
     MailboxSmtpConfig, SmtpMailboxTransport, SmtpTlsMode, build_email_transport, build_message,
@@ -92,10 +91,13 @@ fn build_email_transport_from_mailbox_config() {
             smtp: Some(smtp_cfg("sales@example.com")),
         },
     );
-    mailboxes.insert("receive_only".to_string(), MailboxConfig {
-        imap: None,
-        smtp: None,
-    });
+    mailboxes.insert(
+        "receive_only".to_string(),
+        MailboxConfig {
+            imap: None,
+            smtp: None,
+        },
+    );
 
     let transport = build_email_transport(&mailboxes, |_| Some("pw".to_string()));
     assert!(transport.is_some(), "an SMTP half yields a transport");

--- a/crates/fraiseql-server/src/inbound/email/warming.rs
+++ b/crates/fraiseql-server/src/inbound/email/warming.rs
@@ -1,0 +1,77 @@
+//! Per-mailbox send warming: a conservative daily cap that ramps up over the
+//! first weeks of a new sending domain, then lifts.
+//!
+//! New sending mailboxes/domains that suddenly emit a high volume look like spam
+//! to receivers; warming ramps the allowed daily volume gradually. This module
+//! owns the pure ramp schedule and the cap check; the per-mailbox counter it reads
+//! (`sends_today`, warming start) is a [`SendCounter`] seam. A DB-backed
+//! `SendCounter` over the application's mailbox table (carrying `sends_today` /
+//! `daily_send_limit` / `warming_start_date`) is the remaining piece — until it is
+//! wired, a transport with no counter enforces no cap (unlimited).
+
+use std::{future::Future, pin::Pin};
+
+use fraiseql_error::Result;
+
+/// Weeks the warming ramp spans before a mailbox is fully warmed (then unlimited).
+const WARMING_WEEKS: u32 = 6;
+/// Daily send limit on the first day of warming.
+const WARMING_INITIAL_DAILY: u32 = 10;
+/// Daily send limit in the final warming week.
+const WARMING_TARGET_DAILY: u32 = 200;
+
+/// The daily send limit for a mailbox `days_since_start` days into warming, or
+/// `None` once fully warmed (no cap).
+///
+/// Ramps linearly from 10/day (week 1) to 200/day (week 6); week 7+ (day 42+) is
+/// uncapped. A negative `days_since_start` (a future-dated start) is treated as
+/// day 0 — the most conservative cap.
+#[must_use]
+pub fn warming_daily_limit(days_since_start: i64) -> Option<u32> {
+    let week = u32::try_from(days_since_start.max(0) / 7).unwrap_or(u32::MAX);
+    if week >= WARMING_WEEKS {
+        return None;
+    }
+    let span = WARMING_TARGET_DAILY - WARMING_INITIAL_DAILY;
+    Some(WARMING_INITIAL_DAILY + span * week / (WARMING_WEEKS - 1))
+}
+
+/// A mailbox's current warming state, read from a [`SendCounter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WarmingState {
+    /// Days since the mailbox began warming (0 on the first day).
+    pub days_since_start: i64,
+    /// Sends already made today.
+    pub sends_today:      u32,
+}
+
+impl WarmingState {
+    /// Whether one more send stays within the mailbox's current daily cap.
+    #[must_use]
+    pub fn within_cap(&self) -> bool {
+        warming_daily_limit(self.days_since_start).is_none_or(|limit| self.sends_today < limit)
+    }
+}
+
+/// The per-mailbox send-count seam the transport consults to enforce warming.
+///
+/// [`state`](Self::state) reports a mailbox's warming state (or `None` when the
+/// mailbox has no warming state → no cap); [`record_send`](Self::record_send)
+/// increments its daily count after a successful relay. A DB-backed implementation
+/// over the application's mailbox table is the remaining piece (see module docs).
+pub trait SendCounter: Send + Sync {
+    /// Read the warming state for a sending address, or `None` for no cap.
+    fn state<'a>(
+        &'a self,
+        address: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<WarmingState>>> + Send + 'a>>;
+
+    /// Record one successful send against a sending address's daily count.
+    fn record_send<'a>(
+        &'a self,
+        address: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/warming/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/warming/tests.rs
@@ -29,11 +29,13 @@ fn a_future_dated_start_uses_the_most_conservative_cap() {
 #[test]
 fn within_cap_enforces_the_daily_limit() {
     // Day 0 → limit 10.
-    assert!(WarmingState {
-        days_since_start: 0,
-        sends_today:      9,
-    }
-    .within_cap());
+    assert!(
+        WarmingState {
+            days_since_start: 0,
+            sends_today:      9,
+        }
+        .within_cap()
+    );
     assert!(
         !WarmingState {
             days_since_start: 0,
@@ -46,9 +48,11 @@ fn within_cap_enforces_the_daily_limit() {
 
 #[test]
 fn a_fully_warmed_mailbox_is_never_over_cap() {
-    assert!(WarmingState {
-        days_since_start: 90,
-        sends_today:      10_000,
-    }
-    .within_cap());
+    assert!(
+        WarmingState {
+            days_since_start: 90,
+            sends_today:      10_000,
+        }
+        .within_cap()
+    );
 }

--- a/crates/fraiseql-server/src/inbound/email/warming/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/warming/tests.rs
@@ -1,0 +1,54 @@
+//! Tests for the pure send-warming ramp + cap.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use super::{WarmingState, warming_daily_limit};
+
+#[test]
+fn ramp_starts_at_ten_and_climbs_to_the_target() {
+    // Week 1 (days 0-6) → 10/day; week 6 (days 35-41) → 200/day.
+    assert_eq!(warming_daily_limit(0), Some(10));
+    assert_eq!(warming_daily_limit(6), Some(10), "still week 1");
+    assert_eq!(warming_daily_limit(7), Some(48), "week 2");
+    assert_eq!(warming_daily_limit(35), Some(200), "week 6");
+    assert_eq!(warming_daily_limit(41), Some(200), "still week 6");
+}
+
+#[test]
+fn fully_warmed_after_six_weeks_is_uncapped() {
+    assert_eq!(warming_daily_limit(42), None, "week 7 → unlimited");
+    assert_eq!(warming_daily_limit(1_000), None);
+}
+
+#[test]
+fn a_future_dated_start_uses_the_most_conservative_cap() {
+    // Negative days (start in the future) → treated as day 0.
+    assert_eq!(warming_daily_limit(-5), Some(10));
+}
+
+#[test]
+fn within_cap_enforces_the_daily_limit() {
+    // Day 0 → limit 10.
+    assert!(WarmingState {
+        days_since_start: 0,
+        sends_today:      9,
+    }
+    .within_cap());
+    assert!(
+        !WarmingState {
+            days_since_start: 0,
+            sends_today:      10,
+        }
+        .within_cap(),
+        "the 10th send of a 10/day mailbox is over cap"
+    );
+}
+
+#[test]
+fn a_fully_warmed_mailbox_is_never_over_cap() {
+    assert!(WarmingState {
+        days_since_start: 90,
+        sends_today:      10_000,
+    }
+    .within_cap());
+}

--- a/crates/fraiseql-server/src/routes/after_mutation/mod.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/mod.rs
@@ -253,19 +253,18 @@ pub fn resolve_dispatch_settings(
 #[cfg(feature = "functions-runtime")]
 #[derive(Clone)]
 struct DurableDispatcher {
-    observer:    std::sync::Arc<fraiseql_functions::FunctionObserver>,
-    host_config: fraiseql_functions::host::live::HostContextConfig,
-    limits:      fraiseql_functions::ResourceLimits,
-    dlq:         std::sync::Arc<dyn fraiseql_observers::DeadLetterQueue>,
+    observer:        std::sync::Arc<fraiseql_functions::FunctionObserver>,
+    host_config:     fraiseql_functions::host::live::HostContextConfig,
+    limits:          fraiseql_functions::ResourceLimits,
+    dlq:             std::sync::Arc<dyn fraiseql_observers::DeadLetterQueue>,
     /// Which trigger subsystem this dispatcher serves — tags dead-letter records
     /// so `after:mutation` and `after:ingest` failures are distinguishable.
-    source:      fraiseql_observers::DispatchSource,
+    source:          fraiseql_observers::DispatchSource,
     /// Host-owned sender-identity resolver + email transport for the `send_email`
     /// op. `None` → the op fails loud on the built host. Threaded from the hooks so
     /// every dispatched function's fresh host can send from the connected user's
     /// verified address.
-    sender_resolver:
-        Option<std::sync::Arc<dyn fraiseql_functions::SenderIdentityResolver>>,
+    sender_resolver: Option<std::sync::Arc<dyn fraiseql_functions::SenderIdentityResolver>>,
     email_transport: Option<std::sync::Arc<dyn fraiseql_functions::EmailTransport>>,
 }
 
@@ -288,7 +287,8 @@ impl DurableDispatcher {
         if let (Some(resolver), Some(transport)) =
             (self.sender_resolver.as_ref(), self.email_transport.as_ref())
         {
-            live = live.with_email(std::sync::Arc::clone(resolver), std::sync::Arc::clone(transport));
+            live =
+                live.with_email(std::sync::Arc::clone(resolver), std::sync::Arc::clone(transport));
         }
         let host: std::sync::Arc<dyn fraiseql_functions::host::dyn_context::DynHostContext> =
             std::sync::Arc::new(live);

--- a/crates/fraiseql-server/src/routes/after_mutation/mod.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/mod.rs
@@ -260,6 +260,13 @@ struct DurableDispatcher {
     /// Which trigger subsystem this dispatcher serves — tags dead-letter records
     /// so `after:mutation` and `after:ingest` failures are distinguishable.
     source:      fraiseql_observers::DispatchSource,
+    /// Host-owned sender-identity resolver + email transport for the `send_email`
+    /// op. `None` → the op fails loud on the built host. Threaded from the hooks so
+    /// every dispatched function's fresh host can send from the connected user's
+    /// verified address.
+    sender_resolver:
+        Option<std::sync::Arc<dyn fraiseql_functions::SenderIdentityResolver>>,
+    email_transport: Option<std::sync::Arc<dyn fraiseql_functions::EmailTransport>>,
 }
 
 #[cfg(feature = "functions-runtime")]
@@ -273,11 +280,18 @@ impl DurableDispatcher {
         // Shared, runtime-agnostic host bridge: the observer dispatches the plan
         // to the WASM or Deno backend by the module's runtime, so the host type
         // must not be tied to either.
+        let mut live = fraiseql_functions::host::live::LiveHostContext::new(
+            payload.clone(),
+            self.host_config.clone(),
+        );
+        // Enable `send_email` (host-owned `from` + transport) when both are wired.
+        if let (Some(resolver), Some(transport)) =
+            (self.sender_resolver.as_ref(), self.email_transport.as_ref())
+        {
+            live = live.with_email(std::sync::Arc::clone(resolver), std::sync::Arc::clone(transport));
+        }
         let host: std::sync::Arc<dyn fraiseql_functions::host::dyn_context::DynHostContext> =
-            std::sync::Arc::new(fraiseql_functions::host::live::LiveHostContext::new(
-                payload.clone(),
-                self.host_config.clone(),
-            ));
+            std::sync::Arc::new(live);
         self.observer
             .invoke_with_context(module, payload, host, self.limits.clone())
             .await
@@ -412,6 +426,8 @@ fn spawn_dispatch(
         limits: fraiseql_functions::ResourceLimits::default(),
         dlq: std::sync::Arc::clone(&hooks.dlq),
         source,
+        sender_resolver: hooks.sender_resolver.clone(),
+        email_transport: hooks.email_transport.clone(),
     };
 
     for plan in plans {

--- a/crates/fraiseql-server/src/routes/after_mutation/tests.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/tests.rs
@@ -259,6 +259,8 @@ mod durable_dispatch {
             limits: ResourceLimits::default(),
             dlq,
             source: fraiseql_observers::DispatchSource::AfterMutation,
+            sender_resolver: None,
+            email_transport: None,
         }
     }
 

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -413,6 +413,8 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             db_pool,
             storage_state: None,
             realtime_state: None,
+            #[cfg(feature = "functions-runtime")]
+            functions_hooks: None,
             tenant_executor_factory: None,
             #[cfg(feature = "arrow")]
             flight_service,

--- a/crates/fraiseql-server/src/server/extensions.rs
+++ b/crates/fraiseql-server/src/server/extensions.rs
@@ -367,6 +367,8 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             db_pool,
             storage_state: None,
             realtime_state: None,
+            #[cfg(feature = "functions-runtime")]
+            functions_hooks: None,
             tenant_executor_factory: None,
             #[cfg(feature = "arrow")]
             flight_service,

--- a/crates/fraiseql-server/src/server/functions_setup.rs
+++ b/crates/fraiseql-server/src/server/functions_setup.rs
@@ -1,0 +1,122 @@
+//! Serve-time functions-runtime preparation.
+//!
+//! Loads the compiled schema's function modules, registers the runtimes, attaches
+//! the `send_email` wiring, and stores the before-mutation hooks so
+//! `build_app_state` mounts them and after:mutation functions actually fire. Runs
+//! once at serve time (async, fail-loud) — the counterpart to the RBAC/inbound
+//! schema init already in the serve path.
+
+use std::sync::Arc;
+
+use fraiseql_core::db::traits::DatabaseAdapter;
+
+use super::{Server, ServerError};
+use crate::{schema::loader::CompiledSchemaLoader, subsystems::loader::build_functions_subsystem};
+
+impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
+    /// Prepare functions-runtime dispatch from the compiled schema.
+    ///
+    /// Loads the extended schema's functions config; when it declares functions,
+    /// builds the subsystem (modules loaded from `module_dir`, runtimes
+    /// registered), attaches the `send_email` wiring, and stores the resulting
+    /// hooks. A no-op (hooks stay `None`) when no functions are declared.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ServerError::ConfigError`] if the schema cannot be loaded or a
+    /// declared function's module is missing/unreadable (fail-loud: a declared
+    /// function that can never run is a misconfiguration).
+    pub(super) async fn prepare_functions_runtime(&mut self) -> Result<(), ServerError> {
+        let extended = CompiledSchemaLoader::new(&self.config.schema_path)
+            .load_extended()
+            .await
+            .map_err(|error| {
+                ServerError::ConfigError(format!("failed to load functions config: {error}"))
+            })?;
+
+        let Some(functions_config) = extended.functions else {
+            return Ok(()); // no `functions` in the compiled schema
+        };
+        if functions_config.definitions.is_empty() {
+            return Ok(());
+        }
+
+        let subsystem = build_functions_subsystem(functions_config).map_err(|error| {
+            ServerError::ConfigError(format!("functions-runtime setup failed: {error}"))
+        })?;
+        let mut hooks = subsystem.into_before_mutation_hooks();
+
+        if let Some((resolver, transport)) = self.build_send_email_wiring() {
+            hooks = hooks.with_email(resolver, transport);
+            tracing::info!(
+                "send_email host op enabled (host-owned from, per-connected-account SMTP)"
+            );
+        }
+
+        let function_count = hooks.module_registry.len();
+        self.functions_hooks = Some(Arc::new(hooks));
+        tracing::info!(functions = function_count, "functions-runtime dispatch enabled");
+        Ok(())
+    }
+
+    /// Build the `send_email` wiring — sender-identity resolver + SMTP transport —
+    /// from config. Returns `None` when no SMTP mailbox is configured, leaving
+    /// `send_email` fail-loud.
+    fn build_send_email_wiring(
+        &self,
+    ) -> Option<(
+        Arc<dyn fraiseql_functions::SenderIdentityResolver>,
+        Arc<dyn fraiseql_functions::EmailTransport>,
+    )> {
+        #[cfg(feature = "inbound-email")]
+        {
+            let transport =
+                crate::inbound::email::build_email_transport(&self.config.mailbox, |name| {
+                    std::env::var(name).ok()
+                })?;
+            Some((self.build_sender_resolver(), transport))
+        }
+        #[cfg(not(feature = "inbound-email"))]
+        {
+            None
+        }
+    }
+
+    /// The sender-identity resolver: DB-backed on the shared identity primitive
+    /// when `[identity.sender]` is enabled, else the login-email default.
+    #[cfg(feature = "inbound-email")]
+    fn build_sender_resolver(&self) -> Arc<dyn fraiseql_functions::SenderIdentityResolver> {
+        #[cfg(feature = "auth")]
+        if let Some(sender) =
+            self.config.identity.as_ref().and_then(|identity| identity.sender.as_ref())
+        {
+            if sender.enabled {
+                if let Some(pool) = self.enrichment_pool.as_ref() {
+                    let resolver = crate::identity::resolver::IdentityResolver::postgres(
+                        sender.clone(),
+                        pool.clone(),
+                    );
+                    return Arc::new(crate::identity::sender::DbSenderIdentityResolver::new(
+                        resolver,
+                        SENDING_ADDRESS_FIELD,
+                        Some(DISPLAY_NAME_FIELD.to_string()),
+                    ));
+                }
+                tracing::warn!(
+                    "[identity.sender] is enabled but no auth database pool is available — \
+                     send_email falls back to the login-email sender"
+                );
+            }
+        }
+        Arc::new(fraiseql_functions::LoginEmailSender)
+    }
+}
+
+/// The resolved sender query's field holding the verified from-address (convention,
+/// matching `docs/architecture/enriched-identity-rls.md`).
+#[cfg(all(feature = "inbound-email", feature = "auth"))]
+const SENDING_ADDRESS_FIELD: &str = "sending_address";
+
+/// The resolved sender query's field holding the sender display name.
+#[cfg(all(feature = "inbound-email", feature = "auth"))]
+const DISPLAY_NAME_FIELD: &str = "display_name";

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -143,6 +143,14 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             }
         }
 
+        // Prepare functions-runtime dispatch (load modules, register runtimes,
+        // attach the send_email wiring) before the router is built, so
+        // `build_app_state` mounts the before-mutation hooks. Async + fail-loud,
+        // like the RBAC/inbound schema init above; a no-op when no functions are
+        // declared or the feature is off.
+        #[cfg(feature = "functions-runtime")]
+        self.prepare_functions_runtime().await?;
+
         let (app, app_state) = self.build_router();
 
         // Start the poll-IMAP email workers.

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -146,20 +146,20 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         let (app, app_state) = self.build_router();
 
         // Start the poll-IMAP email workers.
-        // Each configured `[imap.<name>]` mailbox runs a background poll loop on
-        // the server's JoinSet, so graceful shutdown aborts them. The workers
+        // Each configured `[mailbox.<name>.imap]` half runs a background poll loop
+        // on the server's JoinSet, so graceful shutdown aborts them. The workers
         // reuse the durable inbound spine and the `after:ingest` dispatch path;
         // attachments stream into the legacy storage backend when one is
         // configured. Must run here (async, after `build_router` supplies the
         // function-dispatch hooks) rather than in the sync `build_router`.
         #[cfg(feature = "inbound-email")]
         if let Some(ref db_pool) = self.db_pool {
-            if !self.config.imap.is_empty() {
+            if self.config.mailbox.values().any(|mailbox| mailbox.imap.is_some()) {
                 use crate::inbound::{email, spine::PostgresInboundSpine};
 
                 // The email path shares the inbound spine; create it here too in
-                // case only `[imap.*]` (no `[webhooks.*]`) is configured. Both
-                // DDLs are idempotent.
+                // case only `[mailbox.*.imap]` (no `[webhooks.*]`) is configured.
+                // Both DDLs are idempotent.
                 PostgresInboundSpine::new(db_pool.clone()).init().await.map_err(|e| {
                     ServerError::ConfigError(format!(
                         "Failed to initialize inbound spine schema: {e}"
@@ -179,7 +179,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                 });
                 let hooks = app_state.before_mutation_hooks.clone();
                 let workers = email::build_workers(
-                    &self.config.imap,
+                    &self.config.mailbox,
                     db_pool,
                     hooks.as_ref(),
                     sink.as_ref(),

--- a/crates/fraiseql-server/src/server/mod.rs
+++ b/crates/fraiseql-server/src/server/mod.rs
@@ -36,6 +36,8 @@ use crate::{
 
 mod builder;
 mod extensions;
+#[cfg(feature = "functions-runtime")]
+mod functions_setup;
 mod initialization;
 mod lifecycle;
 mod routing;
@@ -144,6 +146,14 @@ pub struct Server<A: DatabaseAdapter> {
     /// When `Some`, `build_base_router` merges `realtime_router(state)` at
     /// `/realtime/v1`. Set via [`Server::with_realtime`].
     pub(super) realtime_state: Option<crate::realtime::server::RealtimeState>,
+
+    /// Before-mutation function-dispatch hooks, prepared at serve time from the
+    /// compiled schema's functions config (modules loaded, runtimes registered,
+    /// `send_email` wiring attached). When `Some`, `build_app_state` attaches them
+    /// so after:mutation functions fire. `None` when no functions are declared or
+    /// the `functions-runtime` feature is off.
+    #[cfg(feature = "functions-runtime")]
+    pub(super) functions_hooks: Option<Arc<crate::subsystems::BeforeMutationHooks>>,
 
     /// Factory for building per-tenant executors at registration time.
     ///

--- a/crates/fraiseql-server/src/server/routing/state.rs
+++ b/crates/fraiseql-server/src/server/routing/state.rs
@@ -82,6 +82,14 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             info!("API key authenticator attached to AppState");
         }
 
+        // Attach the functions-runtime before-mutation hooks prepared at serve time
+        // (modules loaded, runtimes registered, send_email wiring attached), so
+        // after:mutation functions fire on the I/O-capable live host.
+        #[cfg(feature = "functions-runtime")]
+        if let Some(hooks) = self.functions_hooks.as_ref() {
+            state = state.with_functions(hooks.clone());
+        }
+
         // Enriched-identity resolution (#539). When `[identity.enrichment]` is
         // enabled, build the resolver on the unscoped auth pool and attach it, so
         // every authenticated request resolves its DB identity and fail-closes

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -619,15 +619,17 @@ pub struct ServerConfig {
     #[serde(default)]
     pub webhooks: HashMap<String, crate::config::WebhookRouteConfig>,
 
-    /// Poll-IMAP inbound email mailboxes (`[imap.<name>]`), keyed by mailbox name.
+    /// Connected mailbox accounts (`[mailbox.<name>]`), keyed by account name.
     ///
-    /// Each entry starts a background poll worker that fetches new messages by UID
-    /// watermark, normalizes their MIME to an `InboundMessage` on the durable
-    /// spine, and fires `after:ingest:email` functions. Requires the
+    /// Each account carries an optional poll-IMAP receive half
+    /// (`[mailbox.<name>.imap]`) — a background poll worker that fetches new
+    /// messages by UID watermark, normalizes their MIME to an `InboundMessage` on
+    /// the durable spine, and fires `after:ingest:email` functions — and (via the
+    /// hardening `send_email` transport) an SMTP send half. Requires the
     /// `inbound-email` feature and a PostgreSQL pool; empty by default.
     #[cfg(feature = "inbound-email")]
     #[serde(default)]
-    pub imap: HashMap<String, crate::inbound::email::ImapMailboxConfig>,
+    pub mailbox: HashMap<String, crate::inbound::email::MailboxConfig>,
 
     /// Multi-tenant executor runtime configuration.
     ///
@@ -826,7 +828,7 @@ impl Default for ServerConfig {
             #[cfg(feature = "inbound")]
             webhooks: HashMap::new(), // No inbound webhook routes by default
             #[cfg(feature = "inbound-email")]
-            imap: HashMap::new(), // No poll-IMAP mailboxes by default
+            mailbox: HashMap::new(), // No connected mailboxes by default
             tenancy: TenancyServerConfig::default(), // Multi-tenant runtime off by default
             #[cfg(feature = "auth")]
             identity: None, // Enriched-identity resolution off by default

--- a/crates/fraiseql-server/src/subsystems/loader.rs
+++ b/crates/fraiseql-server/src/subsystems/loader.rs
@@ -1,0 +1,176 @@
+//! Load function modules from disk and assemble the functions-runtime subsystem.
+//!
+//! The compiled schema declares each function (name, trigger, runtime) and a
+//! `module_dir`; the compiled/authored module lives on disk as
+//! `<module_dir>/<name>.<ext>` (`.wasm` for WASM, `.js`/`.ts` for Deno). This
+//! module reads those files, builds the runtime observer with the compiled-in
+//! runtimes registered, and assembles the [`FunctionsSubsystem`] the server turns
+//! into before-mutation hooks.
+//!
+//! **Fail-loud:** a declared function whose module file is missing or unreadable,
+//! or whose runtime is not compiled into this build, aborts startup — a declared
+//! function that can never run is a misconfiguration, not something to skip
+//! silently (it is the very class of bug that leaves after:mutation work
+//! mysteriously never firing).
+
+use std::{collections::HashMap, path::Path};
+
+use fraiseql_error::{FraiseQLError, Result};
+use fraiseql_functions::{
+    FunctionModule, FunctionObserver, RuntimeType, triggers::TriggerRegistry,
+    types::FunctionDefinition,
+};
+
+use super::FunctionsSubsystem;
+use crate::schema::loader::FunctionsConfig;
+
+/// Build the functions-runtime subsystem from the compiled-schema functions config.
+///
+/// Loads each declared function's module from `config.module_dir`, registers the
+/// runtimes compiled into this build, and assembles the observer + trigger
+/// registry.
+///
+/// # Errors
+///
+/// Returns [`FraiseQLError::Configuration`] if a declared module file is missing or
+/// unreadable, a function targets a runtime not compiled in, the trigger set is
+/// invalid, or a runtime engine fails to initialize.
+pub fn build_functions_subsystem(config: FunctionsConfig) -> Result<FunctionsSubsystem> {
+    let module_registry = load_modules(&config)?;
+
+    let trigger_registry =
+        TriggerRegistry::load_from_definitions(&config.definitions).map_err(|error| {
+            FraiseQLError::Configuration {
+                message: format!("invalid function triggers: {error}"),
+            }
+        })?;
+
+    let mut observer = FunctionObserver::new();
+
+    // Register the runtimes compiled into this build. `functions-runtime` always
+    // pulls the WASM runtime; the Deno runtime is opt-in (`functions-runtime-deno`).
+    observer.register_runtime(
+        RuntimeType::Wasm,
+        fraiseql_functions::runtime::wasm::WasmRuntime::new(
+            &fraiseql_functions::runtime::wasm::WasmConfig::default(),
+        )
+        .map_err(|error| FraiseQLError::Configuration {
+            message: format!("failed to initialize the WASM function runtime: {error}"),
+        })?,
+    );
+    #[cfg(feature = "functions-runtime-deno")]
+    observer.register_runtime(
+        RuntimeType::Deno,
+        fraiseql_functions::runtime::deno::DenoRuntime::new(
+            &fraiseql_functions::runtime::deno::DenoConfig::default(),
+        )
+        .map_err(|error| FraiseQLError::Configuration {
+            message: format!("failed to initialize the Deno function runtime: {error}"),
+        })?,
+    );
+
+    Ok(FunctionsSubsystem {
+        observer: std::sync::Arc::new(observer),
+        trigger_registry,
+        module_registry,
+        config,
+    })
+}
+
+/// Load every declared function's module, keyed by function name.
+fn load_modules(config: &FunctionsConfig) -> Result<HashMap<String, FunctionModule>> {
+    let mut registry = HashMap::with_capacity(config.definitions.len());
+    for definition in &config.definitions {
+        let module = load_one_module(&config.module_dir, definition)?;
+        registry.insert(definition.name.clone(), module);
+    }
+    Ok(registry)
+}
+
+/// Load one function's module from `<module_dir>/<name>.<ext>`, trying each
+/// extension the function's runtime supports.
+fn load_one_module(module_dir: &Path, definition: &FunctionDefinition) -> Result<FunctionModule> {
+    if !runtime_compiled_in(definition.runtime) {
+        return Err(FraiseQLError::Configuration {
+            message: format!(
+                "function {:?} targets the {:?} runtime, which is not compiled into this build \
+                 (enable the corresponding `functions-runtime*` feature)",
+                definition.name, definition.runtime
+            ),
+        });
+    }
+
+    for extension in definition.runtime.supported_extensions() {
+        let path = module_dir.join(format!("{}{extension}", definition.name));
+        if !path.exists() {
+            continue;
+        }
+        return build_module(definition, &path);
+    }
+
+    Err(FraiseQLError::Configuration {
+        message: format!(
+            "function {:?} declares the {:?} runtime but no module file was found at {}/{}.{{{}}}",
+            definition.name,
+            definition.runtime,
+            module_dir.display(),
+            definition.name,
+            definition
+                .runtime
+                .supported_extensions()
+                .iter()
+                .map(|ext| ext.trim_start_matches('.'))
+                .collect::<Vec<_>>()
+                .join(","),
+        ),
+    })
+}
+
+/// Read `path` into a [`FunctionModule`] appropriate for the function's runtime:
+/// raw bytecode for WASM, source text for Deno.
+fn build_module(definition: &FunctionDefinition, path: &Path) -> Result<FunctionModule> {
+    match definition.runtime {
+        RuntimeType::Wasm => {
+            let bytecode = std::fs::read(path).map_err(|error| FraiseQLError::Configuration {
+                message: format!(
+                    "failed to read WASM module for function {:?} at {}: {error}",
+                    definition.name,
+                    path.display()
+                ),
+            })?;
+            Ok(FunctionModule::from_bytecode(definition.name.clone(), bytecode.into()))
+        },
+        RuntimeType::Deno => {
+            let source =
+                std::fs::read_to_string(path).map_err(|error| FraiseQLError::Configuration {
+                    message: format!(
+                        "failed to read Deno module for function {:?} at {}: {error}",
+                        definition.name,
+                        path.display()
+                    ),
+                })?;
+            Ok(FunctionModule::from_source(definition.name.clone(), source, RuntimeType::Deno))
+        },
+        // `RuntimeType` is non-exhaustive; a future runtime lands with its own arm.
+        other => Err(FraiseQLError::Configuration {
+            message: format!(
+                "function {:?} declares an unsupported runtime {other:?}",
+                definition.name
+            ),
+        }),
+    }
+}
+
+/// Whether the given runtime is compiled into this build.
+const fn runtime_compiled_in(runtime: RuntimeType) -> bool {
+    match runtime {
+        // `functions-runtime` always pulls the WASM runtime.
+        RuntimeType::Wasm => true,
+        RuntimeType::Deno => cfg!(feature = "functions-runtime-deno"),
+        // Unknown future runtime → not compiled in.
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/subsystems/loader/tests.rs
+++ b/crates/fraiseql-server/src/subsystems/loader/tests.rs
@@ -1,0 +1,95 @@
+//! Tests for the function-module loader.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use fraiseql_functions::{RuntimeType, types::FunctionDefinition};
+use tempfile::tempdir;
+
+use super::{build_functions_subsystem, load_one_module};
+use crate::schema::loader::FunctionsConfig;
+
+// WASM is always compiled in under `functions-runtime`, so the loader tests use it
+// (the module bytes are not validated at load time — the runtime instantiates them
+// lazily). Deno loading is exercised only when the Deno runtime is compiled in.
+fn wasm_def(name: &str) -> FunctionDefinition {
+    FunctionDefinition::new(name, &format!("after:mutation:Deal:update@{name}"), RuntimeType::Wasm)
+}
+
+#[test]
+fn loads_a_wasm_module_from_bytecode() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("scoreDeal.wasm"), b"\0asm\x01\0\0\0").unwrap();
+
+    let module = load_one_module(dir.path(), &wasm_def("scoreDeal")).unwrap();
+    assert_eq!(module.name, "scoreDeal");
+    assert_eq!(module.runtime, RuntimeType::Wasm);
+    assert_eq!(&module.bytecode[..], b"\0asm\x01\0\0\0");
+}
+
+#[test]
+fn a_missing_module_file_fails_loud() {
+    let dir = tempdir().unwrap();
+    // No file written → the declared function has no loadable module.
+    let error = load_one_module(dir.path(), &wasm_def("ghost")).unwrap_err();
+    assert!(error.to_string().contains("ghost"), "the error names the function");
+}
+
+#[test]
+fn build_subsystem_loads_all_declared_modules() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("scoreDeal.wasm"), b"\0asm\x01\0\0\0").unwrap();
+    std::fs::write(dir.path().join("chargeCard.wasm"), b"\0asm\x01\0\0\0").unwrap();
+
+    let config = FunctionsConfig {
+        module_dir:  dir.path().to_path_buf(),
+        definitions: vec![wasm_def("scoreDeal"), wasm_def("chargeCard")],
+    };
+
+    let subsystem = build_functions_subsystem(config).unwrap();
+    assert_eq!(subsystem.module_registry.len(), 2, "both modules loaded");
+    assert!(subsystem.module_registry.contains_key("scoreDeal"));
+    assert!(subsystem.module_registry.contains_key("chargeCard"));
+}
+
+#[test]
+fn build_subsystem_fails_loud_on_a_missing_module() {
+    let dir = tempdir().unwrap();
+    // Declared but no file on disk.
+    let config = FunctionsConfig {
+        module_dir:  dir.path().to_path_buf(),
+        definitions: vec![wasm_def("missing")],
+    };
+    assert!(build_functions_subsystem(config).is_err());
+}
+
+/// A function targeting a runtime that is not compiled into this build fails loud.
+#[cfg(not(feature = "functions-runtime-deno"))]
+#[test]
+fn a_deno_function_without_the_deno_runtime_fails_loud() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("followUp.ts"), "export default async () => ({});").unwrap();
+    let def = FunctionDefinition::new(
+        "followUp",
+        "after:mutation:Deal:update@followUp",
+        RuntimeType::Deno,
+    );
+    let error = load_one_module(dir.path(), &def).unwrap_err();
+    assert!(error.to_string().contains("not compiled into this build"));
+}
+
+/// When the Deno runtime is compiled in, a `.ts`/`.js` module loads from source.
+#[cfg(feature = "functions-runtime-deno")]
+#[test]
+fn loads_a_deno_module_from_source() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("followUp.ts"), "export default async () => ({ ok: true });")
+        .unwrap();
+    let def = FunctionDefinition::new(
+        "followUp",
+        "after:mutation:Deal:update@followUp",
+        RuntimeType::Deno,
+    );
+    let module = load_one_module(dir.path(), &def).unwrap();
+    assert_eq!(module.runtime, RuntimeType::Deno);
+    assert!(String::from_utf8_lossy(&module.bytecode).contains("export default"));
+}

--- a/crates/fraiseql-server/src/subsystems/mod.rs
+++ b/crates/fraiseql-server/src/subsystems/mod.rs
@@ -183,6 +183,17 @@ pub struct BeforeMutationHooks {
     #[cfg(feature = "functions-runtime")]
     pub dispatch_settings:
         std::collections::HashMap<String, crate::routes::after_mutation::FunctionDispatchSetting>,
+
+    /// Host-owned sender-identity resolver for the `send_email` op — resolves the
+    /// `from` from the authenticated context (the #539 seam). `None` → `send_email`
+    /// is unconfigured and fails loud. Set together with `email_transport` via
+    /// [`with_email`](Self::with_email).
+    #[cfg(feature = "functions-runtime")]
+    pub sender_resolver: Option<std::sync::Arc<dyn fraiseql_functions::SenderIdentityResolver>>,
+
+    /// Email transport for the `send_email` op. `None` → `send_email` fails loud.
+    #[cfg(feature = "functions-runtime")]
+    pub email_transport: Option<std::sync::Arc<dyn fraiseql_functions::EmailTransport>>,
 }
 
 impl BeforeMutationHooks {
@@ -207,7 +218,31 @@ impl BeforeMutationHooks {
             dlq: Arc::new(crate::observers::runtime::InMemoryDlq::new_with_max(None)),
             #[cfg(feature = "functions-runtime")]
             dispatch_settings: std::collections::HashMap::new(),
+            #[cfg(feature = "functions-runtime")]
+            sender_resolver: None,
+            #[cfg(feature = "functions-runtime")]
+            email_transport: None,
         }
+    }
+
+    /// Enable the `send_email` host op for dispatched functions by attaching a
+    /// sender-identity resolver (the host-owned `from`) and an email transport.
+    ///
+    /// Without both, `send_email` fails loud (mirrors the `sql_query`
+    /// fail-loud-until-wired stance). The resolver is the #539 seam —
+    /// `LoginEmailSender` (from = login email) by default, a DB-backed resolver
+    /// where the sending mailbox differs; the transport is the per-connected-account
+    /// SMTP relay ([`SmtpMailboxTransport`](crate::inbound::email::SmtpMailboxTransport)).
+    #[cfg(feature = "functions-runtime")]
+    #[must_use]
+    pub fn with_email(
+        mut self,
+        sender_resolver: Arc<dyn fraiseql_functions::SenderIdentityResolver>,
+        email_transport: Arc<dyn fraiseql_functions::EmailTransport>,
+    ) -> Self {
+        self.sender_resolver = Some(sender_resolver);
+        self.email_transport = Some(email_transport);
+        self
     }
 }
 
@@ -237,6 +272,8 @@ impl FunctionsSubsystem {
             observer: self.observer,
             dlq,
             dispatch_settings,
+            sender_resolver: None,
+            email_transport: None,
         }
     }
 }

--- a/crates/fraiseql-server/src/subsystems/mod.rs
+++ b/crates/fraiseql-server/src/subsystems/mod.rs
@@ -31,6 +31,10 @@
 pub mod builder;
 pub mod validator;
 
+/// Loads function modules from disk and assembles the functions-runtime subsystem.
+#[cfg(feature = "functions-runtime")]
+pub mod loader;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/fraiseql-server/src/subsystems/tests.rs
+++ b/crates/fraiseql-server/src/subsystems/tests.rs
@@ -19,6 +19,8 @@ use fraiseql_storage::{
 use sqlx::PgPool;
 use tempfile::tempdir;
 
+#[cfg(feature = "functions-runtime")]
+use super::BeforeMutationHooks;
 use super::{
     FunctionsSubsystem, RealtimeSubsystem, ServerSubsystems, StorageSubsystem,
     builder::{ServerSubsystemsBuilder, SubsystemBuildError},
@@ -173,6 +175,49 @@ fn into_before_mutation_hooks_resolves_dispatch_settings() {
         "re_runnable resolved from schema"
     );
     assert!(!hooks.dispatch_settings["chargeCard"].re_runnable);
+}
+
+#[cfg(feature = "functions-runtime")]
+#[test]
+fn with_email_attaches_sender_resolver_and_transport() {
+    use std::{future::Future, pin::Pin};
+
+    use fraiseql_functions::{
+        EmailTransport, LoginEmailSender, SendEmailRequest, SendEmailResponse, SenderIdentity,
+    };
+
+    // A transport stub so the seam test needs no SMTP / `inbound-email`.
+    struct NoopTransport;
+    impl EmailTransport for NoopTransport {
+        fn send<'a>(
+            &'a self,
+            _sender: &'a SenderIdentity,
+            _request: &'a SendEmailRequest,
+        ) -> Pin<Box<dyn Future<Output = fraiseql_error::Result<SendEmailResponse>> + Send + 'a>>
+        {
+            Box::pin(async {
+                Ok(SendEmailResponse {
+                    message_id: None,
+                    accepted:   true,
+                })
+            })
+        }
+    }
+
+    let trigger_registry = TriggerRegistry::load_from_definitions(&[]).unwrap();
+    let hooks = BeforeMutationHooks::new(
+        trigger_registry,
+        HashMap::new(),
+        Arc::new(FunctionObserver::new()),
+    );
+    // Unconfigured by default → send_email fails loud.
+    assert!(hooks.sender_resolver.is_none());
+    assert!(hooks.email_transport.is_none());
+
+    // Attaching both enables the op for every dispatched function's fresh host.
+    let hooks = hooks.with_email(Arc::new(LoginEmailSender), Arc::new(NoopTransport));
+    assert!(hooks.sender_resolver.is_some(), "resolver attached");
+    assert!(hooks.email_transport.is_some(), "transport attached");
 }
 
 // ── Realtime ──────────────────────────────────────────────────────────────────

--- a/docs/architecture/inbound-email.md
+++ b/docs/architecture/inbound-email.md
@@ -29,12 +29,15 @@ It is opt-in behind the `inbound-email` Cargo feature.
 
 ## Configuration
 
-Each mailbox is one `[imap.<name>]` section. The section name is the mailbox's
-stable identity — it names the cursor row, so do not rename a mailbox in
-production.
+Each connected account is one `[mailbox.<name>]` section. The section name is the
+account's stable identity — it names the cursor row, so do not rename a mailbox in
+production. The poll-IMAP *receive* half lives under `[mailbox.<name>.imap]`; the
+SMTP *send* half (used by the `send_email` host op) lives under
+`[mailbox.<name>.smtp]`. Either half is optional — a `[mailbox.<name>.imap]`-only
+account only receives; a `[mailbox.<name>.smtp]`-only account only sends.
 
 ```toml
-[imap.support]
+[mailbox.support.imap]
 host = "imap.example.com"        # also the TLS SNI / certificate name
 port = 993                        # default 993 (IMAPS)
 username = "support@example.com"
@@ -47,13 +50,18 @@ attachment_bucket = "inbound"     # optional; attachments dropped if unset
 # Declared dedicated-address routing (optional). A message to a rule's address
 # maps to `entity_type`; the recipient's plus-tag becomes the entity id
 # (`support+ticket-42@…` → Ticket / 42).
-[[imap.support.routing]]
+[[mailbox.support.imap.routing]]
 address = "support@example.com"
 entity_type = "Ticket"
 ```
 
-A mailbox whose `password_env` is unset is **skipped with a warning**, never
+A mailbox whose IMAP `password_env` is unset is **skipped with a warning**, never
 polled without credentials. Requires a PostgreSQL pool.
+
+> **Renamed (breaking).** The receive config moved from `[imap.<name>]` to
+> `[mailbox.<name>.imap]` so one connected account can carry both its inbound and
+> outbound halves under one section name. Update any `[imap.*]` sections to
+> `[mailbox.*.imap]` (and `[[imap.*.routing]]` to `[[mailbox.*.imap.routing]]`).
 
 ---
 

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -64,7 +64,7 @@ promoted from opt-in to stable.
 
 3. **Verified sending address vs. authenticated email.** Today the per-user
    `from` is taken from the authenticated identity's `email`. An outreach tool's
-   *sending* mailbox (the connected IMAP/SMTP account, cf. `[imap.<name>]`) can
+   *sending* mailbox (the connected IMAP/SMTP account, cf. `[mailbox.<name>]`) can
    differ from the JWT subject's email. **Planned: a distinct, verified
    `sending_address` on the security/auth context**, resolved from the connected
    mailbox rather than assumed equal to the login email.

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -62,12 +62,10 @@ promoted from opt-in to stable.
    (10/day → 200/day → unlimited). Failures classify onto durable dispatch: a
    permanent refusal (denied identity, bad recipient, SMTP 5xx, over-cap) is a 4xx
    → dead-letter; a transient one (SMTP timeout/greylist, identity store down) is a
-   5xx → retry. `follow-up-email.ts` now calls the op instead of a hand-rolled
-   send. **Known limitation:** the stock server binary does not yet populate
-   `before_mutation_hooks`, so after:mutation functions (this op included) run only
-   where the functions-runtime hooks are built — a separate pre-existing gap. **Not
-   yet closed:** the DB-backed `SendCounter` over the application's mailbox table
-   (see gap on warming state).
+   5xx → retry (effective end-to-end via permanent-error tagging, gap #5).
+   `follow-up-email.ts` now calls the op instead of a hand-rolled send. **Not yet
+   closed:** the DB-backed `SendCounter` over the application's mailbox table (the
+   remaining warming piece).
 
 3. **Verified sending address vs. authenticated email.** Today the per-user
    `from` is taken from the authenticated identity's `email`. An outreach tool's
@@ -88,19 +86,17 @@ promoted from opt-in to stable.
    a downstream money or mail API, so paired sends can move to the durable path
    safely.
 
-5. **Error model is throw-or-return.** Transient vs permanent is inferred from the
-   resulting `FraiseQLError` classification, which is the right default, but a
-   function cannot yet *say* "this is permanent, do not retry" (e.g. a validation
-   failure that happens to surface as a 5xx). This bites the `send_email` op: the op
-   classifies its failures precisely (a denied identity / bad recipient / SMTP 5xx /
-   over-cap is a permanent 4xx; a timeout / greylist / identity store down is a
-   transient 5xx), but a guest that lets the op throw crosses the Deno exception
-   boundary, where every guest error flattens to `Unsupported` (501) — so durable
-   dispatch currently treats even a permanent send failure as transient (retries,
-   then dead-letters) instead of dead-lettering immediately. **Planned: let a
-   function tag a thrown error as permanent** so it dead-letters immediately instead
-   of exhausting retries — that is what makes the op's permanent/transient split
-   effective end-to-end.
+5. **Permanent-error tagging — DELIVERED.** A function can now say "this failure is
+   permanent, do not retry": a guest throws a tagged error
+   (`Object.assign(new Error(msg), { fraiseqlPermanent: true })`, or a message
+   carrying the `[fraiseql:permanent]` marker), and the runtime maps it to a 4xx
+   `FraiseQLError` — which durable dispatch dead-letters on the first attempt rather
+   than exhausting retries. Host ops auto-tag: any op that returns a 4xx (client)
+   error is permanent by default, so a `send_email` refusal (denied identity, bad
+   recipient, SMTP 5xx, over-cap) dead-letters immediately, while a transient one
+   (timeout, greylist, identity store down) still retries. Untagged errors are
+   unchanged (transient / 501). This makes the op's permanent/transient split
+   effective end-to-end across the guest boundary.
 
 6. **Testing: one V8 isolate per process.** Two Deno invocations in a single test
    process abort (V8). Each workload test therefore does exactly one invocation

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -50,17 +50,24 @@ promoted from opt-in to stable.
    sharing types with the rest of a TS codebase. **Planned: wire real
    type-stripping** (`deno_ast` / swc) so authors write ordinary TypeScript.
 
-2. **Per-user send is a policy + reference pattern, not yet a host op.** The
-   banked constraint — a paired outbound email is sent *from the connected user's
-   verified address, never a shared mailbox* — is enforced today by
-   `fraiseql_functions::outbound::resolve_sender_identity` (a pure, fail-loud
-   policy) plus surfacing the verified `email` in `auth_context`, and the
-   `follow-up-email.ts` reference mirrors it in TypeScript. That makes the rule
-   real and tested, but the `from` still lives in guest code. **Planned: a
-   first-class `send_email` host op that injects the bound `from` (structural,
-   guest cannot override) over a concrete SMTP / provider transport**, reusing the
-   `resolve_sender_identity` policy. The transport is the missing piece — mirror
-   the `sql_query` fail-loud-until-wired stance until it lands.
+2. **Per-user send — DELIVERED as a host op.** The banked constraint — a paired
+   outbound email is sent *from the connected user's verified address, never a
+   shared mailbox* — is now enforced structurally by the `send_email` host op: the
+   guest supplies only `to`/`subject`/body, and the host injects the `from` from
+   the resolved sender identity (the #539 seam — `LoginEmailSender` by default, a
+   DB-backed resolver where the sending mailbox differs). A guest-supplied `from`
+   is dropped at the type level. The transport is per-connected-account SMTP
+   (`[mailbox.<name>.smtp]`, STARTTLS, server-side secrets keyed by mailbox,
+   selected by the verified sending address), with a send-warming daily cap
+   (10/day → 200/day → unlimited). Failures classify onto durable dispatch: a
+   permanent refusal (denied identity, bad recipient, SMTP 5xx, over-cap) is a 4xx
+   → dead-letter; a transient one (SMTP timeout/greylist, identity store down) is a
+   5xx → retry. `follow-up-email.ts` now calls the op instead of a hand-rolled
+   send. **Known limitation:** the stock server binary does not yet populate
+   `before_mutation_hooks`, so after:mutation functions (this op included) run only
+   where the functions-runtime hooks are built — a separate pre-existing gap. **Not
+   yet closed:** the DB-backed `SendCounter` over the application's mailbox table
+   (see gap on warming state).
 
 3. **Verified sending address vs. authenticated email.** Today the per-user
    `from` is taken from the authenticated identity's `email`. An outreach tool's
@@ -84,9 +91,16 @@ promoted from opt-in to stable.
 5. **Error model is throw-or-return.** Transient vs permanent is inferred from the
    resulting `FraiseQLError` classification, which is the right default, but a
    function cannot yet *say* "this is permanent, do not retry" (e.g. a validation
-   failure that happens to surface as a 5xx). **Planned: let a function tag a
-   thrown error as permanent** so it dead-letters immediately instead of
-   exhausting retries.
+   failure that happens to surface as a 5xx). This bites the `send_email` op: the op
+   classifies its failures precisely (a denied identity / bad recipient / SMTP 5xx /
+   over-cap is a permanent 4xx; a timeout / greylist / identity store down is a
+   transient 5xx), but a guest that lets the op throw crosses the Deno exception
+   boundary, where every guest error flattens to `Unsupported` (501) — so durable
+   dispatch currently treats even a permanent send failure as transient (retries,
+   then dead-letters) instead of dead-lettering immediately. **Planned: let a
+   function tag a thrown error as permanent** so it dead-letters immediately instead
+   of exhausting retries — that is what makes the op's permanent/transient split
+   effective end-to-end.
 
 6. **Testing: one V8 isolate per process.** Two Deno invocations in a single test
    process abort (V8). Each workload test therefore does exactly one invocation

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -63,9 +63,11 @@ promoted from opt-in to stable.
    permanent refusal (denied identity, bad recipient, SMTP 5xx, over-cap) is a 4xx
    → dead-letter; a transient one (SMTP timeout/greylist, identity store down) is a
    5xx → retry (effective end-to-end via permanent-error tagging, gap #5).
-   `follow-up-email.ts` now calls the op instead of a hand-rolled send. **Not yet
-   closed:** the DB-backed `SendCounter` over the application's mailbox table (the
-   remaining warming piece).
+   `follow-up-email.ts` now calls the op instead of a hand-rolled send. The op runs
+   in the stock server binary: the server loads function modules from the compiled
+   schema's `module_dir` and mounts the after:mutation dispatch hooks at serve time
+   (a missing module fails startup, fail-loud). **Not yet closed:** the DB-backed
+   `SendCounter` over the application's mailbox table (the remaining warming piece).
 
 3. **Verified sending address vs. authenticated email.** Today the per-user
    `from` is taken from the authenticated identity's `email`. An outreach tool's

--- a/examples/native-functions/follow-up-email.ts
+++ b/examples/native-functions/follow-up-email.ts
@@ -2,17 +2,15 @@
 // that acts on the scorer's recommended next action.
 //
 // This is the reference implementation of the banked per-user send constraint:
-// a paired outbound email goes FROM the connected user's verified address, taken
-// only from the host auth context, NEVER a shared or default mailbox. There is no
-// path here to send from anything else, and a missing verified address fails loud
-// rather than falling back to a default sender. It mirrors the Rust policy
-// `fraiseql_functions::outbound::resolve_sender_identity`, which a planned
-// `send_email` host op will enforce structurally (host-owned `from`).
+// a paired outbound email goes FROM the connected user's verified address, NEVER
+// a shared or default mailbox. That is now enforced STRUCTURALLY by the
+// `send_email` host op: the guest supplies only `to`/`subject`/body, and the host
+// injects the `from` from the resolved sender identity (the connected user's
+// verified address). There is no path here to send from anything else, and a
+// missing verified identity fails the op loud rather than falling back.
 //
-// Host surface used (all via `Deno.core.ops.fraiseql_*`, typed by the runtime):
-//   - auth_context  — the connected user's verified sending identity (the `from`)
-//   - env_var       — the mail-provider API key (a secret, allowlisted by host)
-//   - http_request  — send via the provider (outbound HTTP, SSRF-allowlisted)
+// Host surface used (via `Deno.core.ops.fraiseql_*`, typed by the runtime):
+//   - send_email  — host-owned `from`, per-connected-account SMTP transport
 //
 // The function receives the mutated Deal row as its argument.
 //
@@ -25,56 +23,28 @@ export default async (deal) => {
     return { skipped: deal.next_action || "no-action", deal_id: deal.id };
   }
 
-  // Per-user send: resolve the `from` from the connected user's verified address
-  // in the host auth context. No verified address → refuse to send (fail loud);
-  // never fall back to a shared or default mailbox.
-  const auth = JSON.parse(Deno.core.ops.fraiseql_auth_context());
-  const from =
-    auth && typeof auth.email === "string" &&
-    auth.email.indexOf("@") !== -1 && auth.email.indexOf(" ") === -1
-      ? auth.email.trim()
-      : null;
-  if (!from) {
-    throw new Error(
-      "refusing to send follow-up: no verified per-user sending address in auth context",
-    );
-  }
-
   const contact = deal.contact_email;
   if (!contact) {
     return { skipped: "no-contact", deal_id: deal.id };
   }
 
-  const apiKey = Deno.core.ops.fraiseql_env_var("MAIL_API_KEY");
-  if (!apiKey) {
-    throw new Error("MAIL_API_KEY is not configured");
-  }
-
-  const reqBody = Deno.core.encode(JSON.stringify({
-    from, // host-owned; the connected user's verified address, never a shared box
+  // Send via the host op. The `from` is NOT ours to choose — the host resolves it
+  // from the connected user's verified sending identity and injects it. A missing
+  // identity or transport failure throws, so the durable dispatcher retries a
+  // transient failure (5xx) and dead-letters a permanent one (a denied identity, a
+  // bad recipient, a rejected relay).
+  const raw = await Deno.core.ops.fraiseql_send_email(JSON.stringify({
     to: contact,
     subject: `Following up on ${deal.name || "our conversation"}`,
     text: `Hi — just following up on ${deal.name || "our last exchange"}. ` +
       `Happy to answer any questions.`,
   }));
-  const resp = await Deno.core.ops.fraiseql_http_request(
-    "POST",
-    "https://mail.provider.test/v1/send",
-    [
-      ["authorization", `Bearer ${apiKey}`],
-      ["content-type", "application/json"],
-    ],
-    reqBody,
-  );
-  if (resp.status < 200 || resp.status >= 300) {
-    throw new Error(`follow-up send failed: HTTP ${resp.status}`);
-  }
-  const sent = JSON.parse(Deno.core.decode(resp.body));
+  const sent = JSON.parse(raw);
 
   return {
     deal_id:    deal.id,
-    sent_from:  from,
     sent_to:    contact,
-    message_id: sent.id,
+    message_id: sent.message_id,
+    accepted:   sent.accepted,
   };
 };


### PR DESCRIPTION
## What

Native `send_email` host op (native-runtime hardening, #539 follow-up) — the last sidecar responsibility (outbound email *send*) becomes native — plus the two gaps that surfaced while building it, both **fixed** here.

A function calls `send_email({to, subject, text?, html?})`; the host injects the `from` from the connected user's verified sending identity (never guest-chosen, never a shared mailbox) and relays over per-connected-account SMTP.

## Cycles

- **C0 — config rename (breaking).** `[imap.<name>]` → `[mailbox.<name>.imap]`; one connected account carries both its IMAP receive half and its SMTP send half under one section. Only affects the opt-in `inbound-email` feature. Migration in the CHANGELOG.
- **C1 — the op.** `send_email` across all 15 `HostContext` impls + both runtimes (WASM + Deno), no new `#[async_trait]`. Host-owned `from` via the #539 `SenderIdentityResolver` seam (`LoginEmailSender` default). A guest-supplied `from` is dropped at the type level. Fail-loud when unconfigured (mirrors `sql_query`).
- **C2 — SMTP transport + seam.** `SmtpMailboxTransport` (`lettre` STARTTLS, per-account, secrets server-side keyed by mailbox, account selected by the verified sending address — never a fall-back). `BeforeMutationHooks::with_email` threads the resolver + transport into every dispatched function's live host. `follow-up-email.ts` rewritten to call the op.
- **C3 — send warming.** Pure ramp (10/day wk1 → 200/day wk6 → unlimited) + a transport cap gate (over-cap → 429 → dead-letter → replay next day). The per-mailbox `sends_today` counter is a `SendCounter` seam; the DB-backed impl over the app's mailbox table is the one remaining piece (tracked below).

## The two findings — surfaced, then fixed

Building C1–C4 surfaced two gaps. Rather than ship the op seam-only, both are closed here:

- **F1 — after:mutation functions now run in the stock binary.** The runtime + dispatch machinery existed and was unit-tested but was never wired into the shipped `fraiseql-server` binary (`before_mutation_hooks` was always `None`). The server now loads each declared function's module from the compiled schema's `module_dir` (`<module_dir>/<name>.<ext>`), registers the compiled-in runtimes, and mounts the dispatch hooks (with the `send_email` wiring) at serve time. A missing/unreadable module — or a runtime not compiled in — **fails startup** (a declared function that can never run is a misconfiguration).
- **F2 — permanent-error tagging.** A permanent `send_email` failure (denied identity, rejected recipient, over-cap) used to flatten to `Unsupported` (501/transient) at the guest exception boundary and retry-then-DLQ. Host ops now auto-tag any 4xx (client) error permanent, and a guest can tag structurally (`err.fraiseqlPermanent = true`); both runtimes map a tagged error to a 4xx, so durable dispatch dead-letters it on the first attempt. Untagged behavior is unchanged.

## Error classification (durable dispatch)

| Failure | Status | Outcome |
|---|---|---|
| Denied identity / bad recipient / SMTP 5xx / over-cap | 4xx | dead-letter (immediate) |
| Identity store down / SMTP timeout / greylist | 5xx | retry |

## Not in scope (tracked follow-ups)

- **DB-backed `SendCounter`** over the app's mailbox table (`sends_today` / `daily_send_limit` / `warming_start_date`) — the seam ships; the DB impl is the remaining warming piece.
- Verified `sending_address` distinct from login email (hardening P03); host idempotency token for exactly-once paired send (P04).
- MySQL/SQLite binary wiring for functions (F1 wires the PostgreSQL path).

## Verification

- `make preflight` green (fmt · ~12 shell gates · rustdoc `-D warnings --all-features` · clippy `--all-targets --all-features -D warnings` · tests · cargo-deny).
- fraiseql-functions: default + `runtime-wasm` + `runtime-deno` legs green (op reachable from a guest on both runtimes; permanent-tag + boundary tests).
- fraiseql-server `inbound-email`: 1331 lib tests (transport selection, warming cap, config parse, module loader, seam) green.
- Default server build unaffected (all new surface is `functions-runtime`-gated).
- Full mutation → after:mutation → `send_email` boot path is covered by `release-smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
