### PR TITLE
feat(#573): Source scheduler — server integration (Phase 06)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -635,6 +635,14 @@ func (m *FraiseqlCi) integrationPostgres(ctx context.Context, source *dagger.Dir
 		// single-firing — the double-poll bug fix). The email test suite otherwise runs nowhere,
 		// so this is also its first Dagger coverage.
 		"cargo test -p fraiseql-server --features inbound-email --lib inbound::email::source inbound::email::sink -- --test-threads=1",
+		// #573 source scheduler (Model B): the SourceQueryExecutor identity/tenant
+		// seam, the SourcePoller build_host composition (cursor round-trip vs PG +
+		// executor reachable via host.query), and the scheduler's schedulable/config
+		// resolution. `--features sources` pulls the Deno path (compiled only). The
+		// one V8 end-to-end (fires_a_model_b_connector_end_to_end — a real connector)
+		// is local-only, excluded here by name (embedded V8 SIGSEGVs in the exec
+		// sandbox), like the functions runtime-deno tests.
+		"cargo test -p fraiseql-server --features sources --lib sources:: -- --skip fires_a_model_b_connector_end_to_end --test-threads=1",
 		// #429 wired saga forward execution + compensation + recovery + coordinator
 		// + remote dispatch (saga): orchestration, rollback, and crash
 		// recovery against the real Postgres saga store + entity mutations, plus the

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -188,37 +188,44 @@ jobs:
         run: kill "$(cat /tmp/fraiseql-server.pid 2>/dev/null)" 2>/dev/null || true
 
       - name: Build fraiseql-server with the native runtime mounted
-        run: cargo build --release -p fraiseql-server --features functions-runtime-deno,inbound-email
+        run: cargo build --release -p fraiseql-server --features functions-runtime-deno,inbound-email,sources
 
-      - name: Boot with the native runtime mounted
+      # Boot against a schema that declares a scheduled source (#573). With the
+      # `sources` feature compiled in, this reaches the feature-gated source-scheduler
+      # startup block a sources-less schema never touches (reading the compiled
+      # `sources` and — when the functions subsystem is present — initializing the
+      # cursor table and building the pollers). It is the "compiles but panics on
+      # boot" guard for that startup code; the full poller wiring is covered
+      # functionally by the Dagger source suite.
+      - name: Boot with the native runtime mounted (+ a scheduled source)
         run: |
           ./target/release/fraiseql-server &
           echo $! > /tmp/fraiseql-server.pid
         env:
           DATABASE_URL: postgresql://fraiseql_test:fraiseql_test_password@localhost:5433/test_fraiseql
-          FRAISEQL_SCHEMA_PATH: docker/e2e/schema.compiled.json
+          FRAISEQL_SCHEMA_PATH: docker/e2e/schema.with-source.compiled.json
           FRAISEQL_BIND_ADDR: 127.0.0.1:8817
           FRAISEQL_INTROSPECTION_ENABLED: "true"
           FRAISEQL_INTROSPECTION_REQUIRE_AUTH: "false"
           FRAISEQL_ENV: development
           RUST_LOG: info
 
-      - name: Wait for /health (native runtime mounted)
+      - name: Wait for /health (native runtime mounted + source scheduler)
         run: |
           set -eu
           for i in $(seq 1 30); do
             if curl -sf http://127.0.0.1:8817/health; then
               echo
-              echo "Server booted healthy with functions-runtime-deno + inbound-email after ~$((i * 1))s."
+              echo "Server booted healthy with functions-runtime-deno + inbound-email + sources after ~$((i * 1))s."
               exit 0
             fi
             if ! kill -0 "$(cat /tmp/fraiseql-server.pid)" 2>/dev/null; then
-              echo "::error::server exited before /health with the native runtime mounted — a panic in the runtime/inbound startup path." >&2
+              echo "::error::server exited before /health with the native runtime + source scheduler mounted — a panic in the runtime/inbound/source startup path." >&2
               exit 1
             fi
             sleep 1
           done
-          echo "::error::Timed out waiting for /health (native runtime mounted) after 30s." >&2
+          echo "::error::Timed out waiting for /health (native runtime + source scheduler) after 30s." >&2
           exit 1
 
       - name: Stop server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Least-privilege identity for scheduled sources (#573, in progress).** A
+  scheduled `Source` runs its background mutations under an explicit, configured
+  authority *ceiling*, not an anonymous or unbounded identity. A source's compiled
+  definition gains an optional `run_as` (`{ roles, scopes, tenant? }`); at runtime
+  its mutations execute under a new `SecurityContext::system_job(...)` — the first
+  use of the `ActorType::SystemJob` principal — carrying exactly those roles/scopes.
+  **Fail-closed:** a source with no `run_as` runs with no authority, so RLS/field
+  authorization deny its writes until an operator grants a ceiling. `run_as.tenant`
+  scopes a single-tenant or global source; multi-tenant sources leave it unset and
+  re-scope each write per message. The compiler validates `run_as` (blank
+  role/scope/tenant → error; a ceiling granting nothing → fail-closed warning). See
+  `.phases/573-source-ingress/DESIGN.md` §7 (D6).
 - **Typed, enforced GraphQL cascade (cascade hardening).** The `cascade`
   feature — a mutation returning every entity it affected, per the graphql-cascade
   spec — is rebuilt from a verbatim JSONB passthrough into a first-class, enforced

--- a/crates/fraiseql-cli/src/schema/validator/schema_validator.rs
+++ b/crates/fraiseql-cli/src/schema/validator/schema_validator.rs
@@ -516,6 +516,48 @@ impl SchemaValidator {
                         suggestion: Some("Set the handler function name".to_string()),
                     });
                 }
+
+                // The `run_as` authority ceiling (#573 D6): a blank grant is a config
+                // error, and an empty ceiling is fail-closed (the source can write
+                // nothing) — valid, but almost always a mistake, so warn.
+                if let Some(run_as) = &source.run_as {
+                    let has_blank = run_as
+                        .roles
+                        .iter()
+                        .chain(run_as.scopes.iter())
+                        .any(|grant| grant.trim().is_empty())
+                        || run_as.tenant.as_ref().is_some_and(|t| t.trim().is_empty());
+                    if has_blank {
+                        report.errors.push(ValidationError {
+                            message:    format!(
+                                "Source '{}' has a blank role, scope, or tenant in run_as",
+                                source.name
+                            ),
+                            path:       format!("sources[{idx}].run_as"),
+                            severity:   ErrorSeverity::Error,
+                            suggestion: Some(
+                                "Remove empty entries; each role/scope/tenant must be non-blank"
+                                    .to_string(),
+                            ),
+                        });
+                    }
+                    if run_as.roles.is_empty() && run_as.scopes.is_empty() {
+                        report.errors.push(ValidationError {
+                            message:    format!(
+                                "Source '{}' declares run_as with no authority (no roles or \
+                                 scopes): its mutations will be denied (fail-closed)",
+                                source.name
+                            ),
+                            path:       format!("sources[{idx}].run_as"),
+                            severity:   ErrorSeverity::Warning,
+                            suggestion: Some(
+                                "Grant the source the least-privilege roles/scopes its mutations \
+                                 need, or drop run_as if it never mutates"
+                                    .to_string(),
+                            ),
+                        });
+                    }
+                }
             }
         }
 

--- a/crates/fraiseql-cli/src/schema/validator/tests.rs
+++ b/crates/fraiseql-cli/src/schema/validator/tests.rs
@@ -1041,3 +1041,54 @@ fn duplicate_source_name_is_rejected() {
     assert!(!report.is_valid());
     assert!(report.errors.iter().any(|e| e.message.contains("Duplicate source name")));
 }
+
+#[test]
+fn run_as_without_authority_warns_but_is_valid() {
+    use fraiseql_core::schema::{RunAs, SourceDefinition};
+    // A run_as that grants neither roles nor scopes is fail-closed: the source can
+    // write nothing. That is a valid (deny-by-default) configuration, but almost
+    // always a mistake — surface it as a warning, not an error.
+    let schema = IntermediateSchema {
+        sources: Some(vec![
+            SourceDefinition::new("orders", "*/5 * * * *", "pollOrders")
+                .with_run_as(RunAs::default()),
+        ]),
+        ..Default::default()
+    };
+    let report = SchemaValidator::validate(&schema).unwrap();
+    assert!(report.is_valid(), "a fail-closed run_as is valid, only warned");
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| e.path.contains("run_as") && e.message.contains("no authority")),
+        "the no-authority run_as is warned"
+    );
+}
+
+#[test]
+fn run_as_with_blank_grant_is_rejected() {
+    use fraiseql_core::schema::{RunAs, SourceDefinition};
+
+    use crate::schema::validator::types::ErrorSeverity;
+    // A blank role/scope/tenant string is a config error, not a silent no-op.
+    let schema = IntermediateSchema {
+        sources: Some(vec![
+            SourceDefinition::new("orders", "*/5 * * * *", "pollOrders").with_run_as(RunAs {
+                roles:  vec!["  ".to_string()],
+                scopes: vec![],
+                tenant: None,
+            }),
+        ]),
+        ..Default::default()
+    };
+    let report = SchemaValidator::validate(&schema).unwrap();
+    assert!(!report.is_valid());
+    assert!(
+        report
+            .errors
+            .iter()
+            .any(|e| e.path.contains("run_as") && e.severity == ErrorSeverity::Error),
+        "the blank role is rejected"
+    );
+}

--- a/crates/fraiseql-core/src/schema/mod.rs
+++ b/crates/fraiseql-core/src/schema/mod.rs
@@ -97,7 +97,7 @@ pub use security_config::{
     InjectedParamSource, RoleDefinition, SecurityConfig, TenancyConfig, TenancyMode,
 };
 pub use source_probe::{SourceKind, SourceProbe, sql_source_probes};
