### PR TITLE
feat(functions): #573 Phase 02 — PullSource trait + scheduling envelope

### DIFF
--- a/crates/fraiseql-functions/src/lib.rs
+++ b/crates/fraiseql-functions/src/lib.rs
@@ -31,8 +31,8 @@ pub use triggers::{
     cron::{CronScheduler, CronSchedulerHandle, CronTrigger},
     ingest::{
         Attachment, Classification, InboundMessage, InboundRouting, IngestError, IngestSource,
-        IngestTrigger, PushSource, RawDelivery, Recipient, RoutingRule, Source, StorageRef,
-        Transport,
+        IngestTrigger, PullBatch, PullContext, PullSource, PushSource, RawDelivery, Recipient,
+        RoutingRule, Source, StorageRef, Transport,
         email::{ParsedEmail, PendingAttachment, classify, derive_thread_key, normalize_email},
         parse_recipient, resolve_routing,
     },
@@ -41,6 +41,7 @@ pub use triggers::{
         EntityEvent, EventKind, TriggerMatcher,
     },
     registry::TriggerRegistry,
+    source::{IngestSink, SourceOutcome, run_source_once},
 };
 pub use types::{
     EventPayload, FunctionDefinition, FunctionModule, FunctionResult, LogEntry, LogLevel,

--- a/crates/fraiseql-functions/src/triggers/ingest.rs
+++ b/crates/fraiseql-functions/src/triggers/ingest.rs
@@ -329,6 +329,72 @@ pub trait PushSource: Source {
     fn normalize(&self, delivery: &RawDelivery<'_>) -> Result<InboundMessage, IngestError>;
 }
 
+/// The cursor state handed to a [`PullSource::poll`]: the opaque watermark the
+/// source advanced on its previous run, or `None` on the first run.
+///
+/// The value is **owned end to end by the source** — the framework carries it as
+/// opaque JSON and never interprets it. A poll-IMAP source encodes
+/// `{uid_validity, last_uid}` here; an API source might carry a page token.
+#[derive(Debug, Clone, Default)]
+pub struct PullContext {
+    /// The cursor the source last returned via [`PullBatch::next_cursor`], or
+    /// `None` if it has never run.
+    pub cursor: Option<serde_json::Value>,
+}
+
+/// The result of one [`PullSource::poll`]: the messages fetched since the incoming
+/// cursor, and the advanced cursor to persist once they are durably ingested.
+#[derive(Debug, Clone)]
+pub struct PullBatch {
+    /// Normalized messages fetched since the incoming cursor, in ingest order.
+    pub messages:    Vec<InboundMessage>,
+    /// The opaque cursor to persist **after** the messages commit. Ignored on an
+    /// empty batch — the watermark does not move on a poll that fetched nothing.
+    pub next_cursor: serde_json::Value,
+}
+
+impl PullBatch {
+    /// An empty batch that leaves the cursor where it was (`next_cursor` echoes the
+    /// incoming cursor, or `null` on the first run).
+    #[must_use]
+    pub fn empty(current_cursor: Option<serde_json::Value>) -> Self {
+        Self {
+            messages:    Vec::new(),
+            next_cursor: current_cursor.unwrap_or(serde_json::Value::Null),
+        }
+    }
+}
+
+/// A poll-delivered source (the dual of [`PushSource`]).
+///
+/// Where a [`PushSource`] receives deliveries and normalizes them synchronously, a
+/// `PullSource` is polled on a schedule: given the cursor from its last run it
+/// fetches everything new from the remote and returns the normalized messages plus
+/// the advanced cursor. The framework owns scheduling, single-firing, the durable
+/// cursor, and idempotent ingest; the source owns only the transport edge and the
+/// (opaque) cursor shape.
+///
+/// Native `async fn` in trait (no `async_trait`); the source envelope uses a
+/// concrete `PullSource`, so the missing `Send` bound on the returned future is not
+/// a constraint here.
+#[allow(async_fn_in_trait)] // Reason: concrete-type use in the source envelope; no dyn dispatch.
+pub trait PullSource: Source {
+    /// Fetch everything new since `ctx.cursor` and return it plus the advanced
+    /// cursor.
+    ///
+    /// Must be idempotent with respect to the cursor: re-polling from the same
+    /// cursor after a crash re-fetches the same window, and the durable spine
+    /// deduplicates the overlap by idempotency key — that is what makes at-least-once
+    /// delivery safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IngestError`] if the remote fetch or normalization fails; the
+    /// framework then leaves the cursor unmoved so the next run retries the same
+    /// window.
+    async fn poll(&self, ctx: &PullContext) -> Result<PullBatch, IngestError>;
+}
+
 /// A trigger that fires after an inbound message is ingested.
 ///
 /// Mirrors [`AfterMutationTrigger`](crate::AfterMutationTrigger): it matches a

--- a/crates/fraiseql-functions/src/triggers/mod.rs
+++ b/crates/fraiseql-functions/src/triggers/mod.rs
@@ -47,6 +47,7 @@ pub mod http;
 pub mod ingest;
 pub mod mutation;
 pub mod registry;
+pub mod source;
 pub mod storage;
 #[cfg(test)]
 mod tests;
@@ -55,10 +56,12 @@ pub use cron::{CronExecutionState, CronSchedule, CronScheduler, CronSchedulerHan
 pub use http::{HttpTriggerMatcher, HttpTriggerPayload, HttpTriggerResponse, HttpTriggerRoute};
 pub use ingest::{
     Attachment, Classification, InboundMessage, InboundRouting, IngestError, IngestSource,
-    IngestTrigger, PushSource, RawDelivery, Recipient, RoutingRule, Source, StorageRef, Transport,
+    IngestTrigger, PullBatch, PullContext, PullSource, PushSource, RawDelivery, Recipient,
+    RoutingRule, Source, StorageRef, Transport,
     email::{ParsedEmail, PendingAttachment, classify, derive_thread_key, normalize_email},
     parse_recipient, resolve_routing,
 };
 pub use mutation::{AfterMutationTrigger, BeforeMutationTrigger};
 pub use registry::{ParsedTrigger, RegistryError, TriggerRegistry};
+pub use source::{IngestSink, SourceOutcome, run_source_once};
 pub use storage::{StorageEventPayload, StorageOperation, StorageTrigger};

--- a/crates/fraiseql-functions/src/triggers/source.rs
+++ b/crates/fraiseql-functions/src/triggers/source.rs
@@ -1,0 +1,160 @@
+//! The scheduling envelope for a [`PullSource`] — the generic orchestration that
+//! turns a native pull source into a rock-solid, single-firing, at-least-once
+//! ingress on a schedule (#573).
+//!
+//! One tick ([`run_source_once`]) does, under the source's advisory lease so it
+//! runs on exactly one replica:
+//!
+//! 1. load the durable cursor,
+//! 2. [`poll`](PullSource::poll) the source for everything new since it,
+//! 3. hand a non-empty batch to the [`IngestSink`], which emits it onto the durable spine and
+//!    advances the cursor **in one transaction** (atomic — no reprocess window) and dispatches
+//!    `after:ingest` once committed.
+//!
+//! ## Layering — why the sink is a seam
+//!
+//! This envelope owns *scheduling* (the lease, the cursor read, the poll), all of
+//! which this crate can express with no database driver. The *transactional* part —
+//! the spine write, the cursor advance, and the `after:ingest` dispatch — lives in
+//! the server (that is where the spine is) and is reached through [`IngestSink`],
+//! so the envelope stays driver-free and unit-testable with a stub sink. Keeping
+//! the transaction inside the sink (rather than owning it here) is what lets this
+//! crate avoid a hard `sqlx` dependency.
+
+use fraiseql_error::{FraiseQLError, Result};
+use fraiseql_observers::{
+    CursorSnapshot, LeaseGuardedRunner, ObserverError, RunOutcome, SourceCursorStore,
+};
+
+use super::ingest::{PullBatch, PullContext, PullSource};
+
+#[cfg(test)]
+mod tests;
+
+/// The durable-ingest seam the envelope drives.
+///
+/// One call must, **atomically**: emit the batch's messages onto the durable spine
+/// (deduplicated by idempotency key) and advance the cursor from `from` to the
+/// batch's `next_cursor`, in a single transaction; then, once committed, dispatch
+/// `after:ingest` for the newly-persisted messages (durable, at-least-once).
+///
+/// Implemented by the server, where the spine and the `after:ingest` dispatcher
+/// live. Splitting it out keeps this crate free of the database driver and lets the
+/// envelope be tested with an in-memory stub.
+#[allow(async_fn_in_trait)] // Reason: concrete-type use by the envelope; no dyn dispatch.
+pub trait IngestSink {
+    /// Transactionally emit `batch` onto the spine and advance the cursor from
+    /// `from`, then dispatch `after:ingest` post-commit.
+    ///
+    /// Returns `true` when the batch committed and the cursor advanced, `false`
+    /// when the cursor advance lost a lease-boundary race (another replica had
+    /// already moved it on) — in which case the transaction is rolled back and
+    /// nothing is ingested or dispatched.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FraiseQLError`] if the spine write, the cursor advance, or the
+    /// commit fails; the caller then leaves the watermark unmoved for a retry.
+    async fn ingest(
+        &self,
+        source_name: &str,
+        batch: PullBatch,
+        from: &CursorSnapshot,
+    ) -> Result<bool>;
+}
+
+/// The outcome of one [`run_source_once`] tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceOutcome {
+    /// Another replica held the lease; this tick did not poll.
+    SkippedNotLeader,
+    /// Polled, but the source returned nothing new; the cursor did not move.
+    NoData,
+    /// Ingested `messages` messages and advanced the cursor.
+    Ingested {
+        /// How many messages the poll returned (before spine dedup).
+        messages: usize,
+    },
+    /// The cursor advance was rejected — another replica had already moved it on
+    /// (a lease-boundary race). The transaction rolled back; nothing ingested.
+    CursorRaceLost,
+}
+
+/// Run one tick of a native [`PullSource`] under its single-firing lease.
+///
+/// `runner` and `store` — and the sink's own spine/cursor handles — must all
+/// target the same PostgreSQL database, through which the advisory lease, the
+/// cursor watermark, and the ingest writes coordinate.
+///
+/// # Errors
+///
+/// Returns a [`FraiseQLError`] if acquiring the lease, loading the cursor, polling
+/// the source, or ingesting the batch fails. On any error nothing commits, so the
+/// cursor stays put and the next tick retries the same window (at-least-once).
+// Reason: the future is Send for concrete source/store/sink types (all do
+// Send sqlx/IMAP I/O); the source scheduler spawns those concrete instantiations,
+// where rustc enforces Send. clippy cannot prove it for the fully generic form.
+#[allow(clippy::future_not_send)]
+pub async fn run_source_once<S, P, K>(
+    runner: &LeaseGuardedRunner,
+    store: &S,
+    source: &P,
+    sink: &K,
+) -> Result<SourceOutcome>
+where
+    S: SourceCursorStore,
+    P: PullSource,
+    K: IngestSink,
+{
+    let name = source.source().as_key();
+
+    let outcome = runner
+        .run(|| ingest_tick(store, source, sink, &name))
+        .await
+        .map_err(|e| obs_err(&e))?;
+
+    match outcome {
+        RunOutcome::SkippedNotLeader => Ok(SourceOutcome::SkippedNotLeader),
+        RunOutcome::Ran(result) => result,
+    }
+}
+
+/// The body of one tick, run under the lease: load the cursor, poll, and hand a
+/// non-empty batch to the sink to ingest transactionally.
+#[allow(clippy::future_not_send)] // Reason: see `run_source_once`.
+async fn ingest_tick<S, P, K>(store: &S, source: &P, sink: &K, name: &str) -> Result<SourceOutcome>
+where
+    S: SourceCursorStore,
+    P: PullSource,
+    K: IngestSink,
+{
+    let cursor = store.load(name).await.map_err(|e| obs_err(&e))?;
+
+    let batch = source
+        .poll(&PullContext {
+            cursor: cursor.value.clone(),
+        })
+        .await
+        .map_err(|error| {
+            FraiseQLError::internal(format!("source '{name}' poll failed: {error}"))
+        })?;
+
+    if batch.messages.is_empty() {
+        // An empty poll never moves the watermark.
+        return Ok(SourceOutcome::NoData);
+    }
+    let message_count = batch.messages.len();
+
+    if sink.ingest(name, batch, &cursor).await? {
+        Ok(SourceOutcome::Ingested {
+            messages: message_count,
+        })
+    } else {
+        Ok(SourceOutcome::CursorRaceLost)
+    }
+}
+
+/// Map an observer-coordination error onto the canonical framework error.
+fn obs_err(error: &ObserverError) -> FraiseQLError {
+    FraiseQLError::database(format!("source coordination: {error}"))
+}

--- a/crates/fraiseql-functions/src/triggers/source/tests.rs
+++ b/crates/fraiseql-functions/src/triggers/source/tests.rs
@@ -1,0 +1,201 @@
+//! Pure (no-database) unit tests for the source scheduling envelope, using an
+//! in-memory cursor store, a canned pull source, and a recording ingest sink. The
+//! transactional emit+advance atomicity and cross-replica single-firing are proven
+//! against real Postgres where the server sink lives (Phase 03).
+#![allow(clippy::unwrap_used)] // Reason: test module
+
+use std::sync::{Arc, Mutex};
+
+use fraiseql_observers::{
+    CursorSnapshot, LeaseGuardedRunner, Result as ObsResult, SourceCursorStore,
+};
+use serde_json::{Value, json};
+
+use super::{IngestSink, SourceOutcome, run_source_once};
+use crate::triggers::ingest::{
+    InboundMessage, IngestError, IngestSource, PullBatch, PullContext, PullSource, Source,
+    Transport,
+};
+
+fn ts() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339("2026-07-08T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}
+
+fn msg(key: &str) -> InboundMessage {
+    InboundMessage::new(IngestSource::Email, key, ts())
+}
+
+/// An in-memory cursor store that always loads the same snapshot.
+struct StubCursorStore {
+    snapshot: CursorSnapshot,
+}
+
+impl SourceCursorStore for StubCursorStore {
+    async fn load(&self, _source: &str) -> ObsResult<CursorSnapshot> {
+        Ok(self.snapshot.clone())
+    }
+
+    async fn advance(
+        &self,
+        _source: &str,
+        _from: &CursorSnapshot,
+        _value: Value,
+    ) -> ObsResult<bool> {
+        Ok(true)
+    }
+}
+
+/// A pull source that returns a canned poll result.
+struct StubPullSource {
+    poll_result: std::result::Result<PullBatch, IngestError>,
+}
+
+impl Source for StubPullSource {
+    fn source(&self) -> IngestSource {
+        IngestSource::Email
+    }
+
+    fn transport(&self) -> Transport {
+        Transport::Pull
+    }
+}
+
+impl PullSource for StubPullSource {
+    async fn poll(&self, _ctx: &PullContext) -> std::result::Result<PullBatch, IngestError> {
+        self.poll_result.clone()
+    }
+}
+
+/// An ingest sink that records every call and returns a canned result.
+struct StubIngestSink {
+    /// `Ok(advanced)` → the sink committed and reports whether the cursor advanced;
+    /// `Err(())` → the sink failed (mapped to a `FraiseQLError`).
+    result: std::result::Result<bool, ()>,
+    calls:  Arc<Mutex<Vec<(String, PullBatch, CursorSnapshot)>>>,
+}
+
+impl StubIngestSink {
+    fn new(result: std::result::Result<bool, ()>) -> Self {
+        Self {
+            result,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+}
+
+impl IngestSink for StubIngestSink {
+    async fn ingest(
+        &self,
+        source_name: &str,
+        batch: PullBatch,
+        from: &CursorSnapshot,
+    ) -> fraiseql_error::Result<bool> {
+        self.calls.lock().unwrap().push((source_name.to_string(), batch, from.clone()));
+        self.result
+            .map_err(|()| fraiseql_error::FraiseQLError::internal("stub sink forced failure"))
+    }
+}
+
+fn empty_store() -> StubCursorStore {
+    StubCursorStore {
+        snapshot: CursorSnapshot::empty(),
+    }
+}
+
+#[tokio::test]
+async fn non_empty_batch_is_ingested_and_reaches_the_sink() {
+    let store = empty_store();
+    let source = StubPullSource {
+        poll_result: Ok(PullBatch {
+            messages:    vec![msg("a"), msg("b")],
+            next_cursor: json!({"uid": 2}),
+        }),
+    };
+    let sink = StubIngestSink::new(Ok(true));
+    let runner = LeaseGuardedRunner::in_process("email");
+
+    let outcome = run_source_once(&runner, &store, &source, &sink).await.unwrap();
+
+    assert_eq!(outcome, SourceOutcome::Ingested { messages: 2 });
+    let calls = sink.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1, "the sink is called exactly once");
+    assert_eq!(calls[0].0, "email", "the sink receives the source's key");
+    assert_eq!(calls[0].1.messages.len(), 2, "the sink receives the polled batch");
+    assert_eq!(
+        calls[0].2,
+        CursorSnapshot::empty(),
+        "the sink receives the loaded snapshot for the CAS"
+    );
+}
+
+#[tokio::test]
+async fn empty_batch_never_reaches_the_sink() {
+    let store = empty_store();
+    let source = StubPullSource {
+        poll_result: Ok(PullBatch::empty(None)),
+    };
+    let sink = StubIngestSink::new(Ok(true));
+    let runner = LeaseGuardedRunner::in_process("email");
+
+    let outcome = run_source_once(&runner, &store, &source, &sink).await.unwrap();
+
+    assert_eq!(outcome, SourceOutcome::NoData, "an empty poll is NoData");
+    assert_eq!(sink.call_count(), 0, "an empty batch must not reach the sink");
+}
+
+#[tokio::test]
+async fn poll_error_propagates_and_skips_the_sink() {
+    let store = empty_store();
+    let source = StubPullSource {
+        poll_result: Err(IngestError::new("remote unreachable")),
+    };
+    let sink = StubIngestSink::new(Ok(true));
+    let runner = LeaseGuardedRunner::in_process("email");
+
+    let result = run_source_once(&runner, &store, &source, &sink).await;
+
+    assert!(result.is_err(), "a poll error propagates");
+    assert_eq!(sink.call_count(), 0, "a failed poll must not reach the sink (cursor unmoved)");
+}
+
+#[tokio::test]
+async fn cursor_race_lost_when_the_sink_reports_no_advance() {
+    let store = empty_store();
+    let source = StubPullSource {
+        poll_result: Ok(PullBatch {
+            messages:    vec![msg("a")],
+            next_cursor: json!(1),
+        }),
+    };
+    // The sink committed nothing because the cursor had moved on (advance == false).
+    let sink = StubIngestSink::new(Ok(false));
+    let runner = LeaseGuardedRunner::in_process("email");
+
+    let outcome = run_source_once(&runner, &store, &source, &sink).await.unwrap();
+
+    assert_eq!(outcome, SourceOutcome::CursorRaceLost);
+    assert_eq!(sink.call_count(), 1, "the sink was attempted but reported no advance");
+}
+
+#[tokio::test]
+async fn sink_error_propagates() {
+    let store = empty_store();
+    let source = StubPullSource {
+        poll_result: Ok(PullBatch {
+            messages:    vec![msg("a")],
+            next_cursor: json!(1),
+        }),
+    };
+    let sink = StubIngestSink::new(Err(()));
+    let runner = LeaseGuardedRunner::in_process("email");
+
+    let result = run_source_once(&runner, &store, &source, &sink).await;
+
+    assert!(result.is_err(), "a sink failure propagates so the tick is retried");
+}

--- a/crates/fraiseql-observers/src/dispatch.rs
+++ b/crates/fraiseql-observers/src/dispatch.rs
@@ -69,6 +69,9 @@ pub enum DispatchSource {
     AfterMutation,
     /// An `after:ingest` function trigger (inbound-message ingestion).
     AfterIngest,
+    /// A scheduled ingress `Source` poll (#573) — the poll/fetch step itself, as
+    /// distinct from the `after:ingest` handlers its messages then fire.
+    Source,
 }
 
 impl DispatchSource {
@@ -82,6 +85,7 @@ impl DispatchSource {
         match self {
             Self::AfterMutation => "after:mutation",
             Self::AfterIngest => "after:ingest",
+            Self::Source => "source",
         }
     }
 }

--- a/crates/fraiseql-observers/src/dispatch/tests.rs
+++ b/crates/fraiseql-observers/src/dispatch/tests.rs
@@ -127,6 +127,7 @@ fn dispatch_source_label_is_stable() {
     // from `Debug`, so a token stays constant across refactors of the enum.
     assert_eq!(DispatchSource::AfterMutation.label(), "after:mutation");
     assert_eq!(DispatchSource::AfterIngest.label(), "after:ingest");
+    assert_eq!(DispatchSource::Source.label(), "source");
 }
 
 #[test]


### PR DESCRIPTION
## #573 `Source` (scheduled ingress) — Phase 02 of 09: `PullSource` + envelope

The expandable backbone for scheduled ingress: the **`PullSource` trait** (the dual of `PushSource`) and a **generic scheduling envelope** that single-fires, polls, and hands each batch to a transactional ingest seam. Adding a native pull source is now "implement one trait."

Built on Phase 01's `LeaseGuardedRunner` + `SourceCursorStore`.

### What this adds (all in `fraiseql-functions`, plus one observers variant)
- **`PullSource: Source`** + `PullContext { cursor: Option<Value> }` + `PullBatch { messages, next_cursor }` in `triggers/ingest.rs`, beside `PushSource`. No refactor of `Source`/`PushSource` was needed — `PullSource` seats cleanly as a new sub-trait, and the webhook/push path is untouched.
- **Envelope** `run_source_once(runner, store, source, sink) -> SourceOutcome` (`triggers/source.rs`): under the source's advisory lease → load cursor → poll → hand a non-empty batch to the `IngestSink`. `SourceOutcome { SkippedNotLeader, NoData, Ingested, CursorRaceLost }`.
- **`IngestSink` seam**: the transactional part (spine emit + `advance_in_tx` + `after:ingest` dispatch, all in one transaction) sits behind this trait, implemented by the server (Phase 03). Keeping it a seam means the envelope needs **no `sqlx` dependency** (sqlx is only a dev-dep of functions) and is unit-testable with an in-memory stub.
- **`DispatchSource::Source`** variant (observers) for source-poll DLQ tagging; label `"source"` pinned in the dispatch-label test (the label feeds the idempotency-token hash).

### Layering note (flagged, not a decision change)
The spine (`emit_in_tx`) and `after:ingest` dispatch live in `fraiseql-server`, so the **real `IngestSink` impl** and the **transactional-atomicity + cross-replica single-firing PG tests** land in **Phase 03** (server), where the sink + email source exist. **D3 (transactional advance) is still honored** — implemented in the server sink. The **source-execution mode on `CronScheduler`** (spawning the envelope on a schedule) lands in **Phase 06**. Phase 02 delivers the schedulable primitive; Phase 06 registers it.

### Tests
5 pure envelope unit tests (`triggers/source/tests.rs`, in-memory store + stub source + recording sink): non-empty → Ingested + sink sees the batch/snapshot; empty → NoData, sink untouched; poll-error → propagates, sink untouched; sink-no-advance → CursorRaceLost; sink-error → propagates. `future_not_send` is allowed on the generic envelope (concrete instantiations are Send — rustc enforces that at the Phase 06 spawn site).

### Verification
- ✅ `make preflight` (fmt, clippy pedantic `-D warnings`, rustdoc `-D warnings`, shell gates)
- ✅ `cargo test -p fraiseql-functions --lib triggers::source` (5 passed); `cargo test -p fraiseql-observers --lib dispatch` (50 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)