### PR TITLE
feat(observers): #573 Phase 01 — source coordination primitives (cursor store + single-firing runner)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -1498,6 +1498,14 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// superuser DATABASE_URL would mask the policy). The test creates its own
 		// tenant/consumer roles off the superuser connection — no extra env needed.
 		"cargo test -p fraiseql-observers --features postgres --test rls_isolation -- --ignored --test-threads=1",
+		// #573 source coordination primitives: the advisory-lease mutual-exclusion
+		// + crash-safety boundary (Phase 00), and the source cursor store (CAS
+		// advance, in-tx rollback, deny-by-default RLS) + single-firing runner
+		// (Phase 01), all vs the bound Postgres. Self-skip on no DATABASE_URL (not
+		// #[ignore]d) → run WITHOUT --ignored, as separate binaries so they never
+		// pull in the SSRF-guard unit tests this suite disables.
+		"cargo test -p fraiseql-observers --features postgres --test advisory_lease_pg -- --test-threads=1",
+		"cargo test -p fraiseql-observers --features postgres --test source_cursor_pg -- --test-threads=1",
 		// #382 outbound CDC: the drain-worker state machine vs the bound Postgres
 		// (stub sink, no broker) + the NATS JetStream sink end-to-end vs the bound
 		// JetStream (DATABASE_URL + NATS_URL + FRAISEQL_NATS_ALLOW_PLAINTEXT below).

--- a/crates/fraiseql-observers/migrations/13_create_source_cursor.sql
+++ b/crates/fraiseql-observers/migrations/13_create_source_cursor.sql
@@ -1,0 +1,87 @@
+-- FraiseQL Source Cursor Store — _fraiseql_source_cursor
+-- ============================================================================
+-- The durable watermark for scheduled ingress `Source`s (#573, the dual of
+-- `Observer`). A source polls an external system on a schedule and drives the
+-- results into the database via mutations; this table holds the opaque cursor it
+-- advances between runs so a re-run resumes from the last committed watermark
+-- (at-least-once, cursor-gated). One row per source, keyed by its stable name.
+--
+-- Columns
+-- -------
+--   source_name  — stable source identifier and primary key (one cursor per source).
+--   cursor_value — OPAQUE JSONB the source owns end to end (e.g. an IMAP
+--                  {uid_validity,last_uid}, an API page token, a high-water
+--                  timestamp). The framework never interprets it; it is written
+--                  only via parameterized binds, never assembled into SQL text.
+--   version      — a monotonic generation counter the store bumps on every
+--                  advance. It is the compare-and-swap guard: an advance that read
+--                  version N only applies while the row is still at N, so a stale
+--                  writer (one that lost the single-firing lease across a failover)
+--                  can never regress the watermark.
+--   tenant_id    — RLS partition stamp (Trinity: the JWT/tenant stamp, NOT a
+--                  business FK). NULL for a global/system source. See RLS below.
+--   updated_at   — last advance time (observability / lag).
+--
+-- Row-Level Security — deny-by-default, mirroring migration 12
+-- -----------------------------------------------------------
+-- The cursor can encode externally-derived positions, so the table is fail-closed
+-- exactly like `core.tb_entity_change_log`: a role that is neither the table owner
+-- nor `BYPASSRLS`, and that has not set the `fraiseql.tenant_id` session GUC, reads
+-- ZERO rows. `NULLIF(current_setting(..., true), '')::uuid` maps both an unset GUC
+-- and an empty string to NULL, so `tenant_id = NULL` is NULL → the row is hidden
+-- (never an `''::uuid` cast error). A global source stamps `tenant_id = NULL`, so
+-- its cursor is likewise invisible to any non-BYPASSRLS role — deny-by-default.
+--
+-- Operator action (matches migration 12): the source scheduler runs on the
+-- server's database role, which MUST be the table owner or carry `BYPASSRLS` (the
+-- same requirement the change-log poller already imposes). `ENABLE`, not `FORCE`,
+-- so the owner is exempt. The permissive INSERT/UPDATE policies let a granted,
+-- non-BYPASSRLS role manage cursors too; the SELECT policy above still governs who
+-- can read them back. FraiseQL does not set `fraiseql.tenant_id` on any read path
+-- today, so the practical effect is deny-by-default; the per-tenant shape is
+-- forward-looking for a future per-tenant reader.
+--
+-- Least-privilege baseline: `REVOKE ALL … FROM PUBLIC` so the cursor store is never
+-- world-readable and RLS is genuine defence-in-depth on top of grants rather than
+-- the sole control. PostgreSQL grants no PUBLIC privileges to a fresh table, so
+-- this is a defensive no-op on a clean install and a real tightening where a prior
+-- broad `GRANT … TO PUBLIC` reached it. Idempotent.
+--
+-- PostgreSQL only. Idempotent / re-run safe (CREATE TABLE IF NOT EXISTS; ENABLE is
+-- a no-op when already on; DROP POLICY IF EXISTS + CREATE POLICY replaces cleanly;
+-- REVOKE is idempotent).
+
+CREATE TABLE IF NOT EXISTS _fraiseql_source_cursor (
+    source_name  TEXT        PRIMARY KEY,
+    cursor_value JSONB,
+    version      BIGINT      NOT NULL DEFAULT 0,
+    tenant_id    UUID,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE _fraiseql_source_cursor ENABLE ROW LEVEL SECURITY;  -- NOT FORCE
+
+-- Read isolation (deny-by-default; forward-compat per-tenant).
+DROP POLICY IF EXISTS p_source_cursor_read ON _fraiseql_source_cursor;
+CREATE POLICY p_source_cursor_read ON _fraiseql_source_cursor
+    FOR SELECT
+    USING (
+        tenant_id = NULLIF(current_setting('fraiseql.tenant_id', true), '')::uuid
+    );
+
+-- Permissive writes: the trusted source scheduler (server role) stamps the correct
+-- tenant. The SELECT policy above still governs reads; REVOKE FROM PUBLIC below
+-- keeps untrusted roles out entirely.
+DROP POLICY IF EXISTS p_source_cursor_insert ON _fraiseql_source_cursor;
+CREATE POLICY p_source_cursor_insert ON _fraiseql_source_cursor
+    FOR INSERT
+    WITH CHECK (true);
+
+DROP POLICY IF EXISTS p_source_cursor_update ON _fraiseql_source_cursor;
+CREATE POLICY p_source_cursor_update ON _fraiseql_source_cursor
+    FOR UPDATE
+    USING (true)
+    WITH CHECK (true);
+
+-- Least-privilege baseline: never world-readable.
+REVOKE ALL ON _fraiseql_source_cursor FROM PUBLIC;

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -79,6 +79,7 @@ pub mod queued_executor;
 pub mod resilience;
 #[cfg(feature = "search")]
 pub mod search;
+pub mod source;
 pub(crate) mod ssrf;
 pub mod storage;
 pub mod traits;
@@ -160,6 +161,10 @@ pub use resilience::{
 pub use search::http::HttpSearchBackend;
 #[cfg(feature = "search")]
 pub use search::{IndexedEvent, SearchBackend, SearchStats};
+pub use source::{
+    CursorSnapshot, LeaseGuardedRunner, PostgresSourceCursorStore, RunOutcome, SourceCursorStore,
+    lock_id,
+};
 pub use storage::EventStorage;
 #[cfg(feature = "postgres")]
 pub use storage::postgres::PostgresEventStorage;

--- a/crates/fraiseql-observers/src/migrations/mod.rs
+++ b/crates/fraiseql-observers/src/migrations/mod.rs
@@ -87,6 +87,30 @@ pub const fn entity_change_log_rls_sql() -> &'static str {
     include_str!("../../migrations/12_enable_change_log_rls.sql")
 }
 
+/// SQL DDL that installs the `_fraiseql_source_cursor` table and its
+/// deny-by-default Row-Level Security (#573 scheduled ingress `Source`s).
+///
+/// One row per source holds the opaque JSONB watermark the source advances between
+/// runs, plus a monotonic `version` generation counter used as the compare-and-swap
+/// guard so a stale writer cannot regress the cursor. RLS + `REVOKE ALL FROM PUBLIC`
+/// make it fail-closed exactly like the change-log (migration 12): a non-owner,
+/// non-`BYPASSRLS` role without the `fraiseql.tenant_id` GUC reads zero rows.
+///
+/// PostgreSQL only; idempotent (`CREATE TABLE IF NOT EXISTS`; `ENABLE` no-ops when
+/// already on; `DROP POLICY IF EXISTS` + `CREATE POLICY` replaces cleanly).
+///
+/// # Example
+///
+/// ```
+/// let sql = fraiseql_observers::migrations::source_cursor_sql();
+/// assert!(sql.contains("_fraiseql_source_cursor"));
+/// assert!(sql.contains("ENABLE ROW LEVEL SECURITY"));
+/// ```
+#[must_use]
+pub const fn source_cursor_sql() -> &'static str {
+    include_str!("../../migrations/13_create_source_cursor.sql")
+}
+
 /// One column of the `core.tb_entity_change_log` contract: its name and the
 /// canonical PostgreSQL base type the migration installs it as.
 ///

