### PR TITLE
feat(server): host idempotency token (P04) + delivery feedback loop (P04b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by the delivery-feedback work). `examples/native-functions/qonto-sync.ts` now
   prefers it and falls back to its invoice-derived key only on a non-dispatched
   invocation; the dead-letter record carries the token for operator inspection.
+- **Delivery feedback loop — bounces, challenges, replies, suppression
+  (native-runtime hardening).** `send_email` is now a *tracked* delivery rather than
+  a one-shot: SMTP `2xx` means accepted, not delivered, and the real outcome arrives
+  inbound. Each send sets a per-send VERP Return-Path
+  (`MAIL FROM: bounces+<send-id>@<domain>`, header `From` unchanged) keyed by the
+  **HMAC** idempotency token (unforgeable, so a forged bounce cannot poison delivery
+  status); the poll-IMAP adapter correlates an inbound bounce/challenge/reply back to
+  the send via the recipient plus-tag (with a `References`/`Message-ID` fallback) and
+  transitions a send-status lifecycle (`Sent → Bounced | ChallengePending | Replied`;
+  **no lying `Delivered`** — "no news ≈ delivered"). A **suppression list** is checked
+  before every send (a suppressed recipient is a permanent refusal); it stores a
+  **keyed hash of the address, never the raw address**, so a GDPR erasure elsewhere
+  keeps the do-not-contact match. Hard bounces suppress immediately (permanent);
+  repeated unanswered **challenges** suppress after N (`[send]
+  challenge_suppress_after`, default 2, per-recipient, event-based) and are
+  **surfaced, never auto-solved** for cold outreach (reputation + GDPR); a genuine
+  reply lifts a challenge suppression at once. A durable retry of an already-sent
+  dispatch is **skipped** (exactly-once). Transient SMTP failures carry a
+  mail-appropriate backoff floor (greylisting clears in minutes, not the policy's
+  seconds). An opt-in startup **Return-Path probe** (`[send] verp_probe_on_start`)
+  verifies the provider preserves plus-addressing before VERP is trusted. All stores
+  are tenant-scoped (RLS); the operator appends/queries suppressions via
+  `POST /api/email/suppress` / `GET /api/email/suppression` (admin bearer,
+  server-side hashing); IMAP processing is read-and-move only (never expunges).
+  Configured via `[server] hmac_secret_env` (VERP-gated: absent → plain token, no
+  correlation), `[mailbox.<name>.smtp.return_path]`, and `[send]`.
 - **After:mutation functions now run in the stock server binary.** The server loads
   each declared function's module from the compiled schema's `module_dir`
   (`<module_dir>/<name>.<ext>` — `.wasm` for WASM, `.js`/`.ts` for Deno), registers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identity store momentarily down) is a 5xx → retry. The DB-backed `SendCounter`
   (over the app's mailbox table) is the remaining warming piece. See
   `docs/architecture/native-runtime-ergonomics.md`.
+- **Host-provided per-dispatch idempotency token (native-runtime hardening).** A
+  function can read a per-dispatch idempotency token —
+  `Deno.core.ops.fraiseql_idempotency_token()` (WASM: `get-idempotency-token`),
+  `string | null` — and pass it straight to a downstream money/mail idempotency
+  header. The durable dispatcher derives it **once** from the dispatch's stable
+  identity (source + function + trigger + payload data — never wall-clock/random)
+  and injects it into every retry attempt, so it is stable across retries and
+  across a resume, and distinct per logical operation; an at-least-once dispatch
+  therefore stays at-most-once. The token is 32 lowercase hex characters, URL-safe
+  and short enough for a VERP email local part (reused as the send correlation id
+  by the delivery-feedback work). `examples/native-functions/qonto-sync.ts` now
+  prefers it and falls back to its invoice-derived key only on a non-dispatched
+  invocation; the dead-letter record carries the token for operator inspection.
 - **After:mutation functions now run in the stock server binary.** The server loads
   each declared function's module from the compiled schema's `module_dir`
   (`<module_dir>/<name>.<ext>` — `.wasm` for WASM, `.js`/`.ts` for Deno), registers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seconds). An opt-in startup **Return-Path probe** (`[send] verp_probe_on_start`)
   verifies the provider preserves plus-addressing before VERP is trusted. All stores
   are tenant-scoped (RLS); the operator appends/queries suppressions via
-  `POST /api/email/suppress` / `GET /api/email/suppression` (admin bearer,
-  server-side hashing); IMAP processing is read-and-move only (never expunges).
+  `POST /api/email/suppress` / `POST /api/email/suppression` (admin bearer,
+  server-side hashing, address in the body — never a query string, so it is not
+  captured by access logs); IMAP processing is read-and-move only (never expunges).
   Configured via `[server] hmac_secret_env` (VERP-gated: absent → plain token, no
   correlation), `[mailbox.<name>.smtp.return_path]`, and `[send]`.
 - **After:mutation functions now run in the stock server binary.** The server loads

--- a/crates/fraiseql-functions/src/host/dyn_context.rs
+++ b/crates/fraiseql-functions/src/host/dyn_context.rs
@@ -84,6 +84,15 @@ pub trait DynHostContext: Send + Sync {
 
     /// Log a message.
     fn log(&self, level: crate::types::LogLevel, message: &str);
+
+    /// A per-dispatch idempotency token (see
+    /// [`HostContext::idempotency_token`](crate::HostContext::idempotency_token)).
+    ///
+    /// Defaults to `None` so direct implementors that do not carry a token (e.g.
+    /// a WASM snapshot) need no change; the blanket impl forwards the real value.
+    fn idempotency_token(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Blanket implementation: any `T: HostContext + Send + Sync` can be used as `DynHostContext`.
@@ -168,5 +177,9 @@ impl<T: crate::HostContext + Send + Sync> DynHostContext for T {
 
     fn log(&self, level: crate::types::LogLevel, message: &str) {
         crate::HostContext::log(self, level, message);
+    }
+
+    fn idempotency_token(&self) -> Option<String> {
+        crate::HostContext::idempotency_token(self)
     }
 }

--- a/crates/fraiseql-functions/src/host/live/mod.rs
+++ b/crates/fraiseql-functions/src/host/live/mod.rs
@@ -105,6 +105,12 @@ pub struct LiveHostContext {
 
     /// Email transport for `send_email`. `None` → `send_email` fails loud.
     email_transport: Option<Arc<dyn crate::outbound::EmailTransport>>,
+
+    /// Per-dispatch idempotency token, injected by the durable dispatcher. `None`
+    /// on non-dispatched paths (bare `invoke`). Stable across retries of the same
+    /// dispatch and distinct per dispatch — see
+    /// [`derive_idempotency_token`](fraiseql_observers::derive_idempotency_token).
+    idempotency_token: Option<String>,
 }
 
 impl LiveHostContext {
@@ -121,6 +127,7 @@ impl LiveHostContext {
             security_context: Self::default_security_context(),
             sender_resolver: None,
             email_transport: None,
+            idempotency_token: None,
         }
     }
 
@@ -140,6 +147,7 @@ impl LiveHostContext {
             security_context: Self::default_security_context(),
             sender_resolver: None,
             email_transport: None,
+            idempotency_token: None,
         }
     }
 
@@ -160,6 +168,7 @@ impl LiveHostContext {
             security_context: Self::default_security_context(),
             sender_resolver: None,
             email_transport: None,
+            idempotency_token: None,
         }
     }
 
@@ -211,6 +220,18 @@ impl LiveHostContext {
     ) -> Self {
         self.sender_resolver = Some(sender_resolver);
         self.email_transport = Some(email_transport);
+        self
+    }
+
+    /// Attach the per-dispatch idempotency token surfaced to the guest via
+    /// [`idempotency_token`](HostContext::idempotency_token).
+    ///
+    /// The durable dispatcher derives the token once (from the dispatch's stable
+    /// identity) and sets it on the fresh host it builds for every retry attempt,
+    /// so the guest observes the same token on each attempt.
+    #[must_use]
+    pub fn with_idempotency_token(mut self, token: impl Into<String>) -> Self {
+        self.idempotency_token = Some(token.into());
         self
     }
 }
@@ -488,5 +509,9 @@ impl HostContext for LiveHostContext {
             timestamp: chrono::Utc::now(),
         };
         self.logs.lock().expect("log mutex poisoned").push(entry);
+    }
+
+    fn idempotency_token(&self) -> Option<String> {
+        self.idempotency_token.clone()
     }
 }

--- a/crates/fraiseql-functions/src/host/live/mod.rs
+++ b/crates/fraiseql-functions/src/host/live/mod.rs
@@ -466,7 +466,14 @@ impl HostContext for LiveHostContext {
             }
         })?;
 
