### PR TITLE
feat(functions): #573 Phase 04 — Deno guest cursor ops (Model B surface)

### DIFF
--- a/crates/fraiseql-functions/src/host/dyn_context.rs
+++ b/crates/fraiseql-functions/src/host/dyn_context.rs
@@ -93,6 +93,24 @@ pub trait DynHostContext: Send + Sync {
     fn idempotency_token(&self) -> Option<String> {
         None
     }
+
+    /// Read this source's opaque cursor (see
+    /// [`HostContext::cursor`](crate::HostContext::cursor)). Defaults to `None`.
+    fn cursor(&self) -> BoxFuture<'_, Result<Option<serde_json::Value>>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    /// Advance this source's opaque cursor (see
+    /// [`HostContext::advance_cursor`](crate::HostContext::advance_cursor)).
+    /// Defaults to failing on a host not bound to a source.
+    fn advance_cursor(&self, value: serde_json::Value) -> BoxFuture<'_, Result<()>> {
+        Box::pin(async move {
+            let _ = value;
+            Err(fraiseql_error::FraiseQLError::validation(
+                "advance_cursor: this function is not a scheduled source (no cursor binding)",
+            ))
+        })
+    }
 }
 
 /// Blanket implementation: any `T: HostContext + Send + Sync` can be used as `DynHostContext`.
@@ -181,5 +199,13 @@ impl<T: crate::HostContext + Send + Sync> DynHostContext for T {
 
     fn idempotency_token(&self) -> Option<String> {
         crate::HostContext::idempotency_token(self)
+    }
+
+    fn cursor(&self) -> BoxFuture<'_, Result<Option<serde_json::Value>>> {
+        Box::pin(async move { crate::HostContext::cursor(self).await })
+    }
+
+    fn advance_cursor(&self, value: serde_json::Value) -> BoxFuture<'_, Result<()>> {
+        Box::pin(async move { crate::HostContext::advance_cursor(self, value).await })
     }
 }

--- a/crates/fraiseql-functions/src/host/live/mod.rs
+++ b/crates/fraiseql-functions/src/host/live/mod.rs
@@ -111,6 +111,22 @@ pub struct LiveHostContext {
     /// dispatch and distinct per dispatch — see
     /// [`derive_idempotency_token`](fraiseql_observers::derive_idempotency_token).
     idempotency_token: Option<String>,
+
+    /// Durable-cursor binding for a Model B scheduled source (#573). `None` on every
+    /// non-source invocation, so `cursor()` / `advance_cursor()` are inert there.
+    source_cursor: Option<SourceCursorBinding>,
+}
+
+/// Binds a [`LiveHostContext`] to exactly one source's durable cursor (Model B).
+///
+/// The guest can only read/advance *its own* source's cursor — the source name is
+/// fixed by the host at construction, never supplied by the guest, so a source
+/// cannot touch another's watermark.
+struct SourceCursorBinding {
+    /// The source this host is bound to (the cursor row + isolation key).
+    source_name: String,
+    /// The durable cursor store.
+    store:       fraiseql_observers::PostgresSourceCursorStore,
 }
 
 impl LiveHostContext {
@@ -128,6 +144,7 @@ impl LiveHostContext {
             sender_resolver: None,
             email_transport: None,
             idempotency_token: None,
+            source_cursor: None,
         }
     }
 
@@ -148,6 +165,7 @@ impl LiveHostContext {
             sender_resolver: None,
             email_transport: None,
             idempotency_token: None,
+            source_cursor: None,
         }
     }
 
@@ -169,6 +187,7 @@ impl LiveHostContext {
             sender_resolver: None,
             email_transport: None,
             idempotency_token: None,
+            source_cursor: None,
         }
     }
 
@@ -232,6 +251,22 @@ impl LiveHostContext {
     #[must_use]
     pub fn with_idempotency_token(mut self, token: impl Into<String>) -> Self {
         self.idempotency_token = Some(token.into());
+        self
+    }
+
+    /// Bind this host to a Model B source's durable cursor (#573). `source_name`
+    /// fixes which cursor row the guest's `fraiseql_cursor_get` /
+    /// `fraiseql_cursor_advance` ops read and write; the guest cannot name another.
+    #[must_use]
+    pub fn with_source_cursor(
+        mut self,
+        source_name: impl Into<String>,
+        store: fraiseql_observers::PostgresSourceCursorStore,
+    ) -> Self {
+        self.source_cursor = Some(SourceCursorBinding {
+            source_name: source_name.into(),
+            store,
+        });
         self
     }
 }
