### PR TITLE
fix(sdk-python): emit naming_convention so the change-log honours the SDK's camelCase (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -562,6 +562,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   de-duplicated, matching the claim names already honoured by the observer-admin RBAC
   engine. The claims continue to be forwarded into `attributes` for RLS / session-var
   injection — the two surfaces are independent. (#503)
+- **Built-in change-log fields now follow the SDK's camelCase convention by default
+  (#500).** The Python SDK recases every field, operation, and argument it emits to
+  camelCase, but it did not record that convention in the exported schema. The
+  compiler's change-log injection (the #149 audit log) renders its identifiers via the
+  schema's `naming_convention`, which defaulted to `Preserve` — so an exposed
+  `EntityChangeLog` / `TransportCheckpoint` came out in snake_case
+  (`pk_entity_change_log`, `object_type`, `created_at`), the only snake_case corner of
+  an otherwise camelCase API. The camelCase change-log support added in #498 was
+  therefore inert unless the caller hand-injected `naming_convention` into the schema
+  JSON. `get_schema_dict()` (and the registry's `get_schema()`) now emit
+  `naming_convention: "camelCase"`, so a change-log exposed from an SDK-authored schema
+  compiles to camelCase fields with no manual intervention. The SQL contract is
+  unchanged — the runtime still recovers the snake_case JSONB keys via `to_snake_case`.
 - **`auto_params` queries now expose their `where`/`orderBy`/`limit`/`offset` as real
   GraphQL arguments.** A list query configured with `auto_params` carried those
   parameters only as compile-time flags — the runtime read them straight from the

--- a/crates/fraiseql-cli/tests/compile_changelog_naming_convention.rs
+++ b/crates/fraiseql-cli/tests/compile_changelog_naming_convention.rs
@@ -1,0 +1,154 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics are acceptable
+//! End-to-end coverage for the SDK's `naming_convention` key surviving `fraiseql compile`
+//! and reaching the built-in change-log injection.
+//!
+//! The Python SDK unconditionally recases every emitted identifier to `camelCase` and now
+//! declares that by exporting a top-level `"naming_convention": "camelCase"` key (#500).
+//! The compiler's change-log injection (#149) renders `EntityChangeLog` /
+//! `TransportCheckpoint` identifiers via the schema's `naming_convention` (#498). Without
+//! the SDK declaring it, the convention defaulted to `Preserve` → `snake_case` change-log
+//! fields in an otherwise `camelCase` schema, so the #498 `camelCase` support never fired.
+//!
+//! These tests prove the whole chain is intact: the SDK's `"naming_convention"` key must
+//! bind into `IntermediateSchema.naming_convention`, thread through `SchemaConverter` onto
+//! `CompiledSchema.naming_convention`, and drive `inject_changelog` to emit `camelCase`
+//! change-log fields — no manual intervention.
+
+use fraiseql_cli::schema::{IntermediateSchema, converter::SchemaConverter};
+use fraiseql_core::schema::NamingConvention;
+
+const ENTITY_CHANGE_LOG: &str = "EntityChangeLog";
+
+/// An SDK-shaped `schema.json` declaring the camelCase convention the SDK applies, with
+/// the built-in change-log exposed. Observers must be enabled, or the converter rejects
+/// an exposed change-log over tables the observer system installs.
+const SDK_SCHEMA_CAMELCASE_CHANGELOG: &str = r#"
+{
+  "version": "2.0.0",
+  "naming_convention": "camelCase",
+  "types": [
+    {
+      "name": "Order",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false},
+        {"name": "customerId", "type": "String", "nullable": false}
+      ],
+      "sql_source": "v_orders",
+      "is_input": false
+    }
+  ],
+  "queries": [],
+  "mutations": [],
+  "subscriptions": [],
+  "observers_config": {"enabled": true},
+  "changelog_config": {"expose": true}
+}
+"#;
+
+/// The same schema with no `naming_convention` key — the compiler defaults to `Preserve`.
+const SDK_SCHEMA_NO_NAMING_CONVENTION: &str = r#"
+{
+  "version": "2.0.0",
+  "types": [
+    {
+      "name": "Order",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false}
+      ],
+      "sql_source": "v_orders",
+      "is_input": false
+    }
+  ],
+  "queries": [],
+  "mutations": [],
+  "subscriptions": [],
+  "observers_config": {"enabled": true},
+  "changelog_config": {"expose": true}
+}
+"#;
+
+#[test]
+fn naming_convention_camelcase_key_binds_into_intermediate() {
+    // The crux: the SDK's top-level `"naming_convention"` key must bind into the
+    // intermediate schema (it deserializes the engine's serde wire value `"camelCase"`).
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_CAMELCASE_CHANGELOG).expect("parse SDK schema.json");
+    assert_eq!(
+        intermediate.naming_convention,
+        NamingConvention::CamelCase,
+        "the SDK's `naming_convention` key must bind into IntermediateSchema.naming_convention"
+    );
+}
+
+#[test]
+fn absent_naming_convention_defaults_to_preserve() {
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_NO_NAMING_CONVENTION).expect("parse SDK schema.json");
+    assert_eq!(
+        intermediate.naming_convention,
+        NamingConvention::Preserve,
+        "an absent `naming_convention` key must default to Preserve"
+    );
+}
+
+#[test]
+fn sdk_camelcase_schema_injects_camelcase_changelog() {
+    // The headline regression: a camelCase SDK schema with the change-log exposed must
+    // compile to a change-log surface that is *also* camelCase, with no snake_case leak.
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_CAMELCASE_CHANGELOG).expect("parse SDK schema.json");
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+
+    assert_eq!(compiled.naming_convention, NamingConvention::CamelCase);
+
+    let ecl = compiled
+        .types
+        .iter()
+        .find(|t| t.name == ENTITY_CHANGE_LOG)
+        .expect("change-log must be injected when exposed");
+
+    // Fields follow the SDK's camelCase convention; the snake_case forms are gone.
+    for camel in ["pkEntityChangeLog", "objectType", "objectData", "createdAt"] {
+        assert!(ecl.find_field(camel).is_some(), "missing camelCase change-log field {camel}");
+    }
+    assert!(
+        ecl.find_field("pk_entity_change_log").is_none(),
+        "snake_case change-log field leaked despite a camelCase schema"
+    );
+    assert!(ecl.find_field("object_type").is_none(), "snake_case change-log field leaked");
+
+    // Operation names recased too — the change-log list query is camelCase.
+    assert!(
+        compiled.queries.iter().any(|q| q.name == "entityChangeLogs"),
+        "change-log list query must be camelCase"
+    );
+    assert!(
+        !compiled.queries.iter().any(|q| q.name == "entity_change_logs"),
+        "snake_case change-log query leaked"
+    );
+}
+
+#[test]
+fn absent_naming_convention_keeps_snake_case_changelog() {
+    // Control: with no convention declared the injection stays snake_case — proving the
+    // SDK's `naming_convention` key is exactly what flips the change-log to camelCase.
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_NO_NAMING_CONVENTION).expect("parse SDK schema.json");
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+
+    assert_eq!(compiled.naming_convention, NamingConvention::Preserve);
+
+    let ecl = compiled
+        .types
+        .iter()
+        .find(|t| t.name == ENTITY_CHANGE_LOG)
+        .expect("change-log must be injected when exposed");
+    assert!(
+        ecl.find_field("pk_entity_change_log").is_some(),
+        "default convention is snake_case"
+    );
+    assert!(
+        ecl.find_field("pkEntityChangeLog").is_none(),
+        "camelCase must not appear by default"
+    );
+}

