### PR TITLE
fix(cli): compile-error observability + entity-identity contract (ADR-0017)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -26,7 +26,11 @@ ignore = [
   # quick-xml DoS pair (published 2026-07-02); transitive via samael 0.0.21 (auth-saml opt-in
   # only, NOT default build); samael pins quick-xml 0.37.5, no fix in range. Deadline 2026-10-01.
   "RUSTSEC-2026-0194",
-  "RUSTSEC-2026-0195"
+  "RUSTSEC-2026-0195",
+  # crossbeam-epoch 0.9.18 fmt::Pointer invalid-pointer deref; only on Debug-formatting an
+  # invalid Atomic/Shared pointer (never done). Transitive via rayon (criterion dev-deps).
+  # Deadline 2026-10-01.
+  "RUSTSEC-2026-0204"
 ]
 # Surface unsound + unmaintained advisories as warnings so new soundness issues are visible
 # in `cargo audit` output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   updatedFields }` whose `cascade: CascadeUpdates` carries `updated`
   (`[UpdatedEntity!]!`), `deleted` (`[DeletedEntity!]!`), `metadata`
   (`CascadeMetadata!`), and `invalidations` (`[QueryInvalidation!]!`) — a
-  `CascadeNode` interface is auto-implemented on every queryable entity so cascade
-  entities are selectable via inline fragments. At runtime every cascade entity is
+  `CascadeNode` interface (`id: ID!`) is auto-implemented on every queryable entity
+  (which must therefore expose `id: ID!`; the compiler fails fast with an
+  aggregated, actionable error otherwise) so cascade entities are selectable via
+  inline fragments. At runtime every cascade entity is
   projected to camelCase and run through the field-level authorizer (#423) exactly
   like a queried entity; cascade is selection-gated (never injected unrequested);
   the response is bounded by `RuntimeConfig.cascade_limits` (max affected entities →
@@ -433,6 +435,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fraiseql compile` now surfaces the full error cause chain.** Converter
+  failures printed only the top-level context (e.g. `Failed to convert schema to
+  compiled format`) with the underlying reason swallowed at every log level and in
+  `--json` — the cause was reachable only via the undocumented `--debug` flag, and
+  never in JSON. The CLI now renders the whole `anyhow` source chain in both modes:
+  `  caused by: …` lines in human output and a `"causes": [...]` array in `--json`
+  (additive; `message`/`code` unchanged). Applies to every command, not just
+  `compile`.
+- **Cascade/Relay type synthesis no longer emits a schema that fails its own
+  validator.** Auto-implementing `CascadeNode` (cascade) or `Node` (`relay = true`)
+  on an entity whose `id` was `UUID`/`Int` or absent produced IR that the
+  compiled-schema validator then rejected with a swallowed "missing field 'id'"
+  bail — so a schema that compiled under 2.10 could fail under 2.11 (which began
+  honoring the previously-dropped SDK `cascade` flag) with the real reason hidden.
+  The conformance check now runs *before* the `implements` push and fails fast with
+  one aggregated, actionable error naming every offending type, its actual id type,
+  and the remedy.
+- **The compiled-schema validator recognizes interfaces as valid return types.** A
+  query or mutation returning an interface type (narrowed via inline fragments) is
+  now accepted instead of silently failing the type-reference check; every
+  validator rejection also logs a `warn!`, not just the query-return case.
 - **Native-column `WHERE` filters no longer 500 on a camelCase argument (#540).**
   A filter argument on a native (real-column) field emitted the camelCase argument
   name verbatim as the SQL column — `comments(postId: …)` became `WHERE postId = …`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`[UpdatedEntity!]!`), `deleted` (`[DeletedEntity!]!`), `metadata`
   (`CascadeMetadata!`), and `invalidations` (`[QueryInvalidation!]!`) — a
   `CascadeNode` interface (`id: ID!`) is auto-implemented on every queryable entity
-  (which must therefore expose `id: ID!`; the compiler fails fast with an
-  aggregated, actionable error otherwise) so cascade entities are selectable via
-  inline fragments. At runtime every cascade entity is
+  (the Trinity `id: UUID` canonicalizes to `id: ID` per the entity-identity contract,
+  ADR-0017; a non-identity id fails fast with an aggregated, actionable error) so
+  cascade entities are selectable via inline fragments. At runtime every cascade
+  entity is
   projected to camelCase and run through the field-level authorizer (#423) exactly
   like a queried entity; cascade is selection-gated (never injected unrequested);
   the response is bounded by `RuntimeConfig.cascade_limits` (max affected entities →
@@ -381,6 +382,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Entity-identity contract: `id: UUID` is canonicalized to `id: ID` (ADR-0017).**
+  FraiseQL now treats a global `id: ID!` as a first-class invariant consumed
+  uniformly by cascade, Relay `Node`, and federation `@key(fields: "id")` — rather
+  than each subsystem re-deriving identity from heterogeneous id types. The compiler
+  rewrites the Trinity external id (`id: UUID`) to `id: ID` on every output object
+  type. This is **wire-transparent** — a UUID and an `ID` serialize to the same JSON
+  string — so clients are unaffected; only introspection/SDL now reports `id: ID`
+  where it previously reported `id: UUID`. Non-identity ids (a serial `id: Int`, or
+  no `id`) are left as-is and must expose `id: ID` (a UUID surrogate) to use
+  cascade/Relay. See ADR-0017 and `docs/architecture/mutation-response.md`.
 - **Inbound email config renamed: `[imap.<name>]` → `[mailbox.<name>.imap]` (breaking).**
   A connected mail account now has one section, `[mailbox.<name>]`, carrying both its
   poll-IMAP *receive* half (`[mailbox.<name>.imap]`) and its SMTP *send* half
@@ -449,9 +460,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiled-schema validator then rejected with a swallowed "missing field 'id'"
   bail — so a schema that compiled under 2.10 could fail under 2.11 (which began
   honoring the previously-dropped SDK `cascade` flag) with the real reason hidden.
-  The conformance check now runs *before* the `implements` push and fails fast with
-  one aggregated, actionable error naming every offending type, its actual id type,
-  and the remedy.
+  Resolved by the entity-identity contract (see *Changed*): the Trinity `id: UUID`
+  now canonicalizes to `id: ID` and satisfies the interface automatically, and any
+  residual non-identity id (`Int`, absent) fails fast — *before* the `implements`
+  push — with one aggregated, actionable error naming every offending type and the
+  remedy, instead of a swallowed bail.
 - **The compiled-schema validator recognizes interfaces as valid return types.** A
   query or mutation returning an interface type (narrowed via inline fragments) is
   now accepted instead of silently failing the type-reference check; every

--- a/crates/fraiseql-cli/src/runner.rs
+++ b/crates/fraiseql-cli/src/runner.rs
@@ -599,7 +599,11 @@ pub async fn run() {
         } else {
             None
         };
-        eprintln!("{}", format_cli_error(&e.to_string(), debug_info.as_deref(), json_output, 1));
+        let causes = error_causes(&e);
+        eprintln!(
+            "{}",
+            format_cli_error(&e.to_string(), &causes, debug_info.as_deref(), json_output, 1)
+        );
         process::exit(1);
     }
 }
@@ -624,19 +628,37 @@ fn enforce_exit_code(result: &crate::output::CommandResult) {
     }
 }
 
+/// Extract an `anyhow` error's source chain — every cause **below** the top-level
+/// message — as display strings, outermost first.
+///
+/// The top-level context (rendered as the error `message`) is skipped, so a
+/// `.context("outer")` over a `bail!("root")` yields `["root"]`. Surfacing this
+/// chain is what turns an opaque `Failed to convert schema to compiled format`
+/// into an actionable `… caused by: Type 'Order' … is missing field 'id'`.
+pub(crate) fn error_causes(err: &anyhow::Error) -> Vec<String> {
+    err.chain().skip(1).map(ToString::to_string).collect()
+}
+
 /// Format a CLI error as either plain text or a JSON object for machine-readable output.
+///
+/// `causes` is the error's source chain below `message` (see [`error_causes`]); it is
+/// surfaced in **both** output modes so a failure is never reduced to its top-level
+/// context alone.
 ///
 /// When `json` is `true`, produces a JSON object:
 /// ```json
-/// { "error": { "message": "...", "code": 1 } }
+/// { "error": { "message": "...", "causes": ["..."], "code": 1 } }
 /// ```
 /// When `json` is `false`, produces a human-readable string:
 /// ```text
 /// Error: <message>
+///   caused by: <cause 1>
+///   caused by: <cause 2>
 /// ```
 /// If `debug_info` is provided and `json` is `false`, a debug section is appended.
 pub(crate) fn format_cli_error(
     message: &str,
+    causes: &[String],
     debug_info: Option<&str>,
     json: bool,
     code: i32,
@@ -645,12 +667,16 @@ pub(crate) fn format_cli_error(
         serde_json::json!({
             "error": {
                 "message": message,
+                "causes": causes,
                 "code": code
             }
         })
         .to_string()
     } else {
         let mut out = format!("Error: {message}");
+        for cause in causes {
+            out.push_str(&format!("\n  caused by: {cause}"));
+        }
         if let Some(debug) = debug_info {
             out.push_str("\n\nDebug info:\n");
             out.push_str(debug);

--- a/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
@@ -64,7 +64,7 @@ const INVALIDATION_SCOPE: &str = "InvalidationScope";
 /// payload wrappers, then rewrite cascade mutations to return their payloads.
 ///
 /// Inert unless a mutation has `cascade = true`.
-pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) {
+pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) -> anyhow::Result<()> {
     let cascade_mutation_indices: Vec<usize> = schema
         .mutations
         .iter()
@@ -73,8 +73,19 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) {
         .map(|(idx, _)| idx)
         .collect();
     if cascade_mutation_indices.is_empty() {
-        return;
+        return Ok(());
     }
+
+    // Enforce the graphql-cascade Node contract *before* forcing `implements
+    // CascadeNode`: an entity that cannot back `id: ID!` would otherwise yield a
+    // compiled schema that `validate()` rejects with a swallowed "missing field
+    // 'id'". Fail fast with one aggregated, actionable error instead.
+    super::interface_conformance::enforce_node_id_conformance(
+        schema.types.iter().filter(|t| is_queryable_entity(t)),
+        "cascade requires `id: ID!` on every cascade entity (the graphql-cascade CascadeNode \
+         interface requires it)",
+        "remove `cascade` from the mutations that return them",
+    )?;
 
     let existing_type_names: HashSet<String> =
         schema.types.iter().map(|t| t.name.to_string()).collect();
@@ -88,11 +99,7 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) {
         schema.interfaces.push(cascade_node_interface());
     }
     for ty in &mut schema.types {
-        // Queryable entity types only: view-backed and non-error. Synthetic types
-        // (the cascade envelope, payloads, MutationError) have an empty sql_source
-        // and are skipped, as are relay connection/edge wrappers.
-        let is_queryable_entity = !ty.is_error && !ty.sql_source.as_str().is_empty();
-        if is_queryable_entity && !ty.implements.iter().any(|i| i == CASCADE_NODE) {
+        if is_queryable_entity(ty) && !ty.implements.iter().any(|i| i == CASCADE_NODE) {
             ty.implements.push(CASCADE_NODE.to_string());
         }
     }
@@ -152,6 +159,16 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) {
         }
         schema.mutations[idx].return_type = payload_name;
     }
+
+    Ok(())
+}
+
+/// A queryable entity type: view-backed and non-error. The `CascadeNode` interface
+/// is auto-implemented on exactly these. Synthetic types (the cascade envelope,
+/// payloads, `MutationError`) have an empty `sql_source` and are excluded, as are
+/// relay connection/edge wrappers.
+fn is_queryable_entity(ty: &TypeDefinition) -> bool {
+    !ty.is_error && !ty.sql_source.as_str().is_empty()
 }
 
 /// `createUser` → `CreateUserPayload`. Uppercases the first character (mutation

--- a/crates/fraiseql-cli/src/schema/converter/identity.rs
+++ b/crates/fraiseql-cli/src/schema/converter/identity.rs
@@ -1,0 +1,34 @@
+//! The FraiseQL entity-identity contract (ADR-0017): every entity's `id` field is a
+//! global GraphQL `ID`.
+//!
+//! The Trinity pattern (`examples/_TEMPLATE`) backs each entity with three columns —
+//! `pk_<entity>` (internal `INTEGER` join key, never exposed), **`id UUID`** (the
+//! external, stable identity), and `identifier TEXT` (an optional human-readable
+//! business key). The external identity is the `id UUID` column.
+//!
+//! GraphQL's `ID` scalar is the spec's opaque, stringified identifier — and a `UUID`
+//! serializes as the *same* JSON string. So an authored `id: UUID` is canonicalized
+//! to `id: ID` at compile time: **wire-transparent**, but it lets every Trinity
+//! entity satisfy the `Node` / `CascadeNode` interfaces uniformly (cascade, Relay,
+//! federation `@key(fields: "id")`) instead of each id-consuming subsystem
+//! rediscovering the type heterogeneity. Non-UUID `id` shapes (`Int`, custom) are
+//! left as authored; an entity that then opts into a Node-style interface must
+//! expose `id: ID` (enforced by [`super::interface_conformance`]).
+
+use fraiseql_core::schema::{CompiledSchema, FieldType};
+
+/// Canonicalize each output object type's `id` field from `UUID` to `ID` — the
+/// Trinity external identity, wire-identical to `ID`.
+///
+/// Runs before Relay/cascade synthesis so the interfaces they auto-implement see a
+/// conformant `id: ID`. A no-op for an `id` already typed `ID` (or any non-`UUID`
+/// shape) and for types with no `id` field.
+pub(super) fn normalize_entity_identity(schema: &mut CompiledSchema) {
+    for ty in &mut schema.types {
+        for field in &mut ty.fields {
+            if field.name == "id" && field.field_type == FieldType::Uuid {
+                field.field_type = FieldType::Id;
+            }
+        }
+    }
+}

--- a/crates/fraiseql-cli/src/schema/converter/interface_conformance.rs
+++ b/crates/fraiseql-cli/src/schema/converter/interface_conformance.rs
@@ -1,0 +1,65 @@
+//! Shared `id: ID!` conformance enforcement for the Node-style interfaces that the
+//! compiler auto-implements on entities: `CascadeNode` (graphql-cascade) and `Node`
+//! (Relay).
+//!
+//! Both interfaces declare `id: ID!` and are force-added to entities by their
+//! synthesis passes ([`super::cascade_types`], [`super::relay`]). An entity that
+//! does not expose `id: ID!` cannot back the interface, so the pass must fail fast
+//! with one aggregated, actionable error — rather than emit a schema that later
+//! fails the compiled-schema validator with a swallowed "missing field 'id'" bail
+//! (the invariant: no synthesis pass may produce IR that `validate()` rejects).
+
+use anyhow::bail;
+use fraiseql_core::schema::{FieldType, TypeDefinition};
+
+/// Why a type fails the Node-style `id: ID!` contract.
+enum IdDefect {
+    /// Has an `id` field, but not of type `ID` (e.g. `UUID`).
+    WrongType(String),
+    /// No `id` field at all.
+    Missing,
+}
+
+/// A type conforms to the Node-style interface field `id: ID!` iff it has a field
+/// named `id` of type [`FieldType::Id`].
+///
+/// Nullability is intentionally *not* required — this mirrors the compiled-schema
+/// validator's own interface-conformance rule, which compares only field name and
+/// type. Tightening it here would reject schemas that compile today.
+fn id_defect(ty: &TypeDefinition) -> Option<IdDefect> {
+    match ty.fields.iter().find(|f| f.name == "id") {
+        Some(f) if f.field_type == FieldType::Id => None,
+        Some(f) => Some(IdDefect::WrongType(f.field_type.to_graphql_string())),
+        None => Some(IdDefect::Missing),
+    }
+}
+
+/// Fail with one aggregated, actionable error if any `entities` cannot back a
+/// Node-style interface (`id: ID!`).
+///
+/// `lead` is the opening sentence (names the feature + the interface contract);
+/// `remedy` completes the `Fix:` line's "or …" clause. Entities are reported in
+/// iteration order so the message is deterministic. Returns `Ok(())` when every
+/// entity conforms.
+pub(super) fn enforce_node_id_conformance<'a>(
+    entities: impl Iterator<Item = &'a TypeDefinition>,
+    lead: &str,
+    remedy: &str,
+) -> anyhow::Result<()> {
+    let offenders: Vec<String> = entities
+        .filter_map(|ty| id_defect(ty).map(|defect| (ty.name.to_string(), defect)))
+        .map(|(name, defect)| match defect {
+            IdDefect::WrongType(actual) => format!("  - Type '{name}': `id` is {actual}, not ID"),
+            IdDefect::Missing => format!("  - Type '{name}': no `id` field"),
+        })
+        .collect();
+
+    if offenders.is_empty() {
+        return Ok(());
+    }
+
+    bail!(
+        "{lead}:\n{}\nFix: expose `id: ID!` on each type, or {remedy}.",
+        offenders.join("\n"),
+    );
+}

--- a/crates/fraiseql-cli/src/schema/converter/mod.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mod.rs
@@ -4,6 +4,7 @@
 
 mod cascade_types;
 mod directives;
+mod identity;
 mod interface_conformance;
 mod mutation_error_union;
 mod mutations;
@@ -263,6 +264,11 @@ impl SchemaConverter {
                 );
             }
         }