-pub use source_types::SourceDefinition;
+pub use source_types::{RunAs, SourceDefinition};
 pub use subscribable_ddl::generate_capture_trigger_ddl;
 pub use subscription_types::{
     FilterOperator, StaticFilterCondition, SubscriptionDefinition, SubscriptionFilter,

--- a/crates/fraiseql-core/src/schema/source_types.rs
+++ b/crates/fraiseql-core/src/schema/source_types.rs
@@ -52,6 +52,41 @@ pub struct SourceDefinition {
     /// Connector-specific options handed to the source, opaque to the framework.
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub options: serde_json::Value,
+
+    /// The authority this source's background mutations run under (#573 D6) — its
+    /// `run_as` *ceiling*. Absent ⇒ **fail-closed**: the source runs with no
+    /// roles/scopes/tenant and can write nothing. See [`identity`](Self::identity).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_as: Option<RunAs>,
+}
+
+/// The least-privilege authority ceiling a scheduled source's background mutations
+/// run under (#573 D6) — the source's `run_as`.
+///
+/// This is a *ceiling*: the source can never exceed these `roles`/`scopes`. It is
+/// authored on `@source`/`@fraiseql.source` and compiled into
+/// [`SourceDefinition::run_as`]. A [`SourceDefinition`] with no `run_as` runs
+/// fail-closed (no authority → RLS/authz deny), so granting a ceiling is a
+/// deliberate operator act.
+///
+/// `tenant` scopes writes for a single-tenant or global source; a multi-tenant
+/// source leaves it unset and re-scopes each write per message at runtime (only the
+/// handler knows which tenant a given payload belongs to).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunAs {
+    /// Roles granted to the source's background identity (the RBAC ceiling).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
+
+    /// Scopes granted to the source's background identity.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+
+    /// The single tenant this source's writes are scoped to, if any. Unset ⇒
+    /// global/system (NULL tenant) or a multi-tenant source that re-scopes per
+    /// message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
 }
 
 /// A source is enabled unless explicitly disabled.
@@ -75,6 +110,7 @@ impl SourceDefinition {
             function: function.into(),
             enabled:  true,
             options:  serde_json::Value::Null,
+            run_as:   None,
         }
     }
 
@@ -97,6 +133,40 @@ impl SourceDefinition {
     pub fn with_options(mut self, options: serde_json::Value) -> Self {
         self.options = options;
         self
+    }
+
+    /// Set the [`run_as`](Self::run_as) authority ceiling (#573 D6).
+    #[must_use]
+    pub fn with_run_as(mut self, run_as: RunAs) -> Self {
+        self.run_as = Some(run_as);
+        self
+    }
+
+    /// The background [`SecurityContext`](crate::security::SecurityContext) this
+    /// source's mutations run under (#573 D6).
+    ///
+    /// Built from [`run_as`](Self::run_as) via
+    /// [`SecurityContext::system_job`](crate::security::SecurityContext::system_job);
+    /// **absent `run_as` yields a fail-closed identity** (no roles, no scopes, no
+    /// tenant → every authz/RLS decision denies). `request_id` correlates one firing
+    /// of the source (typically its per-fire idempotency token).
+    #[must_use]
+    pub fn identity(&self, request_id: impl Into<String>) -> crate::security::SecurityContext {
+        let (roles, scopes, tenant) = match &self.run_as {
+            Some(run_as) => (
+                run_as.roles.clone(),
+                run_as.scopes.clone(),
+                run_as.tenant.clone().map(crate::types::TenantId::from),
+            ),
+            None => (Vec::new(), Vec::new(), None),
+        };
+        crate::security::SecurityContext::system_job(
+            self.name.as_str(),
+            request_id,
+            roles,
+            scopes,
+            tenant,
+        )
     }
 
     /// Mark the source disabled (compiled, but not scheduled).

--- a/crates/fraiseql-core/src/schema/source_types/tests.rs
+++ b/crates/fraiseql-core/src/schema/source_types/tests.rs
@@ -2,7 +2,10 @@
 //! the compiled schema.
 #![allow(clippy::unwrap_used)] // Reason: test module
 
-use crate::schema::{CompiledSchema, SourceDefinition};
+use crate::{
+    schema::{CompiledSchema, RunAs, SourceDefinition},
+    security::ActorType,
+};
 
 #[test]
 fn cursor_name_defaults_to_the_source_name() {
@@ -44,6 +47,51 @@ fn enabled_defaults_to_true_when_absent() {
     .unwrap();
     assert!(source.enabled);
     assert_eq!(source.cursor_name(), "orders");
+}
+
+#[test]
+fn run_as_round_trips_and_is_omitted_when_absent() {
+    // A source with no run_as omits the field entirely (byte-stable pass-through).
+    let source = SourceDefinition::new("orders", "*/5 * * * *", "pollOrders");
+    let json = serde_json::to_value(&source).unwrap();
+    assert!(json.get("run_as").is_none(), "an absent run_as is omitted");
+    assert!(source.run_as.is_none());
+
+    // A populated run_as survives a serde round-trip.
+    let with = source.with_run_as(RunAs {
+        roles:  vec!["ingest_writer".to_string()],
+        scopes: vec!["write:order".to_string()],
+        tenant: Some("acme".to_string()),
+    });
+    let round_tripped: SourceDefinition =
+        serde_json::from_value(serde_json::to_value(&with).unwrap()).unwrap();
+    assert_eq!(round_tripped, with);
+}
+
+#[test]
+fn identity_maps_run_as_to_a_system_job_context() {
+    let source = SourceDefinition::new("orders", "*/5 * * * *", "pollOrders").with_run_as(RunAs {
+        roles:  vec!["ingest_writer".to_string()],
+        scopes: vec!["write:order".to_string()],
+        tenant: Some("acme".to_string()),
+    });
+    let ctx = source.identity("fire-1");
+    assert_eq!(ctx.actor_type(), ActorType::SystemJob);
+    assert!(ctx.has_role("ingest_writer"));
+    assert!(ctx.has_scope("write:order"));
+    assert_eq!(ctx.tenant_id.as_ref().map(|t| t.as_str()), Some("acme"));
+}
+
+#[test]
+fn identity_is_fail_closed_without_run_as() {
+    // No run_as ⇒ an authority-less identity: the source can write nothing until an
+    // operator grants it a run_as ceiling.
+    let source = SourceDefinition::new("orders", "*/5 * * * *", "pollOrders");
+    let ctx = source.identity("fire-1");
+    assert_eq!(ctx.actor_type(), ActorType::SystemJob);
+    assert!(ctx.roles.is_empty(), "no roles → RBAC grants nothing");
+    assert!(ctx.scopes.is_empty(), "no scopes → grants nothing");
+    assert!(ctx.tenant_id.is_none(), "no tenant → global/deny");
 }
 
 #[test]

--- a/crates/fraiseql-core/src/security/security_context.rs
+++ b/crates/fraiseql-core/src/security/security_context.rs
@@ -218,6 +218,58 @@ impl SecurityContext {
         .with_acting_for(acting_for)
     }
 
+    /// Construct the context for an internal scheduled / system job (#573 D6).
+    ///
+    /// Unlike [`from_user`](Self::from_user), this carries **no JWT and no request**
+    /// — it is the server acting *as itself* for background work: a scheduled
+    /// [`Source`](crate::schema::SourceDefinition), and (in future) `after:ingest`
+    /// handlers and saga steps. It is the first and, at introduction, only
+    /// construction of [`ActorType::SystemJob`].
+    ///
+    /// Its authority is **exactly** the `roles` + `scopes` the caller grants (the
+    /// source's `run_as` ceiling). With neither, it is **fail-closed**: no roles and
+    /// no scopes mean every RBAC / field-authz check denies and — with no `tenant` —
+    /// tenant-scoped RLS admits nothing. A source therefore cannot write until an
+    /// operator grants it a ceiling.
+    ///
+    /// `tenant` scopes writes for a single-tenant or global source (`None` = global
+    /// / NULL tenant); a multi-tenant source leaves it `None` and re-scopes each
+    /// write per message via [`with_tenant`](Self::with_tenant). `job_id` names the
+    /// job (the source name) and becomes the `system_job:<id>` principal for the
+    /// audit envelope; `request_id` correlates a single firing.
+    ///
+    /// The [`ActorType`] is *recorded* for audit, never an authorization input — the
+    /// authority comes solely from `roles`/`scopes`.
+    #[must_use]
+    pub fn system_job(
+        job_id: impl Into<String>,
+        request_id: impl Into<String>,
+        roles: Vec<String>,
+        scopes: Vec<String>,
+        tenant: Option<TenantId>,
+    ) -> Self {
+        let now = Utc::now();
+        SecurityContext {
+            user_id: UserId(format!("system_job:{}", job_id.into())),
+            roles,
+            tenant_id: tenant,
+            scopes,
+            attributes: HashMap::new(),
+            request_id: request_id.into(),
+            ip_address: None,
+            authenticated_at: now,
+            // A background job's identity is minted fresh per firing and does not
+            // outlive the run; a generous window keeps any TTL check from tripping
+            // mid-poll (mirrors the live host's default context).
+            expires_at: now + chrono::Duration::hours(24),
+            issuer: None,
+            audience: None,
+            email: None,
+            display_name: None,
+        }
+        .with_actor_type(ActorType::SystemJob)
+    }
+
     /// Check if the user has a specific role.
     ///
     /// # Arguments

--- a/crates/fraiseql-core/src/security/tests.rs
+++ b/crates/fraiseql-core/src/security/tests.rs
@@ -3841,3 +3841,44 @@ mod actor_context_tests {
         assert!(ctx.roles.is_empty());
     }
 }
+
+/// `SecurityContext::system_job` — the background/system identity for scheduled
+/// sources and other server-initiated work (#573 D6). The first (and, at
+/// introduction, only) construction of [`ActorType::SystemJob`].
+mod system_job_tests {
+    use crate::{
+        security::{ActorType, SecurityContext},
+        types::TenantId,
+    };
+
+    #[test]
+    fn system_job_carries_granted_authority_and_actor_type() {
+        let ctx = SecurityContext::system_job(
+            "orders",
+            "fire-1",
+            vec!["ingest_writer".to_string()],
+            vec!["write:order".to_string()],
+            Some(TenantId::from("acme")),
+        );
+        assert_eq!(ctx.actor_type(), ActorType::SystemJob);
+        assert!(ctx.has_role("ingest_writer"));
+        assert!(ctx.has_scope("write:order"));
+        assert_eq!(ctx.tenant_id.as_ref().map(TenantId::as_str), Some("acme"));
+        assert!(ctx.is_multi_tenant());
+        assert!(!ctx.is_expired(), "a fresh system-job context is not expired");
+        // The principal reads as an internal job, mirroring the `apikey:` convention.
+        assert_eq!(ctx.user_id.as_str(), "system_job:orders");
+    }
+
+    #[test]
+    fn system_job_without_grants_is_fail_closed() {
+        // No roles, no scopes, no tenant → the identity grants nothing: every
+        // authz/RLS decision denies. This is the fail-closed default a source with
+        // no `run_as` runs under.
+        let ctx = SecurityContext::system_job("orders", "fire-1", vec![], vec![], None);
+        assert_eq!(ctx.actor_type(), ActorType::SystemJob);
+        assert!(!ctx.has_role("admin"));
+        assert!(!ctx.has_scope("write:order"));
+        assert!(!ctx.is_multi_tenant(), "no tenant → scoped to nothing");
+    }
+}

--- a/crates/fraiseql-functions/src/host/live/mod.rs
+++ b/crates/fraiseql-functions/src/host/live/mod.rs
@@ -148,25 +148,16 @@ impl LiveHostContext {
         }
     }
 