--- a/sdks/official/fraiseql-python/src/fraiseql/registry.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/registry.py
@@ -13,6 +13,16 @@ _CAMEL_RE = re.compile(r"(?<!^)(?=[A-Z])")
 # so the round trip is bijective.
 _SNAKE_WORD_RE = re.compile(r"_([a-zA-Z0-9])")
 
+# The naming convention the SDK advertises in its exported schema. Every emitted
+# identifier (type fields, operation/argument names) is unconditionally recased to
+# camelCase via `_snake_to_camel`, so the schema must declare that convention — the
+# compiler then injects built-in surfaces (the #149 change-log's EntityChangeLog /
+# TransportCheckpoint) with matching casing instead of defaulting to `Preserve` →
+# snake_case in an otherwise camelCase schema (#500). The literal is the exact wire
+# value the engine's `NamingConvention::CamelCase` deserializes from
+# (`crates/fraiseql-core/src/schema/config_types.rs`).
+_NAMING_CONVENTION = "camelCase"
+
 
 def _pascal_to_snake(name: str) -> str:
     """Convert PascalCase to snake_case (e.g. OrderItem → order_item)."""
@@ -447,7 +457,8 @@ class SchemaRegistry:
 
         Returns:
             Dictionary with "types", "enums", "input_types", "interfaces", "unions",