-        transport.send(&sender, request).await
+        // The per-dispatch context: the send-id is the host idempotency token (the
+        // VERP correlation key + exactly-once dedup key); the tenant scopes the
+        // send-status / suppression rows. Both are host-owned, never guest input.
+        let context = crate::outbound::SendContext {
+            send_id: self.idempotency_token.as_deref(),
+            tenant:  self.security_context.tenant_id.as_ref().map(|tenant| tenant.as_str()),
+        };
+        transport.send(&sender, request, context).await
     }
 
     fn auth_context(&self) -> Result<serde_json::Value> {

--- a/crates/fraiseql-functions/src/host/live/tests.rs
+++ b/crates/fraiseql-functions/src/host/live/tests.rs
@@ -968,15 +968,26 @@ async fn test_host_event_payload_returns_trigger_data() {
 // ── send_email host op (host-owned `from`) ──────────────────────────────────────
 
 use crate::outbound::{
-    BoxFuture, EmailTransport, LoginEmailSender, SendEmailRequest, SendEmailResponse,
+    BoxFuture, EmailTransport, LoginEmailSender, SendContext, SendEmailRequest, SendEmailResponse,
     SendPolicyError, SenderIdentity, SenderIdentityResolver,
 };
 
-/// A transport that records the `(sender, request)` it was last asked to send and
-/// returns success — so a test can assert on the host-owned `from` the op bound.
+/// What a [`RecordingTransport`] captured on its last send: the resolved sender,
+/// the request, and the per-dispatch send-id / tenant the host threaded in.
+#[derive(Clone)]
+struct RecordedSend {
+    sender:  SenderIdentity,
+    request: SendEmailRequest,
+    send_id: Option<String>,
+    tenant:  Option<String>,
+}
+
+/// A transport that records the send it was last asked to make and returns success
+/// — so a test can assert on the host-owned `from` the op bound and the
+/// per-dispatch context (send-id / tenant) the host threaded through.
 #[derive(Default)]
 struct RecordingTransport {
-    last: std::sync::Mutex<Option<(SenderIdentity, SendEmailRequest)>>,
+    last: std::sync::Mutex<Option<RecordedSend>>,
 }
 
 impl EmailTransport for RecordingTransport {
@@ -984,8 +995,14 @@ impl EmailTransport for RecordingTransport {
         &'a self,
         sender: &'a SenderIdentity,
         request: &'a SendEmailRequest,
+        context: SendContext<'a>,
     ) -> BoxFuture<'a, Result<SendEmailResponse>> {
-        *self.last.lock().unwrap() = Some((sender.clone(), request.clone()));
+        *self.last.lock().unwrap() = Some(RecordedSend {
+            sender:  sender.clone(),
+            request: request.clone(),
+            send_id: context.send_id.map(ToString::to_string),
+            tenant:  context.tenant.map(ToString::to_string),
+        });
         Box::pin(async {
             Ok(SendEmailResponse {
                 message_id: Some("recorded".to_string()),
@@ -1036,11 +1053,61 @@ async fn test_send_email_from_is_host_owned_not_guest_supplied() {
     let response = host.send_email(&request).await.unwrap();
     assert!(response.accepted);
 
-    let (sender, sent) = transport.last.lock().unwrap().clone().unwrap();
+    let recorded = transport.last.lock().unwrap().clone().unwrap();
     // The transport was handed the connected user's verified address, never the
     // guest's attempted `from`.
-    assert_eq!(sender.address, "alice@example.com");
-    assert_eq!(sent.to, "bob@example.com");
+    assert_eq!(recorded.sender.address, "alice@example.com");
+    assert_eq!(recorded.request.to, "bob@example.com");
+}
+
+#[tokio::test]
+async fn test_send_email_threads_the_idempotency_token_as_send_id() {
+    // The per-dispatch idempotency token reaches the transport as the VERP send-id /
+    // exactly-once key, and the tenant is threaded through for RLS scoping. Both are
+    // host-owned context, never guest input.
+    let host = LiveHostContext::new(send_email_payload(), HostContextConfig::default())
+        .with_idempotency_token("abc123def456");
+    let mut host = host;
+    host.security_context.email = Some("alice@example.com".to_string());
+    host.security_context.tenant_id = Some(fraiseql_core::types::TenantId::new("tenant-7"));
+    let transport = Arc::new(RecordingTransport::default());
+    let host = host.with_email(Arc::new(LoginEmailSender), transport.clone());
+
+    let request = SendEmailRequest {
+        to:       "bob@example.com".to_string(),
+        subject:  "hi".to_string(),
+        text:     Some("b".to_string()),
+        html:     None,
+        reply_to: None,
+    };
+    host.send_email(&request).await.unwrap();
+
+    let recorded = transport.last.lock().unwrap().clone().unwrap();
+    assert_eq!(recorded.send_id.as_deref(), Some("abc123def456"), "send-id = host token");
+    assert_eq!(recorded.tenant.as_deref(), Some("tenant-7"), "tenant threaded for RLS");
+}
+
+#[tokio::test]
+async fn test_send_email_without_idempotency_token_sends_uncorrelated() {
+    // Zero-config (no HMAC secret → no token): the send still happens, just without
+    // a VERP send-id or tenant scope.
+    let mut host = LiveHostContext::new(send_email_payload(), HostContextConfig::default());
+    host.security_context.email = Some("alice@example.com".to_string());
+    let transport = Arc::new(RecordingTransport::default());
+    let host = host.with_email(Arc::new(LoginEmailSender), transport.clone());
+
+    let request = SendEmailRequest {
+        to:       "bob@example.com".to_string(),
+        subject:  "hi".to_string(),
+        text:     Some("b".to_string()),
+        html:     None,
+        reply_to: None,
+    };
+    host.send_email(&request).await.unwrap();
+
+    let recorded = transport.last.lock().unwrap().clone().unwrap();
+    assert_eq!(recorded.send_id, None, "no token → no send-id");
+    assert_eq!(recorded.tenant, None, "no tenant → no scope");
 }
 
 #[tokio::test]

--- a/crates/fraiseql-functions/src/host/mod.rs
+++ b/crates/fraiseql-functions/src/host/mod.rs
@@ -128,6 +128,19 @@ pub trait HostContext: Send + Sync {
 
     /// Log a message to the tracing subscriber.
     fn log(&self, level: LogLevel, message: &str);
+
+    /// A per-dispatch idempotency token, stable across retries of the same
+    /// dispatch and distinct per dispatch.
+    ///
+    /// `None` on invocation paths that are not durably dispatched (the bare sync
+    /// `invoke` path, or a mock host that does not set one). The durable
+    /// dispatcher derives the token from the dispatch's stable identity and
+    /// injects it so a guest can pass it straight to a downstream money/mail
+    /// idempotency header, keeping an at-least-once dispatch at-most-once end to
+    /// end. Defaults to `None` so only hosts that carry a token override it.
+    fn idempotency_token(&self) -> Option<String> {
+        None
+    }
 }
 
 /// A no-op host context for testing WASM execution without real backends.

--- a/crates/fraiseql-functions/src/lib.rs
+++ b/crates/fraiseql-functions/src/lib.rs
@@ -22,8 +22,8 @@ pub mod types;
 pub use host::{HostContext, NoopHostContext};
 pub use observer::FunctionObserver;
 pub use outbound::{
-    EmailTransport, LoginEmailSender, SendEmailRequest, SendEmailResponse, SendPolicyError,
-    SenderIdentity, SenderIdentityResolver, resolve_sender_identity,
+    EmailTransport, LoginEmailSender, SendContext, SendEmailRequest, SendEmailResponse,
+    SendPolicyError, SenderIdentity, SenderIdentityResolver, resolve_sender_identity,
 };
 pub use runtime::{FunctionRuntime, SendFunctionRuntime};
 pub use store::{FunctionRecord, FunctionStatus, FunctionStore, memory::InMemoryFunctionStore};

--- a/crates/fraiseql-functions/src/migrations/mod.rs
+++ b/crates/fraiseql-functions/src/migrations/mod.rs
@@ -9,6 +9,9 @@
 //!   ([`inbound_migration_sql`]).
 //! - `_fraiseql_inbound_email_cursor` — the per-mailbox UID watermark the poll-IMAP email adapter
 //!   advances between polls ([`inbound_email_cursor_migration_sql`]).
+//! - `_fraiseql_send_status` + `_fraiseql_suppression` — the delivery-feedback stores that
+//!   correlate an inbound bounce/challenge/reply back to a tracked send and hold the do-not-contact
+//!   list checked before every send ([`send_tracking_migration_sql`]).
 
 #[cfg(test)]
 mod tests;
@@ -153,5 +156,91 @@ CREATE TABLE IF NOT EXISTS _fraiseql_inbound_email_cursor (
     updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (mailbox_key)
 );
+"
+}
+
+/// Returns the SQL DDL to create the delivery-feedback stores.
+///
+/// Two fraiseql-managed tables underpin the delivery-feedback loop (the outbound
+/// mirror of the inbound spine):
+///
+/// - `_fraiseql_send_status` — one row per tracked send, keyed by the per-dispatch VERP `send_id`.
+///   It records the recipient, the sending address, the send-status lifecycle (`Sent` → `Bounced` /
+///   `ChallengePending` / `Replied` / …), the challenge count, and the relay message id. The
+///   exactly-once unique key on `(COALESCE(tenant_id, ''), send_id)` is what makes a durable retry
+///   skip an already-sent dispatch instead of double-sending.
+/// - `_fraiseql_suppression` — the do-not-contact list checked before every send, keyed on a
+///   **keyed hash** of the address (never the raw address, so the match survives a GDPR erasure of
+///   the recipient's PII elsewhere) plus a granular reason (`hard_bounce` / `challenge_unanswered`
+///   / `unsubscribe`) and optional TTL.
+///
+/// Both tables carry an explicit `tenant_id` (stamped from the security context at
+/// write time — a `TEXT` column because the runtime tenant id is an opaque string,
+/// not necessarily a UUID) and are protected by a tenant-scoped RLS policy for
+/// app-facing reads, mirroring #443's `tb_entity_change_log`. The platform writes
+/// through the table-owning role (which bypasses RLS) and stamps `tenant_id`
+/// explicitly; app reads through a non-owner role are filtered to the session's
+/// `fraiseql.tenant_id`. `COALESCE(tenant_id, '')` in the unique indexes keeps the
+/// exactly-once and suppression keys correct for single-tenant (NULL) rows, which a
+/// bare `UNIQUE (tenant_id, …)` would treat as always-distinct.
+///
+/// The DDL is idempotent: `CREATE … IF NOT EXISTS` for tables/indexes, `ENABLE ROW
+/// LEVEL SECURITY` is a no-op when already enabled, and each policy is dropped-if-
+/// exists before creation (`CREATE POLICY` has no `IF NOT EXISTS` form).
+///
+/// # Example
+///
+/// ```
+/// let sql = fraiseql_functions::migrations::send_tracking_migration_sql();
+/// assert!(sql.contains("_fraiseql_send_status"));
+/// assert!(sql.contains("_fraiseql_suppression"));
+/// ```
+#[must_use]
+pub const fn send_tracking_migration_sql() -> &'static str {
+    "\
+CREATE TABLE IF NOT EXISTS _fraiseql_send_status (
+    pk_send_status  BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    send_id         TEXT        NOT NULL,
+    tenant_id       TEXT,
+    recipient       TEXT        NOT NULL,
+    sending_address TEXT        NOT NULL,
+    status          TEXT        NOT NULL,
+    challenge_count INT         NOT NULL DEFAULT 0,
+    last_signal     TEXT,
+    message_id      TEXT,
+    sent_at         TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_send_status_tenant_send
+    ON _fraiseql_send_status (COALESCE(tenant_id, ''), send_id);
+
+-- The correlation path looks a send up by send_id alone (from the inbound
+-- Return-Path plus-tag), without a session tenant, so it needs its own index.
+CREATE INDEX IF NOT EXISTS idx_send_status_send_id
+    ON _fraiseql_send_status (send_id);
+
+ALTER TABLE _fraiseql_send_status ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS p_send_status_tenant ON _fraiseql_send_status;
+CREATE POLICY p_send_status_tenant ON _fraiseql_send_status
+    USING (tenant_id IS NOT DISTINCT FROM current_setting('fraiseql.tenant_id', true));
+
+CREATE TABLE IF NOT EXISTS _fraiseql_suppression (
+    pk_suppression BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    tenant_id      TEXT,
+    address_hash   TEXT        NOT NULL,
+    reason         TEXT        NOT NULL,
+    since          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ttl            TIMESTAMPTZ,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_suppression_tenant_addr
+    ON _fraiseql_suppression (COALESCE(tenant_id, ''), address_hash);
+
+ALTER TABLE _fraiseql_suppression ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS p_suppression_tenant ON _fraiseql_suppression;
+CREATE POLICY p_suppression_tenant ON _fraiseql_suppression
+    USING (tenant_id IS NOT DISTINCT FROM current_setting('fraiseql.tenant_id', true));
 "
 }

--- a/crates/fraiseql-functions/src/migrations/mod.rs
+++ b/crates/fraiseql-functions/src/migrations/mod.rs
@@ -220,6 +220,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_send_status_tenant_send
 CREATE INDEX IF NOT EXISTS idx_send_status_send_id
     ON _fraiseql_send_status (send_id);
 
+-- Fallback correlation: matching our sent message-id quoted in the inbound
+-- References / In-Reply-To when the VERP plus-tag was stripped.
+CREATE INDEX IF NOT EXISTS idx_send_status_message_id
+    ON _fraiseql_send_status (message_id)
+    WHERE message_id IS NOT NULL;
+
+-- The challenge policy counts a recipient's pending challenges across campaigns.
+CREATE INDEX IF NOT EXISTS idx_send_status_recipient
+    ON _fraiseql_send_status (recipient);
+
 ALTER TABLE _fraiseql_send_status ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS p_send_status_tenant ON _fraiseql_send_status;
 CREATE POLICY p_send_status_tenant ON _fraiseql_send_status

--- a/crates/fraiseql-functions/src/migrations/tests.rs
+++ b/crates/fraiseql-functions/src/migrations/tests.rs
@@ -5,7 +5,7 @@
 
 use sqlx::PgPool;
 
-use super::{cron_migration_sql, inbound_migration_sql};
+use super::{cron_migration_sql, inbound_migration_sql, send_tracking_migration_sql};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -161,6 +161,75 @@ async fn test_inbound_migration_creates_table() {
     .unwrap();
 
     assert!(exists, "table _fraiseql_inbound_message must exist after migration");
+}
+
+/// Verify the send-tracking DDL is syntactically complete and contains the
+/// columns, exactly-once key, and tenant RLS. Runs without a database.
+#[test]
+fn test_send_tracking_migration_ddl_is_valid_sql() {
+    let ddl = send_tracking_migration_sql();
+
+    for table in ["_fraiseql_send_status", "_fraiseql_suppression"] {
+        assert!(ddl.contains(table), "DDL must create {table}");
+    }
+    assert!(ddl.contains("IF NOT EXISTS"), "DDL must use IF NOT EXISTS");
+
+    for col in [
+        "send_id",
+        "tenant_id",
+        "recipient",
+        "sending_address",
+        "status",
+        "challenge_count",
+        "last_signal",
+        "address_hash",
+        "reason",
+    ] {
+        assert!(ddl.contains(col), "DDL must contain column: {col}");
+    }
+
+    // Exactly-once + suppression keys coalesce NULL tenants so single-tenant rows
+    // are not treated as always-distinct.
+    assert!(
+        ddl.contains("COALESCE(tenant_id, '')"),
+        "unique keys must coalesce NULL tenant_id"
+    );
+    // Tenant-scoped RLS for app-facing reads.
+    assert!(ddl.contains("ENABLE ROW LEVEL SECURITY"), "DDL must enable RLS");
+    assert!(
+        ddl.contains("current_setting('fraiseql.tenant_id', true)"),
+        "RLS policy must key on the fraiseql.tenant_id GUC"
+    );
+    // Policies are dropped-if-exists first so re-running the DDL is idempotent
+    // (CREATE POLICY has no IF NOT EXISTS form).
+    assert!(ddl.contains("DROP POLICY IF EXISTS"), "policies must be idempotent");
+}
+
+/// Verify the send-tracking migration creates both tables in a real PostgreSQL
+/// database and is idempotent (re-running does not error).
+#[tokio::test]
+async fn test_send_tracking_migration_creates_tables_idempotently() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!(
+            "SKIP test_send_tracking_migration_creates_tables_idempotently: no postgres (set DATABASE_URL or enable fraiseql-test-support/local-testcontainers)"
+        );
+        return;
+    };
+
+    let ddl = send_tracking_migration_sql();
+    // Run twice — the RLS policy drop-and-recreate must keep it idempotent.
+    execute_ddl(&pool, ddl).await;
+    execute_ddl(&pool, ddl).await;
+
+    for table in ["_fraiseql_send_status", "_fraiseql_suppression"] {
+        let (exists,): (bool,) =
+            sqlx::query_as("SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = $1)")
+                .bind(table)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(exists, "table {table} must exist after migration");
+    }
 }
 
 /// Verify the migration is idempotent — running it twice does not error.

--- a/crates/fraiseql-functions/src/outbound/mod.rs
+++ b/crates/fraiseql-functions/src/outbound/mod.rs
@@ -204,6 +204,31 @@ pub struct SendEmailResponse {
     pub accepted:   bool,
 }
 
+/// The per-dispatch context a [`send`](EmailTransport::send) carries beyond the
+/// sender and the request: the correlation send-id and the tenant scope.
+///
+/// The `send_id` is the host's per-dispatch idempotency token (see
+/// [`idempotency_token`](crate::HostContext::idempotency_token)); the transport
+/// uses it two ways — as the VERP `bounces+<send-id>@…` Return-Path that
+/// correlates an inbound bounce/challenge/reply back to this send, and as an
+/// exactly-once key so a durable retry of an already-sent dispatch does not
+/// double-send. The `tenant` scopes the send-status and suppression rows the
+/// transport reads/writes. Both are `Option` because a zero-config deployment (no
+/// HMAC secret, no tenant) sends without correlation or tenant scoping.
+///
+/// A named struct rather than positional `Option<&str>` parameters: `send_id` and
+/// `tenant` are both optional strings and would be trivially transposable at the
+/// call site.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SendContext<'a> {
+    /// The per-dispatch VERP send-id / exactly-once key. `None` → the transport
+    /// sends with no VERP Return-Path and no exactly-once dedup.
+    pub send_id: Option<&'a str>,
+    /// The tenant the send is scoped to (RLS stamp on send-status / suppression
+    /// rows). `None` → single-tenant.
+    pub tenant:  Option<&'a str>,
+}
+
 /// The transport seam the `send_email` host op relays through, once the op has
 /// resolved the host-owned `from` from the [`SenderIdentityResolver`].
 ///
@@ -216,11 +241,13 @@ pub struct SendEmailResponse {
 /// permanent failure routed straight to the dead-letter queue, a **5xx** (e.g.
 /// `ServiceUnavailable`) is transient and retried.
 pub trait EmailTransport: Send + Sync {
-    /// Send `request` from the resolved verified `sender` identity.
+    /// Send `request` from the resolved verified `sender` identity, within the
+    /// per-dispatch [`SendContext`] (correlation send-id + tenant scope).
     fn send<'a>(
         &'a self,
         sender: &'a SenderIdentity,
         request: &'a SendEmailRequest,
+        context: SendContext<'a>,
     ) -> BoxFuture<'a, fraiseql_error::Result<SendEmailResponse>>;
 }
 

--- a/crates/fraiseql-functions/src/runtime/deno/executor.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/executor.rs
@@ -82,6 +82,7 @@ fn make_fraiseql_extension(
             ops::fraiseql_send_email(),
             ops::fraiseql_auth_context(),
             ops::fraiseql_env_var(),
+            ops::fraiseql_idempotency_token(),
         ]),
         op_state_fn: Some(Box::new(move |state: &mut OpState| {
             state.put(collector);

--- a/crates/fraiseql-functions/src/runtime/deno/idempotency_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/idempotency_tests.rs
@@ -1,0 +1,76 @@
+//! The per-dispatch idempotency token, end-to-end through the Deno runtime.
+//!
+//! Drives a minimal guest that returns `fraiseql_idempotency_token()` through the
+//! real `DenoRuntime`, on a real `LiveHostContext`, to prove the op surfaces the
+//! host-carried token (and `null` when none is set). Each test runs exactly one
+//! guest → one V8 isolate per test process, which is required (two isolates in one
+//! process SIGSEGV even under nextest).
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::{
+    EventPayload, FunctionModule, ResourceLimits, RuntimeType,
+    host::{
+        dyn_context::DynHostContext,
+        live::{HostContextConfig, LiveHostContext},
+    },
+    runtime::deno::{DenoConfig, DenoRuntime},
+};
+
+/// A guest that echoes the host-provided idempotency token straight back.
+const ECHO_TOKEN_TS: &str = r"
+export default async () => ({ token: Deno.core.ops.fraiseql_idempotency_token() });
+";
+
+fn event() -> EventPayload {
+    EventPayload {
+        trigger_type: "after:mutation".to_string(),
+        entity:       "Deal".to_string(),
+        event_kind:   "updated".to_string(),
+        data:         serde_json::json!({ "id": "deal-1" }),
+        timestamp:    Utc::now(),
+    }
+}
+
+async fn run_echo(host: Arc<dyn DynHostContext>) -> serde_json::Value {
+    let module = FunctionModule::from_source(
+        "echo-token".to_string(),
+        ECHO_TOKEN_TS.to_string(),
+        RuntimeType::Deno,
+    );
+    let runtime = DenoRuntime::new(&DenoConfig::default()).unwrap();
+    runtime
+        .invoke_with_context(&module, event(), host, ResourceLimits::default())
+        .await
+        .expect("guest runs")
+        .value
+        .expect("returns a value")
+}
+
+#[tokio::test]
+async fn token_is_exposed_to_the_guest() {
+    let token = "1a2b3c4d5e6f70818283848586878889";
+    let host: Arc<dyn DynHostContext> = Arc::new(
+        LiveHostContext::new(event(), HostContextConfig::default()).with_idempotency_token(token),
+    );
+
+    let value = run_echo(host).await;
+
+    assert_eq!(value["token"], token, "the guest reads the host-carried token verbatim");
+}
+
+#[tokio::test]
+async fn absent_token_is_null_to_the_guest() {
+    // A host that carries no token (the default) surfaces `null`, so a guest can
+    // branch on it (e.g. fall back to a hand-derived key on a non-dispatched path).
+    let host: Arc<dyn DynHostContext> =
+        Arc::new(LiveHostContext::new(event(), HostContextConfig::default()));
+
+    let value = run_echo(host).await;
+
+    assert!(value["token"].is_null(), "no token set → null, got {:?}", value["token"]);
+}

--- a/crates/fraiseql-functions/src/runtime/deno/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/mod.rs
@@ -23,6 +23,10 @@ pub mod tests;
 
 #[cfg(test)]
 mod follow_up_tests;
+// Uses the real `LiveHostContext` (host-live) to prove the op end-to-end, so it is
+// gated on host-live as well — the `runtime-deno`-only clippy combo has no live host.
+#[cfg(all(test, feature = "host-live"))]
+mod idempotency_tests;
 #[cfg(test)]
 mod qonto_tests;
 #[cfg(test)]
@@ -101,6 +105,12 @@ function fraiseql_auth_context(): string; // JSON string
 
 // Get an environment variable
 function fraiseql_env_var(name: string): string | null;
+
+// Get the per-dispatch idempotency token, or null when this invocation was not
+// durably dispatched. Stable across retries of the same dispatch and distinct
+// per dispatch; pass it to a downstream money/mail idempotency header so an
+// at-least-once retry stays at-most-once.
+function fraiseql_idempotency_token(): string | null;
 
 // Log a message
 function fraiseql_log(level: number, message: string): void;

--- a/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
@@ -215,6 +215,21 @@ pub(crate) fn fraiseql_env_var(
     host.env_var(&name).map_err(op_error)
 }
 
+/// Return the per-dispatch idempotency token, or `null` when this invocation was
+/// not durably dispatched (sync).
+///
+/// `Deno.core.ops.fraiseql_idempotency_token() -> string | null`
+///
+/// Stable across retries of the same dispatch and distinct per dispatch; a guest
+/// passes it straight to a downstream money/mail API idempotency header so an
+/// at-least-once retry stays at-most-once.
+#[op2]
+#[string]
+pub(crate) fn fraiseql_idempotency_token(state: &OpState) -> Result<Option<String>, AnyError> {
+    let host = require_host(state)?;
+    Ok(host.idempotency_token())
+}
+
 /// Parse a JSON-string op argument, treating an empty string as an empty object.
 fn parse_json_arg(raw: &str, what: &str) -> Result<serde_json::Value, AnyError> {
     if raw.trim().is_empty() {

--- a/crates/fraiseql-functions/src/runtime/deno/qonto_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/qonto_tests.rs
@@ -54,6 +54,9 @@ struct QontoHost {
     event:       EventPayload,
     recorded:    Arc<Mutex<Recorded>>,
     http_status: u16,
+    /// The per-dispatch idempotency token the dispatcher would inject; `None`
+    /// models a non-dispatched invocation (the guest falls back to its own key).
+    token:       Option<String>,
 }
 
 impl crate::HostContext for QontoHost {
@@ -137,6 +140,10 @@ impl crate::HostContext for QontoHost {
     }
 
     fn log(&self, _level: crate::LogLevel, _message: &str) {}
+
+    fn idempotency_token(&self) -> Option<String> {
+        self.token.clone()
+    }
 }
 
 fn invoice_event(invoice: serde_json::Value) -> EventPayload {
@@ -154,11 +161,21 @@ async fn run_sync(
     http_status: u16,
     recorded: &Arc<Mutex<Recorded>>,
 ) -> fraiseql_error::Result<serde_json::Value> {
+    run_sync_with_token(invoice, http_status, None, recorded).await
+}
+
+async fn run_sync_with_token(
+    invoice: serde_json::Value,
+    http_status: u16,
+    token: Option<String>,
+    recorded: &Arc<Mutex<Recorded>>,
+) -> fraiseql_error::Result<serde_json::Value> {
     let event = invoice_event(invoice);
     let host: Arc<dyn DynHostContext> = Arc::new(QontoHost {
         event: event.clone(),
         recorded: Arc::clone(recorded),
         http_status,
+        token,
     });
     let module = FunctionModule::from_source(
         "qonto-sync".to_string(),
@@ -232,6 +249,33 @@ async fn test_qonto_idempotency_key_is_invoice_derived_not_random() {
         .unwrap()
         .to_string();
     assert_eq!(sent, "qonto-invoice-inv-42");
+}
+
+/// When the durable dispatcher provides a per-dispatch idempotency token, the
+/// money call carries THAT token — a resume-stable key the host derived — instead
+/// of the hand-derived invoice key. Proves the example consumes the host op and
+/// prefers it when present.
+#[tokio::test]
+async fn test_qonto_uses_the_host_token_when_present() {
+    let recorded = Arc::new(Mutex::new(Recorded::default()));
+    let token = "aabbccddeeff00112233445566778899";
+    let value = run_sync_with_token(
+        serde_json::json!({
+            "id": "inv-77", "reference": "INV-77", "amount_cents": 100, "counterparty": "acme"
+        }),
+        200,
+        Some(token.to_string()),
+        &recorded,
+    )
+    .await
+    .expect("sync should run");
+
+    assert_eq!(value["idempotency_key"], token, "the guest prefers the host-provided token");
+    assert_eq!(
+        recorded.lock().unwrap().http_calls[0].header("idempotency-key"),
+        Some(token),
+        "the money call carries the host-provided per-dispatch token"
+    );
 }
 
 /// A transient (5xx) Qonto failure fails loud — the function never fabricates a

--- a/crates/fraiseql-functions/src/runtime/wasm/store/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/wasm/store/mod.rs
@@ -150,6 +150,13 @@ impl context::Host for StoreData {
         };
         host.env_var(&name).ok().flatten()
     }
+
+    async fn get_idempotency_token(&mut self) -> Option<String> {
+        let Ok(host) = self.require_host_context() else {
+            return None;
+        };
+        host.idempotency_token()
+    }
 }
 
 /// Stringify a host error for the WIT `result<_, string>` boundary, tagging a

--- a/crates/fraiseql-functions/wit/fraiseql-host.wit
+++ b/crates/fraiseql-functions/wit/fraiseql-host.wit
@@ -9,6 +9,9 @@ interface context {
     get-event-payload: func() -> string;  // JSON
     get-auth-context: func() -> result<string, string>;  // JSON or error
     get-env-var: func(name: string) -> option<string>;
+    // Per-dispatch idempotency token, or none when not durably dispatched.
+    // Stable across retries of the same dispatch, distinct per dispatch.
+    get-idempotency-token: func() -> option<string>;
 }
 
 interface io {

--- a/crates/fraiseql-observers/src/dispatch.rs
+++ b/crates/fraiseql-observers/src/dispatch.rs
@@ -131,31 +131,70 @@ pub fn derive_idempotency_token(
         buf.extend_from_slice(field.as_bytes());
     }
     match key {
-        Some(key) => {
-            let mut mac = Hmac::<Sha256>::new_from_slice(key)
-                .expect("HMAC-SHA256 accepts a key of any length");
-            mac.update(&buf);
-            hex::encode(&mac.finalize().into_bytes()[..16])
-        },
+        Some(key) => hex::encode(&hmac_sha256(key, &buf)[..16]),
         None => hex::encode(&Sha256::digest(&buf)[..16]),
     }
 }
 
+/// Compute `HMAC-SHA256(key, data)`.
+///
+/// The single place the HMAC construction lives: HMAC accepts a key of any length,
+/// so `new_from_slice` is infallible here — keeping the one unreachable `.expect`
+/// out of the public functions (and their panic docs).
+fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(key).expect("HMAC-SHA256 accepts a key of any length");
+    mac.update(data);
+    mac.finalize().into_bytes().into()
+}
+
+/// Expand a server root secret into a domain-separated 32-byte subkey.
+///
+/// HKDF-Expand-style: a single `HMAC-SHA256(root, info)` block. `info` is the
+/// domain-separation label so two uses of the same root secret (the send-id key,
+/// the suppression address-hash key, …) derive independent, non-interchangeable
+/// subkeys — knowing one never reveals another.
+fn expand_subkey(root_secret: &[u8], info: &[u8]) -> [u8; 32] {
+    hmac_sha256(root_secret, info)
+}
+
 /// Derive the idempotency-token HMAC subkey from a server root secret.
 ///
-/// Domain-separates the send-id key from any other use of the same root secret
-/// (HKDF-Expand-style: a single `HMAC-SHA256(root, info)` block), so the send-id
-/// key is independent of, say, a JWT-signing use of the same secret. The 32-byte
-/// output is the `key` passed to [`derive_idempotency_token`] to produce the
-/// unforgeable, signed send-id.
+/// The 32-byte output is the `key` passed to [`derive_idempotency_token`] to
+/// produce the unforgeable, signed send-id. Domain-separated (see
+/// [`expand_subkey`]) so it is independent of any other use of the same root
+/// secret, such as [`derive_address_hash_key`] or a JWT-signing use.
 #[must_use]
 pub fn derive_idempotency_subkey(root_secret: &[u8]) -> [u8; 32] {
-    let mut mac = Hmac::<Sha256>::new_from_slice(root_secret)
-        .expect("HMAC-SHA256 accepts a key of any length");
-    mac.update(b"fraiseql:idempotency-send-id:v1");
-    let mut key = [0u8; 32];
-    key.copy_from_slice(&mac.finalize().into_bytes());
-    key
+    expand_subkey(root_secret, b"fraiseql:idempotency-send-id:v1")
+}
+
+/// Derive the suppression-address-hash key from a server root secret.
+///
+/// The 32-byte output keys [`hash_address`], which turns a recipient address into
+/// the opaque hash stored on the suppression list. Domain-separated from the
+/// send-id subkey (see [`expand_subkey`]) so the two are cryptographically
+/// independent. Keying the hash (rather than a bare digest) both makes it
+/// unforgeable and lets the "do-not-contact" match survive a GDPR erasure of the
+/// raw address elsewhere — the hash is retained, the address is not.
+#[must_use]
+pub fn derive_address_hash_key(root_secret: &[u8]) -> [u8; 32] {
+    expand_subkey(root_secret, b"fraiseql:suppression-address:v1")
+}
+
+/// Hash a recipient email address for the suppression list, keyed with the
+/// [`derive_address_hash_key`] subkey.
+///
+/// The address is normalised (trimmed, lowercased) before hashing so casing and
+/// surrounding whitespace do not split a recipient into distinct suppression
+/// entries. The output is 64 lowercase hex characters (a full `HMAC-SHA256`) —
+/// this hash is stored/compared in a table column, not an email local part, so it
+/// is not truncated. Storing only this keyed hash (never the raw address) is what
+/// keeps the suppression match intact after the address is erased elsewhere.
+#[must_use]
+pub fn hash_address(key: &[u8], address: &str) -> String {
+    let normalised = address.trim().to_lowercase();
+    hex::encode(hmac_sha256(key, normalised.as_bytes()))
 }
 
 /// A function-trigger dispatch that exhausted its retries (or failed

--- a/crates/fraiseql-observers/src/dispatch.rs
+++ b/crates/fraiseql-observers/src/dispatch.rs
@@ -15,6 +15,7 @@
 
 use std::future::Future;
 
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::config::{FailurePolicy, RetryConfig};
@@ -67,6 +68,59 @@ pub enum DispatchSource {
     AfterMutation,
     /// An `after:ingest` function trigger (inbound-message ingestion).
     AfterIngest,
+}
+
+impl DispatchSource {
+    /// A stable string label for this source, decoupled from `Debug`.
+    ///
+    /// It is part of the [`derive_idempotency_token`] hash input, so it must stay
+    /// constant across refactors — a changed label would silently change every
+    /// dispatch token and break at-most-once downstream dedup.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::AfterMutation => "after:mutation",
+            Self::AfterIngest => "after:ingest",
+        }
+    }
+}
+
+/// Derive a per-dispatch idempotency token from a dispatch's stable identity.
+///
+/// The token is a deterministic function of `(source, function_name,
+/// trigger_type, payload)` — never wall-clock or random — so it is **identical
+/// across every retry of the same dispatch, and across a resume** that re-derives
+/// the same inputs, and **distinct per logical operation** (a different function,
+/// trigger, or payload yields a different token). It generalises the hand-derived
+/// money-path key (`qonto-invoice-${id}`): a guest can pass it straight to a
+/// downstream idempotency header, and the send path uses it as the VERP send-id,
+/// so an at-least-once dispatch stays at-most-once end to end.
+///
+/// The output is 32 lowercase hex characters (a 128-bit truncated SHA-256): URL-
+/// safe and short enough for a 64-character email local part (`bounces+<token>@…`).
+/// The payload is hashed via its canonical JSON form — `serde_json::Value` orders
+/// object keys — so a resume that re-serialises the payload produces the same
+/// token. Each field is length-prefixed so no two distinct field tuples can
+/// collide by concatenation.
+#[must_use]
+pub fn derive_idempotency_token(
+    source: DispatchSource,
+    function_name: &str,
+    trigger_type: &str,
+    payload: &serde_json::Value,
+) -> String {
+    let payload_json = payload.to_string();
+    let mut hasher = Sha256::new();
+    for field in [
+        source.label(),
+        function_name,
+        trigger_type,
+        payload_json.as_str(),
+    ] {
+        hasher.update((field.len() as u64).to_le_bytes());
+        hasher.update(field.as_bytes());
+    }
+    hex::encode(&hasher.finalize()[..16])
 }
 
 /// A function-trigger dispatch that exhausted its retries (or failed

--- a/crates/fraiseql-observers/src/dispatch.rs
+++ b/crates/fraiseql-observers/src/dispatch.rs
@@ -140,20 +140,25 @@ pub fn derive_idempotency_token(
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionDispatchRecord {
     /// Unique identifier for this dead-letter entry.
-    pub id:            Uuid,
+    pub id:                Uuid,
     /// Which trigger subsystem produced the failed dispatch.
-    pub source:        DispatchSource,
+    pub source:            DispatchSource,
     /// Name of the function whose dispatch failed.
-    pub function_name: String,
+    pub function_name:     String,
     /// The trigger type string, e.g. `after:mutation:onUserCreated`.
-    pub trigger_type:  String,
+    pub trigger_type:      String,
+    /// The per-dispatch idempotency token every attempt of this dispatch saw (see
+    /// [`derive_idempotency_token`]). Recorded so an operator inspecting or
+    /// replaying the dead-letter knows the exact idempotency key the guest used
+    /// downstream — a redundant retry with the same token stays at-most-once.
+    pub idempotency_token: String,
     /// The event payload the function was dispatched with (opaque JSON), kept for
     /// operator inspection and replay.
-    pub payload:       serde_json::Value,
+    pub payload:           serde_json::Value,
     /// The final error message from the exhausted or permanently-failed dispatch.
-    pub error_message: String,
+    pub error_message:     String,
     /// How many attempts were made before the dispatch was dead-lettered.
-    pub attempts:      u32,
+    pub attempts:          u32,
 }
 
 impl FunctionDispatchRecord {
@@ -163,6 +168,7 @@ impl FunctionDispatchRecord {
         source: DispatchSource,
         function_name: impl Into<String>,
         trigger_type: impl Into<String>,
+        idempotency_token: impl Into<String>,
         payload: serde_json::Value,
         error_message: impl Into<String>,
         attempts: u32,
@@ -172,6 +178,7 @@ impl FunctionDispatchRecord {
             source,
             function_name: function_name.into(),
             trigger_type: trigger_type.into(),
+            idempotency_token: idempotency_token.into(),
             payload,
             error_message: error_message.into(),
             attempts,

--- a/crates/fraiseql-observers/src/dispatch.rs
+++ b/crates/fraiseql-observers/src/dispatch.rs
@@ -15,6 +15,7 @@
 
 use std::future::Future;
 
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
@@ -96,31 +97,65 @@ impl DispatchSource {
 /// downstream idempotency header, and the send path uses it as the VERP send-id,
 /// so an at-least-once dispatch stays at-most-once end to end.
 ///
-/// The output is 32 lowercase hex characters (a 128-bit truncated SHA-256): URL-
-/// safe and short enough for a 64-character email local part (`bounces+<token>@…`).
-/// The payload is hashed via its canonical JSON form — `serde_json::Value` orders
-/// object keys — so a resume that re-serialises the payload produces the same
-/// token. Each field is length-prefixed so no two distinct field tuples can
-/// collide by concatenation.
+/// `key` selects the mode:
+/// - `Some(key)` → **HMAC-SHA256** keyed with a server-side secret. Unforgeable: required once the
+///   token is exposed externally (a VERP `bounces+<token>@…` Return-Path), because a bare hash of
+///   guessable identity fields could be forged to poison a send's delivery status.
+/// - `None` → a plain SHA-256 digest. Fine while the token is only an internal idempotency key (the
+///   zero-config default); the keyed form is opt-in via the server HMAC secret.
+///
+/// The output is 32 lowercase hex characters (128 bits): URL-safe and short
+/// enough for a 64-character email local part. The payload is hashed via its
+/// canonical JSON form — `serde_json::Value` orders object keys — so a resume that
+/// re-serialises the payload produces the same token. Each field is
+/// length-prefixed so no two distinct field tuples can collide by concatenation.
 #[must_use]
 pub fn derive_idempotency_token(
+    key: Option<&[u8]>,
     source: DispatchSource,
     function_name: &str,
     trigger_type: &str,
     payload: &serde_json::Value,
 ) -> String {
     let payload_json = payload.to_string();
-    let mut hasher = Sha256::new();
+    // Length-prefix each field so no two distinct field tuples collide by
+    // concatenation (e.g. ("ab","c") vs ("a","bc")).
+    let mut buf = Vec::new();
     for field in [
         source.label(),
         function_name,
         trigger_type,
         payload_json.as_str(),
     ] {
-        hasher.update((field.len() as u64).to_le_bytes());
-        hasher.update(field.as_bytes());
+        buf.extend_from_slice(&(field.len() as u64).to_le_bytes());
+        buf.extend_from_slice(field.as_bytes());
     }
-    hex::encode(&hasher.finalize()[..16])
+    match key {
+        Some(key) => {
+            let mut mac = Hmac::<Sha256>::new_from_slice(key)
+                .expect("HMAC-SHA256 accepts a key of any length");
+            mac.update(&buf);
+            hex::encode(&mac.finalize().into_bytes()[..16])
+        },
+        None => hex::encode(&Sha256::digest(&buf)[..16]),
+    }
+}
+
+/// Derive the idempotency-token HMAC subkey from a server root secret.
+///
+/// Domain-separates the send-id key from any other use of the same root secret
+/// (HKDF-Expand-style: a single `HMAC-SHA256(root, info)` block), so the send-id
+/// key is independent of, say, a JWT-signing use of the same secret. The 32-byte
+/// output is the `key` passed to [`derive_idempotency_token`] to produce the
+/// unforgeable, signed send-id.
+#[must_use]
+pub fn derive_idempotency_subkey(root_secret: &[u8]) -> [u8; 32] {
+    let mut mac = Hmac::<Sha256>::new_from_slice(root_secret)
+        .expect("HMAC-SHA256 accepts a key of any length");
+    mac.update(b"fraiseql:idempotency-send-id:v1");
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&mac.finalize().into_bytes());
+    key
 }
 
 /// A function-trigger dispatch that exhausted its retries (or failed

--- a/crates/fraiseql-observers/src/dispatch.rs
+++ b/crates/fraiseql-observers/src/dispatch.rs
@@ -161,9 +161,9 @@ fn expand_subkey(root_secret: &[u8], info: &[u8]) -> [u8; 32] {
 /// Derive the idempotency-token HMAC subkey from a server root secret.
 ///
 /// The 32-byte output is the `key` passed to [`derive_idempotency_token`] to
-/// produce the unforgeable, signed send-id. Domain-separated (see
-/// [`expand_subkey`]) so it is independent of any other use of the same root
-/// secret, such as [`derive_address_hash_key`] or a JWT-signing use.
+/// produce the unforgeable, signed send-id. Domain-separated (a per-use `info`
+/// label) so it is independent of any other use of the same root secret, such as
+/// [`derive_address_hash_key`] or a JWT-signing use.
 #[must_use]
 pub fn derive_idempotency_subkey(root_secret: &[u8]) -> [u8; 32] {
     expand_subkey(root_secret, b"fraiseql:idempotency-send-id:v1")
@@ -173,7 +173,7 @@ pub fn derive_idempotency_subkey(root_secret: &[u8]) -> [u8; 32] {
 ///
 /// The 32-byte output keys [`hash_address`], which turns a recipient address into
 /// the opaque hash stored on the suppression list. Domain-separated from the
-/// send-id subkey (see [`expand_subkey`]) so the two are cryptographically
+/// send-id subkey (a distinct `info` label) so the two are cryptographically
 /// independent. Keying the hash (rather than a bare digest) both makes it
 /// unforgeable and lets the "do-not-contact" match survive a GDPR erasure of the
 /// raw address elsewhere — the hash is retained, the address is not.
@@ -282,6 +282,14 @@ pub enum RetryDecision {
 /// zero backoff (`initial_delay_ms = 0`) runs with no real delay, which keeps the
 /// unit tests instant.
 ///
+/// `retry_after` lets a transient error request a **minimum** backoff before the
+/// next attempt — the driver waits the longer of the policy's computed delay and
+/// this hint. It is the greylisting lever: an SMTP transient (a `4xx` tempfail from
+/// a greylister) clears in minutes, not the seconds a default policy backs off, so
+/// the transport returns a mail-appropriate `retry_after` and the driver honors it
+/// without a per-function retry-config change. Return `None` (the common case) to
+/// use the policy backoff verbatim.
+///
 /// # Errors
 ///
 /// Returns the error `E` from the last attempt: either a permanent error (one
@@ -290,6 +298,7 @@ pub enum RetryDecision {
 pub async fn run_with_retry<T, E, F, Fut>(
     policy: &DispatchPolicy,
     is_transient: impl Fn(&E) -> bool,
+    retry_after: impl Fn(&E) -> Option<std::time::Duration>,
     mut attempt: F,
 ) -> Result<T, E>
 where
@@ -306,7 +315,12 @@ where
                     return Err(error);
                 }
                 match policy.after_transient_failure(n) {
-                    RetryDecision::Retry(delay) => tokio::time::sleep(delay).await,
+                    // Honor an error-supplied backoff floor (greylisting): wait the
+                    // longer of the policy delay and the error's hint.
+                    RetryDecision::Retry(delay) => {
+                        let wait = retry_after(&error).map_or(delay, |hint| delay.max(hint));
+                        tokio::time::sleep(wait).await;
+                    },
                     RetryDecision::GiveUp => return Err(error),
                 }
             },

--- a/crates/fraiseql-observers/src/dispatch/tests.rs
+++ b/crates/fraiseql-observers/src/dispatch/tests.rs
@@ -284,3 +284,38 @@ fn subkey_is_deterministic_and_root_dependent() {
     // Domain separation: the subkey is not the raw root truncated/padded.
     assert_ne!(&derive_idempotency_subkey(b"root")[..], b"root");
 }
+
+// ── Suppression address hashing (GDPR: never store the raw address) ───────────────
+
+#[test]
+fn address_hash_key_is_domain_separated_from_the_send_id_subkey() {
+    // The two subkeys derive from the same root but must be independent — one must
+    // not be recoverable from the other.
+    assert_ne!(derive_address_hash_key(b"root"), derive_idempotency_subkey(b"root"));
+    // Deterministic + root-dependent, like the send-id subkey.
+    assert_eq!(derive_address_hash_key(b"root"), derive_address_hash_key(b"root"));
+    assert_ne!(derive_address_hash_key(b"root-a"), derive_address_hash_key(b"root-b"));
+}
+
+#[test]
+fn address_hash_is_deterministic_case_and_whitespace_insensitive() {
+    let key = derive_address_hash_key(b"root");
+    let canonical = hash_address(&key, "bob@example.com");
+    // Casing and surrounding whitespace must not split one recipient into distinct
+    // suppression entries.
+    assert_eq!(hash_address(&key, "Bob@Example.COM"), canonical);
+    assert_eq!(hash_address(&key, "  bob@example.com  "), canonical);
+    // A full HMAC-SHA256, hex-encoded → 64 chars, lowercase hex.
+    assert_eq!(canonical.len(), 64);
+    assert!(canonical.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)));
+}
+
+#[test]
+fn address_hash_binds_to_the_key() {
+    // Without the key an attacker cannot recompute the stored hash from the address,
+    // and a different address hashes differently under the same key.
+    let key_a = derive_address_hash_key(b"root-a");
+    let key_b = derive_address_hash_key(b"root-b");
+    assert_ne!(hash_address(&key_a, "bob@example.com"), hash_address(&key_b, "bob@example.com"));
+    assert_ne!(hash_address(&key_a, "bob@example.com"), hash_address(&key_a, "eve@example.com"));
+}

--- a/crates/fraiseql-observers/src/dispatch/tests.rs
+++ b/crates/fraiseql-observers/src/dispatch/tests.rs
@@ -29,6 +29,7 @@ async fn retries_transient_failure_until_success() {
     let result: Result<u32, &str> = run_with_retry(
         &zero_delay_policy(3),
         |_error| true, // every error is transient
+        |_error| None, // no backoff-floor hint
         |n| {
             calls.fetch_add(1, Ordering::SeqCst);
             async move { if n < 3 { Err("transient boom") } else { Ok(n) } }
@@ -46,6 +47,7 @@ async fn gives_up_after_max_attempts() {
     let result: Result<u32, &str> = run_with_retry(
         &zero_delay_policy(3),
         |_error| true,
+        |_error| None,
         |_n| {
             calls.fetch_add(1, Ordering::SeqCst);
             async { Err::<u32, &str>("always fails") }
@@ -63,6 +65,7 @@ async fn permanent_error_is_not_retried() {
     let result: Result<u32, &str> = run_with_retry(
         &zero_delay_policy(5),
         |_error| false, // permanent
+        |_error| None,
         |_n| {
             calls.fetch_add(1, Ordering::SeqCst);
             async { Err::<u32, &str>("permanent") }
@@ -72,6 +75,26 @@ async fn permanent_error_is_not_retried() {
 
     assert_eq!(result, Err("permanent"));
     assert_eq!(calls.load(Ordering::SeqCst), 1, "permanent error is not retried");
+}
+
+#[tokio::test(start_paused = true)]
+async fn honors_the_error_supplied_backoff_floor() {
+    // Greylisting: a zero-delay policy would retry in seconds, but a 5-minute error
+    // hint raises the floor, so the retry waits the mail-appropriate delay (virtual
+    // time under the paused clock keeps this instant and deterministic).
+    let start = tokio::time::Instant::now();
+    let result: Result<u32, &str> = run_with_retry(
+        &zero_delay_policy(2),
+        |_error| true,
+        |_error| Some(Duration::from_secs(300)),
+        |n| async move { if n < 2 { Err("greylisted") } else { Ok(n) } },
+    )
+    .await;
+    assert_eq!(result, Ok(2));
+    assert!(
+        start.elapsed() >= Duration::from_secs(300),
+        "the retry waited the error's mail-appropriate floor, not the policy's zero delay"
+    );
 }
 
 #[test]

--- a/crates/fraiseql-observers/src/dispatch/tests.rs
+++ b/crates/fraiseql-observers/src/dispatch/tests.rs
@@ -1,4 +1,5 @@
 //! Tests for the shared dispatch policy and retry driver.
+#![allow(clippy::unwrap_used)] // Reason: test code — unwrap on known-valid JSON literals
 
 use std::{
     sync::atomic::{AtomicU32, Ordering},
@@ -93,4 +94,123 @@ fn backoff_delay_matches_configured_strategy() {
     };
     assert_eq!(config.backoff_delay(1), Duration::from_millis(50));
     assert_eq!(config.backoff_delay(9), Duration::from_millis(50));
+}
+
+// ── Idempotency token derivation ────────────────────────────────────────────────
+
+#[test]
+fn dispatch_source_label_is_stable() {
+    // The label feeds the idempotency hash; it must be a stable string, decoupled
+    // from `Debug`, so a token stays constant across refactors of the enum.
+    assert_eq!(DispatchSource::AfterMutation.label(), "after:mutation");
+    assert_eq!(DispatchSource::AfterIngest.label(), "after:ingest");
+}
+
+#[test]
+fn idempotency_token_is_deterministic() {
+    let payload = serde_json::json!({ "id": 42, "amount_cents": 1000 });
+    let a = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "syncInvoice",
+        "after:mutation:Invoice:create",
+        &payload,
+    );
+    let b = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "syncInvoice",
+        "after:mutation:Invoice:create",
+        &payload,
+    );
+    assert_eq!(a, b, "same inputs must yield the same token (stable across retries and resume)");
+}
+
+#[test]
+fn idempotency_token_is_email_safe_hex() {
+    // The token doubles as a VERP send-id (`bounces+<token>@domain`), so it must be
+    // lowercase hex only and short enough for a 64-char local part.
+    let payload = serde_json::json!({ "id": 7 });
+    let token = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "f",
+        "after:mutation:X:create",
+        &payload,
+    );
+    assert_eq!(token.len(), 32, "128-bit truncated digest → 32 hex chars");
+    assert!(
+        token.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+        "token must be lowercase hex only, got {token:?}"
+    );
+}
+
+#[test]
+fn idempotency_token_distinct_per_function() {
+    let payload = serde_json::json!({ "id": 1 });
+    let a = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "sendFollowUp",
+        "after:mutation:Deal:update",
+        &payload,
+    );
+    let b = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "syncQonto",
+        "after:mutation:Deal:update",
+        &payload,
+    );
+    assert_ne!(a, b, "distinct functions on the same event are distinct logical operations");
+}
+
+#[test]
+fn idempotency_token_distinct_per_trigger() {
+    let payload = serde_json::json!({ "id": 1 });
+    let a = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "f",
+        "after:mutation:Deal:create",
+        &payload,
+    );
+    let b = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "f",
+        "after:mutation:Deal:update",
+        &payload,
+    );
+    assert_ne!(a, b);
+}
+
+#[test]
+fn idempotency_token_distinct_per_payload() {
+    let a = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "f",
+        "after:mutation:Deal:update",
+        &serde_json::json!({ "id": 1 }),
+    );
+    let b = derive_idempotency_token(
+        DispatchSource::AfterMutation,
+        "f",
+        "after:mutation:Deal:update",
+        &serde_json::json!({ "id": 2 }),
+    );
+    assert_ne!(a, b, "distinct entities are distinct logical operations");
+}
+
+#[test]
+fn idempotency_token_distinct_per_source() {
+    let payload = serde_json::json!({ "id": 1 });
+    let a = derive_idempotency_token(DispatchSource::AfterMutation, "f", "t", &payload);
+    let b = derive_idempotency_token(DispatchSource::AfterIngest, "f", "t", &payload);
+    assert_ne!(a, b, "the source is part of the dispatch identity");
+}
+
+#[test]
+fn idempotency_token_ignores_object_key_order() {
+    // Two payloads that differ only in textual key order must hash identically:
+    // the token is canonical (serde_json::Value sorts object keys), which is what
+    // makes it stable across a resume that re-serialises the payload.
+    let a: serde_json::Value = serde_json::from_str(r#"{"a":1,"b":2}"#).unwrap();
+    let b: serde_json::Value = serde_json::from_str(r#"{"b":2,"a":1}"#).unwrap();
+    let ta = derive_idempotency_token(DispatchSource::AfterMutation, "f", "t", &a);
+    let tb = derive_idempotency_token(DispatchSource::AfterMutation, "f", "t", &b);
+    assert_eq!(ta, tb, "canonical payload → order-independent token");
 }

--- a/crates/fraiseql-observers/src/dispatch/tests.rs
+++ b/crates/fraiseql-observers/src/dispatch/tests.rs
@@ -110,12 +110,14 @@ fn dispatch_source_label_is_stable() {
 fn idempotency_token_is_deterministic() {
     let payload = serde_json::json!({ "id": 42, "amount_cents": 1000 });
     let a = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "syncInvoice",
         "after:mutation:Invoice:create",
         &payload,
     );
     let b = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "syncInvoice",
         "after:mutation:Invoice:create",
@@ -127,31 +129,36 @@ fn idempotency_token_is_deterministic() {
 #[test]
 fn idempotency_token_is_email_safe_hex() {
     // The token doubles as a VERP send-id (`bounces+<token>@domain`), so it must be
-    // lowercase hex only and short enough for a 64-char local part.
+    // lowercase hex only and short enough for a 64-char local part — in both modes.
     let payload = serde_json::json!({ "id": 7 });
-    let token = derive_idempotency_token(
-        DispatchSource::AfterMutation,
-        "f",
-        "after:mutation:X:create",
-        &payload,
-    );
-    assert_eq!(token.len(), 32, "128-bit truncated digest → 32 hex chars");
-    assert!(
-        token.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
-        "token must be lowercase hex only, got {token:?}"
-    );
+    for key in [None, Some(b"server-secret".as_slice())] {
+        let token = derive_idempotency_token(
+            key,
+            DispatchSource::AfterMutation,
+            "f",
+            "after:mutation:X:create",
+            &payload,
+        );
+        assert_eq!(token.len(), 32, "128-bit truncated digest → 32 hex chars");
+        assert!(
+            token.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b)),
+            "token must be lowercase hex only, got {token:?}"
+        );
+    }
 }
 
 #[test]
 fn idempotency_token_distinct_per_function() {
     let payload = serde_json::json!({ "id": 1 });
     let a = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "sendFollowUp",
         "after:mutation:Deal:update",
         &payload,
     );
     let b = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "syncQonto",
         "after:mutation:Deal:update",
@@ -164,12 +171,14 @@ fn idempotency_token_distinct_per_function() {
 fn idempotency_token_distinct_per_trigger() {
     let payload = serde_json::json!({ "id": 1 });
     let a = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "f",
         "after:mutation:Deal:create",
         &payload,
     );
     let b = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "f",
         "after:mutation:Deal:update",
@@ -181,12 +190,14 @@ fn idempotency_token_distinct_per_trigger() {
 #[test]
 fn idempotency_token_distinct_per_payload() {
     let a = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "f",
         "after:mutation:Deal:update",
         &serde_json::json!({ "id": 1 }),
     );
     let b = derive_idempotency_token(
+        None,
         DispatchSource::AfterMutation,
         "f",
         "after:mutation:Deal:update",
@@ -198,8 +209,8 @@ fn idempotency_token_distinct_per_payload() {
 #[test]
 fn idempotency_token_distinct_per_source() {
     let payload = serde_json::json!({ "id": 1 });
-    let a = derive_idempotency_token(DispatchSource::AfterMutation, "f", "t", &payload);
-    let b = derive_idempotency_token(DispatchSource::AfterIngest, "f", "t", &payload);
+    let a = derive_idempotency_token(None, DispatchSource::AfterMutation, "f", "t", &payload);
+    let b = derive_idempotency_token(None, DispatchSource::AfterIngest, "f", "t", &payload);
     assert_ne!(a, b, "the source is part of the dispatch identity");
 }
 
@@ -210,7 +221,66 @@ fn idempotency_token_ignores_object_key_order() {
     // makes it stable across a resume that re-serialises the payload.
     let a: serde_json::Value = serde_json::from_str(r#"{"a":1,"b":2}"#).unwrap();
     let b: serde_json::Value = serde_json::from_str(r#"{"b":2,"a":1}"#).unwrap();
-    let ta = derive_idempotency_token(DispatchSource::AfterMutation, "f", "t", &a);
-    let tb = derive_idempotency_token(DispatchSource::AfterMutation, "f", "t", &b);
+    let ta = derive_idempotency_token(None, DispatchSource::AfterMutation, "f", "t", &a);
+    let tb = derive_idempotency_token(None, DispatchSource::AfterMutation, "f", "t", &b);
     assert_eq!(ta, tb, "canonical payload → order-independent token");
+}
+
+// ── Keyed (HMAC) mode — the unforgeable VERP send-id ─────────────────────────────
+
+#[test]
+fn keyed_token_differs_from_unkeyed() {
+    // The keyed (HMAC) token must not equal the plain digest of the same identity —
+    // otherwise the secret adds nothing and the send-id stays forgeable.
+    let payload = serde_json::json!({ "id": 1 });
+    let plain = derive_idempotency_token(None, DispatchSource::AfterMutation, "f", "t", &payload);
+    let keyed = derive_idempotency_token(
+        Some(b"server-secret"),
+        DispatchSource::AfterMutation,
+        "f",
+        "t",
+        &payload,
+    );
+    assert_ne!(plain, keyed, "the HMAC key must change the token");
+}
+
+#[test]
+fn keyed_token_is_deterministic() {
+    // Same key + same identity → same token (still resume-stable, retry-stable).
+    let payload = serde_json::json!({ "id": 1 });
+    let a = derive_idempotency_token(Some(b"k"), DispatchSource::AfterMutation, "f", "t", &payload);
+    let b = derive_idempotency_token(Some(b"k"), DispatchSource::AfterMutation, "f", "t", &payload);
+    assert_eq!(a, b, "keyed derivation is deterministic");
+}
+
+#[test]
+fn keyed_token_differs_by_key() {
+    // A different secret yields a different token: an attacker without the secret
+    // cannot mint a valid send-id even knowing the identity fields.
+    let payload = serde_json::json!({ "id": 1 });
+    let a = derive_idempotency_token(
+        Some(b"secret-a"),
+        DispatchSource::AfterMutation,
+        "f",
+        "t",
+        &payload,
+    );
+    let b = derive_idempotency_token(
+        Some(b"secret-b"),
+        DispatchSource::AfterMutation,
+        "f",
+        "t",
+        &payload,
+    );
+    assert_ne!(a, b, "the token binds to the secret");
+}
+
+#[test]
+fn subkey_is_deterministic_and_root_dependent() {
+    // The subkey is a stable function of the root (so tokens survive restart), and
+    // domain-separated so a different root yields a different subkey.
+    assert_eq!(derive_idempotency_subkey(b"root"), derive_idempotency_subkey(b"root"));
+    assert_ne!(derive_idempotency_subkey(b"root-a"), derive_idempotency_subkey(b"root-b"));
+    // Domain separation: the subkey is not the raw root truncated/padded.
+    assert_ne!(&derive_idempotency_subkey(b"root")[..], b"root");
 }

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -112,7 +112,7 @@ pub use dedup::redis::RedisDeduplicationStore;
 pub use dedup::{DeduplicationStats, DeduplicationStore};
 pub use dispatch::{
     DispatchPolicy, DispatchSource, FunctionDispatchRecord, RetryDecision,
-    derive_idempotency_token, run_with_retry,
+    derive_idempotency_subkey, derive_idempotency_token, run_with_retry,
 };
 pub use elasticsearch_sink::{ElasticsearchSink, ElasticsearchSinkConfig};
 pub use error::{ObserverError, ObserverErrorCode, Result};

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -111,8 +111,8 @@ pub use config::{
 pub use dedup::redis::RedisDeduplicationStore;
 pub use dedup::{DeduplicationStats, DeduplicationStore};
 pub use dispatch::{
-    DispatchPolicy, DispatchSource, FunctionDispatchRecord, RetryDecision,
-    derive_idempotency_subkey, derive_idempotency_token, run_with_retry,
+    DispatchPolicy, DispatchSource, FunctionDispatchRecord, RetryDecision, derive_address_hash_key,
+    derive_idempotency_subkey, derive_idempotency_token, hash_address, run_with_retry,
 };
 pub use elasticsearch_sink::{ElasticsearchSink, ElasticsearchSinkConfig};
 pub use error::{ObserverError, ObserverErrorCode, Result};

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -111,7 +111,8 @@ pub use config::{
 pub use dedup::redis::RedisDeduplicationStore;
 pub use dedup::{DeduplicationStats, DeduplicationStore};
 pub use dispatch::{
-    DispatchPolicy, DispatchSource, FunctionDispatchRecord, RetryDecision, run_with_retry,
+    DispatchPolicy, DispatchSource, FunctionDispatchRecord, RetryDecision,
+    derive_idempotency_token, run_with_retry,
 };
 pub use elasticsearch_sink::{ElasticsearchSink, ElasticsearchSinkConfig};
 pub use error::{ObserverError, ObserverErrorCode, Result};

--- a/crates/fraiseql-server/src/inbound/email/admin.rs
+++ b/crates/fraiseql-server/src/inbound/email/admin.rs
@@ -14,13 +14,7 @@
 
 use std::sync::Arc;
 
-use axum::{
-    Json, Router,
-    extract::{Query, State},
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-};
+use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::post};
 use serde::Deserialize;
 
 use super::tracking::{PgSendTracker, SendCorrelator, SendTracker, SuppressionReason};
@@ -49,12 +43,15 @@ impl SuppressionAdminState {
 /// Build the suppression admin router.
 ///
 /// - `POST /api/email/suppress` — add/refresh a suppression for an address.
-/// - `GET /api/email/suppression?address=…[&tenant=…]` — whether an address is suppressed (and
-///   why).
+/// - `POST /api/email/suppression` — whether an address is suppressed (and why).
+///
+/// The query is a `POST` (not a `GET` with the address in the query string) so the
+/// raw recipient address stays out of access logs and proxy caches — matching the
+/// no-raw-address hygiene the store itself keeps (it only ever sees the keyed hash).
 pub fn suppression_admin_router(state: Arc<SuppressionAdminState>) -> Router {
     Router::new()
         .route("/api/email/suppress", post(suppress))
-        .route("/api/email/suppression", get(query))
+        .route("/api/email/suppression", post(query))
         .with_state(state)
 }
 
@@ -71,10 +68,11 @@ struct SuppressRequest {
     tenant:  Option<String>,
 }
 
-/// Query of `GET /api/email/suppression`.
+/// Body of `POST /api/email/suppression`.
 #[derive(Debug, Deserialize)]
 struct SuppressionQuery {
-    /// The recipient address to check.
+    /// The recipient address to check (in the body — never a query string — so it
+    /// is not captured by access logs / proxies).
     address: String,
     /// Optional tenant scope.
     #[serde(default)]
@@ -111,10 +109,10 @@ async fn suppress(
 /// Whether an address is currently suppressed (and why).
 async fn query(
     State(state): State<Arc<SuppressionAdminState>>,
-    Query(params): Query<SuppressionQuery>,
+    Json(request): Json<SuppressionQuery>,
 ) -> impl IntoResponse {
-    let hash = fraiseql_observers::hash_address(&state.address_hash_key, &params.address);
-    match state.tracker.suppression_reason(params.tenant.as_deref(), &hash).await {
+    let hash = fraiseql_observers::hash_address(&state.address_hash_key, &request.address);
+    match state.tracker.suppression_reason(request.tenant.as_deref(), &hash).await {
         Ok(reason) => (
             StatusCode::OK,
             Json(serde_json::json!({

--- a/crates/fraiseql-server/src/inbound/email/admin.rs
+++ b/crates/fraiseql-server/src/inbound/email/admin.rs
@@ -1,0 +1,133 @@
+//! Admin surface for the suppression list — append + query.
+//!
+//! The correlation step auto-suppresses on hard bounces and repeated challenges;
+//! this router is the **operator** surface for the manual cases: a support removal,
+//! a GDPR do-not-contact request, an unsubscribe processed out of band. Mounted
+//! behind the same admin bearer gate as the RBAC / identity-cache APIs.
+//!
+//! The address is hashed **server-side** with the recipient address-hash key (the
+//! server HMAC subkey) before it touches the store — the suppression list holds no
+//! raw address, so a query or an append both go through here rather than direct
+//! SQL, which could not compute the same keyed hash. Read of *send* status (keyed
+//! by the non-secret send-id) needs no hashing and can be a direct RLS-scoped query
+//! against `_fraiseql_send_status`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use serde::Deserialize;
+
+use super::tracking::{PgSendTracker, SendCorrelator, SendTracker, SuppressionReason};
+
+/// Shared state for the suppression admin router.
+pub struct SuppressionAdminState {
+    /// The delivery-feedback store (append via `SendCorrelator::suppress`, query
+    /// via `SendTracker::suppression_reason`).
+    tracker:          Arc<PgSendTracker>,
+    /// The recipient address-hash key — the server HMAC subkey used to hash an
+    /// address before it touches the store.
+    address_hash_key: Arc<[u8]>,
+}
+
+impl SuppressionAdminState {
+    /// Assemble the router state from the store and the address-hash key.
+    #[must_use]
+    pub const fn new(tracker: Arc<PgSendTracker>, address_hash_key: Arc<[u8]>) -> Self {
+        Self {
+            tracker,
+            address_hash_key,
+        }
+    }
+}
+
+/// Build the suppression admin router.
+///
+/// - `POST /api/email/suppress` — add/refresh a suppression for an address.
+/// - `GET /api/email/suppression?address=…[&tenant=…]` — whether an address is suppressed (and
+///   why).
+pub fn suppression_admin_router(state: Arc<SuppressionAdminState>) -> Router {
+    Router::new()
+        .route("/api/email/suppress", post(suppress))
+        .route("/api/email/suppression", get(query))
+        .with_state(state)
+}
+
+/// Body of `POST /api/email/suppress`.
+#[derive(Debug, Deserialize)]
+struct SuppressRequest {
+    /// The recipient address to suppress (hashed server-side; never stored raw).
+    address: String,
+    /// The suppression reason (`hard_bounce` / `challenge_unanswered` /
+    /// `unsubscribe`). An operator append is usually `unsubscribe`.
+    reason:  String,
+    /// Optional tenant to scope the suppression to.
+    #[serde(default)]
+    tenant:  Option<String>,
+}
+
+/// Query of `GET /api/email/suppression`.
+#[derive(Debug, Deserialize)]
+struct SuppressionQuery {
+    /// The recipient address to check.
+    address: String,
+    /// Optional tenant scope.
+    #[serde(default)]
+    tenant:  Option<String>,
+}
+
+/// Append (or refresh) a suppression for an address.
+async fn suppress(
+    State(state): State<Arc<SuppressionAdminState>>,
+    Json(request): Json<SuppressRequest>,
+) -> impl IntoResponse {
+    let Some(reason) = SuppressionReason::parse(&request.reason) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("unknown suppression reason {:?}", request.reason)
+            })),
+        );
+    };
+    let hash = fraiseql_observers::hash_address(&state.address_hash_key, &request.address);
+    let ttl = reason.default_ttl(chrono::Utc::now());
+    match state.tracker.suppress(request.tenant.as_deref(), &hash, reason, ttl).await {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "suppressed": true, "reason": reason.as_str() })),
+        ),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error.to_string() })),
+        ),
+    }
+}
+
+/// Whether an address is currently suppressed (and why).
+async fn query(
+    State(state): State<Arc<SuppressionAdminState>>,
+    Query(params): Query<SuppressionQuery>,
+) -> impl IntoResponse {
+    let hash = fraiseql_observers::hash_address(&state.address_hash_key, &params.address);
+    match state.tracker.suppression_reason(params.tenant.as_deref(), &hash).await {
+        Ok(reason) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "suppressed": reason.is_some(),
+                "reason": reason.map(SuppressionReason::as_str),
+            })),
+        ),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error.to_string() })),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/admin/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/admin/tests.rs
@@ -1,0 +1,30 @@
+//! Tests for the suppression admin router.
+//!
+//! A `router_construction` test that actually builds the router under
+//! `#[tokio::test]` — axum validates path-capture syntax inside `Router::route`,
+//! so a bad literal panics here in `cargo test` rather than at first server boot
+//! (see the "Bumping axum" gate in `.claude/CLAUDE.md`).
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use std::sync::Arc;
+
+use sqlx::postgres::PgPoolOptions;
+
+use super::{SuppressionAdminState, suppression_admin_router};
+use crate::inbound::email::PgSendTracker;
+
+mod router_construction {
+    use super::*;
+
+    #[tokio::test]
+    async fn suppression_admin_router_constructs() {
+        // A lazy pool never connects — construction only exercises the route
+        // syntax, not the database.
+        let pool = PgPoolOptions::new().connect_lazy("postgres://user@localhost/db").unwrap();
+        let tracker = Arc::new(PgSendTracker::new(pool));
+        let key: Arc<[u8]> = Arc::from(b"key".as_slice());
+        let state = Arc::new(SuppressionAdminState::new(tracker, key));
+        let _router = suppression_admin_router(state);
+    }
+}

--- a/crates/fraiseql-server/src/inbound/email/config.rs
+++ b/crates/fraiseql-server/src/inbound/email/config.rs
@@ -137,6 +137,68 @@ pub struct MailboxSmtpConfig {
     /// Connection/send timeout in seconds; defaults to 30.
     #[serde(default = "default_smtp_timeout_secs")]
     pub timeout_secs: u64,
+    /// The VERP Return-Path for delivery tracking (`[mailbox.<name>.smtp.return_path]`).
+    /// Absent → defaults (`bounces` local part, the sending address's own domain).
+    #[serde(default)]
+    pub return_path:  Option<ReturnPathConfig>,
+}
+
+impl MailboxSmtpConfig {
+    /// The domain part of the account's verified sending address (everything after
+    /// the last `@`), or the whole string if it has no `@`.
+    #[must_use]
+    pub fn sending_domain(&self) -> &str {
+        self.address
+            .rsplit_once('@')
+            .map_or(self.address.as_str(), |(_, domain)| domain)
+    }
+
+    /// The resolved VERP Return-Path local part (`bounces` by default).
+    #[must_use]
+    pub fn return_path_local_part(&self) -> &str {
+        self.return_path
+            .as_ref()
+            .and_then(|rp| rp.local_part.as_deref())
+            .unwrap_or(DEFAULT_RETURN_PATH_LOCAL_PART)
+    }
+
+    /// The resolved VERP Return-Path domain — the configured override, or the
+    /// sending address's own domain (SPF/DMARC alignment).
+    #[must_use]
+    pub fn return_path_domain(&self) -> &str {
+        self.return_path
+            .as_ref()
+            .and_then(|rp| rp.domain.as_deref())
+            .unwrap_or_else(|| self.sending_domain())
+    }
+}
+
+/// The default VERP Return-Path local part.
+const DEFAULT_RETURN_PATH_LOCAL_PART: &str = "bounces";
+
+/// The VERP Return-Path configuration for delivery tracking
+/// (`[mailbox.<name>.smtp.return_path]`).
+///
+/// The transport sets the SMTP envelope sender (`MAIL FROM`) to
+/// `<local_part>+<send-id>@<domain>` while the header `From` stays the verified
+/// sending address, so an inbound bounce/challenge/reply addressed to the
+/// Return-Path carries the send-id back for correlation.
+///
+/// Both fields are optional: the local part defaults to `bounces` and the domain
+/// defaults to the sending address's own domain. **The domain should equal the
+/// sending domain** — the envelope sender is the SPF/DMARC alignment target, so a
+/// bounce domain on a different domain silently degrades deliverability of the very
+/// sends it tracks; a mismatch is warned about at build time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReturnPathConfig {
+    /// The Return-Path local part before the `+<send-id>` tag; defaults to `bounces`.
+    #[serde(default)]
+    pub local_part: Option<String>,
+    /// The Return-Path domain; defaults to the sending address's own domain.
+    /// Should equal the sending domain for SPF/DMARC alignment.
+    #[serde(default)]
+    pub domain:     Option<String>,
 }
 
 /// A declared `[[mailbox.<name>.imap.routing]]` rule: a dedicated address that maps

--- a/crates/fraiseql-server/src/inbound/email/config.rs
+++ b/crates/fraiseql-server/src/inbound/email/config.rs
@@ -201,6 +201,37 @@ pub struct ReturnPathConfig {
     pub domain:     Option<String>,
 }
 
+/// The default number of unanswered challenges before a recipient is suppressed.
+const fn default_challenge_suppress_after() -> u32 {
+    2
+}
+
+/// Delivery-feedback send policy (`[send]`).
+///
+/// Governs how the correlation step reacts to inbound signals. Currently just the
+/// challenge-suppression threshold; separated from the per-mailbox config because
+/// it is a cross-mailbox policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendSettings {
+    /// The number of **unanswered** challenge-response prompts to a recipient
+    /// (across campaigns) before that recipient is suppressed. Default 2: a
+    /// challenge means the mailbox works but quarantines us, so a third send would
+    /// only re-quarantine (near-zero read, nonzero reputation cost); N=1 forecloses
+    /// the human decision window (a surfaced `ChallengePending` a salesperson can
+    /// personally solve, or the recipient can release). "Unanswered" is event-based
+    /// — a reply or a released send resets it, never elapsed time.
+    #[serde(default = "default_challenge_suppress_after")]
+    pub challenge_suppress_after: u32,
+}
+
+impl Default for SendSettings {
+    fn default() -> Self {
+        Self {
+            challenge_suppress_after: default_challenge_suppress_after(),
+        }
+    }
+}
+
 /// A declared `[[mailbox.<name>.imap.routing]]` rule: a dedicated address that maps
 /// to an entity type (the recipient's plus-tag becomes the entity id).
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/fraiseql-server/src/inbound/email/config.rs
+++ b/crates/fraiseql-server/src/inbound/email/config.rs
@@ -222,12 +222,21 @@ pub struct SendSettings {
     /// — a reply or a released send resets it, never elapsed time.
     #[serde(default = "default_challenge_suppress_after")]
     pub challenge_suppress_after: u32,
+
+    /// Run a Return-Path probe at startup for each mailbox with both an IMAP and an
+    /// SMTP half: send a self-addressed `bounces+probe-<nonce>@…` and confirm it
+    /// lands with the plus-tag intact, so VERP delivery correlation can be trusted.
+    /// Off by default (it emits a probe message per boot); enable it once to verify
+    /// a new deployment's provider preserves plus-addressing.
+    #[serde(default)]
+    pub verp_probe_on_start: bool,
 }
 
 impl Default for SendSettings {
     fn default() -> Self {
         Self {
             challenge_suppress_after: default_challenge_suppress_after(),
+            verp_probe_on_start:      false,
         }
     }
 }

--- a/crates/fraiseql-server/src/inbound/email/correlation.rs
+++ b/crates/fraiseql-server/src/inbound/email/correlation.rs
@@ -1,0 +1,227 @@
+//! Inbound-to-outbound correlation: the built-in poll-worker step that links an
+//! inbound bounce / challenge / reply back to the send that triggered it.
+//!
+//! This is **platform infrastructure**, not an app-written `after:ingest` function
+//! — fraiseql mints the sends and detects their outcomes, and only exposes the
+//! result (send-status + suppression) to the app. App `after:ingest` functions
+//! still fire afterwards for app logic.
+//!
+//! The link is the per-send VERP send-id: a bounce/challenge addressed to the
+//! `bounces+<send-id>@…` Return-Path carries the send-id in its recipient plus-tag
+//! ([`extract_send_id`]); a reply on the thread carries our sent message-id in its
+//! `References` ([`referenced_message_ids`], the fallback). Given a matched send,
+//! [`correlate`] transitions its status and the recipient's suppression state per
+//! the classifier's verdict — including the **event-based, per-recipient,
+//! never-auto-solve** challenge policy.
+
+use fraiseql_functions::{Classification, InboundMessage, parse_recipient};
+use tracing::{info, warn};
+
+use super::tracking::{CorrelatedSend, SendCorrelator, SuppressionReason};
+
+/// Headers whose value is (or contains) the envelope recipient the message was
+/// actually delivered to — where a VERP `bounces+<send-id>@…` Return-Path lands.
+const DELIVERY_HEADERS: [&str; 3] = ["delivered-to", "x-original-to", "envelope-to"];
+
+/// Headers that quote the message-ids of the thread (the reply fallback).
+const REFERENCE_HEADERS: [&str; 2] = ["references", "in-reply-to"];
+
+/// Whether a plus-tag has the shape of a send-id (32 lowercase hex chars).
+///
+/// A cheap pre-filter so an unrelated plus-tag (`support+ticket-42@…`) is not
+/// looked up as a send-id; a genuine send-id is an unguessable 32-hex HMAC, so a
+/// non-matching tag would only ever miss anyway.
+fn looks_like_send_id(tag: &str) -> bool {
+    tag.len() == 32 && tag.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// Extract the send-id from an inbound message's recipient plus-tag.
+///
+/// Scans the primary recipients and the delivery headers for a
+/// `bounces+<send-id>@domain` address and returns the first `<send-id>` that has
+/// the send-id shape. Pure — no I/O.
+#[must_use]
+pub fn extract_send_id(message: &InboundMessage) -> Option<String> {
+    let header_addrs = DELIVERY_HEADERS
+        .iter()
+        .filter_map(|name| message.headers.get(*name))
+        .flat_map(|value| value.split([',', ' ']))
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    message
+        .to
+        .iter()
+        .map(String::as_str)
+        .chain(header_addrs)
+        .filter_map(parse_recipient)
+        .filter_map(|recipient| recipient.tag)
+        .find(|tag| looks_like_send_id(tag))
+}
+
+/// The message-ids this message quotes in its `References` / `In-Reply-To`, the
+/// fallback correlation when the VERP plus-tag was stripped by a mailbox. Pure.
+#[must_use]
+pub fn referenced_message_ids(message: &InboundMessage) -> Vec<String> {
+    REFERENCE_HEADERS
+        .iter()
+        .filter_map(|name| message.headers.get(*name))
+        .flat_map(|value| value.split_whitespace())
+        .map(str::trim)
+        .filter(|token| token.starts_with('<') && token.ends_with('>'))
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// What the correlation step did with a message (for logging + tests).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorrelationOutcome {
+    /// No tracked send matched this message (not one of ours, or the id was lost).
+    NoMatch,
+    /// A send matched but the classification is not actionable (or absent).
+    Ignored,
+    /// The send was marked `Bounced` and the recipient suppressed (`hard_bounce`).
+    Bounced,
+    /// The send was marked `ChallengePending`; `suppressed` when the recipient
+    /// reached the unanswered-challenge threshold. Never auto-solved.
+    Challenge {
+        /// The recipient's total unanswered challenges (across campaigns).
+        pending_count: i64,
+        /// Whether this pushed the recipient over the suppression threshold.
+        suppressed:    bool,
+    },
+    /// The send was marked `Replied`; any `challenge_unanswered` suppression lifted.
+    Replied,
+    /// An informational signal (out-of-office / auto-generated) was recorded.
+    Informational,
+}
+
+/// The action a classification maps to. Pure decision, separated for testing.
+enum Action {
+    Bounce,
+    Challenge,
+    Reply,
+    Signal(&'static str),
+    Ignore,
+}
+
+/// Map a classification to a correlation action.
+const fn decide(classification: Option<Classification>) -> Action {
+    match classification {
+        Some(Classification::Bounce) => Action::Bounce,
+        Some(Classification::Challenge) => Action::Challenge,
+        Some(Classification::Human) => Action::Reply,
+        Some(Classification::OutOfOffice) => Action::Signal("out_of_office"),
+        Some(Classification::AutoGenerated) => Action::Signal("auto_generated"),
+        // No classification, or a future variant → not actionable.
+        _ => Action::Ignore,
+    }
+}
+
+/// Look a tracked send up from an inbound message: the VERP send-id plus-tag first,
+/// then the quoted message-id fallback.
+async fn resolve_send(
+    correlator: &dyn SendCorrelator,
+    message: &InboundMessage,
+) -> fraiseql_error::Result<Option<CorrelatedSend>> {
+    if let Some(send_id) = extract_send_id(message) {
+        if let Some(send) = correlator.find_by_send_id(&send_id).await? {
+            return Ok(Some(send));
+        }
+    }
+    for message_id in referenced_message_ids(message) {
+        if let Some(send) = correlator.find_by_message_id(&message_id).await? {
+            return Ok(Some(send));
+        }
+    }
+    Ok(None)
+}
+
+/// Correlate one inbound message back to its send and transition status +
+/// suppression per the classifier's verdict.
+///
+/// `address_hash_key` (the server-HMAC subkey) keys the recipient hash for
+/// suppression writes; when `None` (no secret), status still transitions but no
+/// suppression is written — matching the send path, which cannot enforce a
+/// suppression it cannot key either. `challenge_suppress_after` is the per-recipient
+/// unanswered-challenge threshold (`N`, default 2). `now` is threaded in for the
+/// TTL so the caller controls the clock.
+///
+/// # Errors
+///
+/// Returns the underlying database error from a lookup or transition.
+pub async fn correlate(
+    correlator: &dyn SendCorrelator,
+    address_hash_key: Option<&[u8]>,
+    challenge_suppress_after: u32,
+    now: chrono::DateTime<chrono::Utc>,
+    message: &InboundMessage,
+) -> fraiseql_error::Result<CorrelationOutcome> {
+    let Some(send) = resolve_send(correlator, message).await? else {
+        return Ok(CorrelationOutcome::NoMatch);
+    };
+    let tenant = send.tenant.as_deref();
+    let recipient_hash =
+        address_hash_key.map(|key| fraiseql_observers::hash_address(key, &send.recipient));
+
+    match decide(message.classification) {
+        Action::Bounce => {
+            correlator.mark_bounced(&send.send_id).await?;
+            if let Some(hash) = recipient_hash.as_deref() {
+                correlator.suppress(tenant, hash, SuppressionReason::HardBounce, None).await?;
+            }
+            info!(send_id = %send.send_id, "delivery correlation: hard bounce → suppressed");
+            Ok(CorrelationOutcome::Bounced)
+        },
+        Action::Challenge => {
+            let pending_count =
+                correlator.bump_challenge(&send.send_id, tenant, &send.recipient).await?;
+            let suppressed = pending_count >= i64::from(challenge_suppress_after);
+            if suppressed {
+                if let Some(hash) = recipient_hash.as_deref() {
+                    correlator
+                        .suppress(
+                            tenant,
+                            hash,
+                            SuppressionReason::ChallengeUnanswered,
+                            SuppressionReason::ChallengeUnanswered.default_ttl(now),
+                        )
+                        .await?;
+                }
+            }
+            // Surface: a challenge is a human decision point — a salesperson may
+            // personally solve it, or the recipient may release us. NEVER
+            // auto-solved for cold outreach.
+            warn!(
+                send_id = %send.send_id,
+                pending_count,
+                suppressed,
+                "delivery correlation: challenge pending — surfaced for review, not auto-solved"
+            );
+            Ok(CorrelationOutcome::Challenge {
+                pending_count,
+                suppressed,
+            })
+        },
+        Action::Reply => {
+            correlator.mark_replied(&send.send_id, tenant, &send.recipient).await?;
+            if let Some(hash) = recipient_hash.as_deref() {
+                // A genuine reply lifts a challenge suppression immediately (never a
+                // hard bounce).
+                correlator
+                    .lift_suppression(tenant, hash, SuppressionReason::ChallengeUnanswered)
+                    .await?;
+            }
+            info!(send_id = %send.send_id, "delivery correlation: reply → engaged");
+            Ok(CorrelationOutcome::Replied)
+        },
+        Action::Signal(signal) => {
+            correlator.record_signal(&send.send_id, signal).await?;
+            Ok(CorrelationOutcome::Informational)
+        },
+        Action::Ignore => Ok(CorrelationOutcome::Ignored),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/correlation/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/correlation/tests.rs
@@ -1,0 +1,369 @@
+//! Tests for the inbound-correlation step.
+//!
+//! The extraction and decision logic is pure; the transition orchestration is
+//! driven against an in-memory [`FakeCorrelator`] that records the calls — no
+//! database, so these all run in the fast leg.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        Mutex,
+        atomic::{AtomicI64, Ordering},
+    },
+};
+
+use fraiseql_error::Result;
+use fraiseql_functions::{Classification, InboundMessage, IngestSource};
+
+use super::{CorrelationOutcome, correlate, extract_send_id, referenced_message_ids};
+use crate::inbound::email::tracking::{CorrelatedSend, SendCorrelator, SuppressionReason};
+
+const SEND_ID: &str = "0123456789abcdef0123456789abcdef"; // 32 hex
+
+fn now() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339("2026-07-05T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}
+
+/// Build an email `InboundMessage` with the given recipients, headers, and
+/// classification.
+fn email(
+    to: &[&str],
+    headers: &[(&str, &str)],
+    classification: Option<Classification>,
+) -> InboundMessage {
+    let mut message = InboundMessage::new(IngestSource::Email, "mid-1", now());
+    message.to = to.iter().map(ToString::to_string).collect();
+    message.headers = headers.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect();
+    message.classification = classification;
+    message
+}
+
+// ── Pure extraction ──────────────────────────────────────────────────────────────
+
+#[test]
+fn extracts_the_send_id_from_a_verp_recipient_plus_tag() {
+    let message = email(&[&format!("bounces+{SEND_ID}@sales.example.com")], &[], None);
+    assert_eq!(extract_send_id(&message).as_deref(), Some(SEND_ID));
+}
+
+#[test]
+fn extracts_the_send_id_from_a_delivery_header() {
+    let message = email(
+        &["postmaster@relay.example.net"],
+        &[("delivered-to", &format!("bounces+{SEND_ID}@sales.example.com"))],
+        None,
+    );
+    assert_eq!(extract_send_id(&message).as_deref(), Some(SEND_ID));
+}
+
+#[test]
+fn ignores_plus_tags_that_are_not_send_ids() {
+    // A non-send-id plus-tag (a routing sub-address) must not be treated as one.
+    let message = email(&["support+ticket-42@example.com"], &[], None);
+    assert_eq!(extract_send_id(&message), None);
+}
+
+#[test]
+fn referenced_message_ids_parses_references_and_in_reply_to() {
+    let message = email(
+        &["sales@example.com"],
+        &[
+            ("references", "<a@x> <b@relay>"),
+            ("in-reply-to", "<c@relay>"),
+        ],
+        None,
+    );
+    let ids = referenced_message_ids(&message);
+    assert!(ids.contains(&"<a@x>".to_string()));
+    assert!(ids.contains(&"<b@relay>".to_string()));
+    assert!(ids.contains(&"<c@relay>".to_string()));
+}
+
+// ── A fake correlator that records calls ─────────────────────────────────────────
+
+#[derive(Default)]
+struct FakeCorrelator {
+    /// What `find_by_send_id` returns.
+    send:            Option<CorrelatedSend>,
+    /// The count `bump_challenge` returns.
+    challenge_count: AtomicI64,
+    /// Recorded transition/suppression calls, in order.
+    calls:           Mutex<Vec<String>>,
+}
+
+impl FakeCorrelator {
+    fn with_send(count: i64) -> Self {
+        Self {
+            send:            Some(CorrelatedSend {
+                send_id:   SEND_ID.to_string(),
+                tenant:    Some("tenant-1".to_string()),
+                recipient: "bob@example.com".to_string(),
+            }),
+            challenge_count: AtomicI64::new(count),
+            calls:           Mutex::new(Vec::new()),
+        }
+    }
+
+    fn record(&self, call: impl Into<String>) {
+        self.calls.lock().unwrap().push(call.into());
+    }
+
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl SendCorrelator for FakeCorrelator {
+    fn find_by_send_id<'a>(
+        &'a self,
+        _send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<CorrelatedSend>>> + Send + 'a>> {
+        let send = self.send.clone();
+        Box::pin(async move { Ok(send) })
+    }
+
+    fn find_by_message_id<'a>(
+        &'a self,
+        _message_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<CorrelatedSend>>> + Send + 'a>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    fn mark_bounced<'a>(
+        &'a self,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        self.record(format!("bounced:{send_id}"));
+        Box::pin(async { Ok(()) })
+    }
+
+    fn bump_challenge<'a>(
+        &'a self,
+        send_id: &'a str,
+        _tenant: Option<&'a str>,
+        _recipient: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<i64>> + Send + 'a>> {
+        self.record(format!("bump:{send_id}"));
+        let count = self.challenge_count.load(Ordering::SeqCst);
+        Box::pin(async move { Ok(count) })
+    }
+
+    fn mark_replied<'a>(
+        &'a self,
+        send_id: &'a str,
+        _tenant: Option<&'a str>,
+        _recipient: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        self.record(format!("replied:{send_id}"));
+        Box::pin(async { Ok(()) })
+    }
+
+    fn record_signal<'a>(
+        &'a self,
+        send_id: &'a str,
+        signal: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        self.record(format!("signal:{send_id}:{signal}"));
+        Box::pin(async { Ok(()) })
+    }
+
+    fn suppress<'a>(
+        &'a self,
+        _tenant: Option<&'a str>,
+        _address_hash: &'a str,
+        reason: SuppressionReason,
+        _ttl: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        self.record(format!("suppress:{}", reason.as_str()));
+        Box::pin(async { Ok(()) })
+    }
+
+    fn lift_suppression<'a>(
+        &'a self,
+        _tenant: Option<&'a str>,
+        _address_hash: &'a str,
+        reason: SuppressionReason,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        self.record(format!("lift:{}", reason.as_str()));
+        Box::pin(async { Ok(()) })
+    }
+}
+
+const KEY: &[u8] = b"address-hash-key";
+
+fn verp(to: &str) -> InboundMessage {
+    email(&[&format!("bounces+{SEND_ID}@sales.example.com")], &[], to_classification(to))
+}
+
+fn to_classification(kind: &str) -> Option<Classification> {
+    match kind {
+        "bounce" => Some(Classification::Bounce),
+        "challenge" => Some(Classification::Challenge),
+        "human" => Some(Classification::Human),
+        "ooo" => Some(Classification::OutOfOffice),
+        _ => None,
+    }
+}
+
+// ── Driver: transitions per classification ───────────────────────────────────────
+
+#[tokio::test]
+async fn a_bounce_marks_bounced_and_suppresses_hard_bounce() {
+    let fake = FakeCorrelator::with_send(0);
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &verp("bounce")).await.unwrap();
+    assert_eq!(outcome, CorrelationOutcome::Bounced);
+    assert_eq!(
+        fake.calls(),
+        vec![
+            format!("bounced:{SEND_ID}"),
+            "suppress:hard_bounce".to_string()
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_challenge_below_threshold_does_not_suppress() {
+    // Count 1 < N=2 → pending, surfaced, but not suppressed.
+    let fake = FakeCorrelator::with_send(1);
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &verp("challenge")).await.unwrap();
+    assert_eq!(
+        outcome,
+        CorrelationOutcome::Challenge {
+            pending_count: 1,
+            suppressed:    false,
+        }
+    );
+    assert_eq!(fake.calls(), vec![format!("bump:{SEND_ID}")], "no suppression yet");
+}
+
+#[tokio::test]
+async fn a_challenge_at_threshold_suppresses_challenge_unanswered() {
+    // Count 2 >= N=2 → suppressed.
+    let fake = FakeCorrelator::with_send(2);
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &verp("challenge")).await.unwrap();
+    assert_eq!(
+        outcome,
+        CorrelationOutcome::Challenge {
+            pending_count: 2,
+            suppressed:    true,
+        }
+    );
+    assert_eq!(
+        fake.calls(),
+        vec![
+            format!("bump:{SEND_ID}"),
+            "suppress:challenge_unanswered".to_string()
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_reply_marks_replied_and_lifts_a_challenge_suppression() {
+    let fake = FakeCorrelator::with_send(0);
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &verp("human")).await.unwrap();
+    assert_eq!(outcome, CorrelationOutcome::Replied);
+    assert_eq!(
+        fake.calls(),
+        vec![
+            format!("replied:{SEND_ID}"),
+            "lift:challenge_unanswered".to_string()
+        ]
+    );
+}
+
+#[tokio::test]
+async fn an_out_of_office_records_an_informational_signal_only() {
+    let fake = FakeCorrelator::with_send(0);
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &verp("ooo")).await.unwrap();
+    assert_eq!(outcome, CorrelationOutcome::Informational);
+    assert_eq!(fake.calls(), vec![format!("signal:{SEND_ID}:out_of_office")]);
+}
+
+#[tokio::test]
+async fn a_message_with_no_matching_send_is_a_no_match() {
+    // No send_id in the recipients and the fake finds nothing.
+    let fake = FakeCorrelator::default();
+    let message = email(&["someone@example.com"], &[], Some(Classification::Bounce));
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &message).await.unwrap();
+    assert_eq!(outcome, CorrelationOutcome::NoMatch);
+    assert!(fake.calls().is_empty(), "no transition without a matched send");
+}
+
+#[tokio::test]
+async fn without_a_key_status_transitions_but_no_suppression_is_written() {
+    // No HMAC secret → the status still moves to Bounced, but no suppression row is
+    // written (the send path could not key the check either).
+    let fake = FakeCorrelator::with_send(0);
+    let outcome = correlate(&fake, None, 2, now(), &verp("bounce")).await.unwrap();
+    assert_eq!(outcome, CorrelationOutcome::Bounced);
+    assert_eq!(fake.calls(), vec![format!("bounced:{SEND_ID}")], "no suppress without a key");
+}
+
+// ── Fixture e2e: real .eml → normalize → classify → extract → correlate ───────────
+
+/// A hard-bounce DSN from a mailer-daemon, addressed to the VERP Return-Path.
+const BOUNCE_EML: &str = "\
+From: MAILER-DAEMON@mail.example.net\r
+To: bounces+0123456789abcdef0123456789abcdef@sales.example.com\r
+Subject: Undelivered Mail Returned to Sender\r
+Message-ID: <bounce-1@mail.example.net>\r
+X-Failed-Recipients: bob@example.com\r
+Content-Type: text/plain\r
+\r
+The following message could not be delivered: 550 5.1.1 user unknown.\r
+";
+
+/// A Mailinblack-style challenge, addressed to the VERP Return-Path.
+const CHALLENGE_EML: &str = "\
+From: guard@mailinblack.example\r
+To: bounces+0123456789abcdef0123456789abcdef@sales.example.com\r
+Subject: Please confirm you are human\r
+Message-ID: <challenge-1@mailinblack.example>\r
+X-Challenge: 7f3a9\r
+Content-Type: text/plain\r
+\r
+Click the link to prove you are not a robot.\r
+";
+
+#[test]
+fn a_real_bounce_eml_classifies_and_yields_its_send_id() {
+    let parsed =
+        fraiseql_functions::normalize_email(BOUNCE_EML.as_bytes(), IngestSource::Email, now())
+            .expect("bounce parses");
+    assert_eq!(parsed.message.classification, Some(Classification::Bounce));
+    assert_eq!(extract_send_id(&parsed.message).as_deref(), Some(SEND_ID));
+}
+
+#[test]
+fn a_real_challenge_eml_classifies_and_yields_its_send_id() {
+    let parsed =
+        fraiseql_functions::normalize_email(CHALLENGE_EML.as_bytes(), IngestSource::Email, now())
+            .expect("challenge parses");
+    assert_eq!(parsed.message.classification, Some(Classification::Challenge));
+    assert_eq!(extract_send_id(&parsed.message).as_deref(), Some(SEND_ID));
+}
+
+#[tokio::test]
+async fn a_real_bounce_eml_drives_the_correlation_transition() {
+    // The full inbound path in miniature: a raw DSN normalizes, classifies as a
+    // bounce, its send-id is recovered from the Return-Path plus-tag, and the
+    // correlation marks the send bounced + suppresses.
+    let parsed =
+        fraiseql_functions::normalize_email(BOUNCE_EML.as_bytes(), IngestSource::Email, now())
+            .expect("bounce parses");
+    let fake = FakeCorrelator::with_send(0);
+    let outcome = correlate(&fake, Some(KEY), 2, now(), &parsed.message).await.unwrap();
+    assert_eq!(outcome, CorrelationOutcome::Bounced);
+    assert_eq!(
+        fake.calls(),
+        vec![
+            format!("bounced:{SEND_ID}"),
+            "suppress:hard_bounce".to_string()
+        ]
+    );
+}

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -29,7 +29,9 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Durat
 use fraiseql_functions::host::live::storage::StorageBackend;
 use tracing::{info, warn};
 
+pub mod admin;
 pub mod config;
+pub mod correlation;
 pub mod cursor;
 pub mod imap;
 pub mod smtp;
@@ -38,14 +40,20 @@ pub mod tracking;
 pub mod warming;
 pub mod worker;
 
+pub use admin::{SuppressionAdminState, suppression_admin_router};
 pub use config::{
-    ImapConfig, MailboxConfig, MailboxSmtpConfig, ReturnPathConfig, RoutingRuleConfig, SmtpTlsMode,
+    ImapConfig, MailboxConfig, MailboxSmtpConfig, ReturnPathConfig, RoutingRuleConfig,
+    SendSettings, SmtpTlsMode,
 };
+pub use correlation::correlate;
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
 pub use smtp::{SmtpMailboxTransport, build_email_transport};
 pub use store::PostgresEmailCursorStore;
-pub use tracking::{PgSendTracker, RecordedSend, SendTracker, SentRecord, SuppressionReason};
+pub use tracking::{
+    CorrelatedSend, PgSendTracker, RecordedSend, SendCorrelator, SendTracker, SentRecord,
+    SuppressionReason,
+};
 pub use warming::{SendCounter, WarmingState, warming_daily_limit};
 pub use worker::EmailPollWorker;
 
@@ -70,11 +78,15 @@ pub async fn init_cursor_store(pool: &sqlx::PgPool) -> fraiseql_error::Result<()
 /// storage backend attachments stream into (`None` drops attachments); `hooks`
 /// fire `after:ingest:email` (`None` ingests without dispatch).
 #[must_use]
+#[allow(clippy::too_many_arguments)] // Reason: worker assembly wires several independent collaborators.
 pub fn build_workers<S: std::hash::BuildHasher>(
     mailboxes: &HashMap<String, MailboxConfig, S>,
     pool: &sqlx::PgPool,
     hooks: Option<&Arc<BeforeMutationHooks>>,
     sink: Option<&Arc<dyn StorageBackend>>,
+    correlator: Option<&Arc<dyn SendCorrelator>>,
+    address_hash_key: Option<&Arc<[u8]>>,
+    challenge_suppress_after: u32,
     get_env: impl Fn(&str) -> Option<String>,
 ) -> Vec<(EmailPollWorker, Duration)> {
     let mut workers = Vec::new();
@@ -114,6 +126,9 @@ pub fn build_workers<S: std::hash::BuildHasher>(
             imap.attachment_bucket.clone(),
             sink.cloned(),
             hooks.cloned(),
+            correlator.cloned(),
+            address_hash_key.cloned(),
+            challenge_suppress_after,
         );
         let interval = Duration::from_secs(imap.poll_interval_secs.max(1));
         info!(

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -34,6 +34,7 @@ pub mod config;
 pub mod correlation;
 pub mod cursor;
 pub mod imap;
+pub mod probe;
 pub mod smtp;
 pub mod store;
 pub mod tracking;
@@ -48,6 +49,7 @@ pub use config::{
 pub use correlation::correlate;
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
+pub use probe::{ProbeOutcome, probe_recipient, run_return_path_probe};
 pub use smtp::{SmtpMailboxTransport, build_email_transport};
 pub use store::PostgresEmailCursorStore;
 pub use tracking::{
@@ -140,6 +142,88 @@ pub fn build_workers<S: std::hash::BuildHasher>(
         workers.push((worker, interval));
     }
     workers
+}
+
+/// How long to wait for a startup Return-Path probe to land before warning.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(120);
+/// How often to poll the mailbox while waiting for the probe.
+const PROBE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Run a Return-Path probe at startup for each mailbox with both halves.
+///
+/// Opt-in (`[send] verp_probe_on_start`): for every mailbox that both sends (SMTP)
+/// and receives (IMAP), send a self-addressed `bounces+probe-<nonce>@…` and confirm
+/// it lands with the plus-tag intact — proving the provider preserves plus-
+/// addressing, without which VERP delivery correlation silently fails. The outcome
+/// is logged loudly; a probe never blocks a send. `get_env` resolves the account
+/// passwords (in production, [`std::env::var`]).
+pub async fn run_startup_probes<S: std::hash::BuildHasher + Sync>(
+    mailboxes: &HashMap<String, MailboxConfig, S>,
+    get_env: impl Fn(&str) -> Option<String> + Send,
+) {
+    for (name, mailbox) in mailboxes {
+        // Only a mailbox that both sends and receives can be self-probed.
+        let (Some(imap), Some(smtp)) = (mailbox.imap.as_ref(), mailbox.smtp.as_ref()) else {
+            continue;
+        };
+        let Some(transport) =
+            SmtpMailboxTransport::build(std::iter::once((name.as_str(), smtp)), &get_env)
+        else {
+            continue; // password unset / relay build failed — already warned by build
+        };
+        let Some(password) = get_env(&imap.password_env) else {
+            continue;
+        };
+        let fetcher = match ImapMailboxFetcher::new(
+            &imap.host,
+            imap.port,
+            &imap.username,
+            password,
+            &imap.mailbox,
+        ) {
+            Ok(fetcher) => fetcher,
+            Err(error) => {
+                warn!(mailbox = %name, %error, "Return-Path probe skipped: IMAP TLS setup failed");
+                continue;
+            },
+        };
+
+        let nonce = uuid::Uuid::new_v4().simple().to_string();
+        let sender = fraiseql_functions::SenderIdentity {
+            address:      smtp.address.clone(),
+            display_name: None,
+        };
+        let probe_to = probe::probe_recipient(
+            smtp.return_path_local_part(),
+            smtp.return_path_domain(),
+            &nonce,
+        );
+        match probe::run_return_path_probe(
+            &transport,
+            &fetcher,
+            &sender,
+            &probe_to,
+            &nonce,
+            PROBE_TIMEOUT,
+            PROBE_INTERVAL,
+        )
+        .await
+        {
+            Ok(ProbeOutcome::Confirmed) => info!(
+                mailbox = %name,
+                "VERP Return-Path probe confirmed — delivery correlation is active"
+            ),
+            Ok(ProbeOutcome::NotObserved) => warn!(
+                mailbox = %name,
+                "VERP Return-Path probe did NOT land within the window — plus-addressing may be \
+                 stripped by the provider; delivery correlation may not work (sends still go out, \
+                 but bounces/challenges/replies will not be tracked)"
+            ),
+            Err(error) => {
+                warn!(mailbox = %name, %error, "VERP Return-Path probe failed to run");
+            },
+        }
+    }
 }
 
 /// An attachment sink backed by the server's legacy storage.

--- a/crates/fraiseql-server/src/inbound/email/mod.rs
+++ b/crates/fraiseql-server/src/inbound/email/mod.rs
@@ -34,14 +34,18 @@ pub mod cursor;
 pub mod imap;
 pub mod smtp;
 pub mod store;
+pub mod tracking;
 pub mod warming;
 pub mod worker;
 
-pub use config::{ImapConfig, MailboxConfig, MailboxSmtpConfig, RoutingRuleConfig, SmtpTlsMode};
+pub use config::{
+    ImapConfig, MailboxConfig, MailboxSmtpConfig, ReturnPathConfig, RoutingRuleConfig, SmtpTlsMode,
+};
 pub use cursor::Cursor;
 pub use imap::{FetchBatch, FetchedMessage, ImapMailboxFetcher, MailboxFetcher};
 pub use smtp::{SmtpMailboxTransport, build_email_transport};
 pub use store::PostgresEmailCursorStore;
+pub use tracking::{PgSendTracker, RecordedSend, SendTracker, SentRecord, SuppressionReason};
 pub use warming::{SendCounter, WarmingState, warming_daily_limit};
 pub use worker::EmailPollWorker;
 

--- a/crates/fraiseql-server/src/inbound/email/probe.rs
+++ b/crates/fraiseql-server/src/inbound/email/probe.rs
@@ -1,0 +1,122 @@
+//! Return-Path probe: verify the provider preserves plus-addressing before trusting
+//! VERP correlation.
+//!
+//! The whole delivery-feedback loop rides on the polled mailbox receiving
+//! `bounces+<send-id>@…` with the `+<send-id>` sub-address intact. Most providers
+//! (Gmail, Fastmail, M365) preserve it, but some — a few French / legacy hosters —
+//! silently strip the plus-tag, so every bounce lands at bare `bounces@` with no
+//! send-id and correlation quietly fails: every send then looks delivered.
+//!
+//! The probe turns that silent, deployment-dependent failure into a diagnosable one
+//! (the same doctrine as the `security_invoker` doctor check): at startup it sends a
+//! self-addressed `bounces+probe-<nonce>@<domain>` and watches the poll cursor for
+//! it. If it lands with the tag intact, VERP correlation is confirmed; if it does
+//! not within the window, the operator is warned loudly that plus-addressing may be
+//! stripped and correlation will not work — sends still go out, just untracked.
+//!
+//! It is opt-in (`[send] verp_probe_on_start`, default off) because it emits a real
+//! message per eligible mailbox on each boot; an operator enables it once to verify
+//! a new deployment.
+
+use std::time::Duration;
+
+use fraiseql_functions::{
+    EmailTransport, IngestSource, SendContext, SendEmailRequest, SenderIdentity, normalize_email,
+    parse_recipient,
+};
+
+use super::imap::MailboxFetcher;
+
+/// The plus-tag prefix that marks a probe (`bounces+probe-<nonce>@…`).
+const PROBE_TAG_PREFIX: &str = "probe-";
+
+/// How many messages to scan per poll while waiting for the probe to land.
+const PROBE_FETCH_BATCH: u32 = 50;
+
+/// The probe recipient address `<local_part>+probe-<nonce>@<domain>`.
+#[must_use]
+pub fn probe_recipient(local_part: &str, domain: &str, nonce: &str) -> String {
+    format!("{local_part}+{PROBE_TAG_PREFIX}{nonce}@{domain}")
+}
+
+/// Whether a normalized inbound message is the probe with `nonce` — i.e. a
+/// recipient carries the `probe-<nonce>` plus-tag (proving the provider kept it).
+#[must_use]
+pub fn message_carries_probe(message: &fraiseql_functions::InboundMessage, nonce: &str) -> bool {
+    let want = format!("{PROBE_TAG_PREFIX}{nonce}");
+    message
+        .to
+        .iter()
+        .map(String::as_str)
+        .filter_map(parse_recipient)
+        .filter_map(|recipient| recipient.tag)
+        .any(|tag| tag == want)
+}
+
+/// The result of a Return-Path probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The probe landed with its plus-tag intact — VERP correlation works.
+    Confirmed,
+    /// The probe did not land (tagged) within the window — plus-addressing may be
+    /// stripped, so correlation cannot be trusted.
+    NotObserved,
+}
+
+/// Send a self-addressed probe and poll the mailbox for it within `timeout`.
+///
+/// Sends `bounces+probe-<nonce>@<domain>` (a plain send — no send-id, so no VERP
+/// envelope or suppression bookkeeping) from `sender`, then polls `fetcher` every
+/// `poll_interval` until the probe lands (tagged) or the window elapses. The poll
+/// reads from the mailbox start with no cursor, so it never disturbs the worker's
+/// cursor.
+///
+/// # Errors
+///
+/// Returns the send error, or a database/transport error from a poll.
+pub async fn run_return_path_probe(
+    transport: &dyn EmailTransport,
+    fetcher: &dyn MailboxFetcher,
+    sender: &SenderIdentity,
+    probe_to: &str,
+    nonce: &str,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> fraiseql_error::Result<ProbeOutcome> {
+    let request = SendEmailRequest {
+        to:       probe_to.to_string(),
+        subject:  "fraiseql Return-Path probe".to_string(),
+        text:     Some(
+            "Automated probe verifying VERP plus-addressing. Safe to ignore.".to_string(),
+        ),
+        html:     None,
+        reply_to: None,
+    };
+    // A plain send (no send-id): the probe address itself carries the tag we watch
+    // for, so no VERP envelope is needed.
+    transport.send(sender, &request, SendContext::default()).await?;
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let batch = fetcher
+            .fetch(None, PROBE_FETCH_BATCH)
+            .await
+            .map_err(|error| fraiseql_error::FraiseQLError::database(error.to_string()))?;
+        for message in &batch.messages {
+            if let Ok(parsed) =
+                normalize_email(&message.raw, IngestSource::Email, chrono::Utc::now())
+            {
+                if message_carries_probe(&parsed.message, nonce) {
+                    return Ok(ProbeOutcome::Confirmed);
+                }
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(ProbeOutcome::NotObserved);
+        }
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/probe/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/probe/tests.rs
@@ -1,0 +1,159 @@
+//! Tests for the Return-Path probe.
+//!
+//! The runner is driven against a fake transport + fetcher, so it exercises the
+//! send-then-poll loop and the confirmed/not-observed outcomes without a mail
+//! server or a database.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+
+use std::{sync::Mutex, time::Duration};
+
+use fraiseql_error::Result;
+use fraiseql_functions::{
+    EmailTransport, IngestError, SendContext, SendEmailRequest, SendEmailResponse, SenderIdentity,
+};
+
+use super::{ProbeOutcome, message_carries_probe, probe_recipient, run_return_path_probe};
+use crate::inbound::email::imap::{FetchBatch, FetchedMessage, MailboxFetcher};
+
+const NONCE: &str = "abc123";
+
+#[test]
+fn probe_recipient_tags_the_local_part() {
+    assert_eq!(
+        probe_recipient("bounces", "sales.example.com", NONCE),
+        "bounces+probe-abc123@sales.example.com"
+    );
+}
+
+#[test]
+fn message_carries_probe_matches_the_tagged_recipient() {
+    // A message whose recipient kept the probe tag → matches; a stripped one → not.
+    let tagged = normalize(&format!("bounces+probe-{NONCE}@sales.example.com"));
+    assert!(message_carries_probe(&tagged, NONCE));
+
+    let stripped = normalize("bounces@sales.example.com"); // provider dropped the +tag
+    assert!(!message_carries_probe(&stripped, NONCE));
+
+    let other = normalize(&format!("bounces+probe-{}@sales.example.com", "different"));
+    assert!(!message_carries_probe(&other, NONCE));
+}
+
+fn normalize(to: &str) -> fraiseql_functions::InboundMessage {
+    let raw = format!(
+        "From: sender@sales.example.com\r\nTo: {to}\r\nSubject: probe\r\nMessage-ID: <p@x>\r\n\r\nbody\r\n"
+    );
+    fraiseql_functions::normalize_email(
+        raw.as_bytes(),
+        fraiseql_functions::IngestSource::Email,
+        chrono::Utc::now(),
+    )
+    .unwrap()
+    .message
+}
+
+/// A transport that records the probe it was asked to send and succeeds.
+#[derive(Default)]
+struct FakeTransport {
+    sent_to: Mutex<Option<String>>,
+}
+
+impl EmailTransport for FakeTransport {
+    fn send<'a>(
+        &'a self,
+        _sender: &'a SenderIdentity,
+        request: &'a SendEmailRequest,
+        _context: SendContext<'a>,
+    ) -> fraiseql_functions::outbound::BoxFuture<'a, Result<SendEmailResponse>> {
+        *self.sent_to.lock().unwrap() = Some(request.to.clone());
+        Box::pin(async {
+            Ok(SendEmailResponse {
+                message_id: None,
+                accepted:   true,
+            })
+        })
+    }
+}
+
+/// A fetcher that returns a fixed batch on every poll.
+struct FakeFetcher {
+    raw: Option<Vec<u8>>,
+}
+
+impl MailboxFetcher for FakeFetcher {
+    fn fetch(
+        &self,
+        _stored: Option<crate::inbound::email::Cursor>,
+        _batch_size: u32,
+    ) -> fraiseql_functions::outbound::BoxFuture<'_, std::result::Result<FetchBatch, IngestError>>
+    {
+        let messages = self
+            .raw
+            .clone()
+            .map(|raw| vec![FetchedMessage { uid: 1, raw }])
+            .unwrap_or_default();
+        Box::pin(async move {
+            Ok(FetchBatch {
+                uid_validity: 1,
+                messages,
+            })
+        })
+    }
+}
+
+fn sender() -> SenderIdentity {
+    SenderIdentity {
+        address:      "sales@sales.example.com".to_string(),
+        display_name: None,
+    }
+}
+
+fn probe_raw() -> Vec<u8> {
+    format!(
+        "From: sales@sales.example.com\r\nTo: bounces+probe-{NONCE}@sales.example.com\r\nSubject: fraiseql Return-Path probe\r\nMessage-ID: <probe@x>\r\n\r\nbody\r\n"
+    )
+    .into_bytes()
+}
+
+#[tokio::test]
+async fn a_landed_probe_confirms() {
+    let transport = FakeTransport::default();
+    let fetcher = FakeFetcher {
+        raw: Some(probe_raw()),
+    };
+    let to = probe_recipient("bounces", "sales.example.com", NONCE);
+    let outcome = run_return_path_probe(
+        &transport,
+        &fetcher,
+        &sender(),
+        &to,
+        NONCE,
+        Duration::from_secs(5),
+        Duration::from_millis(1),
+    )
+    .await
+    .unwrap();
+    assert_eq!(outcome, ProbeOutcome::Confirmed);
+    assert_eq!(transport.sent_to.lock().unwrap().as_deref(), Some(to.as_str()));
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_probe_that_never_lands_is_not_observed() {
+    // The fetcher never returns the probe → after the window, NotObserved (the
+    // paused clock keeps the timeout instant).
+    let transport = FakeTransport::default();
+    let fetcher = FakeFetcher { raw: None };
+    let to = probe_recipient("bounces", "sales.example.com", NONCE);
+    let outcome = run_return_path_probe(
+        &transport,
+        &fetcher,
+        &sender(),
+        &to,
+        NONCE,
+        Duration::from_secs(30),
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap();
+    assert_eq!(outcome, ProbeOutcome::NotObserved);
+}

--- a/crates/fraiseql-server/src/inbound/email/smtp.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp.rs
@@ -31,6 +31,14 @@ use super::{
     tracking::{SendTracker, SentRecord},
 };
 
+/// Mail-appropriate backoff floor for a transient SMTP failure (greylisting).
+///
+/// Greylisters tempfail a first delivery and accept a retry a few minutes later, so
+/// a seconds-scale policy backoff would exhaust its attempts before the greylist
+/// lifts. Five minutes is a common greylist window; the durable dispatcher waits at
+/// least this long between retries of a transient send.
+const GREYLISTING_BACKOFF_SECS: u64 = 300;
+
 /// Build the `send_email` transport from the SMTP halves of the configured mailboxes.
 ///
 /// Returns an `Arc<dyn EmailTransport>` ready to attach via
@@ -256,6 +264,13 @@ impl EmailTransport for SmtpMailboxTransport {
                 // 2. Exactly-once: a durable retry of an already-sent dispatch must not
                 //    double-send. If this send-id already completed, skip the relay and return the
                 //    recorded response.
+                //
+                //    ASSUMPTION — one send per dispatch: the send-id is per *dispatch*,
+                //    so a single dispatch that sends N distinct emails would share one
+                //    send-id and only the first would relay (the rest skip as
+                //    "already sent"). The outreach use case is one send per dispatch;
+                //    per-recipient send-ids (derive a sub-key per `to`) are a future
+                //    refinement if a multi-send dispatch is ever needed.
                 if let Some(send_id) = context.send_id {
                     if let Some(recorded) = tracker.recorded_send(context.tenant, send_id).await? {
                         return Ok(SendEmailResponse {
@@ -328,10 +343,13 @@ impl EmailTransport for SmtpMailboxTransport {
                     path:    None,
                 }),
                 // Everything else (connection refused, timeout, 4xx greylisting) is
-                // transient — a 5xx so durable dispatch retries.
+                // transient — a 5xx so durable dispatch retries. Greylisting clears
+                // in minutes, not seconds, so the error carries a mail-appropriate
+                // backoff floor the durable dispatcher honors (a fast policy backoff
+                // would otherwise exhaust before the greylist lifts).
                 Err(error) => Err(FraiseQLError::ServiceUnavailable {
                     message:     format!("SMTP transient error: {error}"),
-                    retry_after: None,
+                    retry_after: Some(GREYLISTING_BACKOFF_SECS),
                 }),
             }
         })

--- a/crates/fraiseql-server/src/inbound/email/smtp.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp.rs
@@ -15,15 +15,21 @@
 use std::{collections::HashMap, future::Future, pin::Pin, time::Duration};
 
 use fraiseql_error::{FraiseQLError, Result};
-use fraiseql_functions::{EmailTransport, SendEmailRequest, SendEmailResponse, SenderIdentity};
+use fraiseql_functions::{
+    EmailTransport, SendContext, SendEmailRequest, SendEmailResponse, SenderIdentity,
+};
 use lettre::{
     Address, AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+    address::Envelope,
     message::{Mailbox, MultiPart, SinglePart},
     transport::smtp::authentication::Credentials,
 };
 use tracing::warn;
 
-use super::config::{MailboxSmtpConfig, SmtpTlsMode};
+use super::{
+    config::{MailboxSmtpConfig, SmtpTlsMode},
+    tracking::{SendTracker, SentRecord},
+};
 
 /// Build the `send_email` transport from the SMTP halves of the configured mailboxes.
 ///
@@ -32,31 +38,73 @@ use super::config::{MailboxSmtpConfig, SmtpTlsMode};
 /// Returns `None` when no `[mailbox.<name>.smtp]` account was successfully built —
 /// the caller then leaves `send_email` unconfigured (fail-loud). `get_env` resolves
 /// each account's password env (in production, [`std::env::var`]).
+///
+/// When both `tracker` and `address_hash_key` are `Some`, the transport enforces
+/// the delivery-feedback loop (suppression check before send, exactly-once skip,
+/// `Sent` record); otherwise it sends without correlation.
 #[must_use]
 pub fn build_email_transport<S: std::hash::BuildHasher>(
     mailboxes: &HashMap<String, super::MailboxConfig, S>,
     get_env: impl Fn(&str) -> Option<String>,
+    tracker: Option<std::sync::Arc<dyn SendTracker>>,
+    address_hash_key: Option<std::sync::Arc<[u8]>>,
 ) -> Option<std::sync::Arc<dyn EmailTransport>> {
     let accounts = mailboxes
         .iter()
         .filter_map(|(name, mailbox)| mailbox.smtp.as_ref().map(|smtp| (name.as_str(), smtp)));
-    SmtpMailboxTransport::build(accounts, get_env)
-        .map(|transport| std::sync::Arc::new(transport) as std::sync::Arc<dyn EmailTransport>)
+    let mut transport = SmtpMailboxTransport::build(accounts, get_env)?;
+    // Attach the delivery-feedback store when present; the address-hash key (which
+    // needs the server HMAC secret) additionally enables the suppression check.
+    if let Some(tracker) = tracker {
+        transport = transport.with_tracker(tracker, address_hash_key);
+    }
+    Some(std::sync::Arc::new(transport) as std::sync::Arc<dyn EmailTransport>)
 }
 
 /// One connected SMTP account: a pooled `lettre` transport, keyed in the parent
 /// map by its verified sending address.
 struct SmtpAccount {
-    transport: AsyncSmtpTransport<Tokio1Executor>,
+    transport:       AsyncSmtpTransport<Tokio1Executor>,
+    /// The VERP Return-Path local part (`bounces` by default) — the envelope
+    /// `MAIL FROM` becomes `<local_part>+<send-id>@<domain>`.
+    verp_local_part: String,
+    /// The VERP Return-Path domain (the sending address's own domain by default,
+    /// for SPF/DMARC alignment).
+    verp_domain:     String,
+}
+
+impl SmtpAccount {
+    /// Build the VERP envelope sender `<local_part>+<send-id>@<domain>` for a send.
+    ///
+    /// Returns a permanent [`FraiseQLError::Validation`] if the resolved
+    /// Return-Path is not a valid address (a misconfigured `return_path`).
+    fn verp_from(&self, send_id: &str) -> Result<Address> {
+        Address::new(format!("{}+{send_id}", self.verp_local_part), &self.verp_domain).map_err(
+            |error| FraiseQLError::Validation {
+                message: format!(
+                    "invalid VERP Return-Path {}+{send_id}@{}: {error}",
+                    self.verp_local_part, self.verp_domain
+                ),
+                path:    None,
+            },
+        )
+    }
 }
 
 /// The `send_email` transport: routes each send to the connected account whose
 /// verified sending address matches the resolved sender identity.
 pub struct SmtpMailboxTransport {
-    accounts: HashMap<String, SmtpAccount>,
+    accounts:         HashMap<String, SmtpAccount>,
     /// Optional per-mailbox send-warming counter. `None` → no daily cap is
     /// enforced (see [`with_send_counter`](Self::with_send_counter)).
-    counter:  Option<std::sync::Arc<dyn super::warming::SendCounter>>,
+    counter:          Option<std::sync::Arc<dyn super::warming::SendCounter>>,
+    /// Optional delivery-feedback store: suppression check before send +
+    /// exactly-once skip + `Sent` record. `None` → no suppression/exactly-once (a
+    /// plain send). Paired with `address_hash_key` (see [`with_tracker`](Self::with_tracker)).
+    tracker:          Option<std::sync::Arc<dyn SendTracker>>,
+    /// The keyed hash of a recipient address for suppression lookups. `None` → no
+    /// suppression check even with a tracker (no secret configured).
+    address_hash_key: Option<std::sync::Arc<[u8]>>,
 }
 
 impl SmtpMailboxTransport {
@@ -83,9 +131,28 @@ impl SmtpMailboxTransport {
                 );
                 continue;
             };
+            // Return-Path domain should align with the sending domain (SPF/DMARC);
+            // a mismatch still sends but silently degrades deliverability, so warn.
+            let verp_domain = cfg.return_path_domain().to_string();
+            if verp_domain != cfg.sending_domain() {
+                warn!(
+                    mailbox = %name,
+                    sending_domain = %cfg.sending_domain(),
+                    return_path_domain = %verp_domain,
+                    "VERP Return-Path domain differs from the sending domain — SPF/DMARC \
+                     alignment is broken and deliverability of tracked sends may degrade"
+                );
+            }
             match build_account_transport(cfg, password) {
                 Ok(transport) => {
-                    accounts.insert(cfg.address.clone(), SmtpAccount { transport });
+                    accounts.insert(
+                        cfg.address.clone(),
+                        SmtpAccount {
+                            transport,
+                            verp_local_part: cfg.return_path_local_part().to_string(),
+                            verp_domain,
+                        },
+                    );
                 },
                 Err(error) => warn!(
                     mailbox = %name,
@@ -100,6 +167,8 @@ impl SmtpMailboxTransport {
             Some(Self {
                 accounts,
                 counter: None,
+                tracker: None,
+                address_hash_key: None,
             })
         }
     }
@@ -115,6 +184,28 @@ impl SmtpMailboxTransport {
         self
     }
 
+    /// Attach the delivery-feedback store, and optionally the recipient
+    /// address-hash key.
+    ///
+    /// The store enables the exactly-once skip (whenever a send carries a send-id)
+    /// and the `Sent` record after a relay. The `address_hash_key` (a subkey of the
+    /// server HMAC secret, see
+    /// [`derive_address_hash_key`](fraiseql_observers::derive_address_hash_key))
+    /// additionally enables the suppression check — it keys the recipient hash so
+    /// the store holds no raw address. Without the key, the suppression check is
+    /// skipped (there is no secret to derive the same hash the admin surface writes
+    /// with), but exactly-once still applies.
+    #[must_use]
+    pub fn with_tracker(
+        mut self,
+        tracker: std::sync::Arc<dyn SendTracker>,
+        address_hash_key: Option<std::sync::Arc<[u8]>>,
+    ) -> Self {
+        self.tracker = Some(tracker);
+        self.address_hash_key = address_hash_key;
+        self
+    }
+
     /// Number of connected send accounts (for diagnostics/tests).
     #[must_use]
     pub fn account_count(&self) -> usize {
@@ -127,6 +218,7 @@ impl EmailTransport for SmtpMailboxTransport {
         &'a self,
         sender: &'a SenderIdentity,
         request: &'a SendEmailRequest,
+        context: SendContext<'a>,
     ) -> Pin<Box<dyn Future<Output = Result<SendEmailResponse>> + Send + 'a>> {
         Box::pin(async move {
             // Select the account by the verified sending address — never fall back
@@ -141,10 +233,42 @@ impl EmailTransport for SmtpMailboxTransport {
                 });
             };
 
-            // Warming cap: refuse when the mailbox is at its daily limit. A daily
-            // cap will not clear on a seconds-scale retry, so this is a permanent
-            // failure for this dispatch (429 → dead-letter → replay next day),
-            // not a transient one.
+            if let Some(tracker) = self.tracker.as_ref() {
+                // 1. Suppression: refuse a recipient on the do-not-contact list before anything
+                //    else — the biggest deliverability + GDPR lever. A suppressed recipient is
+                //    permanent (a retry won't un-suppress), so a 4xx durable dispatch dead-letters
+                //    rather than retries. Only with the address-hash key (the same secret the admin
+                //    surface hashes with); without it the suppression check is skipped.
+                if let Some(key) = self.address_hash_key.as_ref() {
+                    let recipient_hash = fraiseql_observers::hash_address(key, &request.to);
+                    if let Some(reason) =
+                        tracker.suppression_reason(context.tenant, &recipient_hash).await?
+                    {
+                        return Err(FraiseQLError::Validation {
+                            message: format!(
+                                "recipient is suppressed ({reason}) — refusing to send"
+                            ),
+                            path:    None,
+                        });
+                    }
+                }
+
+                // 2. Exactly-once: a durable retry of an already-sent dispatch must not
+                //    double-send. If this send-id already completed, skip the relay and return the
+                //    recorded response.
+                if let Some(send_id) = context.send_id {
+                    if let Some(recorded) = tracker.recorded_send(context.tenant, send_id).await? {
+                        return Ok(SendEmailResponse {
+                            message_id: recorded.message_id,
+                            accepted:   true,
+                        });
+                    }
+                }
+            }
+
+            // 3. Warming cap: refuse when the mailbox is at its daily limit. A daily cap will not
+            //    clear on a seconds-scale retry, so this is a permanent failure for this dispatch
+            //    (429 → dead-letter → replay next day), not a transient one.
             if let Some(counter) = self.counter.as_ref() {
                 if let Some(state) = counter.state(&sender.address).await? {
                     if !state.within_cap() {
@@ -159,20 +283,42 @@ impl EmailTransport for SmtpMailboxTransport {
                 }
             }
 
-            let message = build_message(sender, request)?;
+            // 4. Set the VERP Return-Path envelope so an inbound bounce/challenge/ reply correlates
+            //    back to this send-id. Only when a send-id is present (a signed token); otherwise
+            //    the plain header-derived envelope is used.
+            let verp_from =
+                context.send_id.map(|send_id| account.verp_from(send_id)).transpose()?;
+            let message = build_message(sender, request, verp_from)?;
 
             match account.transport.send(message).await {
                 Ok(response) => {
-                    // Best-effort accounting: the message is already sent, so a
-                    // counter error is logged, not surfaced (it must not un-send).
+                    let message_id = response.first_line().map(ToString::to_string);
+                    // Record the send as `Sent` so the correlation step has a row to
+                    // transition and the exactly-once skip fires on a retry. The
+                    // message is already sent, so a bookkeeping error is logged, not
+                    // surfaced (it must not un-send / trigger a retry).
+                    if let (Some(tracker), Some(send_id)) = (self.tracker.as_ref(), context.send_id)
+                    {
+                        let record = SentRecord {
+                            send_id,
+                            tenant: context.tenant,
+                            recipient: &request.to,
+                            sending_address: &sender.address,
+                            message_id: message_id.as_deref(),
+                        };
+                        if let Err(error) = tracker.record_sent(record).await {
+                            warn!(%send_id, %error, "failed to record Sent status after relay");
+                        }
+                    }
+                    // Best-effort warming accounting (same must-not-un-send rule).
                     if let Some(counter) = self.counter.as_ref() {
                         if let Err(error) = counter.record_send(&sender.address).await {
                             warn!(address = %sender.address, %error, "failed to record send for warming");
                         }
                     }
                     Ok(SendEmailResponse {
-                        message_id: response.first_line().map(ToString::to_string),
-                        accepted:   true,
+                        message_id,
+                        accepted: true,
                     })
                 },
                 // A permanent SMTP failure (5xx: auth rejected, bad recipient) must
@@ -219,13 +365,38 @@ fn build_account_transport(
 }
 
 /// Build the `lettre` message: host-owned `from`, guest-supplied recipient/body.
-fn build_message(sender: &SenderIdentity, request: &SendEmailRequest) -> Result<Message> {
+///
+/// When `verp_from` is `Some`, the SMTP envelope sender (`MAIL FROM`) is overridden
+/// to the VERP Return-Path while the header `From` stays the verified sending
+/// address — so a bounce/challenge addressed to the Return-Path carries the send-id
+/// back for correlation. When `None`, `lettre` derives the envelope from the
+/// headers (the plain, uncorrelated path).
+fn build_message(
+    sender: &SenderIdentity,
+    request: &SendEmailRequest,
+    verp_from: Option<Address>,
+) -> Result<Message> {
+    let to_address = request.to.parse::<Address>().map_err(|error| FraiseQLError::Validation {
+        message: format!("invalid email address {:?}: {error}", request.to),
+        path:    None,
+    })?;
     let from = mailbox(&sender.address, sender.display_name.as_deref())?;
-    let to = mailbox(&request.to, None)?;
+    let to = Mailbox::new(None, to_address.clone());
 
     let mut builder = Message::builder().from(from).to(to).subject(request.subject.clone());
     if let Some(reply_to) = request.reply_to.as_deref() {
         builder = builder.reply_to(mailbox(reply_to, None)?);
+    }
+    if let Some(verp) = verp_from {
+        // Override MAIL FROM only; RCPT TO stays the recipient. `Envelope::new`
+        // only errors on an empty recipient list, which cannot happen here.
+        let envelope = Envelope::new(Some(verp), vec![to_address]).map_err(|error| {
+            FraiseQLError::Validation {
+                message: format!("failed to build VERP envelope: {error}"),
+                path:    None,
+            }
+        })?;
+        builder = builder.envelope(envelope);
     }
 
     let built = match (request.text.as_deref(), request.html.as_deref()) {

--- a/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/smtp/tests.rs
@@ -10,12 +10,15 @@
 use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use fraiseql_error::Result;
-use fraiseql_functions::{EmailTransport, SendEmailRequest, SenderIdentity};
+use fraiseql_functions::{EmailTransport, SendContext, SendEmailRequest, SenderIdentity};
 
 use super::{
     MailboxSmtpConfig, SmtpMailboxTransport, SmtpTlsMode, build_email_transport, build_message,
 };
-use crate::inbound::email::{MailboxConfig, SendCounter, WarmingState};
+use crate::inbound::email::{
+    MailboxConfig, RecordedSend, SendCounter, SendTracker, SuppressionReason, WarmingState,
+    tracking::SentRecord,
+};
 
 fn smtp_cfg(address: &str) -> MailboxSmtpConfig {
     MailboxSmtpConfig {
@@ -28,6 +31,7 @@ fn smtp_cfg(address: &str) -> MailboxSmtpConfig {
         // in these tests, so no network is touched.
         tls:          SmtpTlsMode::None,
         timeout_secs: 5,
+        return_path:  None,
     }
 }
 
@@ -74,7 +78,10 @@ async fn send_from_an_unconnected_address_is_a_permanent_refusal() {
         address:      "stranger@example.com".to_string(),
         display_name: None,
     };
-    let error = transport.send(&sender, &request("bob@example.com")).await.unwrap_err();
+    let error = transport
+        .send(&sender, &request("bob@example.com"), SendContext::default())
+        .await
+        .unwrap_err();
     // Permanent (400) → durable dispatch dead-letters rather than retries.
     assert_eq!(error.status_code(), 400);
 }
@@ -99,7 +106,7 @@ fn build_email_transport_from_mailbox_config() {
         },
     );
 
-    let transport = build_email_transport(&mailboxes, |_| Some("pw".to_string()));
+    let transport = build_email_transport(&mailboxes, |_| Some("pw".to_string()), None, None);
     assert!(transport.is_some(), "an SMTP half yields a transport");
 
     // No SMTP halves at all → no transport (send_email stays fail-loud).
@@ -111,7 +118,7 @@ fn build_email_transport_from_mailbox_config() {
         },
     ))
     .collect();
-    assert!(build_email_transport(&receive_only, |_| Some("pw".to_string())).is_none());
+    assert!(build_email_transport(&receive_only, |_| Some("pw".to_string()), None, None).is_none());
 }
 
 /// A counter reporting a fixed warming state, for cap-enforcement tests.
@@ -156,7 +163,10 @@ async fn send_is_refused_at_the_warming_daily_cap() {
         display_name: None,
     };
     // The cap gate refuses BEFORE any SMTP connection is attempted.
-    let error = transport.send(&sender, &request("bob@example.com")).await.unwrap_err();
+    let error = transport
+        .send(&sender, &request("bob@example.com"), SendContext::default())
+        .await
+        .unwrap_err();
     // 429 → a client error → durable dispatch dead-letters (replay next day).
     assert_eq!(error.status_code(), 429);
 }
@@ -167,7 +177,7 @@ fn build_message_rejects_a_malformed_recipient() {
         address:      "sales@example.com".to_string(),
         display_name: Some("Sales".to_string()),
     };
-    assert!(build_message(&sender, &request("not-an-email")).is_err());
+    assert!(build_message(&sender, &request("not-an-email"), None).is_err());
 }
 
 #[test]
@@ -189,6 +199,155 @@ fn build_message_supports_text_html_and_multipart_bodies() {
             html:     html.map(ToString::to_string),
             reply_to: None,
         };
-        assert!(build_message(&sender, &req).is_ok(), "text={text:?} html={html:?}");
+        assert!(build_message(&sender, &req, None).is_ok(), "text={text:?} html={html:?}");
     }
+}
+
+// ── VERP Return-Path + suppression + exactly-once (cycle 2) ──────────────────────
+
+/// A tracker with programmable suppression + recorded-send answers, and a record
+/// of the last write — so tests can drive the transport's pre-send gates without a
+/// database.
+#[derive(Default)]
+struct FakeTracker {
+    suppressed:   Option<SuppressionReason>,
+    already_sent: Option<RecordedSend>,
+    recorded:     std::sync::Mutex<Vec<(String, Option<String>)>>,
+}
+
+impl SendTracker for FakeTracker {
+    fn suppression_reason<'a>(
+        &'a self,
+        _tenant: Option<&'a str>,
+        _address_hash: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<SuppressionReason>>> + Send + 'a>> {
+        let reason = self.suppressed;
+        Box::pin(async move { Ok(reason) })
+    }
+
+    fn recorded_send<'a>(
+        &'a self,
+        _tenant: Option<&'a str>,
+        _send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<RecordedSend>>> + Send + 'a>> {
+        let recorded = self.already_sent.clone();
+        Box::pin(async move { Ok(recorded) })
+    }
+
+    fn record_sent<'a>(
+        &'a self,
+        record: SentRecord<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        self.recorded
+            .lock()
+            .unwrap()
+            .push((record.send_id.to_string(), record.message_id.map(ToString::to_string)));
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn tracked_transport(tracker: Arc<FakeTracker>) -> SmtpMailboxTransport {
+    let cfg = smtp_cfg("sales@example.com");
+    let key: Arc<[u8]> = Arc::from(b"address-hash-key".as_slice());
+    SmtpMailboxTransport::build(std::iter::once(("sales", &cfg)), |_| Some("pw".to_string()))
+        .unwrap()
+        .with_tracker(tracker, Some(key))
+}
+
+fn sales_sender() -> SenderIdentity {
+    SenderIdentity {
+        address:      "sales@example.com".to_string(),
+        display_name: None,
+    }
+}
+
+#[tokio::test]
+async fn a_suppressed_recipient_is_refused_before_any_relay() {
+    let tracker = Arc::new(FakeTracker {
+        suppressed: Some(SuppressionReason::HardBounce),
+        ..Default::default()
+    });
+    let transport = tracked_transport(tracker);
+    let ctx = SendContext {
+        send_id: Some("send-1"),
+        tenant:  None,
+    };
+    // Refused before any SMTP connection — a permanent 400 → dead-letter.
+    let error = transport
+        .send(&sales_sender(), &request("bob@example.com"), ctx)
+        .await
+        .unwrap_err();
+    assert_eq!(error.status_code(), 400);
+}
+
+#[tokio::test]
+async fn an_already_sent_dispatch_skips_the_relay_exactly_once() {
+    let tracker = Arc::new(FakeTracker {
+        already_sent: Some(RecordedSend {
+            message_id: Some("<original@relay>".to_string()),
+        }),
+        ..Default::default()
+    });
+    let transport = tracked_transport(tracker);
+    let ctx = SendContext {
+        send_id: Some("send-1"),
+        tenant:  None,
+    };
+    // The recorded send is returned without a relay (no SMTP connection attempted,
+    // so this returns Ok rather than a connection error).
+    let response = transport.send(&sales_sender(), &request("bob@example.com"), ctx).await.unwrap();
+    assert!(response.accepted);
+    assert_eq!(response.message_id.as_deref(), Some("<original@relay>"));
+}
+
+#[test]
+fn verp_envelope_overrides_mail_from_but_keeps_the_header_from() {
+    // With a send-id, the envelope MAIL FROM is the VERP Return-Path; the header
+    // From stays the verified sending address (so replies still go to the user).
+    let cfg = smtp_cfg("sales@example.com"); // no return_path → domain = example.com
+    let account_domain = cfg.return_path_domain();
+    assert_eq!(account_domain, "example.com");
+
+    let verp = super::Address::new(format!("bounces+{}", "send-abc"), account_domain).unwrap();
+    let message = build_message(&sales_sender(), &request("bob@example.com"), Some(verp)).unwrap();
+
+    let envelope = message.envelope();
+    assert_eq!(
+        envelope.from().map(ToString::to_string),
+        Some("bounces+send-abc@example.com".to_string()),
+        "MAIL FROM is the VERP Return-Path"
+    );
+    assert_eq!(
+        envelope.to().iter().map(ToString::to_string).collect::<Vec<_>>(),
+        vec!["bob@example.com".to_string()],
+        "RCPT TO stays the recipient"
+    );
+}
+
+#[test]
+fn without_a_send_id_the_envelope_is_the_plain_sender() {
+    // No VERP → lettre derives the envelope from the headers: MAIL FROM = sender.
+    let message = build_message(&sales_sender(), &request("bob@example.com"), None).unwrap();
+    assert_eq!(
+        message.envelope().from().map(ToString::to_string),
+        Some("sales@example.com".to_string())
+    );
+}
+
+#[test]
+fn return_path_config_resolves_local_part_and_domain_with_alignment_default() {
+    // Default: local part `bounces`, domain = the sending address's own domain.
+    let cfg = smtp_cfg("sales@mail.example.com");
+    assert_eq!(cfg.return_path_local_part(), "bounces");
+    assert_eq!(cfg.return_path_domain(), "mail.example.com");
+    assert_eq!(cfg.sending_domain(), "mail.example.com");
+
+    // Explicit override.
+    let mut cfg = smtp_cfg("sales@example.com");
+    cfg.return_path = Some(crate::inbound::email::ReturnPathConfig {
+        local_part: Some("dsn".to_string()),
+        domain:     Some("bounce.example.com".to_string()),
+    });
+    assert_eq!(cfg.return_path_local_part(), "dsn");
+    assert_eq!(cfg.return_path_domain(), "bounce.example.com");
 }

--- a/crates/fraiseql-server/src/inbound/email/tracking.rs
+++ b/crates/fraiseql-server/src/inbound/email/tracking.rs
@@ -66,6 +66,24 @@ impl SuppressionReason {
             _ => None,
         }
     }
+
+    /// The default suppression expiry for this reason, relative to `now`.
+    ///
+    /// A hard bounce and a manual unsubscribe are ~permanent (`None`): the address
+    /// does not accept mail / the recipient opted out. An unanswered-challenge
+    /// suppression expires after ~30 days — long enough to stop re-quarantining the
+    /// domain, short enough that a since-fixed mailbox is not muted forever (and it
+    /// lifts immediately on a genuine reply, well before the TTL).
+    #[must_use]
+    pub fn default_ttl(
+        self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Option<chrono::DateTime<chrono::Utc>> {
+        match self {
+            SuppressionReason::HardBounce | SuppressionReason::Unsubscribe => None,
+            SuppressionReason::ChallengeUnanswered => Some(now + chrono::Duration::days(30)),
+        }
+    }
 }
 
 impl std::fmt::Display for SuppressionReason {
@@ -129,6 +147,96 @@ pub trait SendTracker: Send + Sync {
     fn record_sent<'a>(
         &'a self,
         record: SentRecord<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+}
+
+/// A send matched by the correlation step.
+///
+/// Carries the fields the transition needs: the tenant (RLS scope for suppression
+/// writes) and the raw recipient (which the correlator keyed-hashes to write/lift a
+/// suppression row).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorrelatedSend {
+    /// The send-id (echoed for send-id lookups; resolved from the row for
+    /// message-id fallback lookups).
+    pub send_id:   String,
+    /// The tenant the original send was scoped to.
+    pub tenant:    Option<String>,
+    /// The raw recipient address of the original send.
+    pub recipient: String,
+}
+
+/// The inbound-correlation seam: look a tracked send up from an inbound signal and
+/// transition its status + the recipient's suppression state.
+///
+/// Separate from [`SendTracker`] (the send path) so the poll worker depends only on
+/// the inbound half and a test fake implements only these methods. `PgSendTracker`
+/// implements both. All lookups run through the table-owning pool (which bypasses
+/// RLS) because an inbound bounce carries no session tenant — the tenant is read
+/// from the matched row and stamped on any suppression write.
+pub trait SendCorrelator: Send + Sync {
+    /// Find a tracked send by its VERP send-id (the Return-Path plus-tag).
+    fn find_by_send_id<'a>(
+        &'a self,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<CorrelatedSend>>> + Send + 'a>>;
+
+    /// Find a tracked send by our sent message-id (the References fallback).
+    fn find_by_message_id<'a>(
+        &'a self,
+        message_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<CorrelatedSend>>> + Send + 'a>>;
+
+    /// Transition a send to `Bounced`.
+    fn mark_bounced<'a>(
+        &'a self,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    /// Transition a send to `ChallengePending` and return the recipient's total
+    /// unanswered-challenge count (across campaigns, tenant-scoped) — the value the
+    /// challenge policy compares against `challenge_suppress_after`.
+    fn bump_challenge<'a>(
+        &'a self,
+        send_id: &'a str,
+        tenant: Option<&'a str>,
+        recipient: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<i64>> + Send + 'a>>;
+
+    /// Transition a send to `Replied` and reset the recipient's unanswered-challenge
+    /// state (a reply is the positive signal that resets the per-recipient counter).
+    fn mark_replied<'a>(
+        &'a self,
+        send_id: &'a str,
+        tenant: Option<&'a str>,
+        recipient: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    /// Record an informational signal (out-of-office / auto-generated) without
+    /// changing the send status.
+    fn record_signal<'a>(
+        &'a self,
+        send_id: &'a str,
+        signal: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    /// Add or refresh a suppression for a recipient (by keyed hash). A permanent
+    /// existing suppression (no TTL, e.g. a hard bounce) is never downgraded.
+    fn suppress<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        address_hash: &'a str,
+        reason: SuppressionReason,
+        ttl: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+
+    /// Lift a suppression of a specific reason for a recipient (by keyed hash) — a
+    /// reply lifts a `challenge_unanswered`, never a `hard_bounce`.
+    fn lift_suppression<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        address_hash: &'a str,
+        reason: SuppressionReason,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 }
 
@@ -240,6 +348,201 @@ impl SendTracker for PgSendTracker {
             .execute(&self.pool)
             .await
             .map_err(|error| db_err("record sent", &error))?;
+            Ok(())
+        })
+    }
+}
+
+/// The columns a correlation lookup selects.
+type SendRow = (String, Option<String>, String);
+
+fn to_correlated((send_id, tenant, recipient): SendRow) -> CorrelatedSend {
+    CorrelatedSend {
+        send_id,
+        tenant,
+        recipient,
+    }
+}
+
+impl SendCorrelator for PgSendTracker {
+    fn find_by_send_id<'a>(
+        &'a self,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<CorrelatedSend>>> + Send + 'a>> {
+        Box::pin(async move {
+            let row: Option<SendRow> = sqlx::query_as(
+                "SELECT send_id, tenant_id, recipient FROM _fraiseql_send_status \
+                 WHERE send_id = $1 LIMIT 1",
+            )
+            .bind(send_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| db_err("find by send-id", &error))?;
+            Ok(row.map(to_correlated))
+        })
+    }
+
+    fn find_by_message_id<'a>(
+        &'a self,
+        message_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<CorrelatedSend>>> + Send + 'a>> {
+        Box::pin(async move {
+            let row: Option<SendRow> = sqlx::query_as(
+                "SELECT send_id, tenant_id, recipient FROM _fraiseql_send_status \
+                 WHERE message_id = $1 LIMIT 1",
+            )
+            .bind(message_id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| db_err("find by message-id", &error))?;
+            Ok(row.map(to_correlated))
+        })
+    }
+
+    fn mark_bounced<'a>(
+        &'a self,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            sqlx::query(
+                "UPDATE _fraiseql_send_status \
+                 SET status = 'Bounced', last_signal = 'bounce', updated_at = now() \
+                 WHERE send_id = $1",
+            )
+            .bind(send_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("mark bounced", &error))?;
+            Ok(())
+        })
+    }
+
+    fn bump_challenge<'a>(
+        &'a self,
+        send_id: &'a str,
+        tenant: Option<&'a str>,
+        recipient: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<i64>> + Send + 'a>> {
+        Box::pin(async move {
+            sqlx::query(
+                "UPDATE _fraiseql_send_status \
+                 SET status = 'ChallengePending', challenge_count = challenge_count + 1, \
+                     last_signal = 'challenge', updated_at = now() \
+                 WHERE send_id = $1",
+            )
+            .bind(send_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("bump challenge", &error))?;
+
+            // Per-recipient across campaigns: how many of this recipient's sends are
+            // still awaiting a challenge answer.
+            let (count,): (i64,) = sqlx::query_as(
+                "SELECT count(*) FROM _fraiseql_send_status \
+                 WHERE recipient = $1 AND tenant_id IS NOT DISTINCT FROM $2 \
+                   AND status = 'ChallengePending'",
+            )
+            .bind(recipient)
+            .bind(tenant)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|error| db_err("count pending challenges", &error))?;
+            Ok(count)
+        })
+    }
+
+    fn mark_replied<'a>(
+        &'a self,
+        send_id: &'a str,
+        tenant: Option<&'a str>,
+        recipient: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            // The replied send → Replied, and reset the recipient's other pending
+            // challenges (a reply is the per-recipient positive signal).
+            sqlx::query(
+                "UPDATE _fraiseql_send_status \
+                 SET status = 'Replied', challenge_count = 0, last_signal = 'reply', \
+                     updated_at = now() \
+                 WHERE tenant_id IS NOT DISTINCT FROM $2 \
+                   AND (send_id = $1 OR (recipient = $3 AND status = 'ChallengePending'))",
+            )
+            .bind(send_id)
+            .bind(tenant)
+            .bind(recipient)
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("mark replied", &error))?;
+            Ok(())
+        })
+    }
+
+    fn record_signal<'a>(
+        &'a self,
+        send_id: &'a str,
+        signal: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            sqlx::query(
+                "UPDATE _fraiseql_send_status SET last_signal = $2, updated_at = now() \
+                 WHERE send_id = $1",
+            )
+            .bind(send_id)
+            .bind(signal)
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("record signal", &error))?;
+            Ok(())
+        })
+    }
+
+    fn suppress<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        address_hash: &'a str,
+        reason: SuppressionReason,
+        ttl: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            // Never downgrade a permanent suppression (ttl IS NULL, e.g. a hard
+            // bounce) to a temporary one — only refresh/upgrade a temporary row or
+            // insert a new one.
+            sqlx::query(
+                "INSERT INTO _fraiseql_suppression (tenant_id, address_hash, reason, ttl) \
+                 VALUES ($1, $2, $3, $4) \
+                 ON CONFLICT (COALESCE(tenant_id, ''), address_hash) DO UPDATE \
+                     SET reason = EXCLUDED.reason, ttl = EXCLUDED.ttl, \
+                         since = now(), updated_at = now() \
+                     WHERE _fraiseql_suppression.ttl IS NOT NULL",
+            )
+            .bind(tenant)
+            .bind(address_hash)
+            .bind(reason.as_str())
+            .bind(ttl)
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("suppress", &error))?;
+            Ok(())
+        })
+    }
+
+    fn lift_suppression<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        address_hash: &'a str,
+        reason: SuppressionReason,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            sqlx::query(
+                "DELETE FROM _fraiseql_suppression \
+                 WHERE address_hash = $1 AND tenant_id IS NOT DISTINCT FROM $2 AND reason = $3",
+            )
+            .bind(address_hash)
+            .bind(tenant)
+            .bind(reason.as_str())
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("lift suppression", &error))?;
             Ok(())
         })
     }