-    /// Create a new live host context with a query executor.
-    pub fn with_executor(
-        event_payload: EventPayload,
-        config: HostContextConfig,
-        executor: Arc<dyn QueryExecutor>,
-    ) -> Self {
-        Self {
-            event_payload,
-            config,
-            logs: Arc::new(std::sync::Mutex::new(Vec::new())),
-            query_executor: Some(executor),
-            http_client: None,
-            storage_backend: None,
-            security_context: Self::default_security_context(),
-            sender_resolver: None,
-            email_transport: None,
-            idempotency_token: None,
-            source_cursor: None,
-        }
+    /// Attach a query executor, enabling [`query`](HostContext::query) — the
+    /// `fraiseql_query` guest bridge.
+    ///
+    /// A chainable builder (like [`with_source_cursor`](Self::with_source_cursor)
+    /// and [`with_email`](Self::with_email)), so a scheduled Model B source can bind
+    /// both its executor and its cursor onto one [`new`](Self::new) host.
+    #[must_use]
+    pub fn with_executor(mut self, executor: Arc<dyn QueryExecutor>) -> Self {
+        self.query_executor = Some(executor);
+        self
     }
 
     /// Create a new live host context with an HTTP client.

--- a/crates/fraiseql-functions/src/host/live/tests.rs
+++ b/crates/fraiseql-functions/src/host/live/tests.rs
@@ -65,7 +65,7 @@ async fn test_host_query_executes_graphql() {
     });
     let executor = MockQueryExecutor::new(response.clone());
 
-    let ctx = LiveHostContext::with_executor(payload, HostContextConfig::default(), executor);
+    let ctx = LiveHostContext::new(payload, HostContextConfig::default()).with_executor(executor);
 
     let result = ctx.query("{ users { id name } }", serde_json::json!({})).await;
 
@@ -90,7 +90,7 @@ async fn test_host_query_passes_variables() {
     });
     let executor = MockQueryExecutor::new(response.clone());
 
-    let ctx = LiveHostContext::with_executor(payload, HostContextConfig::default(), executor);
+    let ctx = LiveHostContext::new(payload, HostContextConfig::default()).with_executor(executor);
 
     let result = ctx
         .query("query($id: Int!) { user(id: $id) { name } }", serde_json::json!({"id": 1}))
@@ -111,7 +111,7 @@ async fn test_host_query_rejects_mutations() {
     };
 
     let executor = MockQueryExecutor::error();
-    let ctx = LiveHostContext::with_executor(payload, HostContextConfig::default(), executor);
+    let ctx = LiveHostContext::new(payload, HostContextConfig::default()).with_executor(executor);
 
     let result = ctx
         .query("mutation { createUser(name: \"Alice\") { id } }", serde_json::json!({}))
@@ -133,7 +133,7 @@ async fn test_host_query_invalid_graphql_returns_validation_error() {
     };
 
     let executor = MockQueryExecutor::error();
-    let ctx = LiveHostContext::with_executor(payload, HostContextConfig::default(), executor);
+    let ctx = LiveHostContext::new(payload, HostContextConfig::default()).with_executor(executor);
 
     let result = ctx.query("{ invalid syntax }", serde_json::json!({})).await;
 

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -236,6 +236,15 @@ inbound-email = [
     "dep:webpki-roots",
     "dep:lettre",
 ]
+# Scheduled ingress sources (#573) — the dual of observers. A `Source` fires a
+# Deno function (Model B) on a cron schedule under a single-firing lease, resuming
+# from a durable cursor, and drives results into the database via mutations. Pulls
+# `functions-runtime-deno` (the guest runtime + the I/O-capable host that runs the
+# connector, incl. the `fraiseql_query` mutation bridge) and `observers` (the
+# cursor store + advisory-lease runner the scheduler coordinates on). Opt-in:
+# without it the whole source scheduler is compiled out. Native pull sources (the
+# poll-IMAP email adapter) run under `inbound-email` independently.
+sources = ["functions-runtime-deno", "observers"]
 # auth is included by default because auth middleware is wired into the core request pipeline.
 # secrets and webhooks are opt-in: add them to your dependency features when needed.
 default = ["auth", "cli"]

--- a/crates/fraiseql-server/src/lib.rs
+++ b/crates/fraiseql-server/src/lib.rs
@@ -43,6 +43,8 @@ pub mod routes;
 pub mod schema;
 pub mod server;
 pub mod server_config;
+#[cfg(feature = "sources")]
+pub mod sources;
 pub mod sql_source_check;
 pub mod subscriptions;
 pub mod url_guard;

--- a/crates/fraiseql-server/src/main.rs
+++ b/crates/fraiseql-server/src/main.rs
@@ -432,6 +432,25 @@ fn warn_observers_feature_missing(config_path: Option<&str>) {
     }
 }
 
+/// Warn at startup when the compiled schema declares scheduled `sources` but this
+/// binary was built without the `sources` feature (#573).
+///
+/// The source *definitions* live in the compiled schema (unlike `[observers]`, which
+/// is TOML), so we can inspect the loaded [`CompiledSchema`] directly: a non-empty
+/// `sources` array with the feature compiled out means the source scheduler never
+/// starts and the declared connectors never fire — with no other signal as to why.
+#[cfg(not(feature = "sources"))]
+fn warn_sources_feature_missing(schema: &CompiledSchema) {
+    if !schema.sources.is_empty() {
+        tracing::warn!(
+            count = schema.sources.len(),
+            "the compiled schema declares scheduled sources but this binary was built without \
+             the `sources` feature; they are ignored — no source scheduler will start. Rebuild \
+             with `--features sources`."
+        );
+    }
+}
+
 /// Warn at startup when `[storage.<name>]` is configured for a database the
 /// binary cannot mount storage on. Object storage is PostgreSQL-only because the
 /// object-metadata repository requires a `sqlx::PgPool`.