-            "queries", "mutations", "subscriptions", and "customScalars"
+            "queries", "mutations", "subscriptions", "naming_convention", and
+            "customScalars"
         """
         schema: dict[str, Any] = {
             "types": list(cls._types.values()),
@@ -458,6 +469,9 @@ class SchemaRegistry:
             "queries": list(cls._queries.values()),
             "mutations": list(cls._mutations.values()),
             "subscriptions": list(cls._subscriptions.values()),
+            # Declare the camelCase recasing the SDK always applies, so the compiler's
+            # change-log injection follows the same convention (#500).
+            "naming_convention": _NAMING_CONVENTION,
         }
 
         # Include inject_defaults if any are set

--- a/sdks/official/fraiseql-python/tests/test_casing.py
+++ b/sdks/official/fraiseql-python/tests/test_casing.py
@@ -7,6 +7,7 @@ collapses onto the previous word (`phone_1` → `phone1`). The Rust runtime's
 
 import pytest
 
+import fraiseql
 from fraiseql.registry import SchemaRegistry, _snake_to_camel
 
 
@@ -45,3 +46,22 @@ def test_repro_issue_field_surface() -> None:
         for n in ("phone_1", "phone_2", "user_id", "http_response")
     ]
     assert names == ["phone1", "phone2", "userId", "httpResponse"]
+
+
+def test_get_schema_advertises_camelcase_naming_convention() -> None:
+    """The registry declares the camelCase convention it unconditionally applies.
+
+    The SDK recases every emitted identifier to camelCase via ``_snake_to_camel``, so
+    the exported schema must say so. Otherwise the compiler's built-in change-log
+    injection (#149) falls back to ``Preserve`` → snake_case fields in an otherwise
+    camelCase schema (#500). The literal here pins the exact wire value that the
+    engine's ``NamingConvention::CamelCase`` deserializes from.
+    """
+    SchemaRegistry.clear()
+    assert SchemaRegistry.get_schema()["naming_convention"] == "camelCase"
+
+
+def test_get_schema_dict_carries_naming_convention() -> None:
+    """The public ``get_schema_dict()`` export carries the convention too (#500)."""
+    SchemaRegistry.clear()
+    assert fraiseql.get_schema_dict()["naming_convention"] == "camelCase"


### PR DESCRIPTION
Defence-in-depth follow-up for #500 (already closed — the reported bug was fixed for the standard `fraiseql compile` path via the CamelCase default). This resurrects the sibling commit `7a6a67a4a`, orphaned on `fix/compile-federation-passthrough` when #495 was squash-merged, and closes the remaining non-CLI gap.

## Gap this closes

The Python SDK recases every field/operation/argument it emits to camelCase, but `get_schema_dict()` did **not** record that convention in the exported schema. The compiler's change-log injection (#149) renders its identifiers via the schema's `naming_convention`, which defaults to `Preserve` — so a consumer that feeds the SDK dict straight into a core-level compile (bypassing the CLI's CamelCase default) still got a snake_case `EntityChangeLog` / `TransportCheckpoint` in an otherwise camelCase API. The camelCase change-log support from #498 was inert on that path unless the caller hand-injected `naming_convention`.

## Fix

- `get_schema_dict()` (and the registry's `get_schema()`) now emit `naming_convention: "camelCase"`, so a change-log exposed from an SDK-authored schema compiles to camelCase fields with no manual intervention — on the CLI path **and** the direct core-compile path.
- The SQL contract is unchanged: the runtime still recovers the snake_case JSONB keys via `to_snake_case`.

## Verification

- ✅ `make preflight` — fmt, lint gates, rustdoc (`-D warnings`), clippy (`--all-targets --all-features -D warnings`) all clean
- ✅ Rust CLI e2e `compile_changelog_naming_convention` 4/4 — the SDK's `"naming_convention"` key binds into `IntermediateSchema`, threads through `SchemaConverter` onto `CompiledSchema`, and drives `inject_changelog` to emit camelCase change-log fields (and absent → `Preserve`/snake_case still holds)
- ✅ Python `tests/test_casing.py` 14/14 — incl. `get_schema()`/`get_schema_dict()` advertising `naming_convention == "camelCase"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