--- a/crates/fraiseql-server/src/inbound/email/tracking.rs
+++ b/crates/fraiseql-server/src/inbound/email/tracking.rs
@@ -1,0 +1,249 @@
+//! The delivery-feedback stores: send-status lifecycle + suppression list.
+//!
+//! Where the [`warming::SendCounter`](super::warming::SendCounter) seam gates a
+//! send by volume, the [`SendTracker`] seam gates it by *outcome history* and
+//! records the send so an inbound bounce/challenge/reply can later be correlated
+//! back to it. The `send_email` transport consults it before every relay:
+//!
+//! 1. **suppression** — is the recipient on the do-not-contact list? (a permanent refusal, the
+//!    biggest deliverability + GDPR lever);
+//! 2. **exactly-once** — has this exact dispatch (`send_id`) already been sent? (a durable retry
+//!    must not double-send);
+//!
+//! and writes a `Sent` row after a successful relay so the correlation step
+//! (cycle 3) has something to transition.
+//!
+//! The Postgres implementation ([`PgSendTracker`]) is the server-side owner of the
+//! `_fraiseql_send_status` / `_fraiseql_suppression` tables (DDL in
+//! [`fraiseql_functions::migrations::send_tracking_migration_sql`]); the seam keeps
+//! the transport testable without a database. Addresses reach the tracker already
+//! **keyed-hashed** (never raw) so the store holds no recipient PII on the
+//! suppression list — see
+//! [`hash_address`](fraiseql_observers::hash_address).
+
+use std::{future::Future, pin::Pin};
+
+use fraiseql_error::Result;
+use sqlx::PgPool;
+
+/// Why a recipient is on the suppression list.
+///
+/// Serialised to the `reason` column as a stable snake-case token; a granular
+/// reason (rather than a bare boolean) lets the correlation step lift only the
+/// right kind of suppression — a reply lifts a `challenge_unanswered`, never a
+/// `hard_bounce`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SuppressionReason {
+    /// A hard bounce (5xx / DSN): the address does not accept mail. ~Permanent.
+    HardBounce,
+    /// N unanswered challenge-response prompts (Mailinblack-style). Lifts on a
+    /// genuine reply; a ~30-day TTL otherwise.
+    ChallengeUnanswered,
+    /// A manual unsubscribe / support removal. Permanent unless re-consented.
+    Unsubscribe,
+}
+
+impl SuppressionReason {
+    /// The stable token stored in the `reason` column.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SuppressionReason::HardBounce => "hard_bounce",
+            SuppressionReason::ChallengeUnanswered => "challenge_unanswered",
+            SuppressionReason::Unsubscribe => "unsubscribe",
+        }
+    }
+
+    /// Parse a stored `reason` token back into a variant, or `None` if unknown
+    /// (a forward-compatible reason written by a newer version).
+    #[must_use]
+    pub fn parse(token: &str) -> Option<Self> {
+        match token {
+            "hard_bounce" => Some(SuppressionReason::HardBounce),
+            "challenge_unanswered" => Some(SuppressionReason::ChallengeUnanswered),
+            "unsubscribe" => Some(SuppressionReason::Unsubscribe),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for SuppressionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A prior send recorded on the send-status store — the exactly-once skip returns
+/// this instead of relaying again.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RecordedSend {
+    /// The relay/provider message id recorded on the original send, if any.
+    pub message_id: Option<String>,
+}
+
+/// The write payload for a successful relay: what the transport records as `Sent`.
+///
+/// The `recipient` is stored **raw** here (operational history the app surfaces —
+/// "sent to bob@…, status Bounced"); it is erasable PII. The suppression list, by
+/// contrast, keeps only a keyed hash (the do-not-contact fact that must survive
+/// erasure). The `tenant` scopes the row for RLS.
+#[derive(Debug, Clone, Copy)]
+pub struct SentRecord<'a> {
+    /// The per-dispatch VERP send-id (the exactly-once key).
+    pub send_id:         &'a str,
+    /// The tenant the send is scoped to (RLS stamp). `None` → single-tenant.
+    pub tenant:          Option<&'a str>,
+    /// The raw recipient address.
+    pub recipient:       &'a str,
+    /// The verified sending address the message went out from.
+    pub sending_address: &'a str,
+    /// The relay/provider message id, if one was returned.
+    pub message_id:      Option<&'a str>,
+}
+
+/// The delivery-feedback seam the `send_email` transport consults before a relay
+/// and writes to after one.
+///
+/// Object-safe (`BoxFuture` returns, no `#[async_trait]`) so the transport holds an
+/// `Arc<dyn SendTracker>` and tests can substitute an in-memory fake.
+pub trait SendTracker: Send + Sync {
+    /// The active suppression reason for a recipient (by keyed hash) in a tenant,
+    /// or `None` if the recipient may be contacted. TTL-expired rows are ignored.
+    fn suppression_reason<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        address_hash: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<SuppressionReason>>> + Send + 'a>>;
+
+    /// The recorded response if a send with `send_id` in this tenant has already
+    /// completed (the exactly-once skip), else `None`.
+    fn recorded_send<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<RecordedSend>>> + Send + 'a>>;
+
+    /// Record a successful relay as `Sent`. Idempotent on the exactly-once key: a
+    /// concurrent/duplicate write for the same `(tenant, send_id)` is discarded.
+    fn record_sent<'a>(
+        &'a self,
+        record: SentRecord<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+}
+
+/// Map a `sqlx` error onto the canonical database error.
+fn db_err(context: &str, error: &sqlx::Error) -> fraiseql_error::FraiseQLError {
+    fraiseql_error::FraiseQLError::database(format!("send tracking: {context}: {error}"))
+}
+
+/// PostgreSQL-backed [`SendTracker`] over a connection pool.
+///
+/// Owns the `_fraiseql_send_status` / `_fraiseql_suppression` tables; the
+/// connecting role must own them (or `BYPASSRLS`), which [`init`](Self::init)
+/// arranges by creating them.
+pub struct PgSendTracker {
+    pool: PgPool,
+}
+
+impl PgSendTracker {
+    /// Create a tracker over an existing pool.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Create the delivery-feedback tables (idempotent). Call once on startup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FraiseQLError::Database`](fraiseql_error::FraiseQLError::Database)
+    /// if the DDL fails.
+    pub async fn init(&self) -> fraiseql_error::Result<()> {
+        sqlx::raw_sql(fraiseql_functions::migrations::send_tracking_migration_sql())
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("init", &error))?;
+        Ok(())
+    }
+}
+
+impl SendTracker for PgSendTracker {
+    fn suppression_reason<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        address_hash: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<SuppressionReason>>> + Send + 'a>> {
+        Box::pin(async move {
+            // `IS NOT DISTINCT FROM` matches a NULL (single-tenant) row against a
+            // NULL bind; the `ttl` guard ignores expired suppressions.
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT reason FROM _fraiseql_suppression \
+                 WHERE address_hash = $1 AND tenant_id IS NOT DISTINCT FROM $2 \
+                   AND (ttl IS NULL OR ttl > now()) \
+                 LIMIT 1",
+            )
+            .bind(address_hash)
+            .bind(tenant)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| db_err("suppression lookup", &error))?;
+
+            // An unknown reason token (forward-compat) still suppresses — a row on
+            // the do-not-contact list means do not contact, whatever the label.
+            Ok(row.map(|(reason,)| {
+                SuppressionReason::parse(&reason).unwrap_or(SuppressionReason::Unsubscribe)
+            }))
+        })
+    }
+
+    fn recorded_send<'a>(
+        &'a self,
+        tenant: Option<&'a str>,
+        send_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<RecordedSend>>> + Send + 'a>> {
+        Box::pin(async move {
+            let row: Option<(Option<String>,)> = sqlx::query_as(
+                "SELECT message_id FROM _fraiseql_send_status \
+                 WHERE send_id = $1 AND tenant_id IS NOT DISTINCT FROM $2 \
+                 LIMIT 1",
+            )
+            .bind(send_id)
+            .bind(tenant)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| db_err("recorded-send lookup", &error))?;
+
+            Ok(row.map(|(message_id,)| RecordedSend { message_id }))
+        })
+    }
+
+    fn record_sent<'a>(
+        &'a self,
+        record: SentRecord<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            // ON CONFLICT on the exactly-once expression index keeps a
+            // crash-retry (or a race) from writing two `Sent` rows for one send.
+            sqlx::query(
+                "INSERT INTO _fraiseql_send_status \
+                     (send_id, tenant_id, recipient, sending_address, status, message_id, \
+                      sent_at, updated_at) \
+                 VALUES ($1, $2, $3, $4, 'Sent', $5, now(), now()) \
+                 ON CONFLICT (COALESCE(tenant_id, ''), send_id) DO NOTHING",
+            )
+            .bind(record.send_id)
+            .bind(record.tenant)
+            .bind(record.recipient)
+            .bind(record.sending_address)
+            .bind(record.message_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("record sent", &error))?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/inbound/email/tracking.rs
+++ b/crates/fraiseql-server/src/inbound/email/tracking.rs
@@ -123,7 +123,7 @@ pub struct SentRecord<'a> {
 /// The delivery-feedback seam the `send_email` transport consults before a relay
 /// and writes to after one.
 ///