--- a/crates/fraiseql-observers/src/source/cursor.rs
+++ b/crates/fraiseql-observers/src/source/cursor.rs
@@ -1,0 +1,241 @@
+//! The durable, opaque cursor store for scheduled ingress sources.
+//!
+//! A [`Source`](https://github.com/fraiseql/fraiseql/issues/573) advances an
+//! opaque watermark between runs; this store persists it so a re-run resumes from
+//! the last committed position (at-least-once, cursor-gated). The stored value is
+//! **owned end to end by the source** — the framework treats it as opaque JSONB
+//! and never interprets or assembles it into SQL text.
+//!
+//! ## Compare-and-swap, not last-writer-wins
+//!
+//! Advances are guarded by a monotonic `version` generation counter, mirroring
+//! [`CheckpointStore::compare_and_swap`](crate::checkpoint::CheckpointStore). An
+//! advance that read version `N` applies only while the row is still at `N`, so a
+//! stale writer — one that acquired the single-firing lease, then lost it across a
+//! failover while another replica moved the cursor on — can never regress the
+//! watermark. Under normal single-firing there is no contention; the CAS is the
+//! belt-and-suspenders guard for the lease-boundary edge case.
+
+use serde_json::Value;
+use sqlx::{PgConnection, PgPool, Postgres, Transaction};
+use uuid::Uuid;
+
+use crate::error::{ObserverError, Result};
+
+/// A point-in-time read of a source's cursor: the opaque value plus the
+/// generation `version` it was read at.
+///
+/// The `version` is the compare-and-swap token: pass the snapshot you loaded back
+/// into [`advance`](SourceCursorStore::advance) so a stale advance is rejected
+/// rather than silently regressing the watermark. A never-advanced source reads as
+/// [`CursorSnapshot::default`] (`value = None`, `version = 0`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CursorSnapshot {
+    /// The opaque cursor value, or `None` if the source has never advanced.
+    pub value:   Option<Value>,
+    /// Generation counter the value was read at; `0` before the first advance.
+    pub version: i64,
+}
+
+impl CursorSnapshot {
+    /// The empty snapshot for a source that has never advanced.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            value:   None,
+            version: 0,
+        }
+    }
+
+    /// Whether the source has never advanced (no cursor row yet).
+    #[must_use]
+    pub const fn is_unset(&self) -> bool {
+        self.version == 0
+    }
+}
+
+/// Durable storage for the opaque per-source cursor.
+///
+/// One implementation ([`PostgresSourceCursorStore`]) backs the shipped runtime;
+/// the trait is the seam a source's coordination is written against. Native
+/// `async fn` in trait (no `async_trait`); used through concrete types, so the
+/// missing `Send` bound on the returned future is not a constraint here.
+#[allow(async_fn_in_trait)] // Reason: concrete-type use only; no dyn dispatch, no cross-await Send bound needed.
+pub trait SourceCursorStore {
+    /// Load the current cursor snapshot for `source`, or the empty snapshot if it
+    /// has never advanced.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObserverError::DatabaseError`] if the query fails or a stored
+    /// value cannot be parsed.
+    async fn load(&self, source: &str) -> Result<CursorSnapshot>;
+
+    /// Advance `source` to `value`, guarded by the snapshot's `version`
+    /// (compare-and-swap). Returns `true` when the advance applied, `false` when a
+    /// concurrent writer had already moved the cursor on (the advance is a no-op).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObserverError::DatabaseError`] if the value cannot be serialized
+    /// or the write fails.
+    async fn advance(&self, source: &str, from: &CursorSnapshot, value: Value) -> Result<bool>;
+}
+
+/// PostgreSQL-backed cursor store over a connection pool.
+///
+/// Stamps `tenant_id` on every write (default: `None` = a global/system source),
+/// so the deny-by-default RLS on `_fraiseql_source_cursor` applies uniformly.
+#[derive(Clone)]
+pub struct PostgresSourceCursorStore {
+    pool:      PgPool,
+    tenant_id: Option<Uuid>,
+}
+
+impl PostgresSourceCursorStore {
+    /// Create a store for global (untenanted) sources over an existing pool.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            tenant_id: None,
+        }
+    }
+
+    /// Create a store that stamps every cursor row with `tenant_id` (the RLS
+    /// partition stamp — Trinity: a tenant stamp, never a business FK).
+    #[must_use]
+    pub const fn with_tenant(pool: PgPool, tenant_id: Uuid) -> Self {
+        Self {
+            pool,
+            tenant_id: Some(tenant_id),
+        }
+    }
+
+    /// Create the `_fraiseql_source_cursor` table and its RLS policies
+    /// (idempotent). Call once on startup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObserverError::DatabaseError`] if the DDL fails.
+    pub async fn init(&self) -> Result<()> {
+        sqlx::raw_sql(crate::migrations::source_cursor_sql())
+            .execute(&self.pool)
+            .await
+            .map_err(|error| db_err("init", &error))?;
+        Ok(())
+    }
+
+    /// Advance the cursor **inside the caller's transaction** (Model A: the native
+    /// `PullSource` path). The watermark then commits or rolls back atomically with
+    /// the ingest writes in the same transaction — no reprocess window.
+    ///
+    /// Same compare-and-swap semantics as [`advance`](SourceCursorStore::advance).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObserverError::DatabaseError`] if the value cannot be serialized
+    /// or the write fails.
+    pub async fn advance_in_tx(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        source: &str,
+        from: &CursorSnapshot,
+        value: Value,
+    ) -> Result<bool> {
+        cas_advance(tx, source, from.version, &value, self.tenant_id).await
+    }
+}
+
+impl SourceCursorStore for PostgresSourceCursorStore {
+    async fn load(&self, source: &str) -> Result<CursorSnapshot> {
+        // Read the value as text (`::text`) and parse it, so this needs only sqlx's
+        // text codec — not the optional `json` feature — mirroring the spine.
+        let row: Option<(Option<String>, i64)> =
+            sqlx::query_as("SELECT cursor_value::text, version FROM _fraiseql_source_cursor WHERE source_name = $1")
+                .bind(source)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|error| db_err("load", &error))?;
+
+        match row {
+            None => Ok(CursorSnapshot::default()),
+            Some((None, version)) => Ok(CursorSnapshot {
+                value: None,
+                version,
+            }),
+            Some((Some(text), version)) => {
+                let value =
+                    serde_json::from_str(&text).map_err(|error| ObserverError::DatabaseError {
+                        reason: format!("source cursor: parse stored value: {error}"),
+                    })?;
+                Ok(CursorSnapshot {
+                    value: Some(value),
+                    version,
+                })
+            },
+        }
+    }
+
+    async fn advance(&self, source: &str, from: &CursorSnapshot, value: Value) -> Result<bool> {
+        let mut conn = self.pool.acquire().await.map_err(|error| db_err("acquire", &error))?;
+        cas_advance(&mut conn, source, from.version, &value, self.tenant_id).await
+    }
+}
+
+/// Serialize the opaque value and apply the compare-and-swap on a single
+/// connection (shared by the pooled and in-transaction advance paths).
+///
+/// `from_version == 0` means "no row expected": a first-write `INSERT … ON
+/// CONFLICT DO NOTHING` that a stale writer (a row already exists) loses. Otherwise
+/// an `UPDATE … WHERE version = from_version` that bumps the generation; it affects
+/// zero rows — and so returns `false` — if another writer moved the cursor on.
+async fn cas_advance(
+    conn: &mut PgConnection,
+    source: &str,
+    from_version: i64,
+    value: &Value,
+    tenant_id: Option<Uuid>,
+) -> Result<bool> {
+    // Serialize to text and cast `$2::jsonb`, so binding needs only the text codec.
+    let json = serde_json::to_string(value).map_err(|error| ObserverError::DatabaseError {
+        reason: format!("source cursor: serialize value: {error}"),
+    })?;
+
+    let affected = if from_version == 0 {
+        sqlx::query(
+            "INSERT INTO _fraiseql_source_cursor (source_name, cursor_value, version, tenant_id, updated_at) \
+             VALUES ($1, $2::jsonb, 1, $3, NOW()) \
+             ON CONFLICT (source_name) DO NOTHING",
+        )
+        .bind(source)
+        .bind(&json)
+        .bind(tenant_id)
+        .execute(&mut *conn)
+        .await
+        .map_err(|error| db_err("insert", &error))?
+        .rows_affected()
+    } else {
+        sqlx::query(
+            "UPDATE _fraiseql_source_cursor \
+             SET cursor_value = $2::jsonb, version = version + 1, updated_at = NOW() \
+             WHERE source_name = $1 AND version = $3",
+        )
+        .bind(source)
+        .bind(&json)
+        .bind(from_version)
+        .execute(&mut *conn)
+        .await
+        .map_err(|error| db_err("update", &error))?
+        .rows_affected()
+    };
+
+    Ok(affected > 0)
+}
+
+/// Map a `sqlx` error onto the canonical observer database error.
+fn db_err(context: &str, error: &sqlx::Error) -> ObserverError {
+    ObserverError::DatabaseError {
+        reason: format!("source cursor: {context}: {error}"),
+    }
+}