@@ -520,5 +555,48 @@ impl HostContext for LiveHostContext {
 
     fn idempotency_token(&self) -> Option<String> {
         self.idempotency_token.clone()
+    }
+
+    async fn cursor(&self) -> Result<Option<serde_json::Value>> {
+        use fraiseql_observers::SourceCursorStore;
+        match &self.source_cursor {
+            Some(binding) => {
+                let snapshot =
+                    binding.store.load(&binding.source_name).await.map_err(|error| {
+                        fraiseql_error::FraiseQLError::database(error.to_string())
+                    })?;
+                Ok(snapshot.value)
+            },
+            None => Ok(None),
+        }
+    }
+
+    async fn advance_cursor(&self, value: serde_json::Value) -> Result<()> {
+        use fraiseql_observers::SourceCursorStore;
+        let Some(binding) = &self.source_cursor else {
+            return Err(fraiseql_error::FraiseQLError::validation(
+                "advance_cursor: this function is not a scheduled source (no cursor binding)",
+            ));
+        };
+        // Model B advances after its writes commit; load the current snapshot for the
+        // compare-and-swap `from` version, then advance. Under single-firing there is
+        // no concurrent writer, so a failed CAS means the source overlapped itself.
+        let snapshot = binding
+            .store
+            .load(&binding.source_name)
+            .await
+            .map_err(|error| fraiseql_error::FraiseQLError::database(error.to_string()))?;
+        let applied = binding
+            .store
+            .advance(&binding.source_name, &snapshot, value)
+            .await
+            .map_err(|error| fraiseql_error::FraiseQLError::database(error.to_string()))?;
+        if applied {
+            Ok(())
+        } else {
+            Err(fraiseql_error::FraiseQLError::database(
+                "advance_cursor: the cursor moved concurrently (lost the compare-and-swap)",
+            ))
+        }
     }
 }

--- a/crates/fraiseql-functions/src/host/mod.rs
+++ b/crates/fraiseql-functions/src/host/mod.rs
@@ -141,6 +141,39 @@ pub trait HostContext: Send + Sync {
     fn idempotency_token(&self) -> Option<String> {
         None
     }
+
+    /// Read this source's durable opaque cursor (Model B pull sources, #573).
+    ///
+    /// Returns the JSON value the source last advanced to via
+    /// [`advance_cursor`](Self::advance_cursor), or `None` if it has never advanced.
+    /// Defaults to `None` on every host not bound to a source — a non-source
+    /// invocation has no cursor — so only source-bound hosts override it.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the cursor load fails on a source-bound host.
+    fn cursor(&self) -> impl Future<Output = Result<Option<serde_json::Value>>> + Send {
+        async { Ok(None) }
+    }
+
+    /// Advance this source's durable cursor to `value` (Model B pull sources, #573).
+    ///
+    /// The value is opaque and owned by the source. Defaults to failing on a host
+    /// not bound to a source, so a guest that is not a scheduled source cannot move
+    /// a cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` on a host not bound to a source (the default), or if the write
+    /// fails / lost a concurrent race on a source-bound host.
+    fn advance_cursor(&self, value: serde_json::Value) -> impl Future<Output = Result<()>> + Send {
+        async move {
+            let _ = value;
+            Err(fraiseql_error::FraiseQLError::validation(
+                "advance_cursor: this function is not a scheduled source (no cursor binding)",
+            ))
+        }
+    }
 }
 
 /// A no-op host context for testing WASM execution without real backends.

