### PR TITLE
ci(docker): ghcr login via GITHUB_TOKEN (fix v2.11.0 image-push failure)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -62,8 +62,13 @@ jobs:
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
+          # Use the built-in, per-run GITHUB_TOKEN (this job declares
+          # `packages: write` above) instead of a long-lived `GHCR_PAT` secret. The
+          # PAT expired/rotated and denied the v2.11.0 image push (it had worked
+          # through v2.10.0); the scoped GITHUB_TOKEN never expires and aligns with
+          # the token-least-privilege posture (#545).
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
@@ -259,13 +264,15 @@ jobs:
     steps:
       - name: Create deployment summary
         run: |
-          echo "## 🎉 Docker Images Built Successfully" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Registry**: GitHub Container Registry (ghcr.io)" >> $GITHUB_STEP_SUMMARY
-          echo "**Images**:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository_owner }}/server\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository_owner }}/server-full\` (rest-transport, arrow)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository_owner }}/tutorial\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch**: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 🎉 Docker Images Built Successfully"
+            echo ""
+            echo "**Registry**: GitHub Container Registry (ghcr.io)"
+            echo "**Images**:"
+            echo "- \`ghcr.io/${{ github.repository_owner }}/server\`"
+            echo "- \`ghcr.io/${{ github.repository_owner }}/server-full\` (rest-transport, arrow)"
+            echo "- \`ghcr.io/${{ github.repository_owner }}/tutorial\`"
+            echo ""
+            echo "**Branch**: ${{ github.ref }}"
+            echo "**Commit**: ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The `v2.11.0` tag's **Build and Push Docker Images** run failed at the ghcr login step (`denied: denied`) because `secrets.GHCR_PAT` had expired/rotated — Docker builds succeeded v2.7.0 → v2.10.0 and this was the first failure, around the 2026-07-04 token-least-privilege hygiene. **The core release was unaffected** (crates.io / npm / PyPI / GitHub Release all published fine); only the server Docker images didn't push.

## What

- **ghcr login → `GITHUB_TOKEN`.** The `build-and-push` job already declares `permissions: packages: write`, so the built-in per-run token can push and there's no long-lived PAT to expire — aligns with the #545 least-privilege posture. The separate Docker Hub publish keeps its own `DOCKER_HUB_*` secrets.
- **actionlint cleanup** in the same file (surfaced because the change re-lints it): quote `$GITHUB_STEP_SUMMARY` (SC2086) and group the redirects into one block (SC2129).

## Caveat / follow-up

- Verify the `ghcr.io/fraiseql/*` packages grant the repo's `GITHUB_TOKEN` write access (Package settings → Manage Actions access). Login will now succeed; if a *push* is denied, that setting is why.
- This fixes releases **from the next tag onward**. Getting **v2.11.0's** images out specifically still needs a re-run against a valid credential (the tag's workflow definition is immutable) — either refresh `GHCR_PAT` and re-run the failed run, or `workflow_dispatch` once this is on a tag.

## Verification
✅ pre-commit (actionlint, yaml) — all pass
✅ YAML validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)