--- a/crates/fraiseql-observers/src/source/mod.rs
+++ b/crates/fraiseql-observers/src/source/mod.rs
@@ -1,0 +1,23 @@
+//! Scheduled-ingress coordination primitives (#573 `Source`).
+//!
+//! `Source` is the dual of `Observer`: on a trigger, pull from an external system
+//! and drive the results into the database via mutations, resuming from a durable
+//! cursor and firing on exactly one replica. This module holds the two generic,
+//! driver-light primitives that make that rock-solid, placed beside the observer
+//! [`CheckpointStore`](crate::checkpoint::CheckpointStore) /
+//! [`CheckpointLease`](crate::listener::CheckpointLease) family because they are
+//! the same concern — durable watermarks and multi-replica coordination — and the
+//! functions subsystem that drives sources already depends on this crate.
+//!
+//! - [`SourceCursorStore`] / [`PostgresSourceCursorStore`] — the durable, opaque per-source cursor
+//!   with compare-and-swap advance.
+//! - [`LeaseGuardedRunner`] — single-firing: run a source's work on one replica.
+
+pub mod cursor;
+pub mod runner;
+
+#[cfg(test)]
+mod tests;
+
+pub use cursor::{CursorSnapshot, PostgresSourceCursorStore, SourceCursorStore};
+pub use runner::{LeaseGuardedRunner, RunOutcome, lock_id};