--- a/crates/fraiseql-functions/src/runtime/deno/cursor_tests.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/cursor_tests.rs
@@ -1,0 +1,175 @@
+//! The Model B source cursor ops, end-to-end through the Deno runtime (#573).
+//!
+//! Drives a minimal guest that reads (`fraiseql_cursor_get`) and advances
+//! (`fraiseql_cursor_advance`) its source's durable cursor through the real
+//! `DenoRuntime`, on a real `LiveHostContext` bound to a source, against real
+//! Postgres. Proves the cursor round-trips through the guest and that advancing is
+//! scoped to the bound source (no cross-source bleed) — and that a non-source host
+//! refuses the advance.
+//!
+//! Each test runs exactly one guest → one V8 isolate per test process, which is
+//! required (two isolates in one process SIGSEGV). Like every `runtime-deno` test
+//! this runs locally only — CI compiles the path but excludes execution (embedded
+//! V8 SIGSEGVs inside the Dagger exec sandbox). The Postgres-backed tests self-skip
+//! when no `DATABASE_URL` is set.
+
+#![allow(clippy::unwrap_used)] // Reason: test code
+#![allow(clippy::print_stderr)] // Reason: skip diagnostic when no backing Postgres
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use fraiseql_observers::{PostgresSourceCursorStore, SourceCursorStore};
+use sqlx::PgPool;
+
+use crate::{
+    EventPayload, FunctionModule, ResourceLimits, RuntimeType,
+    host::{
+        dyn_context::DynHostContext,
+        live::{HostContextConfig, LiveHostContext},
+    },
+    runtime::deno::{DenoConfig, DenoRuntime},
+};
+
+fn event() -> EventPayload {
+    EventPayload {
+        trigger_type: "cron:poll".to_string(),
+        entity:       "cron".to_string(),
+        event_kind:   "scheduled".to_string(),
+        data:         serde_json::json!({}),
+        timestamp:    Utc::now(),
+    }
+}
+
+async fn connect_pool() -> Option<(PgPool, fraiseql_test_support::Service)> {
+    let svc = fraiseql_test_support::postgres().await?;
+    let pool = PgPool::connect(svc.url()).await.unwrap();
+    Some((pool, svc))
+}
+
+/// Ensure the cursor table exists and this source starts with no row (so re-runs of
+/// a fixed-name test are independent).
+async fn reset(pool: &PgPool, source: &str) {
+    PostgresSourceCursorStore::new(pool.clone()).init().await.unwrap();
+    sqlx::query("DELETE FROM _fraiseql_source_cursor WHERE source_name = $1")
+        .bind(source)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn run_guest(host: Arc<dyn DynHostContext>, ts: &str) -> serde_json::Value {
+    let module =
+        FunctionModule::from_source("cursor-guest".to_string(), ts.to_string(), RuntimeType::Deno);
+    let runtime = DenoRuntime::new(&DenoConfig::default()).unwrap();
+    runtime
+        .invoke_with_context(&module, event(), host, ResourceLimits::default())
+        .await
+        .expect("guest runs")
+        .value
+        .expect("returns a value")
+}
+
+fn source_host(pool: &PgPool, source: &str) -> Arc<dyn DynHostContext> {
+    Arc::new(
+        LiveHostContext::new(event(), HostContextConfig::default())
+            .with_source_cursor(source.to_string(), PostgresSourceCursorStore::new(pool.clone())),
+    )
+}
+
+/// A guest that reads the cursor, advances it, then reads it back — all in one
+/// invocation (a second invocation would need a second isolate).
+const ROUNDTRIP_TS: &str = r"
+export default async () => {
+  const before = await Deno.core.ops.fraiseql_cursor_get();
+  await Deno.core.ops.fraiseql_cursor_advance(JSON.stringify({ page: 5 }));
+  const after = await Deno.core.ops.fraiseql_cursor_get();
+  return { before: JSON.parse(before), after: JSON.parse(after) };
+};
+";
+
+#[tokio::test]
+async fn guest_reads_and_advances_its_cursor() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP guest_reads_and_advances_its_cursor: no postgres");
+        return;
+    };
+    let source = "test-cursor-roundtrip";
+    reset(&pool, source).await;
+
+    let value = run_guest(source_host(&pool, source), ROUNDTRIP_TS).await;
+
+    assert!(
+        value["before"].is_null(),
+        "the first read is null (never advanced), got {:?}",
+        value["before"]
+    );
+    assert_eq!(
+        value["after"],
+        serde_json::json!({ "page": 5 }),
+        "the guest reads back what it advanced"
+    );
+
+    // Durability: the advance persisted to the store beyond the guest invocation.
+    let snapshot = PostgresSourceCursorStore::new(pool.clone()).load(source).await.unwrap();
+    assert_eq!(snapshot.value, Some(serde_json::json!({ "page": 5 })));
+}
+
+/// A guest that advances its (bound) source's cursor.
+const ADVANCE_TS: &str = r"
+export default async () => {
+  await Deno.core.ops.fraiseql_cursor_advance(JSON.stringify({ a: 1 }));
+  return { ok: true };
+};
+";
+
+#[tokio::test]
+async fn advance_is_scoped_to_the_bound_source() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP advance_is_scoped_to_the_bound_source: no postgres");
+        return;
+    };
+    let source_a = "test-cursor-scope-a";
+    let source_b = "test-cursor-scope-b";
+    reset(&pool, source_a).await;
+    reset(&pool, source_b).await;
+
+    // The guest is bound to source A only.
+    run_guest(source_host(&pool, source_a), ADVANCE_TS).await;
+
+    let a = PostgresSourceCursorStore::new(pool.clone()).load(source_a).await.unwrap();
+    let b = PostgresSourceCursorStore::new(pool.clone()).load(source_b).await.unwrap();
+    assert_eq!(a.value, Some(serde_json::json!({ "a": 1 })), "source A advanced");
+    assert!(
+        b.value.is_none(),
+        "advancing source A must not touch source B (no cross-source bleed)"
+    );
+}
+
+/// A guest that catches the error from advancing on a non-source host.
+const REJECT_TS: &str = r"
+export default async () => {
+  try {
+    await Deno.core.ops.fraiseql_cursor_advance('{}');
+    return { errored: false };
+  } catch (e) {
+    return { errored: true, message: String(e) };
+  }
+};
+";
+
+#[tokio::test]
+async fn non_source_host_refuses_to_advance() {
+    // No cursor binding (the default host): a guest that is not a scheduled source
+    // cannot move a cursor. Needs no database — the default fails before any I/O.
+    let host: Arc<dyn DynHostContext> =
+        Arc::new(LiveHostContext::new(event(), HostContextConfig::default()));
+
+    let value = run_guest(host, REJECT_TS).await;
+
+    assert_eq!(
+        value["errored"],
+        serde_json::json!(true),
+        "advance on a non-source host must reject"
+    );
+}