@@ -546,6 +565,8 @@ async fn main() -> anyhow::Result<()> {
     warn_files_not_wired(&config);
     #[cfg(not(feature = "observers"))]
     warn_observers_feature_missing(cli.server.config.as_deref());
+    #[cfg(not(feature = "sources"))]
+    warn_sources_feature_missing(&schema);
 
     // Box::pin: the per-scheme dispatch holds adapter init futures for all
     // enabled adapters, which combined exceeds clippy's `large_futures`

--- a/crates/fraiseql-server/src/routes/after_mutation/mod.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/mod.rs
@@ -112,6 +112,11 @@ pub fn plan_after_mutation_dispatch(
 /// message as JSON). Like [`plan_after_mutation_dispatch`] this is pure,
 /// always-compiled, and unit-tested: it needs no function runtime and returns an
 /// empty vector when no trigger matches (the common fast path).
+// Reason: the after:ingest planner is inbound-only (its callers live behind
+// `inbound`/`inbound-email`), yet stays always-compiled so its pure logic is
+// unit-tested without the runtime. A functions-runtime build without `inbound`
+// (e.g. `sources`) therefore legitimately has no caller.
+#[cfg_attr(not(feature = "inbound"), allow(dead_code))]
 pub fn plan_after_ingest_dispatch(
     hooks: &BeforeMutationHooks,
     message: &fraiseql_functions::InboundMessage,
@@ -449,7 +454,11 @@ pub fn spawn_after_mutation(hooks: &BeforeMutationHooks, plans: Vec<AfterMutatio
 /// [`DispatchSource::AfterIngest`](fraiseql_observers::DispatchSource::AfterIngest).
 ///
 /// [`LiveHostContext`]: fraiseql_functions::host::live::LiveHostContext
-#[cfg(feature = "functions-runtime")]
+// Gated on `inbound` (not merely `functions-runtime`): the after:ingest dispatcher
+// is only ever called from the inbound path (webhook + poll-IMAP email sinks), so a
+// functions-runtime build without `inbound` (e.g. `sources`) must not compile it
+// uncalled.
+#[cfg(feature = "inbound")]
 pub fn spawn_after_ingest(hooks: &BeforeMutationHooks, plans: Vec<AfterMutationDispatch>) {
     spawn_dispatch(hooks, plans, fraiseql_observers::DispatchSource::AfterIngest);
 }

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -227,6 +227,57 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             }
         }
 
+        // Start the scheduled-ingress source scheduler (#573): one poller per
+        // enabled Model B (Deno) source in the compiled schema, each firing its
+        // connector on its cron schedule under a single-firing lease with a host
+        // bound to the source's durable cursor and its `run_as` executor. Runs on
+        // the server's JoinSet so graceful shutdown drains it. Native pull sources
+        // (poll-IMAP email) run via their own pollers above. Must run here (async,
+        // after `build_router` supplies the function-dispatch hooks).
+        #[cfg(feature = "sources")]
+        if let Some(ref db_pool) = self.db_pool {
+            let sources = app_state.executor().schema().sources.clone();
+            if !sources.is_empty() {
+                let sources_config = self.config.sources.clone().unwrap_or_default();
+                if !crate::sources::sources_enabled(&sources_config) {
+                    info!(
+                        count = sources.len(),
+                        "source scheduler disabled by config — sources not started"
+                    );
+                } else if let Some(hooks) = app_state.before_mutation_hooks.as_ref() {
+                    // The shared durable source-cursor table (idempotent DDL).
+                    fraiseql_observers::PostgresSourceCursorStore::new(db_pool.clone())
+                        .init()
+                        .await
+                        .map_err(|e| {
+                            ServerError::ConfigError(format!(
+                                "Failed to initialize source cursor schema: {e}"
+                            ))
+                        })?;
+                    let host_config = crate::sources::source_host_config(&sources_config);
+                    let pollers = crate::sources::build_source_pollers(
+                        &sources,
+                        db_pool,
+                        &app_state.executor,
+                        hooks.as_ref(),
+                        &host_config,
+                        &fraiseql_functions::ResourceLimits::default(),
+                    );
+                    let started = pollers.len();
+                    for poller in pollers {
+                        self.tasks.spawn(async move { poller.run_forever().await });
+                    }
+                    info!(sources = started, "source scheduler started");
+                } else {
+                    warn!(
+                        count = sources.len(),
+                        "compiled schema declares sources but the functions subsystem is not \
+                         configured — no source scheduler started"
+                    );
+                }
+            }
+        }
+
         // Spawn SIGUSR1 schema reload handler when running on Unix.
         // The handler loops forever, reloading on each signal, until the
         // server process exits — tracked on the server's JoinSet so graceful

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -473,9 +473,14 @@ pub struct ServerConfig {
     /// `sources` feature). The source *definitions* live in the compiled schema;
     /// this `[sources]` section tunes the runtime (global on/off, connector SSRF
     /// allowlist).
+    ///
+    /// Boxed to keep `ServerConfig` small: this section is rarely set and read once
+    /// at startup, so it does not belong inline in a struct that sits on the
+    /// request-handling futures (an inline copy tips borderline futures past
+    /// clippy's `large_futures` stack budget).
     #[cfg(feature = "sources")]
     #[serde(default)]
-    pub sources: Option<SourcesConfig>,
+    pub sources: Option<Box<SourcesConfig>>,
 
     /// Connection pool pressure monitoring configuration.
     ///
@@ -732,8 +737,9 @@ impl Default for SourcesConfig {
     }
 }
 
-/// The connection fields mirror [`fraiseql_storage::config::StorageConfig`]; the
-/// policy fields (`access`, `max_object_bytes`, `allowed_mime_types`,
+/// The connection fields mirror [`fraiseql_storage::config::StorageConfig`].
+///
+/// The policy fields (`access`, `max_object_bytes`, `allowed_mime_types`,
 /// `serve_inline`) are optional and default to a private, force-download bucket.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageSectionConfig {

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -469,6 +469,14 @@ pub struct ServerConfig {
     #[serde(default)]
     pub observers: Option<ObserverConfig>,
 
+    /// Scheduled-ingress source scheduler configuration (optional, requires the
+    /// `sources` feature). The source *definitions* live in the compiled schema;
+    /// this `[sources]` section tunes the runtime (global on/off, connector SSRF
+    /// allowlist).
+    #[cfg(feature = "sources")]
+    #[serde(default)]
+    pub sources: Option<SourcesConfig>,
+
     /// Connection pool pressure monitoring configuration.
     ///
     /// When `enabled = true`, the server spawns a background task that monitors
@@ -689,6 +697,41 @@ pub struct ServerConfig {
 /// policy (mapped to `fraiseql_storage::config::BucketConfig`). The section name
 /// becomes the logical bucket name in the URL path.
 ///
+/// `[sources]` — runtime configuration for the scheduled-ingress source scheduler
+/// (#573, requires the `sources` feature).
+///
+/// The source *definitions* (name, schedule, function, `run_as`) come from the
+/// compiled schema; this section is operator-facing runtime tuning. Both fields are
+/// overridable by environment variables (env > TOML > default) so production can
+/// tune without recompiling:
+///
+/// - `FRAISEQL_SOURCES_ENABLED` — global on/off (`false`/`0`/`no`/`off` disables).
+/// - `FRAISEQL_SOURCES_ALLOWED_DOMAINS` — comma-separated SSRF allowlist.
+#[cfg(feature = "sources")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourcesConfig {
+    /// Global on/off for the source scheduler. Per-source `enabled` in the compiled
+    /// schema still applies; this disables the whole scheduler without recompiling.
+    /// Default: `true`.
+    #[serde(default = "defaults::default_true")]
+    pub enabled: bool,
+
+    /// SSRF allowlist (glob patterns) for source connectors' outbound fetches.
+    /// Deny-by-default: empty permits no outbound host.
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+}
+
+#[cfg(feature = "sources")]
+impl Default for SourcesConfig {
+    fn default() -> Self {
+        Self {
+            enabled:         true,
+            allowed_domains: Vec::new(),
+        }
+    }
+}
+
 /// The connection fields mirror [`fraiseql_storage::config::StorageConfig`]; the
 /// policy fields (`access`, `max_object_bytes`, `allowed_mime_types`,
 /// `serve_inline`) are optional and default to a private, force-download bucket.
@@ -840,10 +883,13 @@ impl Default for ServerConfig {
             rate_limiting: None,             // Rate limiting uses defaults
             #[cfg(feature = "observers")]
             observers: None, // Observers disabled by default
-            pool_tuning: None,               // Pool pressure monitoring disabled by default
-            admission_control: None,         // Admission control disabled by default
-            security_contact: None,          // No security.txt by default
-            validation: None,                // Use compiled schema defaults
+            #[cfg(feature = "sources")]
+            sources: None, /* Source scheduler configured from the compiled
+                                              * schema by default */
+            pool_tuning: None,       // Pool pressure monitoring disabled by default
+            admission_control: None, // Admission control disabled by default
+            security_contact: None,  // No security.txt by default
+            validation: None,        // Use compiled schema defaults
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
             request_timeout_secs: None,
             max_get_query_bytes: defaults::default_max_get_query_bytes(),

--- a/crates/fraiseql-server/src/sources/executor.rs
+++ b/crates/fraiseql-server/src/sources/executor.rs
@@ -1,0 +1,112 @@
+//! The query-executor bridge for scheduled sources (#573 D6, Phase 06 Step 2).
+//!
+//! A Model B source's Deno connector issues mutations via `fraiseql_query`, which
+//! reaches the host as [`HostContext::query`](fraiseql_functions::HostContext::query)
+//! and delegates to a [`QueryExecutor`](fraiseql_functions::host::live::QueryExecutor).
+//! Production dispatch never wired one, so a connector's `host.query()` failed with
+//! "query executor not configured". [`SourceQueryExecutor`] is that missing bridge:
+//! it wraps the server's [`Executor`] and runs each query/mutation under the
+//! source's **`run_as` identity** (a `SystemJob` [`SecurityContext`], D6).
+//!
+//! Two properties matter:
+//!
+//! - **Hot-reload-safe.** It holds the same `Arc<ArcSwap<Executor<A>>>` the request path holds and
+//!   `load`s a fresh snapshot per call, so a schema reload is picked up by the next source firing
+//!   rather than pinned at construction.
+//! - **Per-message tenant seam.** The identity is not a frozen field. A single `execute_query`
+//!   re-scopes to a per-message tenant carried in the reserved [`SOURCE_TENANT_VAR`] variable — the
+//!   runtime half of the multi-tenant path (only the connector knows which tenant a fetched record
+//!   belongs to). A source already pinned to a tenant by `run_as` ignores the override and cannot
+//!   forge writes for another tenant.
+
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use arc_swap::ArcSwap;
+use fraiseql_core::{db::traits::DatabaseAdapter, runtime::Executor, security::SecurityContext};
+use fraiseql_error::Result;
+use fraiseql_functions::host::live::QueryExecutor;
+use serde_json::Value;
+
+/// Reserved GraphQL variable a multi-tenant source sets to scope one write to a
+/// tenant (#573 D6). It is stripped from the variables before the query runs, so it
+/// never reaches the mutation itself. The Phase 07 SDK surfaces it ergonomically
+/// (e.g. `ctx.query(mutation, vars, { tenant })`); this constant is the wire
+/// contract both sides agree on.
+pub const SOURCE_TENANT_VAR: &str = "__source_tenant";
+
+/// Adapts the server's [`Executor`] to the functions
+/// [`QueryExecutor`](fraiseql_functions::host::live::QueryExecutor) so a scheduled
+/// source's mutations run under its `run_as` identity (#573 D6).
+pub struct SourceQueryExecutor<A: DatabaseAdapter> {
+    /// The hot-reloadable executor — the exact handle the request path uses, so a
+    /// schema swap is reflected on the next firing (loaded per call).
+    executor: Arc<ArcSwap<Executor<A>>>,
+    /// The source's base `run_as` identity (a `SystemJob` context). A per-message
+    /// tenant may re-scope it, but never widen its roles/scopes.
+    identity: SecurityContext,
+}
+
+impl<A: DatabaseAdapter> SourceQueryExecutor<A> {
+    /// Bridge `executor` to a source running under `identity` (its `run_as`
+    /// ceiling, built via
+    /// [`SourceDefinition::identity`](fraiseql_core::schema::SourceDefinition::identity)).
+    #[must_use]
+    pub const fn new(executor: Arc<ArcSwap<Executor<A>>>, identity: SecurityContext) -> Self {
+        Self { executor, identity }
+    }
+}
+
+/// The effective identity for one source query: the base `run_as` ceiling,
+/// re-scoped to `tenant` **only** when the base is not already pinned to a tenant.
+///
+/// A multi-tenant source (base tenant unset) scopes each write to the message's
+/// tenant; a single-tenant/global source (base tenant set, or no override) runs
+/// under its base identity — a pinned source cannot forge writes for a tenant it
+/// was not granted. Either way the roles/scopes ceiling is untouched.
+fn resolve_identity(base: &SecurityContext, tenant: Option<&str>) -> SecurityContext {
+    match (base.tenant_id.is_none(), tenant) {
+        (true, Some(tenant)) => base.clone().with_tenant(tenant),
+        _ => base.clone(),
+    }
+}
+
+/// Split the reserved [`SOURCE_TENANT_VAR`] out of a connector's query variables.
+///
+/// Returns the variables with the reserved key **always removed** (so it never
+/// reaches the mutation) plus the tenant when the key held a non-blank string. A
+/// blank or non-string value is stripped but yields no tenant.
+fn split_tenant_override(variables: Option<&Value>) -> (Option<Value>, Option<String>) {
+    let Some(Value::Object(map)) = variables else {
+        return (variables.cloned(), None);
+    };
+    if !map.contains_key(SOURCE_TENANT_VAR) {
+        return (Some(Value::Object(map.clone())), None);
+    }
+    let mut map = map.clone();
+    let tenant = match map.remove(SOURCE_TENANT_VAR) {
+        Some(Value::String(tenant)) if !tenant.trim().is_empty() => Some(tenant),
+        _ => None,
+    };
+    (Some(Value::Object(map)), tenant)
+}
+
+impl<A: DatabaseAdapter + 'static> QueryExecutor for SourceQueryExecutor<A> {
+    fn execute_query(
+        &self,
+        query: &str,
+        variables: Option<&Value>,
+    ) -> Pin<Box<dyn Future<Output = Result<Value>> + Send + '_>> {
+        // Snapshot the current executor (hot-reload-safe) and resolve the identity
+        // for this call, then own everything so the future borrows nothing.
+        let executor = self.executor.load_full();
+        let (variables, tenant) = split_tenant_override(variables);
+        let identity = resolve_identity(&self.identity, tenant.as_deref());
+        let query = query.to_owned();
+        Box::pin(async move {
+            executor.execute_with_security(&query, variables.as_ref(), &identity).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/sources/executor.rs
+++ b/crates/fraiseql-server/src/sources/executor.rs
@@ -28,10 +28,12 @@ use fraiseql_functions::host::live::QueryExecutor;
 use serde_json::Value;
 
 /// Reserved GraphQL variable a multi-tenant source sets to scope one write to a
-/// tenant (#573 D6). It is stripped from the variables before the query runs, so it
-/// never reaches the mutation itself. The Phase 07 SDK surfaces it ergonomically
-/// (e.g. `ctx.query(mutation, vars, { tenant })`); this constant is the wire
-/// contract both sides agree on.
+/// tenant (#573 D6).
+///
+/// It is stripped from the variables before the query runs, so it never reaches the
+/// mutation itself. The Phase 07 SDK surfaces it ergonomically (e.g.
+/// `ctx.query(mutation, vars, { tenant })`); this constant is the wire contract both
+/// sides agree on.
 pub const SOURCE_TENANT_VAR: &str = "__source_tenant";
 
 /// Adapts the server's [`Executor`] to the functions

--- a/crates/fraiseql-server/src/sources/executor/tests.rs
+++ b/crates/fraiseql-server/src/sources/executor/tests.rs
@@ -1,0 +1,83 @@
+//! Unit tests for the source query-executor bridge's pure logic: identity
+//! resolution (the per-message tenant seam) and reserved-variable splitting.
+//!
+//! The live `execute_query` round-trip (a connector actually mutating through the
+//! server `Executor`) is exercised end-to-end by the scheduler integration test
+//! against real PostgreSQL (Phase 06 Step 3); here we pin the identity/variable
+//! logic that has no database dependency.
+#![allow(clippy::unwrap_used)] // Reason: test module
+
+use fraiseql_core::{security::SecurityContext, types::TenantId};
+use serde_json::json;
+
+use super::{SOURCE_TENANT_VAR, resolve_identity, split_tenant_override};
+
+/// The base `run_as` identity: a `SystemJob` context with a role ceiling and,
+/// optionally, a pinned tenant.
+fn base(tenant: Option<&str>) -> SecurityContext {
+    SecurityContext::system_job(
+        "orders",
+        "fire-1",
+        vec!["ingest_writer".to_string()],
+        vec!["write:order".to_string()],
+        tenant.map(TenantId::from),
+    )
+}
+
+#[test]
+fn multi_tenant_source_scopes_to_the_per_message_tenant() {
+    // Base has no pinned tenant (multi-tenant source) → a per-message tenant scopes
+    // this write, and the role/scope ceiling is preserved.
+    let ctx = resolve_identity(&base(None), Some("acme"));
+    assert_eq!(ctx.tenant_id.as_ref().map(TenantId::as_str), Some("acme"));
+    assert!(ctx.has_role("ingest_writer"));
+    assert!(ctx.has_scope("write:order"));
+}
+
+#[test]
+fn pinned_source_ignores_a_tenant_override() {
+    // Base is pinned to "corp" (single-tenant source) → an override cannot forge a
+    // write for another tenant; the identity stays scoped to "corp".
+    let ctx = resolve_identity(&base(Some("corp")), Some("acme"));
+    assert_eq!(ctx.tenant_id.as_ref().map(TenantId::as_str), Some("corp"));
+}
+
+#[test]
+fn global_source_without_override_stays_global() {
+    let ctx = resolve_identity(&base(None), None);
+    assert!(ctx.tenant_id.is_none());
+    assert!(ctx.has_role("ingest_writer"));
+}
+
+#[test]
+fn split_extracts_and_strips_the_reserved_tenant() {
+    let vars = json!({ SOURCE_TENANT_VAR: "acme", "id": 1 });
+    let (cleaned, tenant) = split_tenant_override(Some(&vars));
+    assert_eq!(tenant.as_deref(), Some("acme"));
+    // The reserved key never reaches the mutation; the real variables survive.
+    let cleaned = cleaned.unwrap();
+    assert!(cleaned.get(SOURCE_TENANT_VAR).is_none());
+    assert_eq!(cleaned.get("id"), Some(&json!(1)));
+}
+
+#[test]
+fn split_passes_variables_through_untouched_when_absent() {
+    let vars = json!({ "id": 1 });
+    let (cleaned, tenant) = split_tenant_override(Some(&vars));
+    assert!(tenant.is_none());
+    assert_eq!(cleaned, Some(json!({ "id": 1 })));
+
+    // No variables at all → nothing to split.
+    let (cleaned, tenant) = split_tenant_override(None);
+    assert!(cleaned.is_none());
+    assert!(tenant.is_none());
+}
+
+#[test]
+fn split_strips_a_blank_tenant_without_scoping() {
+    // A blank reserved value is a no-op tenant, but the key is still stripped.
+    let vars = json!({ SOURCE_TENANT_VAR: "   ", "id": 1 });
+    let (cleaned, tenant) = split_tenant_override(Some(&vars));
+    assert!(tenant.is_none(), "a blank tenant scopes nothing");
+    assert!(cleaned.unwrap().get(SOURCE_TENANT_VAR).is_none(), "but the key is stripped");
+}

--- a/crates/fraiseql-server/src/sources/mod.rs
+++ b/crates/fraiseql-server/src/sources/mod.rs
@@ -1,0 +1,18 @@
+//! Scheduled ingress sources (#573) — the runtime half of the `Source` primitive.
+//!
+//! A `Source` is the dual of an observer: on a cron schedule, under a single-firing
+//! lease, a Model B (Deno) connector fetches an external system and drives the
+//! results into the database via mutations, resuming from a durable cursor. This
+//! module holds the server-side wiring:
+//!
+//! - [`SourceQueryExecutor`] — the [`QueryExecutor`](fraiseql_functions::host::live::QueryExecutor)
+//!   bridge that lets a source's `fraiseql_query` mutations execute against the server's
+//!   [`Executor`](fraiseql_core::runtime::Executor) under the source's `run_as` identity (#573 D6).
+//!
+//! The source scheduler that drives connectors on their schedule lands alongside
+//! this (Phase 06 Step 3); native pull sources (poll-IMAP email) run under the
+//! `inbound-email` feature independently.
+
+mod executor;
+
+pub use executor::{SOURCE_TENANT_VAR, SourceQueryExecutor};

--- a/crates/fraiseql-server/src/sources/mod.rs
+++ b/crates/fraiseql-server/src/sources/mod.rs
@@ -8,11 +8,15 @@
 //! - [`SourceQueryExecutor`] — the [`QueryExecutor`](fraiseql_functions::host::live::QueryExecutor)
 //!   bridge that lets a source's `fraiseql_query` mutations execute against the server's
 //!   [`Executor`](fraiseql_core::runtime::Executor) under the source's `run_as` identity (#573 D6).
+//! - [`SourcePoller`] — the per-source scheduler loop: cron-tick → single-firing lease → a cursor +
+//!   executor host → invoke the Deno connector.
 //!
-//! The source scheduler that drives connectors on their schedule lands alongside
-//! this (Phase 06 Step 3); native pull sources (poll-IMAP email) run under the
-//! `inbound-email` feature independently.
+//! Native pull sources (poll-IMAP email) run under the `inbound-email` feature
+//! independently; lifecycle wiring (reading `sources` from the compiled schema and
+//! spawning a poller per enabled source) lands in Phase 06 Step 4.
 
 mod executor;
+mod poller;
 
 pub use executor::{SOURCE_TENANT_VAR, SourceQueryExecutor};
+pub use poller::SourcePoller;

--- a/crates/fraiseql-server/src/sources/mod.rs
+++ b/crates/fraiseql-server/src/sources/mod.rs
@@ -17,6 +17,8 @@
 
 mod executor;
 mod poller;
+mod scheduler;
 
 pub use executor::{SOURCE_TENANT_VAR, SourceQueryExecutor};
 pub use poller::SourcePoller;
+pub use scheduler::{build_source_pollers, source_host_config, sources_enabled};

--- a/crates/fraiseql-server/src/sources/poller.rs
+++ b/crates/fraiseql-server/src/sources/poller.rs
@@ -1,0 +1,180 @@
+//! The per-source scheduler loop (#573 D6, Phase 06 Step 3).
+//!
+//! One [`SourcePoller`] drives one Model B (Deno) source: on its cron schedule it
+//! fires the connector, single-firing across replicas via the advisory lease, under
+//! a host bound to both the source's durable cursor (Phase 04) and its `run_as`
+//! query executor (Step 2). It is the Model B analogue of the poll-IMAP
+//! `MailboxPoller` — cron-tick instead of a fixed interval, and a Deno guest with a
+//! cursor + executor host instead of a native `PullSource`.
+//!
+//! The tick loop mirrors the functions `CronScheduler` (a 60-second tick, missed
+//! ticks skipped, in-memory [`CronExecutionState`] windowing) but replaces its
+//! fire-and-forget `NoopHostContext` path with the leased, cursor+executor host a
+//! source needs to read its watermark and mutate.
+
+use std::{sync::Arc, time::Duration};
+
+use chrono::{DateTime, Utc};
+use fraiseql_functions::{
+    EventPayload, FunctionModule, FunctionObserver, FunctionResult, ResourceLimits,
+    host::{
+        dyn_context::DynHostContext,
+        live::{HostContextConfig, LiveHostContext, QueryExecutor},
+    },
+    triggers::{CronExecutionState, CronSchedule},
+};
+use fraiseql_observers::{LeaseGuardedRunner, PostgresSourceCursorStore, RunOutcome};
+use tracing::{debug, info, warn};
+
+/// The collaborators one [`SourcePoller`] drives — assembled by the lifecycle from
+/// a compiled [`SourceDefinition`](fraiseql_core::schema::SourceDefinition).
+pub struct SourcePoller {
+    /// The source name — the cursor row and advisory-lease key.
+    source_name:  String,
+    /// The parsed cron schedule the source fires on.
+    schedule:     CronSchedule,
+    /// The Deno connector module to invoke.
+    module:       FunctionModule,
+    /// The runtime-agnostic function observer that dispatches the module.
+    observer:     Arc<FunctionObserver>,
+    /// The durable cursor store, bound onto each firing's host.
+    cursor_store: PostgresSourceCursorStore,
+    /// The query-executor bridge (the source's `run_as` identity), bound onto each
+    /// firing's host. A trait object so the lifecycle passes a `SourceQueryExecutor`
+    /// while tests pass a stub.
+    executor:     Arc<dyn QueryExecutor>,
+    /// The single-firing runner (advisory lease keyed on the source name).
+    runner:       LeaseGuardedRunner,
+    /// Host config (SSRF allowlist, timeouts) for the connector's outbound I/O.
+    host_config:  HostContextConfig,
+    /// Guest resource limits.
+    limits:       ResourceLimits,
+    /// In-memory fire-window state (the durable cursor is the real resume point, so
+    /// missed-fire catch-up across restarts is unnecessary — the next fire resumes
+    /// from the cursor).
+    state:        CronExecutionState,
+}
+
+impl SourcePoller {
+    /// Assemble a poller. `runner`, `cursor_store`, and `executor` must all be keyed
+    /// on / scoped to `source_name`.
+    // Reason: a constructor wiring a source's fixed set of runtime collaborators; a
+    // params struct would relocate the same fields without reducing coupling.
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        source_name: impl Into<String>,
+        schedule: CronSchedule,
+        module: FunctionModule,
+        observer: Arc<FunctionObserver>,
+        cursor_store: PostgresSourceCursorStore,
+        executor: Arc<dyn QueryExecutor>,
+        runner: LeaseGuardedRunner,
+        host_config: HostContextConfig,
+        limits: ResourceLimits,
+    ) -> Self {
+        Self {
+            source_name: source_name.into(),
+            schedule,
+            module,
+            observer,
+            cursor_store,
+            executor,
+            runner,
+            host_config,
+            limits,
+            state: CronExecutionState::new(),
+        }
+    }
+
+    /// Build the Model B host for one firing: a live host bound to the source's
+    /// durable cursor *and* its `run_as` executor, so the guest can read/advance its
+    /// watermark and issue `fraiseql_query` mutations.
+    fn build_host(&self, payload: EventPayload) -> Arc<dyn DynHostContext> {
+        Arc::new(
+            LiveHostContext::new(payload, self.host_config.clone())
+                .with_source_cursor(self.source_name.clone(), self.cursor_store.clone())
+                .with_executor(Arc::clone(&self.executor)),
+        )
+    }
+
+    /// Fire the source once, under the lease. Returns the outcome: skipped (another
+    /// replica leads), or ran with the guest's own result. An acquire failure is
+    /// logged and reported as a skip (the guest did not run this tick).
+    async fn fire_once(
+        &self,
+        now: DateTime<Utc>,
+    ) -> RunOutcome<fraiseql_error::Result<FunctionResult>> {
+        let payload = build_source_payload(&self.source_name, &self.schedule.expression, now);
+        let attempt = self
+            .runner
+            .run(|| async {
+                let host = self.build_host(payload.clone());
+                self.observer
+                    .invoke_with_context(&self.module, payload.clone(), host, self.limits.clone())
+                    .await
+            })
+            .await;
+        match attempt {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                warn!(source = %self.source_name, %error, "source lease acquire failed — skipping tick");
+                RunOutcome::SkippedNotLeader
+            },
+        }
+    }
+
+    /// Run the source forever: tick once a minute, fire when the schedule window
+    /// opens (and has not already fired in it). Shutdown is by task abort — the
+    /// lifecycle drives the poller on its `JoinSet`.
+    pub async fn run_forever(mut self) {
+        let mut ticker = tokio::time::interval(Duration::from_secs(60));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Skip the immediate initial tick so a source does not fire on startup.
+        ticker.tick().await;
+        info!(
+            source = %self.source_name,
+            schedule = %self.schedule.expression,
+            "source scheduler started"
+        );
+        loop {
+            ticker.tick().await;
+            let now = Utc::now();
+            if !self.state.should_execute(&self.schedule, &now) {
+                continue;
+            }
+            self.state.record_execution(now);
+            match self.fire_once(now).await {
+                RunOutcome::Ran(Ok(_)) => {
+                    info!(source = %self.source_name, "source fired");
+                },
+                RunOutcome::Ran(Err(error)) => {
+                    warn!(source = %self.source_name, %error, "source invocation failed");
+                },
+                RunOutcome::SkippedNotLeader => {
+                    debug!(source = %self.source_name, "source skipped — another replica leads");
+                },
+            }
+        }
+    }
+}
+
+/// Build the event payload for one source firing. The connector reads its trigger
+/// context from `ctx.eventPayload`; the durable cursor (`ctx.cursor`) carries the
+/// resume point, not this payload.
+fn build_source_payload(source_name: &str, schedule: &str, now: DateTime<Utc>) -> EventPayload {
+    EventPayload {
+        trigger_type: format!("source:{source_name}"),
+        entity:       "source".to_string(),
+        event_kind:   "scheduled".to_string(),
+        data:         serde_json::json!({
+            "source": source_name,
+            "schedule": schedule,
+            "scheduled_at": now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        }),
+        timestamp:    now,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/sources/poller/tests.rs
+++ b/crates/fraiseql-server/src/sources/poller/tests.rs
@@ -15,9 +15,12 @@ use chrono::Utc;
 use fraiseql_functions::{
     FunctionModule, FunctionObserver, ResourceLimits, RuntimeType,
     host::live::{HostContextConfig, QueryExecutor},
+    runtime::deno::{DenoConfig, DenoRuntime},
     triggers::CronSchedule,
 };
-use fraiseql_observers::{LeaseGuardedRunner, PostgresSourceCursorStore, SourceCursorStore};
+use fraiseql_observers::{
+    LeaseGuardedRunner, PostgresSourceCursorStore, RunOutcome, SourceCursorStore,
+};
 use serde_json::{Value, json};
 use sqlx::PgPool;
 
@@ -125,4 +128,79 @@ async fn build_host_binds_both_the_cursor_and_the_executor() {
     // Durability: the advance persisted beyond the host.
     let snapshot = PostgresSourceCursorStore::new(pool.clone()).load(source).await.unwrap();
     assert_eq!(snapshot.value, Some(json!({ "page": 3 })));
+}
+
+/// A minimal Model B connector: read the cursor, mutate via `fraiseql_query`,
+/// advance the cursor — the exact loop the #573 issue shows.
+const CONNECTOR_TS: &str = r#"
+export default async () => {
+  const before = JSON.parse(await Deno.core.ops.fraiseql_cursor_get());
+  const page = (before && before.page ? before.page : 0) + 1;
+  await Deno.core.ops.fraiseql_query(
+    "mutation { createOrder(page: " + page + ") { id } }",
+    "{}"
+  );
+  await Deno.core.ops.fraiseql_cursor_advance(JSON.stringify({ page: page }));
+  return { page: page };
+};
+"#;
+
+/// The whole Model B slice end-to-end through the poller: a real Deno connector,
+/// fired once under the lease, reads its (null) cursor, issues a `fraiseql_query`
+/// mutation (reaching the bound executor), and advances the durable cursor.
+///
+/// LOCAL-ONLY: this invokes a real Deno guest (one V8 isolate), so — like every
+/// `runtime-deno` test — it is excluded from CI (embedded V8 SIGSEGVs in the Dagger
+/// exec sandbox); the `.dagger` source suite skips it by name. Run locally with
+/// `DATABASE_URL` set, one isolate per process.
+#[tokio::test]
+async fn fires_a_model_b_connector_end_to_end() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP fires_a_model_b_connector_end_to_end: no postgres");
+        return;
+    };
+    let source = "test-poller-e2e";
+    PostgresSourceCursorStore::new(pool.clone()).init().await.unwrap();
+    sqlx::query("DELETE FROM _fraiseql_source_cursor WHERE source_name = $1")
+        .bind(source)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let executor = StubExecutor::new(json!({ "data": { "createOrder": { "id": "1" } } }));
+    let mut observer = FunctionObserver::new();
+    observer.register_runtime(RuntimeType::Deno, DenoRuntime::new(&DenoConfig::default()).unwrap());
+    let module = FunctionModule::from_source(
+        "connector".to_string(),
+        CONNECTOR_TS.to_string(),
+        RuntimeType::Deno,
+    );
+
+    let poller = SourcePoller::new(
+        source,
+        CronSchedule::parse("*/5 * * * *").unwrap(),
+        module,
+        Arc::new(observer),
+        PostgresSourceCursorStore::new(pool.clone()),
+        executor.clone(),
+        LeaseGuardedRunner::in_process(source),
+        HostContextConfig::default(),
+        ResourceLimits::default(),
+    );
+
+    let outcome = poller.fire_once(chrono::Utc::now()).await;
+    assert!(
+        matches!(outcome, RunOutcome::Ran(Ok(_))),
+        "the connector fired and ran to completion under the lease"
+    );
+
+    // The connector's fraiseql_query reached the bound executor.
+    let seen = executor.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1, "the guest issued exactly one query");
+    assert!(seen[0].contains("createOrder"), "it was the connector's mutation: {}", seen[0]);
+    drop(seen);
+
+    // The connector advanced its durable cursor from null → { page: 1 }.
+    let snapshot = PostgresSourceCursorStore::new(pool.clone()).load(source).await.unwrap();
+    assert_eq!(snapshot.value, Some(json!({ "page": 1 })));
 }

--- a/crates/fraiseql-server/src/sources/poller/tests.rs
+++ b/crates/fraiseql-server/src/sources/poller/tests.rs
@@ -1,0 +1,128 @@
+//! Tests for the source poller.
+//!
+//! - [`source_payload_carries_the_trigger_context`] is pure.
+//! - [`build_host_binds_both_the_cursor_and_the_executor`] proves the poller's novel composition —
+//!   that one firing's host reaches *both* the durable cursor (vs real PostgreSQL) *and* the
+//!   `run_as` executor — without a V8 guest, so it runs in the PG integration leg. The full Model B
+//!   guest-through-poller round-trip (a Deno connector reading its cursor, mutating via
+//!   `fraiseql_query`, advancing) is a local-only V8 test landing with the runnable example in
+//!   Phase 07.
+#![allow(clippy::unwrap_used)] // Reason: test module
+
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use chrono::Utc;
+use fraiseql_functions::{
+    FunctionModule, FunctionObserver, ResourceLimits, RuntimeType,
+    host::live::{HostContextConfig, QueryExecutor},
+    triggers::CronSchedule,
+};
+use fraiseql_observers::{LeaseGuardedRunner, PostgresSourceCursorStore, SourceCursorStore};
+use serde_json::{Value, json};
+use sqlx::PgPool;
+
+use super::{SourcePoller, build_source_payload};
+
+#[test]
+fn source_payload_carries_the_trigger_context() {
+    let payload = build_source_payload("orders", "*/5 * * * *", Utc::now());
+    assert_eq!(payload.trigger_type, "source:orders");
+    assert_eq!(payload.entity, "source");
+    assert_eq!(payload.event_kind, "scheduled");
+    assert_eq!(payload.data["source"], "orders");
+    assert_eq!(payload.data["schedule"], "*/5 * * * *");
+}
+
+/// A query executor that returns a canned response and records the query it saw, so
+/// a test can prove the host reached *an* executor (the poller wired one on).
+struct StubExecutor {
+    response: Value,
+    seen:     std::sync::Mutex<Vec<String>>,
+}
+
+impl StubExecutor {
+    fn new(response: Value) -> Arc<Self> {
+        Arc::new(Self {
+            response,
+            seen: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+}
+
+impl QueryExecutor for StubExecutor {
+    fn execute_query(
+        &self,
+        query: &str,
+        _variables: Option<&Value>,
+    ) -> Pin<Box<dyn Future<Output = fraiseql_error::Result<Value>> + Send + '_>> {
+        self.seen.lock().unwrap().push(query.to_string());
+        let response = self.response.clone();
+        Box::pin(async move { Ok(response) })
+    }
+}
+
+async fn connect_pool() -> Option<(PgPool, fraiseql_test_support::Service)> {
+    let svc = fraiseql_test_support::postgres().await?;
+    let pool = PgPool::connect(svc.url()).await.unwrap();
+    Some((pool, svc))
+}
+
+/// Build a poller whose collaborators are all scoped to `source`, with `executor`
+/// as its query bridge. The module/observer are inert here — `build_host` does not
+/// invoke the guest.
+fn poller(pool: &PgPool, source: &str, executor: Arc<dyn QueryExecutor>) -> SourcePoller {
+    SourcePoller::new(
+        source,
+        CronSchedule::parse("*/5 * * * *").unwrap(),
+        FunctionModule::from_source("noop".to_string(), String::new(), RuntimeType::Deno),
+        Arc::new(FunctionObserver::new()),
+        PostgresSourceCursorStore::new(pool.clone()),
+        executor,
+        LeaseGuardedRunner::in_process(source),
+        HostContextConfig::default(),
+        ResourceLimits::default(),
+    )
+}
+
+#[tokio::test]
+async fn build_host_binds_both_the_cursor_and_the_executor() {
+    let Some((pool, _svc)) = connect_pool().await else {
+        eprintln!("SKIP build_host_binds_both_the_cursor_and_the_executor: no postgres");
+        return;
+    };
+    let source = "test-poller-build-host";
+    // Fresh cursor row so re-runs are independent.
+    PostgresSourceCursorStore::new(pool.clone()).init().await.unwrap();
+    sqlx::query("DELETE FROM _fraiseql_source_cursor WHERE source_name = $1")
+        .bind(source)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let executor = StubExecutor::new(json!({ "data": { "createOrder": { "status": "ok" } } }));
+    let poller = poller(&pool, source, executor.clone());
+    let host = poller.build_host(build_source_payload(source, "*/5 * * * *", Utc::now()));
+
+    // The cursor is bound: it round-trips through the host against real Postgres.
+    assert!(host.cursor().await.unwrap().is_none(), "a fresh source has no cursor");
+    host.advance_cursor(json!({ "page": 3 })).await.unwrap();
+    assert_eq!(
+        host.cursor().await.unwrap(),
+        Some(json!({ "page": 3 })),
+        "the host reads back what it advanced"
+    );
+
+    // The executor is bound: host.query reaches it (the fraiseql_query bridge that
+    // production dispatch left unwired).
+    let result = host.query("mutation { createOrder }", json!({})).await.unwrap();
+    assert_eq!(result, json!({ "data": { "createOrder": { "status": "ok" } } }));
+    assert_eq!(
+        executor.seen.lock().unwrap().as_slice(),
+        ["mutation { createOrder }"],
+        "the query reached the bound executor"
+    );
+
+    // Durability: the advance persisted beyond the host.
+    let snapshot = PostgresSourceCursorStore::new(pool.clone()).load(source).await.unwrap();
+    assert_eq!(snapshot.value, Some(json!({ "page": 3 })));
+}

--- a/crates/fraiseql-server/src/sources/poller/tests.rs
+++ b/crates/fraiseql-server/src/sources/poller/tests.rs
@@ -8,6 +8,8 @@
 //!   `fraiseql_query`, advancing) is a local-only V8 test landing with the runnable example in
 //!   Phase 07.
 #![allow(clippy::unwrap_used)] // Reason: test module
+#![allow(clippy::print_stderr)] // Reason: skip diagnostic when no backing Postgres
+#![allow(clippy::large_futures)] // Reason: a test future holds a poller + runtime; stack size is irrelevant in a #[tokio::test]
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
@@ -194,11 +196,11 @@ async fn fires_a_model_b_connector_end_to_end() {
         "the connector fired and ran to completion under the lease"
     );
 
-    // The connector's fraiseql_query reached the bound executor.
-    let seen = executor.seen.lock().unwrap();
+    // The connector's fraiseql_query reached the bound executor. Clone out of the
+    // lock so no guard is held across the later await.
+    let seen = executor.seen.lock().unwrap().clone();
     assert_eq!(seen.len(), 1, "the guest issued exactly one query");
     assert!(seen[0].contains("createOrder"), "it was the connector's mutation: {}", seen[0]);
-    drop(seen);
 
     // The connector advanced its durable cursor from null → { page: 1 }.
     let snapshot = PostgresSourceCursorStore::new(pool.clone()).load(source).await.unwrap();

--- a/crates/fraiseql-server/src/sources/scheduler.rs
+++ b/crates/fraiseql-server/src/sources/scheduler.rs
@@ -1,0 +1,150 @@
+//! Assembling the source scheduler from the compiled schema (#573 Phase 06 Step 4).
+//!
+//! [`build_source_pollers`] turns the compiled `sources` array into one
+//! [`SourcePoller`] per enabled Model B source, resolving each source's function
+//! module, `run_as` identity ([`SourceQueryExecutor`]), durable cursor, and
+//! single-firing lease. The lifecycle spawns the returned pollers on the server's
+//! `JoinSet`. [`sources_enabled`] and [`source_host_config`] resolve the `[sources]`
+//! runtime config with environment overrides (env > TOML > default).
+
+use std::{collections::HashMap, sync::Arc};
+
+use arc_swap::ArcSwap;
+use fraiseql_core::{db::traits::DatabaseAdapter, runtime::Executor, schema::SourceDefinition};
+use fraiseql_functions::{
+    FunctionModule, ResourceLimits,
+    host::live::{HostContextConfig, QueryExecutor},
+    triggers::CronSchedule,
+};
+use fraiseql_observers::{LeaseGuardedRunner, PostgresSourceCursorStore};
+use tracing::warn;
+
+use super::{SourcePoller, SourceQueryExecutor};
+use crate::{server_config::SourcesConfig, subsystems::BeforeMutationHooks};
+
+/// Whether the source scheduler runs: `FRAISEQL_SOURCES_ENABLED` overrides the
+/// `[sources] enabled` config (env > TOML > default `true`). Any of
+/// `false`/`0`/`no`/`off` (case-insensitive) disables it.
+#[must_use]
+pub fn sources_enabled(config: &SourcesConfig) -> bool {
+    sources_enabled_from(config, |key| std::env::var(key).ok())
+}
+
+fn sources_enabled_from(config: &SourcesConfig, get: impl Fn(&str) -> Option<String>) -> bool {
+    match get("FRAISEQL_SOURCES_ENABLED") {
+        Some(value) => {
+            !matches!(value.trim().to_ascii_lowercase().as_str(), "false" | "0" | "no" | "off")
+        },
+        None => config.enabled,
+    }
+}
+
+/// The host config for source connectors: the SSRF allowlist from
+/// `FRAISEQL_SOURCES_ALLOWED_DOMAINS` (comma-separated) overriding `[sources]
+/// allowed_domains`, deny-by-default.
+#[must_use]
+pub fn source_host_config(config: &SourcesConfig) -> HostContextConfig {
+    source_host_config_from(config, |key| std::env::var(key).ok())
+}
+
+fn source_host_config_from(
+    config: &SourcesConfig,
+    get: impl Fn(&str) -> Option<String>,
+) -> HostContextConfig {
+    let allowed_domains = match get("FRAISEQL_SOURCES_ALLOWED_DOMAINS") {
+        Some(value) => value
+            .split(',')
+            .map(str::trim)
+            .filter(|domain| !domain.is_empty())
+            .map(String::from)
+            .collect(),
+        None => config.allowed_domains.clone(),
+    };
+    HostContextConfig {
+        allowed_domains,
+        ..HostContextConfig::default()
+    }
+}
+
+/// The enabled sources that are schedulable Model B connectors: each is `enabled`,
+/// resolves to a loaded function module, and has a valid cron schedule. A disabled
+/// source is skipped silently (compiled but intentionally not scheduled); a source
+/// whose function has no loaded module (a native source, or a module that never
+/// loaded) or an unparseable schedule is logged and skipped.
+fn schedulable<'a>(
+    sources: &'a [SourceDefinition],
+    modules: &HashMap<String, FunctionModule>,
+) -> Vec<(&'a SourceDefinition, FunctionModule, CronSchedule)> {
+    sources
+        .iter()
+        .filter_map(|source| {
+            if !source.enabled {
+                return None;
+            }
+            let Some(module) = modules.get(&source.function) else {
+                warn!(
+                    source = %source.name,
+                    function = %source.function,
+                    "source function has no loaded module — skipping (native source, or the \
+                     module did not load)"
+                );
+                return None;
+            };
+            match CronSchedule::parse(&source.schedule) {
+                Ok(schedule) => Some((source, module.clone(), schedule)),
+                Err(error) => {
+                    warn!(
+                        source = %source.name,
+                        schedule = %source.schedule,
+                        %error,
+                        "invalid cron schedule — skipping source"
+                    );
+                    None
+                },
+            }
+        })
+        .collect()
+}
+
+/// Build one [`SourcePoller`] per enabled Model B source in the compiled schema.
+///
+/// Each poller runs under the source's `run_as` identity (via
+/// [`SourceQueryExecutor`] over the hot-reloadable `executor`), reads/advances the
+/// shared durable cursor store, and single-fires across replicas on a
+/// PostgreSQL advisory lease keyed on the source name. The caller spawns each
+/// returned poller's [`run_forever`](SourcePoller::run_forever) on the server's
+/// `JoinSet`; the shared `_fraiseql_source_cursor` table must already be
+/// initialized.
+pub fn build_source_pollers<A: DatabaseAdapter + Send + Sync + 'static>(
+    sources: &[SourceDefinition],
+    db_pool: &sqlx::PgPool,
+    executor: &Arc<ArcSwap<Executor<A>>>,
+    hooks: &BeforeMutationHooks,
+    host_config: &HostContextConfig,
+    limits: &ResourceLimits,
+) -> Vec<SourcePoller> {
+    schedulable(sources, &hooks.module_registry)
+        .into_iter()
+        .map(|(source, module, schedule)| {
+            // The source's mutations run under its run_as ceiling (D6); the
+            // request-id correlates the source in the audit envelope.
+            let identity = source.identity(source.name.as_str());
+            let query_executor: Arc<dyn QueryExecutor> =
+                Arc::new(SourceQueryExecutor::new(Arc::clone(executor), identity));
+            SourcePoller::new(
+                source.name.clone(),
+                schedule,
+                module,
+                Arc::clone(&hooks.observer),
+                PostgresSourceCursorStore::new(db_pool.clone()),
+                query_executor,
+                LeaseGuardedRunner::postgres(db_pool.clone(), source.name.clone()),
+                host_config.clone(),
+                limits.clone(),
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/sources/scheduler/tests.rs
+++ b/crates/fraiseql-server/src/sources/scheduler/tests.rs
@@ -1,0 +1,88 @@
+//! Tests for the source-scheduler assembly: the pure `schedulable` filter and the
+//! env-overridable config resolution. The full poller-wiring (`build_source_pollers`)
+//! is exercised by the lifecycle integration and Step 3's `build_host` composition.
+#![allow(clippy::unwrap_used)] // Reason: test module
+
+use std::collections::HashMap;
+
+use fraiseql_core::schema::SourceDefinition;
+use fraiseql_functions::{FunctionModule, RuntimeType};
+
+use super::{schedulable, source_host_config_from, sources_enabled_from};
+use crate::server_config::SourcesConfig;
+
+fn module(name: &str) -> FunctionModule {
+    FunctionModule::from_source(name.to_string(), String::new(), RuntimeType::Deno)
+}
+
+/// A registry with one loaded Model B module, `pollOrders`.
+fn registry() -> HashMap<String, FunctionModule> {
+    HashMap::from([("pollOrders".to_string(), module("pollOrders"))])
+}
+
+#[test]
+fn schedulable_keeps_only_enabled_backed_valid_sources() {
+    let sources = vec![
+        // Kept: enabled, module loaded, valid cron.
+        SourceDefinition::new("orders", "*/5 * * * *", "pollOrders"),
+        // Skipped: disabled.
+        SourceDefinition::new("disabled", "*/5 * * * *", "pollOrders").disabled(),
+        // Skipped: no loaded module (e.g. a native source).
+        SourceDefinition::new("native", "*/5 * * * *", "nativeThing"),
+        // Skipped: invalid cron.
+        SourceDefinition::new("bad-cron", "not-a-cron", "pollOrders"),
+    ];
+    let kept = schedulable(&sources, &registry());
+    let names: Vec<&str> = kept.iter().map(|(source, _, _)| source.name.as_str()).collect();
+    assert_eq!(names, ["orders"], "only the enabled, backed, valid-cron source is scheduled");
+    // The parsed schedule rides along.
+    assert_eq!(kept[0].2.expression, "*/5 * * * *");
+}
+
+#[test]
+fn schedulable_is_empty_when_nothing_qualifies() {
+    let sources = vec![SourceDefinition::new("native", "*/5 * * * *", "unloaded")];
+    assert!(schedulable(&sources, &registry()).is_empty());
+}
+
+#[test]
+fn enabled_resolves_env_over_config() {
+    let on = SourcesConfig {
+        enabled:         true,
+        allowed_domains: vec![],
+    };
+    let off = SourcesConfig {
+        enabled:         false,
+        allowed_domains: vec![],
+    };
+
+    // No env → the config value.
+    assert!(sources_enabled_from(&on, |_| None));
+    assert!(!sources_enabled_from(&off, |_| None));
+
+    // Env overrides the config, either way.
+    assert!(!sources_enabled_from(&on, |_| Some("false".to_string())));
+    assert!(!sources_enabled_from(&on, |_| Some("OFF".to_string())));
+    assert!(sources_enabled_from(&off, |_| Some("true".to_string())));
+    assert!(sources_enabled_from(&off, |_| Some("1".to_string())));
+}
+
+#[test]
+fn host_config_allowlist_resolves_env_over_config() {
+    let config = SourcesConfig {
+        enabled:         true,
+        allowed_domains: vec!["from-toml.example".to_string()],
+    };
+
+    // No env → the config allowlist.
+    let host = source_host_config_from(&config, |_| None);
+    assert_eq!(host.allowed_domains, vec!["from-toml.example".to_string()]);
+
+    // Env overrides, comma-split and trimmed.
+    let host = source_host_config_from(&config, |_| Some(" a.example, b.example ".to_string()));
+    assert_eq!(host.allowed_domains, vec!["a.example".to_string(), "b.example".to_string()]);
+
+    // Deny-by-default when neither is set.
+    let empty = SourcesConfig::default();
+    assert!(source_host_config_from(&empty, |_| None).allowed_domains.is_empty());
+}

--- a/docker/e2e/schema.with-source.compiled.json
+++ b/docker/e2e/schema.with-source.compiled.json
@@ -1,0 +1,40 @@
+{
+  "types": [
+    {
+      "name": "User",
+      "sql_source": "v_users",
+      "jsonb_column": "data",
+      "fields": [
+        {"name": "id",   "field_type": "Int",    "nullable": false},
+        {"name": "name", "field_type": "String", "nullable": false}
+      ]
+    }
+  ],
+  "queries": [
+    {
+      "name": "users",
+      "return_type": "User",
+      "returns_list": true,
+      "nullable": false,
+      "sql_source": "v_users",
+      "jsonb_column": "data",
+      "arguments": []
+    }
+  ],
+  "mutations": [],
+  "subscriptions": [],
+  "enums": [],
+  "input_types": [],
+  "interfaces": [],
+  "unions": [],
+  "directives": [],
+  "sources": [
+    {
+      "name": "example_source",
+      "schedule": "*/5 * * * *",
+      "function": "pollExample",
+      "enabled": true,
+      "run_as": {"roles": ["ingest_writer"], "scopes": ["write:order"]}
+    }
+  ]
+}


### PR DESCRIPTION
Phase 06 of #573 (the `Source` primitive — scheduled/idempotent ingress, the dual of `Observer`). Wires the compiled `sources` into a running server: a **Model B (Deno) source** fires its connector on a cron schedule, single-firing across replicas under an advisory lease, from a host bound to the source's durable cursor **and** its `run_as` query executor, driving results into the DB via `fraiseql_query` mutations. Behind the opt-in `sources` feature; default binary stays lean.

Phases 00–05 (the primitive: cursor store + lease, `PullSource` envelope, email as reference Model A, Deno cursor ops, compiled `sources`) already merged. This closes the runtime gap the recon under-counted: the `fraiseql_query` mutation bridge had **no executor** in the real dispatch path (`with_executor` was test-only), so a connector's `host.query()` failed "query executor not configured."

## Design decision — D6 (source identity)

A scheduled source has no JWT/request, yet its mutations must run under *some* `SecurityContext`. Resolved after two code investigations (full reasoning in `.phases/573-source-ingress/DESIGN.md` §7):

- **Explicit, per-source, least-privilege, fail-closed identity.** `run_as = { roles, scopes, tenant? }` on the compiled `SourceDefinition` → a `SecurityContext::system_job(...)` (first construction of the long-defined-but-unused `ActorType::SystemJob`). Unset ⇒ anonymous ⇒ RLS/authz deny. Source handlers are *user-authored* Deno, so this bounded ceiling is safer than the two existing precedents (background paths run anonymous; sagas bypass RLS as trusted infra).
- **Authority (static, config) is separate from tenant (per-write scope).** Every framework isolation mechanism reads the single `SecurityContext.tenant_id` with no per-call override, so a static tenant forces one-source-per-tenant. Multi-tenant sources re-scope each write per message via a reserved `__source_tenant` variable seam (runtime half here; SDK sugar in Phase 07).

## What's in it (6 commits)

1. **Identity** — `run_as` + `RunAs` on `SourceDefinition`, `SecurityContext::system_job`, CLI validation (core, cli).
2. **Executor bridge** — `SourceQueryExecutor` adapting the server `Executor<A>` (over `AppState`'s hot-reloadable `ArcSwap`) to the functions `QueryExecutor`, zero error conversion; the `sources` feature. Also fixes a latent `after:ingest` dead-code gap the feature combo revealed.
3. **`SourcePoller`** — cron-tick → single-firing lease → cursor + executor host → `invoke_with_context`. `LiveHostContext::with_executor` made a chainable builder.
4. **Lifecycle wiring** — read `CompiledSchema.sources`, build a poller per enabled source, spawn on the JoinSet; `[sources]` TOML + `FRAISEQL_SOURCES_*` env; `warn_sources_feature_missing` fail-loud.
5. **CI + E2E** — a **live Model B end-to-end** (a real Deno connector: cursor → `fraiseql_query` → advance) verified vs real PostgreSQL locally; Dagger `postgres` suite wired; release-smoke boots against a source fixture.
6. **Preflight lint cleanup** — boxed the `[sources]` config field to keep `ServerConfig` off the large-futures budget; doc/test lints.

## Verification

- ✅ `cargo test -p fraiseql-server --features sources` — 13 source tests incl. the Model B E2E vs real PostgreSQL + V8 (`build_host` proves the cursor round-trips **and** the executor is reachable from `host.query`).
- ✅ `make preflight` (fmt, ~12 shell gates, rustdoc `-D warnings`, clippy `--all-features` nursery+pedantic deny).
- ✅ Local boot against the source fixture — server starts healthy, source-scheduler startup path reached.
- ✅ Default-feature build unaffected (fail-loud warn path).

The full V8 Deno-guest E2E is **local-only** (embedded V8 SIGSEGVs in the Dagger exec sandbox), excluded from CI by name like every `runtime-deno` test; each link in that chain is independently CI-covered.

**Remaining in #573:** Phase 07 (authoring SDKs + runnable Deno example — the `__source_tenant` sugar lands here), 08 (observability), 09 (finalize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)