-/// Object-safe (`BoxFuture` returns, no `#[async_trait]`) so the transport holds an
+/// Object-safe (`BoxFuture` returns, no `async_trait` macro) so the transport holds an
 /// `Arc<dyn SendTracker>` and tests can substitute an in-memory fake.
 pub trait SendTracker: Send + Sync {
     /// The active suppression reason for a recipient (by keyed hash) in a tenant,

--- a/crates/fraiseql-server/src/inbound/email/tracking/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/tracking/tests.rs
@@ -1,0 +1,101 @@
+//! Tests for the delivery-feedback stores.
+//!
+//! The pure tests (enum round-trip) run everywhere; the store tests need a
+//! Postgres and skip cleanly without one.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+#![allow(clippy::print_stderr)] // Reason: skip message when no backing Postgres is available
+
+use sqlx::PgPool;
+
+use super::{PgSendTracker, RecordedSend, SendTracker, SentRecord, SuppressionReason};
+
+#[test]
+fn suppression_reason_round_trips_through_its_token() {
+    for reason in [
+        SuppressionReason::HardBounce,
+        SuppressionReason::ChallengeUnanswered,
+        SuppressionReason::Unsubscribe,
+    ] {
+        assert_eq!(SuppressionReason::parse(reason.as_str()), Some(reason));
+    }
+    // An unknown token does not parse — the caller treats it as "suppressed anyway".
+    assert_eq!(SuppressionReason::parse("something_new"), None);
+}
+
+/// Connect to the harness Postgres (Dagger-bound in CI; a local spawn with the
+/// `local-testcontainers` feature); `None` → the test skips cleanly.
+async fn connect_pool() -> Option<(PgPool, fraiseql_test_support::Service)> {
+    let svc = fraiseql_test_support::postgres().await?;
+    let pool = PgPool::connect(svc.url()).await.unwrap();
+    Some((pool, svc))
+}
+
+#[tokio::test]
+async fn suppression_and_exactly_once_round_trip_through_postgres() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!(
+            "SKIP suppression_and_exactly_once_round_trip_through_postgres: no postgres (set DATABASE_URL or enable fraiseql-test-support/local-testcontainers)"
+        );
+        return;
+    };
+    let tracker = PgSendTracker::new(pool.clone());
+    tracker.init().await.unwrap();
+
+    // A never-seen send is not recorded; a fresh recipient is not suppressed.
+    assert_eq!(tracker.recorded_send(None, "send-xyz").await.unwrap(), None);
+    assert_eq!(tracker.suppression_reason(None, "hash-abc").await.unwrap(), None);
+
+    // Record a send → exactly-once lookup now returns the recorded response, and a
+    // second record for the same send-id is discarded (no double row).
+    let record = SentRecord {
+        send_id:         "send-xyz",
+        tenant:          None,
+        recipient:       "bob@example.com",
+        sending_address: "sales@example.com",
+        message_id:      Some("<relay-1@smtp>"),
+    };
+    tracker.record_sent(record).await.unwrap();
+    assert_eq!(
+        tracker.recorded_send(None, "send-xyz").await.unwrap(),
+        Some(RecordedSend {
+            message_id: Some("<relay-1@smtp>".to_string()),
+        })
+    );
+    // A conflicting second write keeps the original message id.
+    tracker
+        .record_sent(SentRecord {
+            message_id: Some("<relay-2@smtp>"),
+            ..record
+        })
+        .await
+        .unwrap();
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT count(*) FROM _fraiseql_send_status WHERE send_id = 'send-xyz'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 1, "exactly-once: one Sent row per send-id");
+
+    // A suppression row surfaces for the matching hash, respecting the TTL guard.
+    sqlx::query(
+        "INSERT INTO _fraiseql_suppression (tenant_id, address_hash, reason) \
+         VALUES (NULL, 'hash-abc', 'hard_bounce')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        tracker.suppression_reason(None, "hash-abc").await.unwrap(),
+        Some(SuppressionReason::HardBounce)
+    );
+    // An expired suppression is ignored.
+    sqlx::query(
+        "INSERT INTO _fraiseql_suppression (tenant_id, address_hash, reason, ttl) \
+         VALUES (NULL, 'hash-expired', 'challenge_unanswered', now() - interval '1 day')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert_eq!(tracker.suppression_reason(None, "hash-expired").await.unwrap(), None);
+}