--- a/crates/fraiseql-functions/src/runtime/deno/executor.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/executor.rs
@@ -83,6 +83,8 @@ fn make_fraiseql_extension(
             ops::fraiseql_auth_context(),
             ops::fraiseql_env_var(),
             ops::fraiseql_idempotency_token(),
+            ops::fraiseql_cursor_get(),
+            ops::fraiseql_cursor_advance(),
         ]),
         op_state_fn: Some(Box::new(move |state: &mut OpState| {
             state.put(collector);

--- a/crates/fraiseql-functions/src/runtime/deno/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/mod.rs
@@ -30,6 +30,10 @@ mod transpile_tests;
 // gated on host-live as well — the `runtime-deno`-only clippy combo has no live host.
 #[cfg(all(test, feature = "host-live"))]
 mod idempotency_tests;
+// Model B cursor ops end-to-end on a source-bound `LiveHostContext` (host-live) +
+// real Postgres; local-only like every deno test (V8 SIGSEGVs in the CI sandbox).
+#[cfg(all(test, feature = "host-live"))]
+mod cursor_tests;
 #[cfg(test)]
 mod qonto_tests;
 #[cfg(test)]
@@ -93,6 +97,11 @@ interface FraiseqlHostOps {
   fraiseql_env_var(name: string): string | null;
   // Per-dispatch idempotency token, or null on a non-durably-dispatched invocation.
   fraiseql_idempotency_token(): string | null;
+  // Scheduled-source cursor (Model B). `fraiseql_cursor_get` returns the JSON string
+  // the source last advanced to, or the string 'null'; `fraiseql_cursor_advance`
+  // persists any JSON value as the new cursor. Both fail on a non-source invocation.
+  fraiseql_cursor_get(): Promise<string>;
+  fraiseql_cursor_advance(valueJson: string): Promise<void>;
   // Structured log. Levels: 0=debug, 1=info, 2=warn, 3=error.
   fraiseql_log(level: number, message: string): void;
 }

--- a/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
+++ b/crates/fraiseql-functions/src/runtime/deno/ops/mod.rs
@@ -230,6 +230,35 @@ pub(crate) fn fraiseql_idempotency_token(state: &OpState) -> Result<Option<Strin
     Ok(host.idempotency_token())
 }
 
+/// Read this scheduled source's durable opaque cursor (Model B, #573).
+///
+/// `Deno.core.ops.fraiseql_cursor_get() -> string` — a JSON string: the cursor
+/// value the source last advanced to, or `"null"` if it has never advanced (or the
+/// host is not a source). The guest owns the shape of the value.
+#[op2(async)]
+#[string]
+pub(crate) async fn fraiseql_cursor_get(state: Rc<RefCell<OpState>>) -> Result<String, AnyError> {
+    let host = require_host_rc(&state)?;
+    let value = host.cursor().await.map_err(op_error)?;
+    serde_json::to_string(&value)
+        .map_err(|e| deno_core::anyhow::anyhow!("failed to serialise cursor: {e}"))
+}
+
+/// Advance this scheduled source's durable cursor (Model B, #573).
+///
+/// `Deno.core.ops.fraiseql_cursor_advance(valueJson)` — persist `valueJson` (any
+/// JSON) as the new cursor. Fails loud when the host is not a source or the write
+/// lost a concurrent race.
+#[op2(async)]
+pub(crate) async fn fraiseql_cursor_advance(
+    state: Rc<RefCell<OpState>>,
+    #[string] value: String,
+) -> Result<(), AnyError> {
+    let host = require_host_rc(&state)?;
+    let parsed = parse_json_arg(&value, "cursor")?;
+    host.advance_cursor(parsed).await.map_err(op_error)
+}
+
 /// Parse a JSON-string op argument, treating an empty string as an empty object.
 fn parse_json_arg(raw: &str, what: &str) -> Result<serde_json::Value, AnyError> {
     if raw.trim().is_empty() {


### PR DESCRIPTION
## #573 `Source` (scheduled ingress) — Phase 04 of 09: Deno guest cursor ops

The **Model B** surface: a Deno handler (a source that is user TypeScript) can read and advance its durable cursor from guest code, backed by the same generic `SourceCursorStore` the email source (Model A) uses.

### What this adds
- **`HostContext::cursor()` + `advance_cursor(value)`** (`host/mod.rs`) as **defaulted async methods** — `trait_variant` accepts async defaults, so they default to `None` / a clear `Err` on every host not bound to a source, and the 7 non-source `HostContext` impls need no change (only `LiveHostContext` overrides). Mirrored on the `DynHostContext` dyn variant + its blanket-impl forward.
- **`LiveHostContext`** gains a `SourceCursorBinding { source_name, store }` + a `with_source_cursor(name, store)` builder. **Isolation:** the source name is fixed by the host at construction and never supplied by the guest, so a guest cannot read or advance another source's cursor.
- **Deno ops** `fraiseql_cursor_get() -> Promise<string>` (JSON: the value or `"null"`) + `fraiseql_cursor_advance(valueJson) -> Promise<void>`, registered in `executor.rs` and typed in `FRAISEQL_HOST_TYPES`.

### Tests (`runtime/deno/cursor_tests.rs`)
- guest **read → advance → read** round-trip in one invocation + a direct store check for durability;
- **advance scoped to the bound source** (advancing A leaves B untouched — no cross-source bleed);
- a **non-source host refuses to advance**.

**Local-only, like every `runtime-deno` test** — CI compiles the path (`--all-features`) but *excludes execution* because embedded V8 SIGSEGVs inside the Dagger exec sandbox (`.dagger/main.go` ~line 367). Verified locally vs **PostgreSQL 16**, one V8 isolate per test process (`--exact`): **3 passed**.

The `ctx.cursor` / `ctx.advance` JS sugar (the DESIGN's wrapper names) is an SDK-authoring concern that lands with the runnable Deno example in Phase 07; the raw ops are the host surface.

### Verification
- ✅ `make preflight` (fmt, clippy pedantic `-D warnings` **all-features**, rustdoc, shell gates)
- ✅ `cargo test --features runtime-deno,host-live runtime::deno::cursor_tests` (3 passed, one isolate/process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)