--- a/crates/fraiseql-observers/src/source/runner.rs
+++ b/crates/fraiseql-observers/src/source/runner.rs
@@ -1,0 +1,137 @@
+//! Single-firing runner: run a source's work on exactly one replica per tick.
+//!
+//! Wraps the (previously unwired) [`CheckpointLease`] advisory lease so a source
+//! scheduled on N replicas fires on one. The runner acquires the lease keyed on
+//! the source name, runs the closure while holding it, then **releases
+//! explicitly** — Phase 00 characterization proved that dropping the lease does
+//! *not* free a PostgreSQL session advisory lock (its pooled connection stays
+//! alive), so drop-based RAII is not enough on the happy path; only a dead
+//! connection (a real crash) releases via the session ending, which is the
+//! crash-safety backstop.
+
+use std::{
+    future::Future,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use sha2::{Digest, Sha256};
+
+use crate::{error::Result, listener::CheckpointLease};
+
+/// Derive the advisory-lock key for a source from its name.
+///
+/// The first 8 bytes of `SHA-256(source_name)` as an `i64`. A cryptographic
+/// digest makes an accidental collision between two distinct source names
+/// negligible (a source's name is also validated unique at compile time), and the
+/// mapping is stable across processes and releases — a plain `Hash` (`SipHash`) is
+/// not, so two replicas would derive different lock keys and never coordinate.
+#[must_use]
+pub fn lock_id(source_name: &str) -> i64 {
+    let digest = Sha256::digest(source_name.as_bytes());
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    i64::from_be_bytes(bytes)
+}
+
+/// The outcome of a [`LeaseGuardedRunner::run`] attempt.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RunOutcome<T> {
+    /// This replica won the lease and ran the closure, which returned `T`.
+    Ran(T),
+    /// Another replica holds the lease; the closure did not run.
+    SkippedNotLeader,
+}
+
+/// Runs a closure only when this replica holds the source's advisory lease.
+///
+/// Construct one per source with [`postgres`](Self::postgres) (cross-replica
+/// coordination) or [`in_process`](Self::in_process) (single-node / test — guards
+/// a source against overlapping *itself*, but does not coordinate across separately
+/// constructed runners). Each [`run`](Self::run) acquires, executes, and releases.
+pub struct LeaseGuardedRunner {
+    lease:            CheckpointLease,
+    source_name:      String,
+    skips_not_leader: AtomicU64,
+}
+
+impl LeaseGuardedRunner {
+    /// A runner backed by a PostgreSQL session advisory lock — the lock key is the
+    /// stable [`lock_id`] of the source name, so every replica contends on the
+    /// same key.
+    #[cfg(feature = "postgres")]
+    #[must_use]
+    pub fn postgres(pool: sqlx::PgPool, source_name: impl Into<String>) -> Self {
+        let source_name = source_name.into();
+        let key = lock_id(&source_name);
+        Self {
+            lease: CheckpointLease::postgres(pool, format!("source:{source_name}"), key),
+            source_name,
+            skips_not_leader: AtomicU64::new(0),
+        }
+    }
+
+    /// A runner backed by an in-process lease (single-node / tests). Prevents a
+    /// source from overlapping itself within one process; does not coordinate
+    /// across replicas — use [`postgres`](Self::postgres) for that.
+    #[must_use]
+    pub fn in_process(source_name: impl Into<String>) -> Self {
+        let source_name = source_name.into();
+        let key = lock_id(&source_name);
+        Self {
+            // No TTL semantics needed: the runner acquires and releases within one
+            // `run`, so an effectively unbounded lease duration is correct.
+            lease: CheckpointLease::in_process(format!("source:{source_name}"), key, u64::MAX),
+            source_name,
+            skips_not_leader: AtomicU64::new(0),
+        }
+    }
+
+    /// The source name this runner coordinates.
+    #[must_use]
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    /// How many times this runner skipped because another replica held the lease.
+    #[must_use]
+    pub fn skips_not_leader(&self) -> u64 {
+        self.skips_not_leader.load(Ordering::Relaxed)
+    }
+
+    /// Acquire the lease; if won, run `f` to completion and then release; if lost,
+    /// count a skip and return [`RunOutcome::SkippedNotLeader`] without running.
+    ///
+    /// The lease is held for the whole closure (so a second replica cannot start
+    /// the same long fetch) and released explicitly afterwards — see the module
+    /// doc on why drop is insufficient. A release failure is logged, not
+    /// propagated: the closure's work already committed, and a stuck lock
+    /// self-heals when the connection dies.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObserverError`](crate::error::ObserverError) only if *acquiring*
+    /// the lease fails (the closure never ran). The closure's own `T` — commonly a
+    /// `Result` — is returned verbatim inside [`RunOutcome::Ran`].
+    pub async fn run<F, Fut, T>(&self, f: F) -> Result<RunOutcome<T>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = T>,
+    {
+        if !self.lease.acquire().await? {
+            self.skips_not_leader.fetch_add(1, Ordering::Relaxed);
+            return Ok(RunOutcome::SkippedNotLeader);
+        }
+
+        let output = f().await;
+
+        if let Err(error) = self.lease.release().await {
+            tracing::warn!(
+                source = %self.source_name,
+                error = %error,
+                "source lease release failed — lock self-heals on connection death"
+            );
+        }
+
+        Ok(RunOutcome::Ran(output))
+    }
+}