--- a/crates/fraiseql-server/src/inbound/email/tracking/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/tracking/tests.rs
@@ -6,9 +6,11 @@
 #![allow(clippy::unwrap_used)] // Reason: test code
 #![allow(clippy::print_stderr)] // Reason: skip message when no backing Postgres is available
 
+use fraiseql_functions::{Classification, InboundMessage, IngestSource};
 use sqlx::PgPool;
 
 use super::{PgSendTracker, RecordedSend, SendTracker, SentRecord, SuppressionReason};
+use crate::inbound::email::correlate;
 
 #[test]
 fn suppression_reason_round_trips_through_its_token() {
@@ -98,4 +100,140 @@ async fn suppression_and_exactly_once_round_trip_through_postgres() {
     .await
     .unwrap();
     assert_eq!(tracker.suppression_reason(None, "hash-expired").await.unwrap(), None);
+}
+
+/// The correlation address-hash key for the e2e tests (any bytes; the store only
+/// stores the resulting hash).
+const KEY: &[u8] = b"correlation-e2e-key";
+
+/// Build a classified inbound message addressed to a VERP Return-Path.
+fn inbound_to_verp(send_id: &str, classification: Classification) -> InboundMessage {
+    let mut message = InboundMessage::new(
+        IngestSource::Email,
+        "mid-e2e",
+        chrono::DateTime::parse_from_rfc3339("2026-07-05T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+    );
+    message.to = vec![format!("bounces+{send_id}@sales.example.com")];
+    message.classification = Some(classification);
+    message
+}
+
+/// The full delivery-feedback loop end to end through Postgres: record a send,
+/// then correlate a bounce → the send is `Bounced` and the recipient suppressed.
+#[tokio::test]
+async fn a_bounce_correlates_to_bounced_and_suppresses_through_postgres() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!(
+            "SKIP a_bounce_correlates_to_bounced_and_suppresses_through_postgres: no postgres (set DATABASE_URL or enable fraiseql-test-support/local-testcontainers)"
+        );
+        return;
+    };
+    let tracker = PgSendTracker::new(pool.clone());
+    tracker.init().await.unwrap();
+
+    let send_id = "0123456789abcdef0123456789abcdef";
+    let recipient = "bob@bounce-e2e.example.com";
+    tracker
+        .record_sent(SentRecord {
+            send_id,
+            tenant: None,
+            recipient,
+            sending_address: "sales@example.com",
+            message_id: Some("<m1@relay>"),
+        })
+        .await
+        .unwrap();
+
+    let now = chrono::DateTime::parse_from_rfc3339("2026-07-05T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let outcome =
+        correlate(&tracker, Some(KEY), 2, now, &inbound_to_verp(send_id, Classification::Bounce))
+            .await
+            .unwrap();
+    assert_eq!(outcome, crate::inbound::email::correlation::CorrelationOutcome::Bounced);
+
+    let (status,): (String,) =
+        sqlx::query_as("SELECT status FROM _fraiseql_send_status WHERE send_id = $1")
+            .bind(send_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(status, "Bounced");
+
+    // The recipient is now suppressed (hard bounce, permanent).
+    let hash = fraiseql_observers::hash_address(KEY, recipient);
+    assert_eq!(
+        tracker.suppression_reason(None, &hash).await.unwrap(),
+        Some(SuppressionReason::HardBounce)
+    );
+}
+
+/// A challenge reaching the threshold suppresses; a subsequent reply lifts it and
+/// marks the send `Replied`.
+#[tokio::test]
+async fn challenge_then_reply_suppresses_then_lifts_through_postgres() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!(
+            "SKIP challenge_then_reply_suppresses_then_lifts_through_postgres: no postgres (set DATABASE_URL or enable fraiseql-test-support/local-testcontainers)"
+        );
+        return;
+    };
+    let tracker = PgSendTracker::new(pool.clone());
+    tracker.init().await.unwrap();
+
+    let send_id = "fedcba9876543210fedcba9876543210";
+    let recipient = "carol@challenge-e2e.example.com";
+    let hash = fraiseql_observers::hash_address(KEY, recipient);
+    let now = chrono::DateTime::parse_from_rfc3339("2026-07-05T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    tracker
+        .record_sent(SentRecord {
+            send_id,
+            tenant: None,
+            recipient,
+            sending_address: "sales@example.com",
+            message_id: None,
+        })
+        .await
+        .unwrap();
+
+    // A challenge with N=1 → the recipient's single pending challenge meets the
+    // threshold → suppressed.
+    let outcome = correlate(
+        &tracker,
+        Some(KEY),
+        1,
+        now,
+        &inbound_to_verp(send_id, Classification::Challenge),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        outcome,
+        crate::inbound::email::correlation::CorrelationOutcome::Challenge {
+            suppressed: true,
+            ..
+        }
+    ));
+    assert_eq!(
+        tracker.suppression_reason(None, &hash).await.unwrap(),
+        Some(SuppressionReason::ChallengeUnanswered)
+    );
+
+    // A genuine reply → Replied, and the challenge suppression lifts immediately.
+    correlate(&tracker, Some(KEY), 1, now, &inbound_to_verp(send_id, Classification::Human))
+        .await
+        .unwrap();
+    let (status,): (String,) =
+        sqlx::query_as("SELECT status FROM _fraiseql_send_status WHERE send_id = $1")
+            .bind(send_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(status, "Replied");
+    assert_eq!(tracker.suppression_reason(None, &hash).await.unwrap(), None, "lifted on reply");
 }

--- a/crates/fraiseql-server/src/inbound/email/worker.rs
+++ b/crates/fraiseql-server/src/inbound/email/worker.rs
@@ -21,9 +21,11 @@ use fraiseql_functions::{
 use tracing::{debug, info, warn};
 
 use super::{
+    correlation::correlate,
     cursor,
     imap::{FetchedMessage, MailboxFetcher},
     store::PostgresEmailCursorStore,
+    tracking::SendCorrelator,
 };
 use crate::{
     inbound::spine::PostgresInboundSpine,
@@ -45,23 +47,31 @@ enum Ingested {
 /// A poll worker for one configured mailbox.
 pub struct EmailPollWorker {
     /// Stable mailbox identity — names the cursor row.
-    mailbox_key:       String,
+    mailbox_key:              String,
     /// The transport that fetches raw messages.
-    fetcher:           Arc<dyn MailboxFetcher>,
+    fetcher:                  Arc<dyn MailboxFetcher>,
     /// The durable inbound spine (dedup by `(source, idempotency_key)`).
-    spine:             PostgresInboundSpine,
+    spine:                    PostgresInboundSpine,
     /// The per-mailbox UID cursor store.
-    cursor_store:      PostgresEmailCursorStore,
+    cursor_store:             PostgresEmailCursorStore,
     /// Declared routing rules applied during normalization.
-    routing_rules:     Vec<RoutingRule>,
+    routing_rules:            Vec<RoutingRule>,
     /// Maximum messages processed per poll.
-    batch_size:        u32,
+    batch_size:               u32,
     /// Storage bucket for attachments + raw retention (`None` drops attachments).
-    attachment_bucket: Option<String>,
+    attachment_bucket:        Option<String>,
     /// Storage sink; `None` disables attachment / raw persistence.
-    attachment_sink:   Option<Arc<dyn StorageBackend>>,
+    attachment_sink:          Option<Arc<dyn StorageBackend>>,
     /// Function-dispatch hooks; `None` ingests without firing `after:ingest`.
-    hooks:             Option<Arc<BeforeMutationHooks>>,
+    hooks:                    Option<Arc<BeforeMutationHooks>>,
+    /// Delivery-feedback correlator; `None` ingests without correlating inbound
+    /// bounces / challenges / replies to their send.
+    correlator:               Option<Arc<dyn SendCorrelator>>,
+    /// The recipient address-hash key for suppression writes (needs the server HMAC
+    /// secret); `None` transitions status without writing suppressions.
+    address_hash_key:         Option<Arc<[u8]>>,
+    /// The per-recipient unanswered-challenge suppression threshold (`N`).
+    challenge_suppress_after: u32,
 }
 
 impl EmailPollWorker {
@@ -77,6 +87,9 @@ impl EmailPollWorker {
         attachment_bucket: Option<String>,
         attachment_sink: Option<Arc<dyn StorageBackend>>,
         hooks: Option<Arc<BeforeMutationHooks>>,
+        correlator: Option<Arc<dyn SendCorrelator>>,
+        address_hash_key: Option<Arc<[u8]>>,
+        challenge_suppress_after: u32,
     ) -> Self {
         Self {
             mailbox_key: mailbox_key.into(),
@@ -88,6 +101,9 @@ impl EmailPollWorker {
             attachment_bucket,
             attachment_sink,
             hooks,
+            correlator,
+            address_hash_key,
+            challenge_suppress_after,
         }
     }
 
@@ -187,10 +203,42 @@ impl EmailPollWorker {
         self.persist_blobs(&mut normalized, &parsed.attachments, &message.raw).await?;
 
         if self.spine.emit(&normalized).await?.is_new() {
+            // Platform correlation runs first (only on a genuinely-new message —
+            // `bump_challenge` is not idempotent, so a redelivery must not
+            // re-count), then app `after:ingest` functions fire for app logic.
+            self.correlate(&normalized).await;
             self.dispatch(&normalized);
             Ok(Ingested::New)
         } else {
             Ok(Ingested::Duplicate)
+        }
+    }
+
+    /// Correlate an inbound bounce / challenge / reply back to its send.
+    ///
+    /// Best-effort: a correlation failure is logged, not propagated — the message
+    /// is already ingested, and a redelivery would be deduplicated by the spine
+    /// (so it would never re-correlate). A stale send-status is a lesser evil than
+    /// wedging the mailbox or losing the message. A no-op when no correlator is
+    /// wired (no database / feature off).
+    async fn correlate(&self, message: &InboundMessage) {
+        let Some(correlator) = self.correlator.as_ref() else {
+            return;
+        };
+        let result = correlate(
+            correlator.as_ref(),
+            self.address_hash_key.as_deref(),
+            self.challenge_suppress_after,
+            chrono::Utc::now(),
+            message,
+        )
+        .await;
+        if let Err(error) = result {
+            warn!(
+                mailbox = %self.mailbox_key,
+                %error,
+                "delivery correlation failed; send-status left unchanged"
+            );
         }
     }
 

--- a/crates/fraiseql-server/src/inbound/email/worker/tests.rs
+++ b/crates/fraiseql-server/src/inbound/email/worker/tests.rs
@@ -112,8 +112,19 @@ async fn poll_ingests_new_mail_and_advances_the_cursor() {
             },
         ],
     });
-    let worker =
-        EmailPollWorker::new(mailbox.clone(), fetcher, pool.clone(), vec![], 50, None, None, None);
+    let worker = EmailPollWorker::new(
+        mailbox.clone(),
+        fetcher,
+        pool.clone(),
+        vec![],
+        50,
+        None,
+        None,
+        None,
+        None,
+        None,
+        2,
+    );
 
     // First poll ingests both and advances the cursor to the highest UID.
     assert_eq!(worker.run_once().await.unwrap(), 2);
@@ -155,6 +166,9 @@ async fn uidvalidity_reset_redelivers_but_dedups_on_message_id() {
         None,
         None,
         None,
+        None,
+        None,
+        2,
     );
     assert_eq!(worker_v1.run_once().await.unwrap(), 1);
     assert_eq!(spine_count(&pool, &key).await, 1);
@@ -176,6 +190,9 @@ async fn uidvalidity_reset_redelivers_but_dedups_on_message_id() {
         None,
         None,
         None,
+        None,
+        None,
+        2,
     );
     assert_eq!(worker_v2.run_once().await.unwrap(), 0, "redelivery dedups; nothing new");
     assert_eq!(spine_count(&pool, &key).await, 1, "still exactly one row");

--- a/crates/fraiseql-server/src/observers/runtime/tests.rs
+++ b/crates/fraiseql-server/src/observers/runtime/tests.rs
@@ -166,6 +166,7 @@ mod function_dlq {
             DispatchSource::AfterMutation,
             "onUserCreated",
             "after:mutation:onUserCreated",
+            "0123456789abcdef0123456789abcdef",
             serde_json::json!({ "event_kind": "insert", "new": { "id": "u1" } }),
             error,
             3,

--- a/crates/fraiseql-server/src/routes/after_mutation/mod.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/mod.rs
@@ -266,6 +266,11 @@ struct DurableDispatcher {
     /// verified address.
     sender_resolver: Option<std::sync::Arc<dyn fraiseql_functions::SenderIdentityResolver>>,
     email_transport: Option<std::sync::Arc<dyn fraiseql_functions::EmailTransport>>,
+    /// HMAC subkey for the per-dispatch idempotency token. `Some` → the token is
+    /// signed (unforgeable, required before it is exposed in a VERP Return-Path);
+    /// `None` → an unsigned digest (the zero-config default). Derived once from the
+    /// server HMAC secret and shared across every dispatch.
+    idempotency_key: Option<std::sync::Arc<[u8]>>,
 }
 
 #[cfg(feature = "functions-runtime")]
@@ -324,6 +329,7 @@ impl DurableDispatcher {
         let trigger_identity =
             format!("{}:{}:{}", payload.trigger_type, payload.entity, payload.event_kind);
         let idempotency_token = fraiseql_observers::derive_idempotency_token(
+            self.idempotency_key.as_deref(),
             self.source,
             &function_name,
             &trigger_identity,
@@ -454,6 +460,7 @@ fn spawn_dispatch(
         source,
         sender_resolver: hooks.sender_resolver.clone(),
         email_transport: hooks.email_transport.clone(),
+        idempotency_key: hooks.idempotency_key.clone(),
     };
 
     for plan in plans {

--- a/crates/fraiseql-server/src/routes/after_mutation/mod.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/mod.rs
@@ -271,10 +271,15 @@ struct DurableDispatcher {
 #[cfg(feature = "functions-runtime")]
 impl DurableDispatcher {
     /// Run one function on a fresh live host context.
+    ///
+    /// `idempotency_token` is derived once per dispatch and passed to every retry
+    /// attempt, so the fresh host each attempt builds carries the *same* token —
+    /// the guest observes a stable, per-dispatch idempotency key across retries.
     async fn invoke_once(
         &self,
         module: &FunctionModule,
         payload: EventPayload,
+        idempotency_token: &str,
     ) -> fraiseql_error::Result<fraiseql_functions::FunctionResult> {
         // Shared, runtime-agnostic host bridge: the observer dispatches the plan
         // to the WASM or Deno backend by the module's runtime, so the host type
@@ -282,7 +287,8 @@ impl DurableDispatcher {
         let mut live = fraiseql_functions::host::live::LiveHostContext::new(
             payload.clone(),
             self.host_config.clone(),
-        );
+        )
+        .with_idempotency_token(idempotency_token);
         // Enable `send_email` (host-owned `from` + transport) when both are wired.
         if let (Some(resolver), Some(transport)) =
             (self.sender_resolver.as_ref(), self.email_transport.as_ref())
@@ -310,10 +316,24 @@ impl DurableDispatcher {
     ) {
         let function_name = module.name.clone();
 
+        // Derive the per-dispatch idempotency token ONCE, from the dispatch's
+        // stable identity (never wall-clock/random), so every retry attempt below
+        // sees the same token and a durable retry of a money/mail call stays
+        // at-most-once. The trigger identity folds in entity + event_kind; the
+        // payload data (which excludes the event timestamp) makes it resume-stable.
+        let trigger_identity =
+            format!("{}:{}:{}", payload.trigger_type, payload.entity, payload.event_kind);
+        let idempotency_token = fraiseql_observers::derive_idempotency_token(
+            self.source,
+            &function_name,
+            &trigger_identity,
+            &payload.data,
+        );
+
         if setting.re_runnable {
             // Fire-and-forget: a single attempt; a failure is re-runnable later
             // by design, so it is logged but never retried or dead-lettered.
-            match self.invoke_once(&module, payload).await {
+            match self.invoke_once(&module, payload, &idempotency_token).await {
                 Ok(_) => tracing::debug!(
                     function = %function_name,
                     "re-runnable function dispatched"
@@ -330,22 +350,27 @@ impl DurableDispatcher {
         // Durable dispatch: retry transient failures with backoff.
         let trigger_type = payload.trigger_type.clone();
         let attempts = std::sync::atomic::AtomicU32::new(0);
-        let result = fraiseql_observers::run_with_retry(
-            &setting.policy,
-            // A 4xx client error (e.g. a malformed payload) will not succeed on
-            // retry; everything else (5xx, timeouts, execution failures) is
-            // treated as transient and retried.
-            |error: &fraiseql_error::FraiseQLError| !error.is_client_error(),
-            |n| {
-                attempts.store(n, std::sync::atomic::Ordering::Relaxed);
-                // Clone per attempt so the retry closure stays `FnMut`; the
-                // bytecode is `bytes::Bytes` (ref-counted), so this is cheap.
-                let attempt_module = module.clone();
-                let attempt_payload = payload.clone();
-                async move { self.invoke_once(&attempt_module, attempt_payload).await }
-            },
-        )
-        .await;
+        let result =
+            fraiseql_observers::run_with_retry(
+                &setting.policy,
+                // A 4xx client error (e.g. a malformed payload) will not succeed on
+                // retry; everything else (5xx, timeouts, execution failures) is
+                // treated as transient and retried.
+                |error: &fraiseql_error::FraiseQLError| !error.is_client_error(),
+                |n| {
+                    attempts.store(n, std::sync::atomic::Ordering::Relaxed);
+                    // Clone per attempt so the retry closure stays `FnMut`; the
+                    // bytecode is `bytes::Bytes` (ref-counted), so this is cheap. The
+                    // token is derived once above, so every attempt shares it.
+                    let attempt_module = module.clone();
+                    let attempt_payload = payload.clone();
+                    let attempt_token = idempotency_token.clone();
+                    async move {
+                        self.invoke_once(&attempt_module, attempt_payload, &attempt_token).await
+                    }
+                },
+            )
+            .await;
 
         let Err(error) = result else {
             tracing::debug!(function = %function_name, "function dispatched");
@@ -358,6 +383,7 @@ impl DurableDispatcher {
             self.source,
             function_name.clone(),
             trigger_type,
+            idempotency_token,
             serde_json::to_value(&payload).unwrap_or(serde_json::Value::Null),
             error.to_string(),
             attempts,

--- a/crates/fraiseql-server/src/routes/after_mutation/mod.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/mod.rs
@@ -363,6 +363,15 @@ impl DurableDispatcher {
                 // retry; everything else (5xx, timeouts, execution failures) is
                 // treated as transient and retried.
                 |error: &fraiseql_error::FraiseQLError| !error.is_client_error(),
+                // A transient error may request a minimum backoff (greylisting: an
+                // SMTP tempfail clears in minutes, not the policy's seconds).
+                |error: &fraiseql_error::FraiseQLError| match error {
+                    fraiseql_error::FraiseQLError::ServiceUnavailable {
+                        retry_after: Some(secs),
+                        ..
+                    } => Some(std::time::Duration::from_secs(*secs)),
+                    _ => None,
+                },
                 |n| {
                     attempts.store(n, std::sync::atomic::Ordering::Relaxed);
                     // Clone per attempt so the retry closure stays `FnMut`; the

--- a/crates/fraiseql-server/src/routes/after_mutation/tests.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/tests.rs
@@ -306,6 +306,37 @@ mod durable_dispatch {
     }
 
     #[tokio::test]
+    async fn dead_letter_carries_the_per_dispatch_idempotency_token() {
+        let dlq = std::sync::Arc::new(InMemoryDlq::new_with_max(None));
+        let dispatcher = failing_dispatcher(dlq.clone());
+        let setting = FunctionDispatchSetting {
+            re_runnable: false,
+            policy:      zero_delay_policy(2),
+        };
+        let event = payload();
+
+        dispatcher.dispatch(module("onUserCreated"), event.clone(), &setting).await;
+
+        // The dispatcher derives the token ONCE and passes it to every attempt; it
+        // is recorded on the dead-letter, and equals the pure derivation from the
+        // dispatch's stable identity (source + function + trigger + payload data).
+        // Same-token-every-attempt therefore holds by construction, and the derived
+        // value is exactly what the guest's `fraiseql_idempotency_token()` returns.
+        let expected = fraiseql_observers::derive_idempotency_token(
+            fraiseql_observers::DispatchSource::AfterMutation,
+            "onUserCreated",
+            "after:mutation:onUserCreated:User:insert",
+            &event.data,
+        );
+        let pending = dlq.get_pending_functions(10).await.expect("list pending function DLQ");
+        assert_eq!(
+            pending[0].idempotency_token, expected,
+            "the dead-letter carries the derived per-dispatch token"
+        );
+        assert_eq!(expected.len(), 32, "the token is a 32-char hex send-id");
+    }
+
+    #[tokio::test]
     async fn re_runnable_dispatch_does_not_dead_letter() {
         let dlq = std::sync::Arc::new(InMemoryDlq::new_with_max(None));
         let dispatcher = failing_dispatcher(dlq.clone());

--- a/crates/fraiseql-server/src/routes/after_mutation/tests.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/tests.rs
@@ -253,6 +253,13 @@ mod durable_dispatch {
     /// `invoke_with_context` returns a permanent-less `Unsupported` error
     /// (`501` → not a client error → transient), letting durable dispatch retry.
     fn failing_dispatcher(dlq: std::sync::Arc<dyn DeadLetterQueue>) -> DurableDispatcher {
+        keyed_failing_dispatcher(dlq, None)
+    }
+
+    fn keyed_failing_dispatcher(
+        dlq: std::sync::Arc<dyn DeadLetterQueue>,
+        idempotency_key: Option<std::sync::Arc<[u8]>>,
+    ) -> DurableDispatcher {
         DurableDispatcher {
             observer: std::sync::Arc::new(FunctionObserver::new()),
             host_config: host_context_config(),
@@ -261,6 +268,7 @@ mod durable_dispatch {
             source: fraiseql_observers::DispatchSource::AfterMutation,
             sender_resolver: None,
             email_transport: None,
+            idempotency_key,
         }
     }
 
@@ -323,6 +331,7 @@ mod durable_dispatch {
         // Same-token-every-attempt therefore holds by construction, and the derived
         // value is exactly what the guest's `fraiseql_idempotency_token()` returns.
         let expected = fraiseql_observers::derive_idempotency_token(
+            None,
             fraiseql_observers::DispatchSource::AfterMutation,
             "onUserCreated",
             "after:mutation:onUserCreated:User:insert",
@@ -334,6 +343,43 @@ mod durable_dispatch {
             "the dead-letter carries the derived per-dispatch token"
         );
         assert_eq!(expected.len(), 32, "the token is a 32-char hex send-id");
+    }
+
+    #[tokio::test]
+    async fn keyed_dispatch_signs_the_idempotency_token() {
+        let dlq = std::sync::Arc::new(InMemoryDlq::new_with_max(None));
+        let key: std::sync::Arc<[u8]> = std::sync::Arc::from(
+            fraiseql_observers::derive_idempotency_subkey(b"root-secret").as_slice(),
+        );
+        let dispatcher = keyed_failing_dispatcher(dlq.clone(), Some(key.clone()));
+        let setting = FunctionDispatchSetting {
+            re_runnable: false,
+            policy:      zero_delay_policy(2),
+        };
+        let event = payload();
+
+        dispatcher.dispatch(module("onUserCreated"), event.clone(), &setting).await;
+
+        // With a key configured, the dispatched (and dead-lettered) token is the
+        // HMAC-keyed derivation — and differs from the unsigned digest of the same
+        // identity, proving the secret is actually applied end-to-end.
+        let signed = fraiseql_observers::derive_idempotency_token(
+            Some(&key[..]),
+            fraiseql_observers::DispatchSource::AfterMutation,
+            "onUserCreated",
+            "after:mutation:onUserCreated:User:insert",
+            &event.data,
+        );
+        let unsigned = fraiseql_observers::derive_idempotency_token(
+            None,
+            fraiseql_observers::DispatchSource::AfterMutation,
+            "onUserCreated",
+            "after:mutation:onUserCreated:User:insert",
+            &event.data,
+        );
+        let pending = dlq.get_pending_functions(10).await.expect("list pending function DLQ");
+        assert_eq!(pending[0].idempotency_token, signed, "the dispatch signs the token");
+        assert_ne!(pending[0].idempotency_token, unsigned, "signed ≠ unsigned digest");
     }
 
     #[tokio::test]

--- a/crates/fraiseql-server/src/server/functions_setup.rs
+++ b/crates/fraiseql-server/src/server/functions_setup.rs
@@ -54,7 +54,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         let mut hooks =
             subsystem.into_before_mutation_hooks().with_idempotency_key(idempotency_key);
 
-        if let Some((resolver, transport)) = self.build_send_email_wiring() {
+        if let Some((resolver, transport)) = self.build_send_email_wiring().await? {
             hooks = hooks.with_email(resolver, transport);
             tracing::info!(
                 "send_email host op enabled (host-owned from, per-connected-account SMTP)"
@@ -90,24 +90,72 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// Build the `send_email` wiring — sender-identity resolver + SMTP transport —
     /// from config. Returns `None` when no SMTP mailbox is configured, leaving
     /// `send_email` fail-loud.
-    fn build_send_email_wiring(
+    ///
+    /// When a database pool is available, the transport is wired to the
+    /// delivery-feedback store (`PgSendTracker`, tables created here); when the
+    /// server HMAC secret is set, the recipient address-hash key is derived so the
+    /// suppression check is active. The store's tables are created here (async,
+    /// fail-loud) rather than in the IMAP-worker block, because a send-only mailbox
+    /// needs them without ever polling.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ServerError::ConfigError`] if the delivery-feedback schema cannot
+    /// be created.
+    // Reason: the body awaits only under `inbound-email`; without it, `Ok(None)`.
+    #[allow(clippy::unused_async)]
+    async fn build_send_email_wiring(
         &self,
-    ) -> Option<(
-        Arc<dyn fraiseql_functions::SenderIdentityResolver>,
-        Arc<dyn fraiseql_functions::EmailTransport>,
-    )> {
+    ) -> Result<
+        Option<(
+            Arc<dyn fraiseql_functions::SenderIdentityResolver>,
+            Arc<dyn fraiseql_functions::EmailTransport>,
+        )>,
+        ServerError,
+    > {
         #[cfg(feature = "inbound-email")]
         {
-            let transport =
-                crate::inbound::email::build_email_transport(&self.config.mailbox, |name| {
-                    std::env::var(name).ok()
-                })?;
-            Some((self.build_sender_resolver(), transport))
+            // The delivery-feedback store (suppression + send-status + exactly-once)
+            // needs a database pool; without one the transport still sends, just
+            // without tracking.
+            let tracker = match self.db_pool.as_ref() {
+                Some(pool) => {
+                    let tracker = crate::inbound::email::PgSendTracker::new(pool.clone());
+                    tracker.init().await.map_err(|error| {
+                        ServerError::ConfigError(format!(
+                            "failed to initialize send-tracking schema: {error}"
+                        ))
+                    })?;
+                    Some(Arc::new(tracker) as Arc<dyn crate::inbound::email::SendTracker>)
+                },
+                None => None,
+            };
+            let address_hash_key = self.build_address_hash_key();
+            let Some(transport) = crate::inbound::email::build_email_transport(
+                &self.config.mailbox,
+                |name| std::env::var(name).ok(),
+                tracker,
+                address_hash_key,
+            ) else {
+                return Ok(None);
+            };
+            Ok(Some((self.build_sender_resolver(), transport)))
         }
         #[cfg(not(feature = "inbound-email"))]
         {
-            None
+            Ok(None)
         }
+    }
+
+    /// Derive the recipient address-hash key from the configured server HMAC secret
+    /// (domain-separated from the send-id subkey). `None` → no suppression check
+    /// (the same fail-closed posture as the unsigned idempotency token).
+    #[cfg(feature = "inbound-email")]
+    fn build_address_hash_key(&self) -> Option<Arc<[u8]>> {
+        let env_name = self.config.hmac_secret_env.as_deref()?;
+        let secret = std::env::var(env_name).ok().filter(|secret| !secret.is_empty())?;
+        let key = fraiseql_observers::derive_address_hash_key(secret.as_bytes());
+        Some(Arc::from(key.as_slice()))
     }
 
     /// The sender-identity resolver: DB-backed on the shared identity primitive

--- a/crates/fraiseql-server/src/server/functions_setup.rs
+++ b/crates/fraiseql-server/src/server/functions_setup.rs
@@ -44,7 +44,15 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         let subsystem = build_functions_subsystem(functions_config).map_err(|error| {
             ServerError::ConfigError(format!("functions-runtime setup failed: {error}"))
         })?;
-        let mut hooks = subsystem.into_before_mutation_hooks();
+
+        // Sign the per-dispatch idempotency token when an HMAC secret is
+        // configured; unsigned digest otherwise (zero-config default).
+        let idempotency_key = self.build_idempotency_key();
+        if idempotency_key.is_some() {
+            tracing::info!("idempotency tokens are HMAC-signed (VERP-ready send-ids)");
+        }
+        let mut hooks =
+            subsystem.into_before_mutation_hooks().with_idempotency_key(idempotency_key);
 
         if let Some((resolver, transport)) = self.build_send_email_wiring() {
             hooks = hooks.with_email(resolver, transport);
@@ -57,6 +65,26 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         self.functions_hooks = Some(Arc::new(hooks));
         tracing::info!(functions = function_count, "functions-runtime dispatch enabled");
         Ok(())
+    }
+
+    /// Derive the idempotency-token HMAC subkey from the configured server HMAC
+    /// secret (`hmac_secret_env` names an env var). `None` → the token stays an
+    /// unsigned digest (the zero-config default); a signed token is required before
+    /// it is exposed externally as a VERP Return-Path (P04b). A configured-but-empty
+    /// secret is a misconfiguration surfaced loudly, not silently signed with "".
+    fn build_idempotency_key(&self) -> Option<Arc<[u8]>> {
+        let env_name = self.config.hmac_secret_env.as_deref()?;
+        if let Some(secret) = std::env::var(env_name).ok().filter(|secret| !secret.is_empty()) {
+            let subkey = fraiseql_observers::derive_idempotency_subkey(secret.as_bytes());
+            Some(Arc::from(subkey.as_slice()))
+        } else {
+            tracing::warn!(
+                env = env_name,
+                "hmac_secret_env is set but the environment variable is empty/unset — \
+                 idempotency tokens stay unsigned and VERP send-correlation is disabled"
+            );
+            None
+        }
     }
 
     /// Build the `send_email` wiring — sender-identity resolver + SMTP transport —

--- a/crates/fraiseql-server/src/server/functions_setup.rs
+++ b/crates/fraiseql-server/src/server/functions_setup.rs
@@ -150,8 +150,11 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// Derive the recipient address-hash key from the configured server HMAC secret
     /// (domain-separated from the send-id subkey). `None` → no suppression check
     /// (the same fail-closed posture as the unsigned idempotency token).
+    ///
+    /// Shared with the poll-worker correlation path (`lifecycle`), which keys the
+    /// same recipient hash to write/lift suppressions.
     #[cfg(feature = "inbound-email")]
-    fn build_address_hash_key(&self) -> Option<Arc<[u8]>> {
+    pub(super) fn build_address_hash_key(&self) -> Option<Arc<[u8]>> {
         let env_name = self.config.hmac_secret_env.as_deref()?;
         let secret = std::env::var(env_name).ok().filter(|secret| !secret.is_empty())?;
         let key = fraiseql_observers::derive_address_hash_key(secret.as_bytes());

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -179,6 +179,19 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                     ))
                 })?;
 
+                // The correlator transitions send-status and suppression from
+                // inbound signals; its tables are also created by the send path,
+                // but a receive-only deployment needs them here too (idempotent).
+                let tracker = std::sync::Arc::new(email::PgSendTracker::new(db_pool.clone()));
+                tracker.init().await.map_err(|e| {
+                    ServerError::ConfigError(format!(
+                        "Failed to initialize send-tracking schema: {e}"
+                    ))
+                })?;
+                let correlator =
+                    std::sync::Arc::clone(&tracker) as std::sync::Arc<dyn email::SendCorrelator>;
+                let address_hash_key = self.build_address_hash_key();
+
                 let sink = self.storage_backend.as_ref().map(|backend| {
                     std::sync::Arc::new(email::LegacyStorageSink::new(backend.clone()))
                         as std::sync::Arc<
@@ -191,6 +204,9 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                     db_pool,
                     hooks.as_ref(),
                     sink.as_ref(),
+                    Some(&correlator),
+                    address_hash_key.as_ref(),
+                    self.config.send.challenge_suppress_after,
                     |name| std::env::var(name).ok(),
                 );
                 let started = workers.len();

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -198,6 +198,16 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                             dyn fraiseql_functions::host::live::storage::StorageBackend,
                         >
                 });
+                // Opt-in Return-Path probe: verify the provider preserves
+                // plus-addressing before trusting VERP correlation. Blocks startup
+                // up to the probe window per eligible mailbox; off by default.
+                if self.config.send.verp_probe_on_start {
+                    email::run_startup_probes(&self.config.mailbox, |name| {
+                        std::env::var(name).ok()
+                    })
+                    .await;
+                }
+
                 let hooks = app_state.before_mutation_hooks.clone();
                 let workers = email::build_workers(
                     &self.config.mailbox,

--- a/crates/fraiseql-server/src/server/routing/extensions.rs
+++ b/crates/fraiseql-server/src/server/routing/extensions.rs
@@ -74,7 +74,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             .route_layer(middleware::from_fn_with_state(auth_state, bearer_auth_middleware));
             app = app.merge(suppression_router);
             info!(
-                "Suppression admin API enabled (POST /api/email/suppress, GET \
+                "Suppression admin API enabled (POST /api/email/suppress, POST \
                  /api/email/suppression; admin bearer token required)"
             );
         }

--- a/crates/fraiseql-server/src/server/routing/extensions.rs
+++ b/crates/fraiseql-server/src/server/routing/extensions.rs
@@ -50,6 +50,35 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             );
         }
 
+        // Suppression admin API (append + query) — the operator surface for manual
+        // do-not-contact entries (support removals, GDPR requests). Same admin
+        // bearer gate; mounted only when a database pool, the admin token, and the
+        // address-hash key (the server HMAC secret) are all present, since the
+        // address must be hashed server-side before it touches the store.
+        #[cfg(feature = "inbound-email")]
+        if let (Some(pool), Some(token), Some(key)) = (
+            self.db_pool.as_ref(),
+            self.config.admin_token.as_ref(),
+            self.build_address_hash_key(),
+        ) {
+            let tracker = Arc::new(crate::inbound::email::PgSendTracker::new(pool.clone()));
+            let suppression_state =
+                Arc::new(crate::inbound::email::SuppressionAdminState::new(tracker, key));
+            let auth_state = BearerAuthState::with_max_failures(
+                token.clone(),
+                self.config.admin_auth_max_failures,
+            );
+            let suppression_router = crate::inbound::email::suppression_admin_router(
+                suppression_state,
+            )
+            .route_layer(middleware::from_fn_with_state(auth_state, bearer_auth_middleware));
+            app = app.merge(suppression_router);
+            info!(
+                "Suppression admin API enabled (POST /api/email/suppress, GET \
+                 /api/email/suppression; admin bearer token required)"
+            );
+        }
+
         // Observer routes (if enabled and compiled with feature)
         #[cfg(feature = "observers")]
         {

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -336,6 +336,22 @@ pub struct ServerConfig {
     #[serde(default)]
     pub auth_hs256: Option<Hs256Config>,
 
+    /// Name of the environment variable holding the server HMAC secret.
+    ///
+    /// When set, the per-dispatch idempotency token surfaced to functions is
+    /// HMAC-signed with a subkey derived from this secret, making it unforgeable —
+    /// required before it is exposed externally as a VERP delivery-tracking
+    /// Return-Path. Unset → the token is an unsigned digest (the zero-config
+    /// default). The secret must be **stable across restarts and shared across
+    /// instances** (a per-process random value would break resume + multi-instance
+    /// idempotency); resolved from the environment at startup, never the config file.
+    ///
+    /// ```toml
+    /// hmac_secret_env = "FRAISEQL_HMAC_SECRET"
+    /// ```
+    #[serde(default)]
+    pub hmac_secret_env: Option<String>,
+
     /// TLS/SSL configuration for HTTPS and encrypted connections.
     ///
     /// When set, enables TLS enforcement for HTTP/gRPC endpoints and
@@ -801,11 +817,12 @@ impl Default for ServerConfig {
             pool_min_size: default_pool_min_size(),
             pool_max_size: default_pool_max_size(),
             pool_timeout_secs: default_pool_timeout(),
-            auth: None,       // No auth by default
-            auth_hs256: None, // No HS256 auth by default
-            tls: None,        // TLS disabled by default
-            database_tls: None, /* Database TLS disabled
-                               * by default */
+            auth: None,            // No auth by default
+            auth_hs256: None,      // No HS256 auth by default
+            hmac_secret_env: None, // No HMAC secret → unsigned idempotency token
+            tls: None,             // TLS disabled by default
+            database_tls: None,    /* Database TLS disabled
+                                    * by default */
             require_json_content_type: true, // CSRF protection
             max_request_body_bytes: default_max_request_body_bytes(), // 1 MB
             max_header_count: default_max_header_count(), // 100 headers

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -647,6 +647,16 @@ pub struct ServerConfig {
     #[serde(default)]
     pub mailbox: HashMap<String, crate::inbound::email::MailboxConfig>,
 
+    /// Delivery-feedback send policy (`[send]`).
+    ///
+    /// Governs how the correlation step reacts to inbound bounces / challenges /
+    /// replies — currently the challenge-suppression threshold
+    /// (`challenge_suppress_after`, default 2). Requires the `inbound-email`
+    /// feature; defaults apply when the section is absent.
+    #[cfg(feature = "inbound-email")]
+    #[serde(default)]
+    pub send: crate::inbound::email::SendSettings,
+
     /// Multi-tenant executor runtime configuration.
     ///
     /// Off by default. Enable with `[tenancy.runtime] enabled = true` to mount the
@@ -846,6 +856,8 @@ impl Default for ServerConfig {
             webhooks: HashMap::new(), // No inbound webhook routes by default
             #[cfg(feature = "inbound-email")]
             mailbox: HashMap::new(), // No connected mailboxes by default
+            #[cfg(feature = "inbound-email")]
+            send: crate::inbound::email::SendSettings::default(),
             tenancy: TenancyServerConfig::default(), // Multi-tenant runtime off by default
             #[cfg(feature = "auth")]
             identity: None, // Enriched-identity resolution off by default

--- a/crates/fraiseql-server/src/subsystems/mod.rs
+++ b/crates/fraiseql-server/src/subsystems/mod.rs
@@ -198,6 +198,13 @@ pub struct BeforeMutationHooks {
     /// Email transport for the `send_email` op. `None` → `send_email` fails loud.
     #[cfg(feature = "functions-runtime")]
     pub email_transport: Option<std::sync::Arc<dyn fraiseql_functions::EmailTransport>>,
+
+    /// HMAC subkey for the per-dispatch idempotency token, derived from the server
+    /// HMAC secret. `Some` → the token is signed (unforgeable, required before it is
+    /// exposed in a VERP Return-Path); `None` → an unsigned digest (zero-config
+    /// default). Set via [`with_idempotency_key`](Self::with_idempotency_key).
+    #[cfg(feature = "functions-runtime")]
+    pub idempotency_key: Option<std::sync::Arc<[u8]>>,
 }
 
 impl BeforeMutationHooks {
@@ -226,7 +233,22 @@ impl BeforeMutationHooks {
             sender_resolver: None,
             #[cfg(feature = "functions-runtime")]
             email_transport: None,
+            #[cfg(feature = "functions-runtime")]
+            idempotency_key: None,
         }
+    }
+
+    /// Attach the HMAC subkey that signs the per-dispatch idempotency token.
+    ///
+    /// Derived once from the server HMAC secret
+    /// ([`fraiseql_observers::derive_idempotency_subkey`]). `None` leaves the token
+    /// as an unsigned digest — the zero-config default; a signed token is required
+    /// before it is exposed externally as a VERP Return-Path (P04b).
+    #[cfg(feature = "functions-runtime")]
+    #[must_use]
+    pub fn with_idempotency_key(mut self, key: Option<std::sync::Arc<[u8]>>) -> Self {
+        self.idempotency_key = key;
+        self
     }
 
     /// Enable the `send_email` host op for dispatched functions by attaching a
@@ -278,6 +300,7 @@ impl FunctionsSubsystem {
             dispatch_settings,
             sender_resolver: None,
             email_transport: None,
+            idempotency_key: None,
         }
     }
 }

--- a/crates/fraiseql-server/src/subsystems/tests.rs
+++ b/crates/fraiseql-server/src/subsystems/tests.rs
@@ -183,7 +183,8 @@ fn with_email_attaches_sender_resolver_and_transport() {
     use std::{future::Future, pin::Pin};
 
     use fraiseql_functions::{
-        EmailTransport, LoginEmailSender, SendEmailRequest, SendEmailResponse, SenderIdentity,
+        EmailTransport, LoginEmailSender, SendContext, SendEmailRequest, SendEmailResponse,
+        SenderIdentity,
     };
 
     // A transport stub so the seam test needs no SMTP / `inbound-email`.
@@ -193,6 +194,7 @@ fn with_email_attaches_sender_resolver_and_transport() {
             &'a self,
             _sender: &'a SenderIdentity,
             _request: &'a SendEmailRequest,
+            _context: SendContext<'a>,
         ) -> Pin<Box<dyn Future<Output = fraiseql_error::Result<SendEmailResponse>> + Send + 'a>>
         {
             Box::pin(async {

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -76,17 +76,24 @@ promoted from opt-in to stable.
    `sending_address` on the security/auth context**, resolved from the connected
    mailbox rather than assumed equal to the login email.
 
-4. **Idempotency keys are author-managed.** The money path is safe only because
-   the author derived a deterministic key (`qonto-invoice-${id}`) by hand. Nothing
-   in the host nudges them toward it, and a random key would silently double-spend
-   on retry. This is also what keeps the per-user follow-up send on the
-   *fire-and-forget* path for now: without a stable send-idempotency token, a
-   durable retry could double-send, and a fire-and-forget failure is simply lost —
-   neither is right for user-facing mail. **Planned: a host-provided,
-   per-dispatch-stable idempotency token** (stable across retries of the same
-   dispatch, distinct per logical operation) the guest passes straight through to
-   a downstream money or mail API, so paired sends can move to the durable path
-   safely.
+4. **Host-provided idempotency token — DELIVERED.** The guest no longer has to
+   hand-derive a deterministic key. The host exposes a per-dispatch idempotency
+   token — `Deno.core.ops.fraiseql_idempotency_token()` (WASM:
+   `get-idempotency-token`) — that the durable dispatcher derives once from the
+   dispatch's stable identity (source + function + trigger + payload data; never
+   wall-clock/random) and injects into every retry attempt. So it is **stable
+   across retries of the same dispatch and across a resume**, and **distinct per
+   logical operation**. The guest passes it straight to a downstream money/mail
+   idempotency header, so an at-least-once dispatch stays at-most-once. It is 32
+   lowercase hex characters — URL-safe and short enough for a VERP email local
+   part (`bounces+<token>@…`), which the delivery-feedback work reuses as the
+   per-send correlation id. `qonto-sync.ts` now prefers it, falling back to the
+   invoice-derived key only on a non-dispatched invocation (`null` token).
+   **Trade-off (both valid):** the host token dedups retries/redeliveries of one
+   dispatch; a content-addressed key (`qonto-invoice-${id}`) additionally dedups
+   across *different* dispatches touching the same entity — use the latter where
+   cross-dispatch money dedup matters. The dead-letter record also carries the
+   token for operator inspection/replay.
 
 5. **Permanent-error tagging — DELIVERED.** A function can now say "this failure is
    permanent, do not retry": a guest throws a tagged error

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -147,7 +147,7 @@ triggered them.
   A hard bounce suppresses immediately (permanent); repeated unanswered challenges
   suppress with a ~30-day TTL; a genuine reply lifts a challenge suppression at once.
   Both the send-status and suppression tables are tenant-scoped (explicit `tenant_id`
-  + RLS).
+  - RLS).
 
 - **Challenge policy (a hard product boundary).** Detect + correlate + **surface** +
   suppress-after-N (`[send] challenge_suppress_after`, default 2, per-recipient

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -114,6 +114,82 @@ promoted from opt-in to stable.
    rather than diffing two runs. Worth documenting for anyone adding tests; not a
    runtime problem.
 
+## Delivery feedback loop (SMTP `2xx` ≠ delivered)
+
+A `send_email` that returns success means the relay *accepted* the message — **not
+that it was delivered**. The real outcome arrives later, *inbound*: a hard bounce, a
+greylist tempfail-then-accept, or a challenge-response prompt (Mailinblack, Boxbe)
+that holds the message until the sender passes a challenge. The delivery-feedback
+loop closes that gap by correlating those inbound events back to the send that
+triggered them.
+
+- **VERP Return-Path correlation.** Each send sets the SMTP envelope sender
+  (`MAIL FROM`) to `bounces+<send-id>@<domain>` while the header `From` stays the
+  verified sending address. A bounce/challenge is addressed to the Return-Path, so it
+  lands at `bounces+<send-id>@…` and the poll-IMAP adapter recovers the `<send-id>`
+  from the recipient plus-tag (falling back to our sent `Message-ID` quoted in the
+  reply's `References`). The `<send-id>` is the per-dispatch **HMAC** idempotency
+  token — deterministic and resume-stable, but *unforgeable*, so a forged
+  `bounces+<token>@…` cannot poison another send's status. Correlation is a built-in
+  Rust step in the poll worker (platform infrastructure); app `after:ingest`
+  functions still fire afterwards for app logic.
+
+- **Send-status lifecycle — no lying `Delivered`.** A send is recorded `Sent` on
+  relay and only transitions on an inbound signal: `Bounced`, `ChallengePending`,
+  `Replied`. Delivery is *not* positively observable, so there is **no** `Delivered`
+  transition — "no news ≈ delivered". A monitoring view may *infer*
+  delivered-after-a-window, but the platform never fabricates the state.
+
+- **Suppression list + GDPR.** A do-not-contact list is checked *before every send*
+  (a suppressed recipient is a permanent refusal — the biggest deliverability lever).
+  It stores a **keyed HMAC hash of the address, never the raw address**, so a GDPR
+  erasure of the recipient's PII elsewhere leaves the "do not contact" fact intact.
+  A hard bounce suppresses immediately (permanent); repeated unanswered challenges
+  suppress with a ~30-day TTL; a genuine reply lifts a challenge suppression at once.
+  Both the send-status and suppression tables are tenant-scoped (explicit `tenant_id`
+  + RLS).
+
+- **Challenge policy (a hard product boundary).** Detect + correlate + **surface** +
+  suppress-after-N (`[send] challenge_suppress_after`, default 2, per-recipient
+  across campaigns, event-based). Challenges are **never auto-solved** for
+  cold/unsolicited outreach — it circumvents the recipient's anti-spam control,
+  torches sender-domain reputation, and (Mailinblack being a French product) the
+  recipients are under GDPR. A surfaced `ChallengePending` is a human decision point:
+  a salesperson personally solves it, or the recipient releases us.
+
+- **Exactly-once send.** Because the send-id is per-dispatch-stable, a durable retry
+  of an already-sent dispatch is detected and **skipped** (the recorded response is
+  returned), so a transient failure after the relay already accepted cannot
+  double-send.
+
+- **Greylisting.** A transient SMTP failure carries a mail-appropriate backoff floor
+  (minutes, not the policy's seconds) that the durable dispatcher honors, so a
+  greylist tempfail is retried after the greylist window rather than exhausting fast
+  retries into the DLQ.
+
+- **Return-Path probe.** Plus-addressing is provider-dependent; a provider that
+  strips the `+<send-id>` tag makes every bounce vanish and every send look
+  delivered. The opt-in startup probe (`[send] verp_probe_on_start`) sends a
+  self-addressed `bounces+probe-<nonce>@…` and confirms it lands with the tag intact,
+  turning that silent, deployment-dependent failure into a loud, diagnosable one.
+
+- **IMAP safety.** Bounce/challenge processing is **read-and-move only** — the poll
+  adapter `BODY.PEEK`s (no `\Seen`) and nothing flags-deleted + expunges. An IMAP
+  mailbox can be the only copy of irreplaceable data; the loop never destroys it.
+
+- **App surface.** Send status is read directly from `_fraiseql_send_status` under
+  RLS (keyed by the non-secret send-id — no server key needed). Suppression append +
+  query go through the admin API (`POST /api/email/suppress`,
+  `GET /api/email/suppression`, bearer-gated) because the address must be hashed
+  server-side with the server HMAC key before it touches the store.
+
+**Configuration.** `[server] hmac_secret_env` names the env var holding the root
+secret — VERP status-tracking activates only when it is set (fail-closed: no secret →
+plain token, plain Return-Path, no correlation). `[mailbox.<name>.smtp.return_path]`
+overrides the local part / domain (default `bounces`@the sending domain; a mismatched
+domain warns, since the envelope sender is the SPF/DMARC alignment target). `[send]`
+carries `challenge_suppress_after` and `verp_probe_on_start`.
+
 ## Bottom line
 
 The host surface — **secrets, HTTP, write-back, auth context, durable dispatch**

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -146,8 +146,8 @@ triggered them.
   erasure of the recipient's PII elsewhere leaves the "do not contact" fact intact.
   A hard bounce suppresses immediately (permanent); repeated unanswered challenges
   suppress with a ~30-day TTL; a genuine reply lifts a challenge suppression at once.
-  Both the send-status and suppression tables are tenant-scoped (explicit `tenant_id`
-  - RLS).
+  Both the send-status and suppression tables carry an explicit `tenant_id` column
+  and are RLS-scoped for app-facing reads.
 
 - **Challenge policy (a hard product boundary).** Detect + correlate + **surface** +
   suppress-after-N (`[send] challenge_suppress_after`, default 2, per-recipient

--- a/docs/architecture/native-runtime-ergonomics.md
+++ b/docs/architecture/native-runtime-ergonomics.md
@@ -180,8 +180,10 @@ triggered them.
 - **App surface.** Send status is read directly from `_fraiseql_send_status` under
   RLS (keyed by the non-secret send-id — no server key needed). Suppression append +
   query go through the admin API (`POST /api/email/suppress`,
-  `GET /api/email/suppression`, bearer-gated) because the address must be hashed
-  server-side with the server HMAC key before it touches the store.
+  `POST /api/email/suppression`, bearer-gated) because the address must be hashed
+  server-side with the server HMAC key before it touches the store. Both are `POST`
+  with the address in the body (never a query string), so the raw address is never
+  captured by access logs or proxies.
 
 **Configuration.** `[server] hmac_secret_env` names the env var holding the root
 secret — VERP status-tracking activates only when it is set (fail-closed: no secret →

--- a/examples/native-functions/qonto-sync.ts
+++ b/examples/native-functions/qonto-sync.ts
@@ -12,6 +12,7 @@
 // is created at-most-once even though dispatch is at-least-once.
 //
 // Host surface used (all via `Deno.core.ops.fraiseql_*`, typed by the runtime):
+//   - idempotency_token — host-provided per-dispatch idempotency key
 //   - env_var       — read the Qonto API key (a secret, allowlisted by the host)
 //   - http_request  — call Qonto (outbound HTTP, SSRF-allowlisted by the host)
 //   - query         — record the Qonto reference back onto the invoice
@@ -42,8 +43,20 @@ export default async (invoice) => {
     throw new Error("QONTO_API_KEY is not configured");
   }
 
-  // Deterministic, invoice-derived idempotency key — the money-path safety net.
-  const idempotencyKey = `qonto-invoice-${invoice.id}`;
+  // Idempotency key — the money-path safety net. The host now provides a
+  // per-dispatch token that is stable across retries and across a resume
+  // (derived from the dispatch's identity, never wall-clock/random), so we no
+  // longer have to hand-derive one. We fall back to an invoice-derived key on a
+  // non-dispatched invocation (e.g. a one-shot `fraiseql query` run), where no
+  // host token exists.
+  //
+  // Trade-off — both are valid: the host token dedups retries and redeliveries
+  // of THIS dispatch. If you also need to dedup across DIFFERENT dispatches that
+  // touch the same invoice (a manual backfill AND this auto-sync), make the
+  // content-addressed `qonto-invoice-${invoice.id}` the primary instead — it
+  // gives the strongest cross-dispatch guarantee at the cost of hand-derivation.
+  const idempotencyKey =
+    Deno.core.ops.fraiseql_idempotency_token() || `qonto-invoice-${invoice.id}`;
 
   const reqBody = Deno.core.encode(JSON.stringify({
     reference:    invoice.reference,


### PR DESCRIPTION
Native-runtime hardening: **P04 (host idempotency token)** + **P04b (delivery feedback loop)**. Both features are **opt-in** (`inbound-email` + `functions-runtime`); version stays provisional. Merging this lands the previously-held P04 too (P04b is stacked on it).

## P04 — host idempotency token
A per-dispatch-stable, resume-stable, distinct-per-op token surfaced to functions (Deno op + WASM wit), derived once by the durable dispatcher from the dispatch's stable identity (never wall-clock/random) and injected into every retry attempt — so an at-least-once dispatch stays at-most-once. 32 lowercase hex, VERP-local-part-safe.

## P04b — delivery feedback loop
Turns `send_email` (SMTP `2xx` = accepted, not delivered) into a **tracked delivery**; the real outcome arrives inbound.

- **C1 — HMAC send-id.** The token becomes HMAC-signed when `[server] hmac_secret_env` is set (unforgeable before it is exposed in a VERP Return-Path); plain digest otherwise (zero-config preserved).
- **C2 — VERP + stores + exactly-once.** Envelope `MAIL FROM: bounces+<send-id>@domain` (header `From` unchanged); `_fraiseql_send_status` + `_fraiseql_suppression` (tenant RLS; suppression stores a **keyed hash of the address, never raw** → survives GDPR erasure); suppression-checked-before-send; a durable retry of an already-sent dispatch is **skipped** (exactly-once). `[mailbox.*.smtp.return_path]` config (defaults `bounces`@sending-domain, warns on SPF/DMARC misalignment).
- **C3 — correlation + challenge policy + app surface.** Built-in poll-worker step correlates an inbound bounce/challenge/reply back to its send (plus-tag → `References` fallback) and transitions status: Bounce→`Bounced`+suppress; Challenge→`ChallengePending`, per-recipient count, suppress at N (`[send] challenge_suppress_after`, default 2, event-based, **surfaced never auto-solved**); Reply→`Replied`+lift the challenge suppression. Operator surface: `POST /api/email/suppress` / `POST /api/email/suppression` (bearer, server-side hashing, address in the body — never a query string). IMAP is read-and-move only.
- **C4 — probe + greylisting + docs.** Opt-in startup Return-Path probe (`[send] verp_probe_on_start`) verifies the provider preserves plus-addressing; transient SMTP failures carry a mail-appropriate backoff floor the durable dispatcher honors (greylisting); no lying `Delivered` state; docs + CHANGELOG.

## Verification
- `make preflight` green (fmt-check[nightly] + shell ratchets + rustdoc `-D --all-features` + workspace clippy `--all-targets --all-features -D warnings`), post-rebase onto current dev.
- Feature legs green: observers 555, functions `runtime-deno,host-live` 322, server `inbound-email` 2383 — only the 11 pre-existing `DATABASE_URL` integration failures (untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