+
+        // Canonicalize the Trinity external identity (`id: UUID` → `id: ID`, ADR-0017)
+        // before the interface-forcing passes, so Relay `Node` / `CascadeNode` see a
+        // conformant `id: ID` on every entity. Wire-transparent (a UUID is an `ID`).
+        identity::normalize_entity_identity(&mut compiled);
 
         // Inject synthetic Relay types (PageInfo, Node interface, XxxConnection, XxxEdge).
         relay::inject_relay_types(&mut compiled)?;

--- a/crates/fraiseql-cli/src/schema/converter/mod.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mod.rs
@@ -352,10 +352,15 @@ impl SchemaConverter {
             type_names.insert(type_def.name.to_string());
         }
 
-        // Build interface registry
+        // Build interface registry. Interfaces are *also* valid query/mutation
+        // return types (a field may return an interface, narrowed via inline
+        // fragments), so register them in `type_names` too — previously omitted,
+        // which made a query/mutation returning an interface silently fail the
+        // reference check below.
         let mut interface_names = HashSet::new();
         for interface_def in &schema.interfaces {
             interface_names.insert(interface_def.name.clone());
+            type_names.insert(interface_def.name.clone());
         }
 
         // Add input types — valid as mutation argument types (fraiseql/fraiseql#190)