--- a/crates/fraiseql-observers/src/source/tests.rs
+++ b/crates/fraiseql-observers/src/source/tests.rs
@@ -1,0 +1,61 @@
+//! Pure (no-database) unit tests for the source coordination primitives: the
+//! stable lock-id hash, the cursor snapshot semantics, and the in-process runner's
+//! acquire → run → release happy path. The database-backed compare-and-swap, RLS,
+//! and cross-replica single-firing are covered in `tests/source_cursor_pg.rs`.
+
+use super::{CursorSnapshot, LeaseGuardedRunner, RunOutcome, lock_id};
+
+#[test]
+fn lock_id_is_deterministic() {
+    assert_eq!(lock_id("orders-poll"), lock_id("orders-poll"));
+    assert_eq!(lock_id("email"), lock_id("email"));
+}
+
+#[test]
+fn lock_id_is_distinct_per_source_name() {
+    let names = ["email", "orders-poll", "stripe-sync", "gmail-history", ""];
+    for (i, a) in names.iter().enumerate() {
+        for b in &names[i + 1..] {
+            assert_ne!(
+                lock_id(a),
+                lock_id(b),
+                "distinct names must derive distinct lock ids: {a} vs {b}"
+            );
+        }
+    }
+}
+
+#[test]
+fn cursor_snapshot_empty_is_unset() {
+    let empty = CursorSnapshot::empty();
+    assert!(empty.is_unset());
+    assert_eq!(empty.value, None);
+    assert_eq!(empty.version, 0);
+    assert_eq!(empty, CursorSnapshot::default());
+}
+
+#[test]
+fn cursor_snapshot_with_version_is_set() {
+    let snap = CursorSnapshot {
+        value:   Some(serde_json::json!({"last_uid": 42})),
+        version: 3,
+    };
+    assert!(!snap.is_unset());
+}
+
+#[tokio::test]
+async fn in_process_runner_runs_the_closure_and_releases() {
+    let runner = LeaseGuardedRunner::in_process("test-source");
+    assert_eq!(runner.source_name(), "test-source");
+
+    // First run wins the lease and executes the closure.
+    let outcome = runner.run(|| async { 42_u32 }).await.expect("acquire must not fail");
+    assert_eq!(outcome, RunOutcome::Ran(42));
+    assert_eq!(runner.skips_not_leader(), 0);
+
+    // The lease was released explicitly, so a second run wins it again — proving
+    // acquire → run → release round-trips rather than leaving the lock held.
+    let outcome = runner.run(|| async { 7_u32 }).await.expect("acquire must not fail");
+    assert_eq!(outcome, RunOutcome::Ran(7));
+    assert_eq!(runner.skips_not_leader(), 0);
+}

--- a/crates/fraiseql-observers/tests/source_cursor_pg.rs
+++ b/crates/fraiseql-observers/tests/source_cursor_pg.rs
@@ -1,0 +1,267 @@
+//! Live-PostgreSQL tests for the #573 source coordination primitives: the durable
+//! [`PostgresSourceCursorStore`] and the single-firing [`LeaseGuardedRunner`].
+//!
+//! Proves the parts only a real database can:
+//!
+//! * **compare-and-swap advance** — a first advance inserts at version 1; each subsequent advance
+//!   from the current snapshot bumps the version; a *stale* advance (wrong version) is rejected and
+//!   never regresses the watermark;
+//! * **transactional advance** — `advance_in_tx` commits or rolls back atomically with the caller's
+//!   transaction (Model A's no-reprocess guarantee);
+//! * **deny-by-default RLS** — a NOBYPASSRLS role with no `fraiseql.tenant_id` GUC reads zero
+//!   cursor rows (mirrors `rls_isolation.rs`);
+//! * **single-firing** — two runners (two replicas) on one source: one runs, the other skips,
+//!   counting `skips_not_leader`.
+//!
+//! Self-skips when no Postgres is available (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: observers` suite.
+//! Each test uses a fresh random source name so runs never collide on cursor rows.
+//!
+//! **Execution engine:** PostgreSQL · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** creates a shared subordinate role → run `--test-threads=1`.
+#![cfg(feature = "postgres")]
+#![allow(clippy::unwrap_used)] // Reason: integration test file — panics are acceptable
+#![allow(clippy::panic)] // Reason: integration test file
+#![allow(clippy::print_stderr)] // Reason: skip diagnostic when no backing Postgres
+
+use std::str::FromStr;
+
+use fraiseql_observers::{
+    CursorSnapshot, LeaseGuardedRunner, PostgresSourceCursorStore, RunOutcome, SourceCursorStore,
+};
+use serde_json::json;
+use sqlx::{
+    PgPool,
+    postgres::{PgConnectOptions, PgPoolOptions},
+};
+
+/// NOBYPASSRLS reader — the RLS-subject role the deny-by-default policy must bind.
+const RLS_ROLE: &str = "fraiseql_source_cursor_rls_reader";
+const ROLE_PASSWORD: &str = "source_cursor_rls_test_password";
+
+/// Connect a pool to the harness-provided Postgres, or `None` to skip cleanly.
+async fn connect_pool() -> Option<(PgPool, fraiseql_test_support::Service)> {
+    let svc = fraiseql_test_support::postgres().await?;
+    let pool = PgPool::connect(svc.url()).await.unwrap();
+    Some((pool, svc))
+}
+
+/// A pool connected as `role` — same host/port/database as the given URL, with the
+/// credentials swapped (mirrors `rls_isolation.rs::role_pool`).
+async fn role_pool(url: &str, role: &str) -> PgPool {
+    let opts = PgConnectOptions::from_str(url)
+        .expect("parse DATABASE_URL")
+        .username(role)
+        .password(ROLE_PASSWORD);
+    PgPoolOptions::new()
+        .max_connections(2)
+        .connect_with(opts)
+        .await
+        .unwrap_or_else(|e| panic!("connect as {role}: {e}"))
+}
+
+/// A fresh source name so parallel/repeat runs never share a cursor row.
+fn unique_source() -> String {
+    format!("test-src-{}", uuid::Uuid::new_v4())
+}
+
+#[tokio::test]
+async fn load_missing_is_the_empty_snapshot() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP load_missing_is_the_empty_snapshot: no postgres");
+        return;
+    };
+    let store = PostgresSourceCursorStore::new(pool);
+    store.init().await.unwrap();
+
+    let snap = store.load(&unique_source()).await.unwrap();
+    assert_eq!(snap, CursorSnapshot::empty(), "an unseen source loads as empty");
+    assert!(snap.is_unset());
+}
+
+#[tokio::test]
+async fn advances_are_monotonic_and_readable() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP advances_are_monotonic_and_readable: no postgres");
+        return;
+    };
+    let store = PostgresSourceCursorStore::new(pool);
+    store.init().await.unwrap();
+    let source = unique_source();
+
+    // First advance inserts at version 1.
+    let empty = store.load(&source).await.unwrap();
+    assert!(store.advance(&source, &empty, json!({"last_uid": 100})).await.unwrap());
+    let v1 = store.load(&source).await.unwrap();
+    assert_eq!(v1.value, Some(json!({"last_uid": 100})));
+    assert_eq!(v1.version, 1);
+
+    // A second advance from the current snapshot bumps to version 2.
+    assert!(store.advance(&source, &v1, json!({"last_uid": 250})).await.unwrap());
+    let v2 = store.load(&source).await.unwrap();
+    assert_eq!(v2.value, Some(json!({"last_uid": 250})));
+    assert_eq!(v2.version, 2);
+}
+
+#[tokio::test]
+async fn stale_advance_is_rejected_and_does_not_regress() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP stale_advance_is_rejected_and_does_not_regress: no postgres");
+        return;
+    };
+    let store = PostgresSourceCursorStore::new(pool);
+    store.init().await.unwrap();
+    let source = unique_source();
+
+    let empty = store.load(&source).await.unwrap();
+    assert!(store.advance(&source, &empty, json!("first")).await.unwrap()); // → v1
+
+    // A stale writer still holding the empty (v0) snapshot: the first-write INSERT
+    // loses on ON CONFLICT, so the advance is rejected.
+    assert!(
+        !store.advance(&source, &empty, json!("stale-from-v0")).await.unwrap(),
+        "a v0 advance against an existing row must be rejected"
+    );
+
+    let v1 = store.load(&source).await.unwrap();
+    assert!(store.advance(&source, &v1, json!("second")).await.unwrap()); // → v2
+
+    // A stale writer still holding the v1 snapshot: the UPDATE matches no row.
+    assert!(
+        !store.advance(&source, &v1, json!("stale-from-v1")).await.unwrap(),
+        "a v1 advance against a v2 row must be rejected"
+    );
+
+    // The watermark is exactly the last winning advance — never regressed.
+    let current = store.load(&source).await.unwrap();
+    assert_eq!(current.value, Some(json!("second")));
+    assert_eq!(current.version, 2);
+}
+
+#[tokio::test]
+async fn advance_in_tx_is_atomic_with_the_caller_transaction() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP advance_in_tx_is_atomic_with_the_caller_transaction: no postgres");
+        return;
+    };
+    let store = PostgresSourceCursorStore::new(pool.clone());
+    store.init().await.unwrap();
+    let source = unique_source();
+    let empty = store.load(&source).await.unwrap();
+
+    // A rolled-back transaction leaves no watermark (re-run is safe).
+    let mut tx = pool.begin().await.unwrap();
+    assert!(store.advance_in_tx(&mut tx, &source, &empty, json!({"n": 5})).await.unwrap());
+    tx.rollback().await.unwrap();
+    assert_eq!(
+        store.load(&source).await.unwrap(),
+        CursorSnapshot::empty(),
+        "a rolled-back advance must leave no watermark"
+    );
+
+    // A committed transaction persists the watermark.
+    let mut tx = pool.begin().await.unwrap();
+    assert!(store.advance_in_tx(&mut tx, &source, &empty, json!({"n": 9})).await.unwrap());
+    tx.commit().await.unwrap();
+    let snap = store.load(&source).await.unwrap();
+    assert_eq!(snap.value, Some(json!({"n": 9})));
+    assert_eq!(snap.version, 1);
+}
+
+#[tokio::test]
+async fn rls_denies_reads_to_a_role_without_the_tenant_guc() {
+    let Some((admin, svc)) = connect_pool().await else {
+        eprintln!("SKIP rls_denies_reads_to_a_role_without_the_tenant_guc: no postgres");
+        return;
+    };
+
+    // Create the NOBYPASSRLS reader (idempotent), re-asserting its attributes in
+    // case it survived an earlier run.
+    sqlx::query(&format!(
+        "DO $$ BEGIN
+             IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{RLS_ROLE}') THEN
+                 CREATE ROLE {RLS_ROLE} LOGIN PASSWORD '{ROLE_PASSWORD}' NOSUPERUSER NOBYPASSRLS;
+             END IF;
+         END $$"
+    ))
+    .execute(&admin)
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "ALTER ROLE {RLS_ROLE} NOSUPERUSER NOBYPASSRLS LOGIN PASSWORD '{ROLE_PASSWORD}'"
+    ))
+    .execute(&admin)
+    .await
+    .unwrap();
+
+    let store = PostgresSourceCursorStore::new(admin.clone());
+    store.init().await.unwrap();
+    sqlx::query(&format!("GRANT SELECT ON _fraiseql_source_cursor TO {RLS_ROLE}"))
+        .execute(&admin)
+        .await
+        .unwrap();
+
+    // Seed a (global, tenant_id NULL) cursor as the superuser.
+    let source = unique_source();
+    let empty = store.load(&source).await.unwrap();
+    assert!(store.advance(&source, &empty, json!({"secret": true})).await.unwrap());
+
+    // The NOBYPASSRLS reader, with no tenant GUC, sees zero rows (deny-by-default).
+    let reader = role_pool(svc.url(), RLS_ROLE).await;
+    let (denied,): (i64,) =
+        sqlx::query_as("SELECT count(*) FROM _fraiseql_source_cursor WHERE source_name = $1")
+            .bind(&source)
+            .fetch_one(&reader)
+            .await
+            .unwrap();
+    assert_eq!(denied, 0, "a NOBYPASSRLS role with no tenant GUC must read zero cursor rows");
+
+    // The superuser (bypasses RLS) still sees the row — proving the deny is RLS,
+    // not a missing row.
+    let (seen,): (i64,) =
+        sqlx::query_as("SELECT count(*) FROM _fraiseql_source_cursor WHERE source_name = $1")
+            .bind(&source)
+            .fetch_one(&admin)
+            .await
+            .unwrap();
+    assert_eq!(seen, 1, "the trusted superuser reads the seeded cursor row");
+}
+
+#[tokio::test]
+async fn two_runners_on_one_source_fire_once() {
+    let Some((pool_a, svc)) = connect_pool().await else {
+        eprintln!("SKIP two_runners_on_one_source_fire_once: no postgres");
+        return;
+    };
+    // A second pool models a second replica with its own sessions.
+    let pool_b = PgPool::connect(svc.url()).await.unwrap();
+    let source = unique_source();
+
+    let runner_a = LeaseGuardedRunner::postgres(pool_a, source.clone());
+    let runner_b = LeaseGuardedRunner::postgres(pool_b, source);
+
+    // Replica A grabs the lease and holds it until told to release; replica B must
+    // attempt while A holds it, so the barrier makes the race deterministic.
+    let (holding_tx, holding_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let a = tokio::spawn(async move {
+        runner_a
+            .run(|| async move {
+                holding_tx.send(()).unwrap();
+                release_rx.await.unwrap();
+                "a-ran"
+            })
+            .await
+    });
+
+    // Wait until A holds the lease, then B attempts and must skip.
+    holding_rx.await.unwrap();
+    let b_outcome = runner_b.run(|| async { "b-ran" }).await.unwrap();
+    assert_eq!(b_outcome, RunOutcome::SkippedNotLeader, "the second replica must skip");
+    assert_eq!(runner_b.skips_not_leader(), 1);
+
+    // Let A finish; it ran exactly once.
+    release_tx.send(()).unwrap();
+    let a_outcome = a.await.unwrap().unwrap();
+    assert_eq!(a_outcome, RunOutcome::Ran("a-ran"));
+}


### PR DESCRIPTION
## #573 `Source` (scheduled ingress) — Phase 01 of 09: Coordination primitives

The generic, driver-light backbone for scheduled ingress `Source`s (the dual of `Observer`): a durable **opaque cursor store** with compare-and-swap advance, and a **single-firing runner** over the (previously unwired) advisory lease. Placed in `fraiseql-observers` beside the `CheckpointStore`/`CheckpointLease` family — same concern, and the functions subsystem that drives sources already depends on this crate (DESIGN §2, D5).

Built directly on [Phase 00](https://github.com/fraiseql/fraiseql/pull/574)'s finding: a PostgreSQL session advisory lock is **not** released by dropping the lease — so the runner releases explicitly on the happy path, with connection-death as the crash-safety backstop only.

### What this adds
- **Migration** `13_create_source_cursor.sql` → `migrations::source_cursor_sql()`: `_fraiseql_source_cursor` (PK `source_name`, opaque `cursor_value JSONB`, monotonic `version`, `tenant_id`, `updated_at`), **deny-by-default RLS + `REVOKE ALL FROM PUBLIC`** (mirrors change-log migration 12). Applied per-store by `init()` — there is no global migration registry.
- **`SourceCursorStore` trait** (native `async fn`, **no new `#[async_trait]`**) + `PostgresSourceCursorStore`. `load` → `CursorSnapshot { value, version }`. `advance` is **version-based CAS**: the value is opaque so it can't be compared; a monotonic `version` generation counter is the guard, so a stale advance (wrong version, e.g. a writer that lost the lease across a failover) is rejected and never regresses the watermark. `advance_in_tx` gives Model A its same-transaction (atomic) advance.
- **`LeaseGuardedRunner`**: acquire → run → **release explicitly** → count `skips_not_leader`. Lock key = `SHA-256(source_name)` truncated to `i64` (stable + collision-resistant; a plain `SipHash` is not stable across processes, so replicas would derive different keys and never coordinate). Backends `in_process | postgres`.

### Tests
- **Pure** (`src/source/tests.rs`): lock-id determinism/distinctness, snapshot semantics, in-process runner acquire→run→release round-trip.
- **PG integration** (`tests/source_cursor_pg.rs`): CAS monotonicity, **stale-advance rejection** (both the first-write and update branches), **in-tx atomicity** (rollback leaves no watermark), **deny-by-default RLS** under a NOBYPASSRLS role, **two-replica single-firing**. Verified locally: **6 passed vs PostgreSQL 16**.
- **CI wiring:** both new observers PG binaries added to the Dagger `integration: observers` leg — including `advisory_lease_pg` from Phase 00, which had shipped in #574 with **no CI wiring** (it only ran locally). Now both run against the bound Postgres.

### Verification
- ✅ `make preflight` (fmt, clippy pedantic `-D warnings`, rustdoc `-D warnings`, shell gates); gofmt clean on the Dagger change
- ✅ `cargo test -p fraiseql-observers --features postgres` — lib + doctests + PG integration, **0 failed** vs real PG 16

🤖 Generated with [Claude Code](https://claude.com/claude-code)