@@ -397,6 +402,10 @@ impl SchemaConverter {
             for arg in &query.arguments {
                 let type_name = Self::extract_type_name(&arg.arg_type);
                 if !type_names.contains(&type_name) {
+                    warn!(
+                        "Query '{}' argument '{}' references unknown type: {}",
+                        query.name, arg.name, type_name
+                    );
                     anyhow::bail!(
                         "Query '{}' argument '{}' references unknown type '{}'",
                         query.name,
@@ -410,6 +419,10 @@ impl SchemaConverter {
         // Validate mutations
         for mutation in &schema.mutations {
             if !type_names.contains(&mutation.return_type) {
+                warn!(
+                    "Mutation '{}' references unknown type: {}",
+                    mutation.name, mutation.return_type
+                );
                 anyhow::bail!(
                     "Mutation '{}' references unknown type '{}'",
                     mutation.name,
@@ -421,6 +434,10 @@ impl SchemaConverter {
             for arg in &mutation.arguments {
                 let type_name = Self::extract_type_name(&arg.arg_type);
                 if !type_names.contains(&type_name) {
+                    warn!(
+                        "Mutation '{}' argument '{}' references unknown type: {}",
+                        mutation.name, arg.name, type_name
+                    );
                     anyhow::bail!(
                         "Mutation '{}' argument '{}' references unknown type '{}'",
                         mutation.name,
@@ -435,6 +452,10 @@ impl SchemaConverter {
         for type_def in &schema.types {
             for interface_name in &type_def.implements {
                 if !interface_names.contains(interface_name) {
+                    warn!(
+                        "Type '{}' implements unknown interface: {}",
+                        type_def.name, interface_name
+                    );
                     anyhow::bail!(
                         "Type '{}' implements unknown interface '{}'",
                         type_def.name,
@@ -450,6 +471,10 @@ impl SchemaConverter {
                                 && f.field_type == interface_field.field_type
                         });
                         if !type_has_field {
+                            warn!(
+                                "Type '{}' implements interface '{}' but is missing field: {}",
+                                type_def.name, interface_name, interface_field.name
+                            );
                             anyhow::bail!(
                                 "Type '{}' implements interface '{}' but is missing field '{}'",
                                 type_def.name,

--- a/crates/fraiseql-cli/src/schema/converter/mod.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mod.rs
@@ -4,6 +4,7 @@
 
 mod cascade_types;
 mod directives;
+mod interface_conformance;
 mod mutation_error_union;
 mod mutations;
 mod queries;
@@ -264,7 +265,7 @@ impl SchemaConverter {
         }
 
         // Inject synthetic Relay types (PageInfo, Node interface, XxxConnection, XxxEdge).
-        relay::inject_relay_types(&mut compiled);
+        relay::inject_relay_types(&mut compiled)?;
 
         // Compile rich filter types (EmailAddress, VIN, IBAN, etc.)
         let rich_filter_config = RichFilterConfig::default();
@@ -281,7 +282,7 @@ impl SchemaConverter {
         // payload becomes the success member of the result union
         // (`<Name>Result = <Name>Payload | MutationError`). Inert with no cascade
         // mutations.
-        cascade_types::synthesize_cascade_types(&mut compiled);
+        cascade_types::synthesize_cascade_types(&mut compiled)?;
 
         // Auto-synthesize a shared MutationError type + per-mutation result unions
         // when opted in (`[fraiseql.mutations] auto_error_union`), so the runtime's

--- a/crates/fraiseql-cli/src/schema/converter/relay.rs
+++ b/crates/fraiseql-cli/src/schema/converter/relay.rs
@@ -14,14 +14,23 @@ use fraiseql_core::schema::{
 /// - `PageInfo` type (once): `{ hasNextPage: Boolean!, hasPreviousPage: Boolean!, startCursor:
 ///   String, endCursor: String }`
 /// - `Node` interface (once): `{ id: ID! }`
-pub(super) fn inject_relay_types(schema: &mut CompiledSchema) {
+pub(super) fn inject_relay_types(schema: &mut CompiledSchema) -> anyhow::Result<()> {
     // Collect relay type names (those with relay=true).
     let relay_types: Vec<String> =
         schema.types.iter().filter(|t| t.relay).map(|t| t.name.to_string()).collect();
 
     if relay_types.is_empty() {
-        return;
+        return Ok(());
     }
+
+    // Enforce the Relay Node contract before forcing `implements Node`: a relay
+    // type that cannot back `id: ID!` would otherwise yield a compiled schema that
+    // `validate()` rejects with a swallowed "missing field 'id'".
+    super::interface_conformance::enforce_node_id_conformance(
+        schema.types.iter().filter(|t| t.relay),
+        "relay = true requires `id: ID!` on every Relay type (the Relay Node interface requires it)",
+        "remove `relay = true` from them",
+    )?;
 
     // --- Node interface (inject once if not already present) ---
     let has_node_interface = schema.interfaces.iter().any(|i| i.name == "Node");
@@ -210,4 +219,6 @@ pub(super) fn inject_relay_types(schema: &mut CompiledSchema) {
     }
 
     schema.types.extend(new_types);
+
+    Ok(())
 }

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2086,6 +2086,150 @@ mod tenancy_tests {
         assert!(!post.implements.iter().any(|i| i == "CascadeNode"));
     }
 
+    // ── Node `id: ID!` conformance enforcement (Option B: hard error) ──────
+
+    /// A view-backed entity with a chosen `id` field type — for conformance tests.
+    fn entity_with_id(name: &str, id_ty: &str) -> IntermediateType {
+        IntermediateType {
+            sql_source: Some(format!("v_{}", name.to_lowercase())),
+            ..make_type(name, vec![make_field("id", id_ty)])
+        }
+    }
+
+    /// A cascade mutation returning `entity` — the opt-in that triggers synthesis.
+    fn cascade_mut(name: &str, entity: &str) -> IntermediateMutation {
+        IntermediateMutation {
+            cascade: true,
+            sql_source: Some(format!("fn_{}", name.to_lowercase())),
+            ..make_mutation(name, entity)
+        }
+    }
+
+    /// The regression: a cascade entity whose `id` is `UUID` (not `ID`) must fail
+    /// with a legible, actionable error at synthesis — not a swallowed validator
+    /// bail. The message names the type, its actual id type, and the remedy.
+    #[test]
+    fn cascade_uuid_id_entity_fails_with_actionable_error() {
+        use crate::schema::SchemaConverter;
+        let schema = make_schema(
+            vec![entity_with_id("Order", "UUID")],
+            vec![],
+            vec![cascade_mut("createOrder", "Order")],
+        );
+        let err = SchemaConverter::convert(schema).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Order"), "names the offending type: {msg}");
+        assert!(msg.contains("UUID"), "names the actual id type (not just 'missing'): {msg}");
+        assert!(msg.contains("id: ID!"), "states the required shape: {msg}");
+        assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
+    }
+
+    /// A cascade entity with no `id` field at all (e.g. keyed on another column)
+    /// fails the same way, with the "no `id` field" wording.
+    #[test]
+    fn cascade_missing_id_entity_fails_with_actionable_error() {
+        use crate::schema::SchemaConverter;
+        let order = IntermediateType {
+            sql_source: Some("v_order".to_string()),
+            ..make_type("Order", vec![make_field("orderNumber", "String")])
+        };
+        let schema = make_schema(vec![order], vec![], vec![cascade_mut("createOrder", "Order")]);
+        let err = SchemaConverter::convert(schema).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Order") && msg.contains("no `id` field"), "{msg}");
+        assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
+    }
+
+    /// One error lists *every* offender, so a developer fixes them in one pass
+    /// rather than whack-a-mole.
+    #[test]
+    fn cascade_conformance_error_aggregates_all_offenders() {
+        use crate::schema::SchemaConverter;
+        let schema = make_schema(
+            vec![
+                entity_with_id("Order", "UUID"),
+                entity_with_id("Invoice", "Int"),
+            ],
+            vec![],
+            vec![cascade_mut("createOrder", "Order")],
+        );
+        let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
+        assert!(msg.contains("Order") && msg.contains("Invoice"), "lists both offenders: {msg}");
+    }
+
+    /// Happy-path guard: a conformant `id: ID!` cascade entity still synthesizes
+    /// and implements `CascadeNode` (the fix must not over-correct).
+    #[test]
+    fn cascade_conformant_id_entity_still_implements_cascade_node() {
+        use crate::schema::SchemaConverter;
+        let schema = make_schema(
+            vec![entity_with_id("Order", "ID")],
+            vec![],
+            vec![cascade_mut("createOrder", "Order")],
+        );
+        let compiled =
+            SchemaConverter::convert(schema).expect("conformant cascade schema compiles");
+        let order = compiled.types.iter().find(|t| t.name.as_str() == "Order").unwrap();
+        assert!(order.implements.iter().any(|i| i == "CascadeNode"));
+    }
+
+    /// The identical latent defect in Relay `Node` injection is now a legible error
+    /// too (previously a swallowed validator bail).
+    #[test]
+    fn relay_uuid_id_type_fails_with_actionable_error() {
+        use crate::schema::SchemaConverter;
+        let mut order = entity_with_id("Order", "UUID");
+        order.relay = true;
+        let schema = make_schema(vec![order], vec![make_query("orders", "Order")], vec![]);
+        let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
+        assert!(msg.contains("Order") && msg.contains("relay"), "{msg}");
+        assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
+    }
+
+    /// Phase-2 soundness invariant: no synthesis pass may emit IR that `validate()`
+    /// rejects with a swallowed bail. Across id types × interface-forcing features,
+    /// `convert()` must either succeed or fail with a *legible* synthesis error
+    /// (a `Fix:` remedy) — never leak the raw validator "…is missing field 'id'".
+    #[test]
+    fn synthesis_never_leaks_a_raw_validator_bail() {
+        use crate::schema::SchemaConverter;
+
+        let mut cases: Vec<(String, bool, IntermediateSchema)> = Vec::new();
+        for (id_ty, expect_ok) in [("ID", true), ("UUID", false), ("Int", false)] {
+            cases.push((
+                format!("cascade+{id_ty}"),
+                expect_ok,
+                make_schema(
+                    vec![entity_with_id("Order", id_ty)],
+                    vec![],
+                    vec![cascade_mut("createOrder", "Order")],
+                ),
+            ));
+            let mut order = entity_with_id("Order", id_ty);
+            order.relay = true;
+            cases.push((
+                format!("relay+{id_ty}"),
+                expect_ok,
+                make_schema(vec![order], vec![make_query("orders", "Order")], vec![]),
+            ));
+        }
+
+        for (label, expect_ok, schema) in cases {
+            match SchemaConverter::convert(schema) {
+                Ok(_) => assert!(expect_ok, "{label} unexpectedly compiled"),
+                Err(e) => {
+                    let msg = format!("{e:#}");
+                    assert!(!expect_ok, "{label} unexpectedly failed: {msg}");
+                    assert!(msg.contains("Fix:"), "{label} error is not legible: {msg}");
+                    assert!(
+                        !msg.contains("but is missing field"),
+                        "{label} leaked the raw validator bail: {msg}"
+                    );
+                },
+            }
+        }
+    }
+
     #[test]
     fn auto_inject_uses_custom_claim() {
         let mut schema = make_schema(

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2086,9 +2086,9 @@ mod tenancy_tests {
         assert!(!post.implements.iter().any(|i| i == "CascadeNode"));
     }
 
-    // ── Node `id: ID!` conformance enforcement (Option B: hard error) ──────
+    // ── Entity-identity contract (ADR-0017) + Node conformance backstop ────
 
-    /// A view-backed entity with a chosen `id` field type — for conformance tests.
+    /// A view-backed entity with a chosen `id` field type — for identity tests.
     fn entity_with_id(name: &str, id_ty: &str) -> IntermediateType {
         IntermediateType {
             sql_source: Some(format!("v_{}", name.to_lowercase())),
@@ -2105,27 +2105,43 @@ mod tenancy_tests {
         }
     }
 
-    /// The regression: a cascade entity whose `id` is `UUID` (not `ID`) must fail
-    /// with a legible, actionable error at synthesis — not a swallowed validator
-    /// bail. The message names the type, its actual id type, and the remedy.
+    /// The identity contract: the Trinity external id `id: UUID` is canonicalized to
+    /// `id: ID` (wire-transparent), independent of any interface. This is what makes
+    /// every Trinity entity uniformly identity-bearing.
     #[test]
-    fn cascade_uuid_id_entity_fails_with_actionable_error() {
+    fn entity_uuid_id_is_canonicalized_to_id() {
+        use fraiseql_core::schema::FieldType;
+
+        use crate::schema::SchemaConverter;
+        let schema = make_schema(
+            vec![entity_with_id("Order", "UUID")],
+            vec![make_query("orders", "Order")],
+            vec![],
+        );
+        let compiled = SchemaConverter::convert(schema).expect("convert");
+        let order = compiled.types.iter().find(|t| t.name.as_str() == "Order").unwrap();
+        let id = order.find_field("id").expect("id field");
+        assert_eq!(id.field_type, FieldType::Id, "id: UUID canonicalizes to id: ID");
+    }
+
+    /// The reporter's case, resolved: a cascade entity with the Trinity `id: UUID`
+    /// now canonicalizes to `id: ID`, satisfies `CascadeNode`, and compiles — no
+    /// hand-editing 64 entities.
+    #[test]
+    fn cascade_uuid_id_entity_canonicalizes_and_compiles() {
         use crate::schema::SchemaConverter;
         let schema = make_schema(
             vec![entity_with_id("Order", "UUID")],
             vec![],
             vec![cascade_mut("createOrder", "Order")],
         );
-        let err = SchemaConverter::convert(schema).unwrap_err();
-        let msg = format!("{err:#}");
-        assert!(msg.contains("Order"), "names the offending type: {msg}");
-        assert!(msg.contains("UUID"), "names the actual id type (not just 'missing'): {msg}");
-        assert!(msg.contains("id: ID!"), "states the required shape: {msg}");
-        assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
+        let compiled = SchemaConverter::convert(schema).expect("Trinity UUID cascade compiles");
+        let order = compiled.types.iter().find(|t| t.name.as_str() == "Order").unwrap();
+        assert!(order.implements.iter().any(|i| i == "CascadeNode"));
     }
 
     /// A cascade entity with no `id` field at all (e.g. keyed on another column)
-    /// fails the same way, with the "no `id` field" wording.
+    /// cannot be identity-bearing — a legible, actionable hard error (the backstop).
     #[test]
     fn cascade_missing_id_entity_fails_with_actionable_error() {
         use crate::schema::SchemaConverter;
@@ -2140,6 +2156,25 @@ mod tenancy_tests {
         assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
     }
 
+    /// An `id: Int` (a serial pk exposed directly — not the Trinity external id) is
+    /// not canonicalized and cannot back `id: ID!`; a cascade over it fails fast with
+    /// the actual id type and the remedy (adopt a UUID/ID identity).
+    #[test]
+    fn cascade_int_id_entity_fails_with_actionable_error() {
+        use crate::schema::SchemaConverter;
+        let schema = make_schema(
+            vec![entity_with_id("Order", "Int")],
+            vec![],
+            vec![cascade_mut("createOrder", "Order")],
+        );
+        let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
+        assert!(
+            msg.contains("Order") && msg.contains("Int"),
+            "names type + actual id type: {msg}"
+        );
+        assert!(msg.contains("id: ID!") && msg.contains("Fix:"), "{msg}");
+    }
+
     /// One error lists *every* offender, so a developer fixes them in one pass
     /// rather than whack-a-mole.
     #[test]
@@ -2147,7 +2182,7 @@ mod tenancy_tests {
         use crate::schema::SchemaConverter;
         let schema = make_schema(
             vec![
-                entity_with_id("Order", "UUID"),
+                entity_with_id("Order", "Int"),
                 entity_with_id("Invoice", "Int"),
             ],
             vec![],
@@ -2157,8 +2192,8 @@ mod tenancy_tests {
         assert!(msg.contains("Order") && msg.contains("Invoice"), "lists both offenders: {msg}");
     }
 
-    /// Happy-path guard: a conformant `id: ID!` cascade entity still synthesizes
-    /// and implements `CascadeNode` (the fix must not over-correct).
+    /// Happy-path guard: an explicit `id: ID!` cascade entity still synthesizes and
+    /// implements `CascadeNode` (the contract must not over-correct).
     #[test]
     fn cascade_conformant_id_entity_still_implements_cascade_node() {
         use crate::schema::SchemaConverter;
@@ -2173,12 +2208,24 @@ mod tenancy_tests {
         assert!(order.implements.iter().any(|i| i == "CascadeNode"));
     }
 
-    /// The identical latent defect in Relay `Node` injection is now a legible error
-    /// too (previously a swallowed validator bail).
+    /// Relay `Node` shares the identity contract: a `relay = true` type with the
+    /// Trinity `id: UUID` canonicalizes and compiles.
     #[test]
-    fn relay_uuid_id_type_fails_with_actionable_error() {
+    fn relay_uuid_id_type_canonicalizes_and_compiles() {
         use crate::schema::SchemaConverter;
         let mut order = entity_with_id("Order", "UUID");
+        order.relay = true;
+        let schema = make_schema(vec![order], vec![make_query("orders", "Order")], vec![]);
+        let compiled = SchemaConverter::convert(schema).expect("Trinity UUID relay type compiles");
+        let order = compiled.types.iter().find(|t| t.name.as_str() == "Order").unwrap();
+        assert!(order.implements.iter().any(|i| i == "Node"));
+    }
+
+    /// A `relay = true` type with a non-identity `id: Int` still fails legibly.
+    #[test]
+    fn relay_int_id_type_fails_with_actionable_error() {
+        use crate::schema::SchemaConverter;
+        let mut order = entity_with_id("Order", "Int");
         order.relay = true;
         let schema = make_schema(vec![order], vec![make_query("orders", "Order")], vec![]);
         let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
@@ -2195,7 +2242,9 @@ mod tenancy_tests {
         use crate::schema::SchemaConverter;
 
         let mut cases: Vec<(String, bool, IntermediateSchema)> = Vec::new();
-        for (id_ty, expect_ok) in [("ID", true), ("UUID", false), ("Int", false)] {
+        // `ID` and the Trinity `UUID` (canonicalized to `ID`) conform; a non-identity
+        // `Int` id does not and must fail *legibly*.
+        for (id_ty, expect_ok) in [("ID", true), ("UUID", true), ("Int", false)] {
             cases.push((
                 format!("cascade+{id_ty}"),
                 expect_ok,

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2230,6 +2230,37 @@ mod tenancy_tests {
         }
     }
 
+    // ── validate(): interfaces are valid return types (latent-gap fix) ─────
+
+    /// An interface named `Node` with a single `id: ID!` field, for return-type tests.
+    fn node_interface() -> crate::schema::intermediate::IntermediateInterface {
+        crate::schema::intermediate::IntermediateInterface {
+            name:        "Node".to_string(),
+            fields:      vec![make_field("id", "ID")],
+            description: None,
+        }
+    }
+
+    /// A query may return an interface (narrowed via inline fragments). Previously
+    /// interfaces weren't in the return-type registry, so this failed the reference
+    /// check (with a `warn!`); now it converts.
+    #[test]
+    fn query_returning_an_interface_is_valid() {
+        use crate::schema::SchemaConverter;
+        let mut schema = make_schema(vec![], vec![make_query("node", "Node")], vec![]);
+        schema.interfaces = vec![node_interface()];
+        SchemaConverter::convert(schema).expect("a query may return an interface type");
+    }
+
+    /// Same for a mutation return type — previously a *silent* bail (no `warn!`).
+    #[test]
+    fn mutation_returning_an_interface_is_valid() {
+        use crate::schema::SchemaConverter;
+        let mut schema = make_schema(vec![], vec![], vec![make_mutation("promote", "Node")]);
+        schema.interfaces = vec![node_interface()];
+        SchemaConverter::convert(schema).expect("a mutation may return an interface type");
+    }
+
     #[test]
     fn auto_inject_uses_custom_claim() {
         let mut schema = make_schema(

--- a/crates/fraiseql-cli/src/tests.rs
+++ b/crates/fraiseql-cli/src/tests.rs
@@ -167,11 +167,13 @@ mod output_schemas_tests {
 }
 
 mod runner_tests {
-    use super::super::runner::format_cli_error;
+    use anyhow::Context as _;
+
+    use super::super::runner::{error_causes, format_cli_error};
 
     #[test]
     fn format_cli_error_json_mode_produces_structured_object() {
-        let output = format_cli_error("something went wrong", None, true, 1);
+        let output = format_cli_error("something went wrong", &[], None, true, 1);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("must be valid JSON");
         assert_eq!(parsed["error"]["message"], "something went wrong");
         assert_eq!(parsed["error"]["code"], 1);
@@ -179,20 +181,21 @@ mod runner_tests {
 
     #[test]
     fn format_cli_error_json_mode_uses_exit_code() {
-        let output = format_cli_error("validation failed", None, true, 2);
+        let output = format_cli_error("validation failed", &[], None, true, 2);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("must be valid JSON");
         assert_eq!(parsed["error"]["code"], 2);
     }
 
     #[test]
     fn format_cli_error_plain_mode_produces_human_readable_text() {
-        let output = format_cli_error("file not found", None, false, 1);
+        // No causes → byte-identical to the pre-chain output (backward compatible).
+        let output = format_cli_error("file not found", &[], None, false, 1);
         assert_eq!(output, "Error: file not found");
     }
 
     #[test]
     fn format_cli_error_plain_mode_appends_debug_info() {
-        let output = format_cli_error("oops", Some("stack trace here"), false, 1);
+        let output = format_cli_error("oops", &[], Some("stack trace here"), false, 1);
         assert!(output.contains("Error: oops"));
         assert!(output.contains("Debug info:"));
         assert!(output.contains("stack trace here"));
@@ -201,9 +204,60 @@ mod runner_tests {
     #[test]
     fn format_cli_error_json_mode_omits_debug_info() {
         // In JSON mode, debug_info is not included — keep the output machine-parseable.
-        let output = format_cli_error("oops", Some("secret internals"), true, 1);
+        let output = format_cli_error("oops", &[], Some("secret internals"), true, 1);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("must be valid JSON");
         let serialized = parsed.to_string();
         assert!(!serialized.contains("secret internals"));
+    }
+
+    #[test]
+    fn format_cli_error_plain_mode_surfaces_cause_chain() {
+        // The regression this fixes: the underlying reason must reach the user, not
+        // just the top-level context.
+        let causes = vec![
+            "Type 'Order' implements interface 'CascadeNode' but is missing field 'id'".to_string(),
+        ];
+        let output = format_cli_error(
+            "Failed to convert schema to compiled format",
+            &causes,
+            None,
+            false,
+            1,
+        );
+        assert!(output.starts_with("Error: Failed to convert schema to compiled format"));
+        assert!(output.contains("caused by: Type 'Order' implements interface 'CascadeNode'"));
+    }
+
+    #[test]
+    fn format_cli_error_json_mode_includes_causes_array() {
+        // `--json` must carry the chain too — previously it dropped it entirely.
+        let causes = vec!["root reason".to_string()];
+        let output = format_cli_error("top context", &causes, None, true, 1);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("must be valid JSON");
+        assert_eq!(parsed["error"]["message"], "top context");
+        assert_eq!(parsed["error"]["causes"][0], "root reason");
+    }
+
+    #[test]
+    fn format_cli_error_plain_mode_lists_every_cause_in_order() {
+        let causes = vec!["middle".to_string(), "root".to_string()];
+        let output = format_cli_error("top", &causes, None, false, 1);
+        let mid = output.find("caused by: middle").expect("middle cause present");
+        let root = output.find("caused by: root").expect("root cause present");
+        assert!(mid < root, "causes are rendered outermost-first");
+    }
+
+    #[test]
+    fn error_causes_extracts_chain_below_top_context() {
+        // `bail!("root")` wrapped in two contexts: top is the message, the rest are causes.
+        let err = Err::<(), _>(anyhow::anyhow!("root reason"))
+            .context("middle context")
+            .context("top context")
+            .unwrap_err();
+        assert_eq!(err.to_string(), "top context");
+        assert_eq!(
+            error_causes(&err),
+            vec!["middle context".to_string(), "root reason".to_string(),]
+        );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,8 @@ ignore = [
   # deadline: 2026-10-01 — re-check samael release cadence; consider a [patch] to a patched
   # quick-xml (validating SAML parsing) or dropping samael.
   {id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic duplicate-attribute-name check (DoS); transitive via samael (auth-saml opt-in only); samael pins quick-xml 0.37.5, no fix in range. Deadline 2026-10-01."},
-  {id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration allocation in NsReader (memory-exhaustion DoS); same cause/path as RUSTSEC-2026-0194 (samael, auth-saml opt-in). Deadline 2026-10-01."}
+  {id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration allocation in NsReader (memory-exhaustion DoS); same cause/path as RUSTSEC-2026-0194 (samael, auth-saml opt-in). Deadline 2026-10-01."},
+  {id = "RUSTSEC-2026-0204", reason = "crossbeam-epoch 0.9.18 fmt::Pointer invalid-pointer dereference; only triggers when Debug/Pointer-formatting an invalid Atomic/Shared pointer, which FraiseQL never does. Transitive via rayon (criterion dev-deps). Deadline 2026-10-01."}
 ]
 unmaintained = "workspace"
 

--- a/docs/adr/0017-entity-identity-contract.md
+++ b/docs/adr/0017-entity-identity-contract.md
@@ -1,0 +1,105 @@
+# ADR-0017: Entity Identity Contract (`id: ID!`)
+
+## Status: Accepted
+
+This ADR records the decision to give FraiseQL a single, enforced notion of entity
+identity: **every queryable entity exposes a global `id: ID!`**, and the compiler
+canonicalizes the Trinity external id (`id: UUID`) to `id: ID` to make that true by
+construction.
+
+Related: `docs/architecture/mutation-response.md` (cascade), `examples/_TEMPLATE`
+(Trinity pattern), ADR-0014 (federation entity backing source), the graphql-cascade
+spec (`../graphql-cascade/reference/cascade_base.graphql`).
+
+---
+
+## Context
+
+Several subsystems independently need "the id of an entity":
+
+- **graphql-cascade** — the `CascadeNode` interface (`id: ID!`); collateral entities
+  ride `UpdatedEntity.entity: CascadeNode!`, selected via inline fragments.
+- **Relay** — the `Node` interface (`id: ID!`) for `relay = true` types.
+- **Apollo Federation** — `@key(fields: "id")` for entity resolution.
+- **Cache normalization / cursor pagination** — keying by a stable id.
+
+All four assume a uniformly-typed opaque identifier. FraiseQL, however, keeps `ID`
+and `UUID` as **distinct scalars**, and entities were authored with heterogeneous id
+types — `ID`, `UUID`, `Int`, or a non-`id` key (`examples/basic` uses `id: Int`).
+
+The concrete failure that motivated this ADR: cascade synthesis (2.11) force-added
+`implements CascadeNode` (`id: ID!`) to every queryable entity, then the compiled
+schema failed its own validator with a swallowed "missing field 'id'" bail whenever
+an entity's id was `UUID`/`Int`. Each id-consuming subsystem was independently
+rediscovering the same heterogeneity — a missing invariant, surfacing as a cascade
+bug.
+
+The Trinity pattern (`examples/_TEMPLATE`) already settles what identity *is*:
+
+```sql
+pk_entity  INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,  -- internal join key, never exposed
+id         UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,    -- external, stable identity
+identifier TEXT UNIQUE                                        -- optional human-readable business key
+```
+
+The external identity is `id UUID`. GraphQL's `ID` scalar is the spec's opaque,
+stringified identifier — and a UUID serializes as the *same* JSON string.
+
+---
+
+## Decision
+
+**1. Contract.** Every queryable entity exposes a global `id: ID!`. This is a
+first-class FraiseQL invariant, consumed uniformly by cascade, Relay, federation,
+and caching — not re-derived per subsystem.
+
+**2. Canonicalize the Trinity id.** The compiler rewrites an authored `id: UUID` to
+`id: ID` on every output object type (`converter::identity`), before the
+interface-forcing passes. This is **wire-transparent** (a UUID and an ID serialize to
+the same string) and makes every Trinity entity satisfy `Node` / `CascadeNode` /
+`@key(fields: "id")` automatically. `ID` is also the canonical, valid federation key
+type, so this is federation-friendly.
+
+**3. Enforce the backstop.** An entity that opts into a Node-style interface
+(cascade/relay) but cannot present `id: ID!` — a non-identity `id: Int`, an exotic
+type, or no `id` field at all — fails `compile` fast with one aggregated, actionable
+error naming each offending type and the remedy (`converter::interface_conformance`).
+It never emits IR that the validator rejects with a swallowed bail.
+
+**4. Legible diagnostics.** The CLI surfaces the full `anyhow` cause chain in human
+and `--json` output, so any residual rejection is self-diagnosing.
+
+### Rejected alternatives
+
+- **Skip + warn** (drop non-conforming entities from cascades): silent degradation —
+  antithetical to a correctness-first platform.
+- **Union instead of interface** (`UpdatedEntity.entity` as a union of concrete
+  types): solves cascade locally but grows unbounded with the schema, forces clients
+  to enumerate every type to select `id`/`__typename`, diverges from the graphql-cascade
+  spec FraiseQL publishes, and leaves Relay/federation with the same tension. A local
+  optimum, not the invariant.
+- **Canonicalize `Int`/`String` ids too**: `id: Int` → `ID` is a wire-visible change
+  (number → string) and legitimizes exposing a serial pk as a global id, which the
+  Trinity deliberately avoids. Left to the backstop so the author adopts a real
+  identity (UUID) consciously. Only the wire-transparent `UUID` → `ID` is automatic.
+
+---
+
+## Consequences
+
+- The reporter's Trinity schema (federation entities with `id: UUID` + cascade) now
+  compiles with no per-entity edits — the id canonicalizes transparently.
+- Cascade, Relay, and federation `@key` share one identity contract; a fix in one no
+  longer leaves the others latently broken.
+- `id: UUID` no longer appears in compiled output / introspection — it is `ID`. This
+  is wire-compatible (same string), but a consumer that introspected `id: UUID`
+  literally will see `ID`. Documented in the CHANGELOG.
+- Entities with a non-identity `id` (`Int`, none) that use cascade/relay must expose
+  `id: ID` (Trinity: a UUID surrogate). This is a clear compile error, not silent.
+- **Follow-up (authoring SDK):** the SDK should emit `id: ID` for a Trinity surrogate
+  directly, so the compiled schema is honest at the source and the compiler
+  canonicalization becomes a backstop for older/hand-authored schemas rather than the
+  primary mechanism.
+- **Future (graphql-cascade#5):** if a genuine need for heterogeneous-identity
+  cascades emerges, the union model can relax this contract without breaking anyone
+  (error → working is non-breaking).

--- a/docs/architecture/mutation-response.md
+++ b/docs/architecture/mutation-response.md
@@ -227,16 +227,17 @@ The compiler then rewrites the mutation to return a **payload wrapper**
 not on the entity, so normalized client caches never store a `cascade` key against
 an entity. A non-cascade mutation is unchanged and never surfaces cascade.
 
-> **Eligibility: every cascade entity must expose `id: ID!`.** Cascade entities
-> ride the `CascadeUpdates` envelope as the `CascadeNode` interface (`id: ID!`, per
-> the graphql-cascade spec), auto-implemented on every queryable entity so it is
-> selectable via an inline fragment. An entity whose GraphQL `id` is `UUID`/`Int`
-> or absent cannot satisfy that interface, so `fraiseql compile` **fails fast** with
-> one aggregated error naming each offending type — rather than emitting a schema
-> the runtime would reject. Expose the identifier as GraphQL `ID` (FraiseQL
-> serializes a UUID surrogate key as `ID`) to make a type cascade-eligible, or drop
-> `cascade` from the mutations that return it. The identical `id: ID!` contract
-> applies to Relay `Node` for `relay = true` types.
+> **Eligibility: every cascade entity has a global `id: ID!`** (the entity-identity
+> contract, ADR-0017). Cascade entities ride the `CascadeUpdates` envelope as the
+> `CascadeNode` interface (`id: ID!`, per the graphql-cascade spec), auto-implemented
+> on every queryable entity so it is selectable via an inline fragment. The **Trinity
+> external id `id: UUID` is canonicalized to `id: ID` at compile time** — wire-transparent,
+> so the common case is cascade-eligible with no action. Only an entity whose `id` is
+> a non-identity type (e.g. a serial `Int`) or absent cannot satisfy the interface:
+> `fraiseql compile` then **fails fast** with one aggregated error naming each
+> offending type, rather than emitting a schema the runtime would reject. Give such a
+> type a UUID surrogate `id` (Trinity), or drop `cascade` from the mutations that
+> return it. The identical contract applies to Relay `Node` for `relay = true` types.
 
 The function fills the `cascade` column with the spec-nested shape (see the
 graphql-cascade spec): `{ updated: [{__typename, id, operation, entity}],

--- a/docs/architecture/mutation-response.md
+++ b/docs/architecture/mutation-response.md
@@ -227,6 +227,17 @@ The compiler then rewrites the mutation to return a **payload wrapper**
 not on the entity, so normalized client caches never store a `cascade` key against
 an entity. A non-cascade mutation is unchanged and never surfaces cascade.
 
+> **Eligibility: every cascade entity must expose `id: ID!`.** Cascade entities
+> ride the `CascadeUpdates` envelope as the `CascadeNode` interface (`id: ID!`, per
+> the graphql-cascade spec), auto-implemented on every queryable entity so it is
+> selectable via an inline fragment. An entity whose GraphQL `id` is `UUID`/`Int`
+> or absent cannot satisfy that interface, so `fraiseql compile` **fails fast** with
+> one aggregated error naming each offending type — rather than emitting a schema
+> the runtime would reject. Expose the identifier as GraphQL `ID` (FraiseQL
+> serializes a UUID surrogate key as `ID`) to make a type cascade-eligible, or drop
+> `cascade` from the mutations that return it. The identical `id: ID!` contract
+> applies to Relay `Node` for `relay = true` types.
+
 The function fills the `cascade` column with the spec-nested shape (see the
 graphql-cascade spec): `{ updated: [{__typename, id, operation, entity}],
 deleted: [{__typename, id, deletedAt}], invalidations: [...], metadata: {...} }`.


### PR DESCRIPTION
## Summary

Fixes the `fraiseql-cli 2.11 compile` regression reported by the beta team: a `schema.json` that 2.10 compiled would fail under 2.11 with only `Error: Failed to convert schema to compiled format` — the real cause swallowed at every log level and in `--json`. This PR makes the failure legible and fixes the underlying regression via a proper entity-identity contract.

**Validated by the beta team** against their real management schema (64 federation entities, cascade on all mutations, `@key(fields: "id")`): *"the fix does exactly what it should… the aggregated hard error + the fix hint are excellent."*

## Root cause

Two defects, one masking the other:

1. **Observability** — the CLI rendered only the top-level `anyhow` context; the source chain was reachable only via the undocumented `--debug`, and never in `--json`.
2. **Regression** — cascade synthesis (new in 2.11) force-added `implements CascadeNode` (`id: ID!`) to *every* queryable entity, then the compiled-schema validator silently `bail!`ed with `missing field 'id'` for any entity whose `id` wasn't exactly `ID!`. Since 2.11 began honoring the previously-dropped SDK `cascade` flag, a schema that compiled under 2.10 now failed — with the reason hidden. The identical latent defect existed in Relay `Node` injection.

The deeper cause: FraiseQL had **no enforced entity-identity contract**. Cascade, Relay, and federation `@key` each independently need "the id of an entity," but entities carry heterogeneous id types (`ID`/`UUID`/`Int`). The fix makes a global `id: ID!` a first-class invariant (ADR-0017).

## Changes (4 commits)

1. **Error observability** — surface the full `anyhow` cause chain in both human (`caused by:` lines) and `--json` (`causes[]` array) output. Cause-agnostic; fixes diagnosis for *every* converter rejection.
2. **Conformance enforcement** — cascade/relay check conformance *before* forcing `implements`, failing fast with one **aggregated, actionable** error naming every offending type — never emitting IR the validator rejects. Plus a soundness-invariant matrix test.
3. **Validator hardening** — `warn!` on every rejection (not just query-return); recognize interfaces as valid return types (a latent silent-fail gap).
4. **Entity-identity contract (ADR-0017)** — canonicalize the Trinity external id `id: UUID` → `id: ID` at compile time (wire-transparent: a UUID *is* an `ID` on the wire). Every Trinity entity then satisfies Node/CascadeNode/`@key` automatically; the hard error narrows to genuinely non-identity ids.

## Behavior

| Schema | Before | After |
|---|---|---|
| Trinity `id: UUID` + cascade | swallowed error, rejected | **compiles** (canonicalized) |
| entity with no `id` + cascade | swallowed error | rejected, **legible aggregated error** |
| any converter failure | top line only | full `caused by:` chain (human + `--json`) |

## Verification

- `cargo test -p fraiseql-cli` — **1037 passed, 0 failed**
- `make preflight` — green (rustdoc `-D warnings`, workspace clippy `--all-targets --all-features`)
- End-to-end confirmed on the reporter's repro shapes

A follow-up PR (stacked on this one) makes the authoring SDKs emit `id: ID` at the source, so the compiler canonicalization becomes a backstop rather than the primary mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
