### PR TITLE
feat(#573): Source authoring SDKs + runnable example (Phase 07)

### DIFF
--- a/sdks/official/fraiseql-python/src/fraiseql/__init__.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/__init__.py
@@ -47,7 +47,7 @@ from fraiseql.client import (
     FraiseQLRateLimitError,
     FraiseQLUnsupportedError,
 )
-from fraiseql.decorators import FieldConfig, field, mutation, query, scalar, subscription
+from fraiseql.decorators import FieldConfig, field, mutation, query, scalar, source, subscription
 from fraiseql.decorators import enum as enum_decorator
 from fraiseql.decorators import error as error_decorator
 from fraiseql.decorators import input as input_decorator
@@ -122,6 +122,7 @@ __all__ = [
     "mutation",
     "query",
     "scalar",
+    "source",
     "subscription",
     "type",
     "union",

--- a/sdks/official/fraiseql-python/src/fraiseql/decorators.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/decorators.py
@@ -1254,6 +1254,59 @@ def subscription(
     return decorator(func)
 
 
+def source(
+    *,
+    schedule: str,
+    function: str | None = None,
+    cursor: str | None = None,
+    enabled: bool = True,
+    run_as: dict[str, Any] | None = None,
+    **options: Any,
+) -> Callable[[F], F]:
+    """Decorator to register a scheduled ingress source (#573).
+
+    A source is the dual of an observer: on a cron ``schedule`` it fires a Deno
+    connector that pulls from an external system and drives results into the
+    database via mutations, resuming from a durable cursor. NO runtime behavior —
+    only used for schema compilation.
+
+    The decorated function's name is the source name (the durable-cursor row and
+    advisory-lease key); the bound ``function`` defaults to the same name.
+
+    Args:
+        schedule: POSIX cron expression the source polls on (e.g. ``"*/5 * * * *"``).
+        function: The bound Deno connector name; defaults to the source name.
+        cursor: Optional distinct cursor name (defaults to the source name).
+        enabled: Whether the source is scheduled (default ``True``).
+        run_as: Optional least-privilege authority ceiling (#573 D6):
+            ``{"roles": [...], "scopes": [...], "tenant": "..."}``. Absent ⇒
+            fail-closed (the source's mutations are RLS/authz-denied).
+        **options: Connector-specific options, opaque to the framework.
+
+    Returns:
+        The original function (unmodified).
+
+    Examples:
+        >>> @fraiseql.source(schedule="*/5 * * * *", run_as={"roles": ["ingest_writer"]})
+        ... def poll_orders() -> None:
+        ...     '''Every 5 minutes, ingest new orders.'''
+    """
+
+    def decorator(f: F) -> F:
+        SchemaRegistry.register_source(
+            name=f.__name__,
+            schedule=schedule,
+            function=function,
+            cursor=cursor,
+            enabled=enabled,
+            run_as=run_as,
+            options=options or None,
+        )
+        return f
+
+    return decorator
+
+
 def union(
     name: str | None = None,
     members: list[type] | None = None,

--- a/sdks/official/fraiseql-python/src/fraiseql/registry.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/registry.py
@@ -55,6 +55,8 @@ class SchemaRegistry:
     _queries: ClassVar[dict[str, SchemaElement]] = {}
     _mutations: ClassVar[dict[str, SchemaElement]] = {}
     _subscriptions: ClassVar[dict[str, SchemaElement]] = {}
+    # Scheduled ingress sources (#573) — the dual of observers.
+    _sources: ClassVar[dict[str, SchemaElement]] = {}
     # Maps scalar name -> (CustomScalar class, optional description)
     _custom_scalars: ClassVar[dict[str, tuple[type, str | None]]] = {}
     # Inject defaults: base applies to all operations; queries/mutations are per-operation-type
@@ -401,6 +403,52 @@ class SchemaRegistry:
         }
 
     @classmethod
+    def register_source(  # noqa: PLR0913 — public API; all parameters are meaningful
+        cls,
+        name: str,
+        schedule: str,
+        function: str | None = None,
+        cursor: str | None = None,
+        enabled: bool = True,
+        run_as: dict[str, Any] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        """Register a scheduled ingress source (#573) — the dual of an observer.
+
+        Metadata only; the runtime is Rust. Emits a `sources` entry matching the
+        compiled ``SourceDefinition``.
+
+        Args:
+            name: Source name (unique); camelCased like other SDK names.
+            schedule: POSIX cron expression (e.g. ``"*/5 * * * *"``).
+            function: The bound Deno connector name; defaults to the source name.
+            cursor: Optional distinct cursor name (defaults to the source name).
+            enabled: Whether the source is scheduled (default ``True``).
+            run_as: Optional least-privilege authority ceiling (#573 D6):
+                ``{"roles": [...], "scopes": [...], "tenant": "..."}``.
+            options: Optional connector-specific options, opaque to the framework.
+        """
+        camel_name = _snake_to_camel(name)
+        if camel_name in cls._sources:
+            raise ValueError(
+                f"Source {camel_name!r} is already registered. "
+                "Each name must be unique within a schema."
+            )
+        definition: dict[str, Any] = {
+            "name": camel_name,
+            "schedule": schedule,
+            "function": function or camel_name,
+            "enabled": enabled,
+        }
+        if cursor is not None:
+            definition["cursor"] = cursor
+        if run_as is not None:
+            definition["run_as"] = run_as
+        if options:
+            definition["options"] = options
+        cls._sources[camel_name] = definition
+
+    @classmethod
     def register_scalar(
         cls,
         name: str,
@@ -474,6 +522,11 @@ class SchemaRegistry:
             "naming_convention": _NAMING_CONVENTION,
         }
 
+        # Include sources only when present (matches the Rust skip-if-empty and the
+        # TypeScript SDK; the source *definitions* live here, the runtime is Rust).
+        if cls._sources:
+            schema["sources"] = list(cls._sources.values())
+
         # Include inject_defaults if any are set
         if cls._inject_defaults:
             schema["inject_defaults"] = cls._inject_defaults
@@ -502,6 +555,7 @@ class SchemaRegistry:
         cls._queries.clear()
         cls._mutations.clear()
         cls._subscriptions.clear()
+        cls._sources.clear()
         cls._custom_scalars.clear()
         cls._inject_defaults.clear()
 

--- a/sdks/official/fraiseql-python/tests/test_sources.py
+++ b/sdks/official/fraiseql-python/tests/test_sources.py
@@ -1,0 +1,67 @@
+"""Tests for @fraiseql.source scheduled-ingress authoring (#573)."""
+
+import pytest
+
+import fraiseql
+from fraiseql.registry import SchemaRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    SchemaRegistry.clear()
+    yield
+    SchemaRegistry.clear()
+
+
+def test_source_registers_with_defaults():
+    @fraiseql.source(schedule="*/5 * * * *")
+    def poll_orders() -> None:
+        pass
+
+    schema = SchemaRegistry.get_schema()
+    assert schema["sources"] == [
+        {
+            "name": "pollOrders",  # camelCased like other SDK names
+            "schedule": "*/5 * * * *",
+            "function": "pollOrders",  # defaults to the source name
+            "enabled": True,
+        }
+    ]
+
+
+def test_source_carries_run_as_cursor_and_explicit_function():
+    @fraiseql.source(
+        schedule="0 * * * *",
+        function="stripePull",
+        cursor="stripe-cursor",
+        enabled=False,
+        run_as={"roles": ["ingest_writer"], "scopes": ["write:order"], "tenant": "acme"},
+    )
+    def stripe_sync() -> None:
+        pass
+
+    source = SchemaRegistry.get_schema()["sources"][0]
+    assert source == {
+        "name": "stripeSync",
+        "schedule": "0 * * * *",
+        "function": "stripePull",
+        "cursor": "stripe-cursor",
+        "enabled": False,
+        "run_as": {"roles": ["ingest_writer"], "scopes": ["write:order"], "tenant": "acme"},
+    }
+
+
+def test_sources_omitted_when_none_registered():
+    assert "sources" not in SchemaRegistry.get_schema()
+
+
+def test_duplicate_source_name_raises():
+    @fraiseql.source(schedule="*/5 * * * *")
+    def poll_orders() -> None:
+        pass
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @fraiseql.source(schedule="0 * * * *")
+        def poll_orders() -> None:
+            pass

--- a/sdks/official/fraiseql-typescript/examples/scheduled_source.ts
+++ b/sdks/official/fraiseql-typescript/examples/scheduled_source.ts
@@ -1,0 +1,64 @@
+/**
+ * Example: authoring a scheduled ingress Source (#573).
+ *
+ * A `Source` is the dual of an observer: instead of reacting to a database change
+ * (egress), it runs on a cron schedule to pull from an external system and drive
+ * results into the database via mutations (ingress), resuming from a durable cursor.
+ *
+ * This file is **authoring only** — it emits `sources[]` into the schema JSON. The
+ * connector that actually runs (the Model B loop: cursor → HTTP → mutate → advance)
+ * is a separate Deno function, `sources/poll_orders.connector.ts`, referenced here
+ * by name.
+ *
+ * Usage:
+ *   ts-node examples/scheduled_source.ts   # writes scheduled_source_schema.json
+ *
+ * Then:
+ *   fraiseql-cli compile scheduled_source_schema.json
+ *   fraiseql-server --schema scheduled_source_schema.compiled.json   # (needs --features sources)
+ */
+
+import { Type, Source, exportSchema } from "../src/index";
+import type { ID } from "../src/index";
+
+// The entity the connector upserts into.
+@Type()
+class Order {
+  /** A customer order ingested from the upstream orders API. */
+  id!: ID;
+  total!: number;
+}
+
+// The source registrations live on a class; the method name is the source name.
+class OrderSources {
+  /**
+   * Every 5 minutes, run the `pollOrders` connector to ingest new orders.
+   *
+   * `runAs` is the least-privilege ceiling the connector's mutations execute under
+   * (#573 D6): here it may only write orders. Omit `runAs` and the source is
+   * fail-closed (its mutations are RLS/authz-denied) until you grant one.
+   *
+   * `function` defaults to the method name (`pollOrders`) — the Deno connector.
+   */
+  @Source({
+    schedule: "*/5 * * * *",
+    runAs: { roles: ["ingest_writer"], scopes: ["write:Order"] },
+  })
+  pollOrders() {
+    /** Scheduled orders ingestion. */
+  }
+}
+
+// Reference the class to trigger decorator registration.
+void OrderSources;
+
+if (require.main === module) {
+  exportSchema("scheduled_source_schema.json");
+
+  console.log("\n🎯 Source Summary:");
+  console.log("   pollOrders → every 5 min, ingest orders as `ingest_writer`");
+  console.log("\n✨ Next steps:");
+  console.log("   1. fraiseql-cli compile scheduled_source_schema.json");
+  console.log("   2. Ship the connector: sources/poll_orders.connector.ts");
+  console.log("   3. fraiseql-server --schema ...compiled.json  (build --features sources)");
+}

--- a/sdks/official/fraiseql-typescript/examples/sources/poll_orders.connector.ts
+++ b/sdks/official/fraiseql-typescript/examples/sources/poll_orders.connector.ts
@@ -1,0 +1,115 @@
+/**
+ * Example Model B source connector (#573) — the runtime half.
+ *
+ * This is a **Deno function** (a scheduled `Source`'s `function`), NOT authoring
+ * code: it runs inside FraiseQL's Deno runtime on the source's cron schedule, under
+ * a single-firing lease, with a host bound to the source's durable cursor and its
+ * `run_as` identity. Register it with `@Source` (see `../scheduled_source.ts`).
+ *
+ * The Model B loop the #573 issue shows:
+ *   read cursor  ->  fetch the world (HTTP)  ->  mutate (fraiseql_query)  ->  advance cursor
+ *
+ * Contract:
+ * - **At-least-once.** A crash before `ctx.advance` re-runs the whole window; make
+ *   your mutation idempotent (natural keys / `ON CONFLICT`), because the framework
+ *   guarantees at-least-once delivery, not exactly-once domain writes.
+ * - **Durable cursor.** `ctx.cursor` is where the last successful run left off; only
+ *   advance it after the writes for that window have committed.
+ * - **Least privilege.** The mutation runs under the source's `run_as` ceiling; it
+ *   can do nothing the ceiling doesn't grant (unset `run_as` ⇒ denied).
+ */
+
+// The host ops FraiseQL injects into the Deno runtime (see the host typings). Only
+// the ones this connector uses are declared here.
+declare const Deno: {
+  core: {
+    ops: {
+      fraiseql_cursor_get(): Promise<string>;
+      fraiseql_cursor_advance(valueJson: string): Promise<void>;
+      fraiseql_query(graphql: string, variablesJson: string): Promise<string>;
+      fraiseql_http_request(
+        method: string,
+        url: string,
+        headers: Array<[string, string]>,
+        body: Uint8Array | null
+      ): Promise<{ status: number; headers: Array<[string, string]>; body: Uint8Array }>;
+    };
+  };
+};
+
+/**
+ * A thin, ergonomic wrapper over the raw `fraiseql_*` host ops — copy this into a
+ * shared module for your connectors. It hides the JSON string-encoding the ops use
+ * and adds the multi-tenant `tenant` option.
+ */
+const ctx = {
+  /** The value the source last advanced to, or `null` on the first run. */
+  async cursor<T = unknown>(): Promise<T | null> {
+    return JSON.parse(await Deno.core.ops.fraiseql_cursor_get()) as T | null;
+  },
+
+  /** Persist the new watermark. Call only after this window's writes committed. */
+  async advance(value: unknown): Promise<void> {
+    await Deno.core.ops.fraiseql_cursor_advance(JSON.stringify(value));
+  },
+
+  /**
+   * Run a GraphQL query/mutation under the source's `run_as` identity.
+   *
+   * For a **multi-tenant** source, pass `{ tenant }` — it is delivered as the
+   * reserved `__source_tenant` variable and re-scopes this one write to that tenant
+   * (a source pinned to a tenant by `run_as` ignores it and cannot forge another).
+   */
+  async query<T = unknown>(
+    graphql: string,
+    variables: Record<string, unknown> = {},
+    opts: { tenant?: string } = {}
+  ): Promise<T> {
+    const vars = opts.tenant ? { ...variables, __source_tenant: opts.tenant } : variables;
+    return JSON.parse(await Deno.core.ops.fraiseql_query(graphql, JSON.stringify(vars))) as T;
+  },
+
+  /** A GET that returns parsed JSON, subject to the host's SSRF allowlist. */
+  async fetchJson<T = unknown>(url: string): Promise<T> {
+    const res = await Deno.core.ops.fraiseql_http_request("GET", url, [], null);
+    return JSON.parse(new TextDecoder().decode(res.body)) as T;
+  },
+};
+
+interface Order {
+  id: string;
+  total: number;
+  tenant: string;
+}
+
+const UPSERT_ORDER = `
+  mutation ($id: ID!, $total: Float!) {
+    upsertOrder(id: $id, total: $total) { id }
+  }
+`;
+
+/**
+ * The connector entrypoint. The runtime invokes this once per scheduled fire.
+ */
+export default async function pollOrders(): Promise<void> {
+  // 1. Resume from the durable cursor (an opaque, connector-defined watermark).
+  const since = (await ctx.cursor<{ lastId: string }>())?.lastId ?? "0";
+
+  // 2. Fetch the world. The host enforces the SSRF allowlist
+  //    (`FRAISEQL_SOURCES_ALLOWED_DOMAINS`); an un-allowlisted host is rejected.
+  const orders = await ctx.fetchJson<Order[]>(
+    `https://orders.example.com/api/orders?since=${since}`
+  );
+  if (orders.length === 0) {
+    return; // Nothing new — leave the cursor untouched.
+  }
+
+  // 3. Drive each record into the database via an idempotent mutation. For a
+  //    multi-tenant source, scope each write to the record's tenant.
+  for (const order of orders) {
+    await ctx.query(UPSERT_ORDER, { id: order.id, total: order.total }, { tenant: order.tenant });
+  }
+
+  // 4. Advance the cursor past the last record — only now that the writes are in.
+  await ctx.advance({ lastId: orders[orders.length - 1].id });
+}

--- a/sdks/official/fraiseql-typescript/src/__tests__/sources.test.ts
+++ b/sdks/official/fraiseql-typescript/src/__tests__/sources.test.ts
@@ -1,0 +1,54 @@
+import { Source } from "../sources";
+import { SchemaRegistry } from "../registry";
+
+describe("@Source", () => {
+  beforeEach(() => {
+    SchemaRegistry.clear();
+  });
+
+  it("registers a source with defaults and emits it in the schema", () => {
+    class Sources {
+      @Source({ schedule: "*/5 * * * *" })
+      pollOrders(): void {}
+    }
+    void Sources;
+
+    const schema = SchemaRegistry.getSchema();
+    expect(schema.sources).toHaveLength(1);
+    expect(schema.sources?.[0]).toEqual({
+      name: "pollOrders",
+      schedule: "*/5 * * * *",
+      function: "pollOrders", // defaults to the decorated method name
+      enabled: true, // defaults to true
+    });
+  });
+
+  it("carries run_as, cursor, and an explicit function/enabled", () => {
+    class Sources {
+      @Source({
+        schedule: "0 * * * *",
+        function: "stripePull",
+        cursor: "stripe-cursor",
+        enabled: false,
+        runAs: { roles: ["ingest_writer"], scopes: ["write:order"], tenant: "acme" },
+      })
+      stripeSync(): void {}
+    }
+    void Sources;
+
+    const schema = SchemaRegistry.getSchema();
+    expect(schema.sources?.[0]).toEqual({
+      name: "stripeSync",
+      schedule: "0 * * * *",
+      function: "stripePull",
+      cursor: "stripe-cursor",
+      enabled: false,
+      run_as: { roles: ["ingest_writer"], scopes: ["write:order"], tenant: "acme" },
+    });
+  });
+
+  it("omits sources from the schema when none are registered", () => {
+    const schema = SchemaRegistry.getSchema();
+    expect(schema.sources).toBeUndefined();
+  });
+});

--- a/sdks/official/fraiseql-typescript/src/index.ts
+++ b/sdks/official/fraiseql-typescript/src/index.ts
@@ -53,6 +53,8 @@ export type {
   InterfaceDefinition,
   InputTypeDefinition,
   UnionDefinition,
+  SourceDefinition,
+  SourceRunAs,
   Schema,
 } from "./registry";
 
@@ -176,6 +178,7 @@ export { validateCustomScalar, getAllCustomScalars, ScalarValidationError } from
 // Export observer authoring API
 export { Observer, webhook, slack, email, DEFAULT_RETRY_CONFIG } from "./observers";
 export type { RetryConfig } from "./observers";
+export { Source } from "./sources";
 
 // Export HTTP client
 export { FraiseQLClient } from "./client";

--- a/sdks/official/fraiseql-typescript/src/registry.ts
+++ b/sdks/official/fraiseql-typescript/src/registry.ts
@@ -227,6 +227,33 @@ export interface UnionDefinition {
 }
 
 /**
+ * The `run_as` authority ceiling a scheduled source's background mutations run
+ * under (#573 D6). Absent ⇒ the source runs fail-closed (no roles/scopes/tenant →
+ * RLS/authz deny). `tenant` scopes a single-tenant or global source; a multi-tenant
+ * source leaves it unset and re-scopes each write per message at runtime.
+ */
+export interface SourceRunAs {
+  roles?: string[];
+  scopes?: string[];
+  tenant?: string;
+}
+
+/**
+ * A scheduled ingress `Source` (#573) — the dual of an observer. On its cron
+ * `schedule` it fires `function` (a Deno connector) under a durable cursor and its
+ * `run_as` identity. Authoring metadata only; the runtime is Rust.
+ */
+export interface SourceDefinition {
+  name: string;
+  schedule: string;
+  function: string;
+  cursor?: string;
+  enabled: boolean;
+  options?: Record<string, unknown>;
+  run_as?: SourceRunAs;
+}
+
+/**
  * Complete schema definition.
  */
 export interface Schema {
@@ -241,6 +268,7 @@ export interface Schema {
   fact_tables?: FactTableDefinition[];
   aggregate_queries?: AggregateQueryDefinition[];
   observers?: ObserverDefinition[];
+  sources?: SourceDefinition[];
   /** Apollo Federation v2 metadata, included when generateSchemaJson() is used. */
   federation?: { enabled: boolean; version: string; [key: string]: unknown };
   /** Custom scalar definitions, included when scalars are registered. */
@@ -400,6 +428,7 @@ export class SchemaRegistry {
   private static factTables: Map<string, FactTableDefinition> = new Map();
   private static aggregateQueries: Map<string, AggregateQueryDefinition> = new Map();
   private static observers: Map<string, ObserverDefinition> = new Map();
+  private static sources: Map<string, SourceDefinition> = new Map();
   private static customScalars: Map<string, { class: typeof CustomScalar; description?: string }> = new Map();
 
   /**
@@ -695,6 +724,39 @@ export class SchemaRegistry {
   }
 
   /**
+   * Register a scheduled ingress source (#573).
+   *
+   * @param name - Source name (unique) — the durable-cursor row and advisory-lease key.
+   * @param schedule - POSIX cron expression (e.g. "*\/5 * * * *").
+   * @param fn - The bound Deno connector function name.
+   * @param cursor - Optional distinct cursor name (defaults to the source name).
+   * @param enabled - Whether the source is scheduled (default true).
+   * @param runAs - Optional least-privilege authority ceiling (#573 D6).
+   * @param options - Optional connector-specific options, opaque to the framework.
+   */
+  static registerSource(
+    name: string,
+    schedule: string,
+    fn: string,
+    cursor?: string,
+    enabled: boolean = true,
+    runAs?: SourceRunAs,
+    options?: Record<string, unknown>
+  ): void {
+    const definition: SourceDefinition = { name, schedule, function: fn, enabled };
+    if (cursor !== undefined) {
+      definition.cursor = cursor;
+    }
+    if (runAs !== undefined) {
+      definition.run_as = runAs;
+    }
+    if (options !== undefined) {
+      definition.options = options;
+    }
+    this.sources.set(name, definition);
+  }
+
+  /**
    * Register a GraphQL enum type.
    *
    * @param name - Enum name (e.g., "OrderStatus")
@@ -850,6 +912,10 @@ export class SchemaRegistry {
       schema.observers = Array.from(this.observers.values());
     }
 
+    if (this.sources.size > 0) {
+      schema.sources = Array.from(this.sources.values());
+    }
+
     if (this.customScalars.size > 0) {
       const customScalars: Record<string, { name: string; description: string; validate: boolean }> = {};
       for (const [name, { class: scalarClass, description }] of this.customScalars) {
@@ -882,6 +948,7 @@ export class SchemaRegistry {
     this.factTables.clear();
     this.aggregateQueries.clear();
     this.observers.clear();
+    this.sources.clear();
     this.customScalars.clear();
   }
 }

--- a/sdks/official/fraiseql-typescript/src/sources.ts
+++ b/sdks/official/fraiseql-typescript/src/sources.ts
@@ -1,0 +1,63 @@
+/**
+ * Source authoring API for FraiseQL scheduled ingress (#573).
+ *
+ * A source is the dual of an observer: on a cron schedule it fires a Deno connector
+ * that pulls from an external system and drives results into the database via
+ * mutations, resuming from a durable cursor. NO runtime behavior — only used for
+ * schema compilation.
+ *
+ * @example
+ * ```typescript
+ * import { Source } from "fraiseql";
+ *
+ * class Sources {
+ *   // Every 5 minutes, run the `pollOrders` connector as `ingest_writer`.
+ *   @Source({ schedule: "*\/5 * * * *", runAs: { roles: ["ingest_writer"] } })
+ *   pollOrders() {}
+ * }
+ * ```
+ */
+
+import { SchemaRegistry, SourceRunAs } from "./registry";
+
+/**
+ * Configuration for the @Source decorator.
+ */
+interface SourceConfig {
+  /** POSIX cron expression the source polls on (e.g. `"*\/5 * * * *"`). */
+  schedule: string;
+  /** The bound Deno connector function name; defaults to the decorated method name. */
+  function?: string;
+  /** Distinct durable-cursor name; defaults to the source name. */
+  cursor?: string;
+  /** Whether the source is scheduled. Default `true`. */
+  enabled?: boolean;
+  /** Least-privilege authority ceiling for the source's mutations (#573 D6). */
+  runAs?: SourceRunAs;
+  /** Connector-specific options, opaque to the framework. */
+  options?: Record<string, unknown>;
+}
+
+/**
+ * Method decorator to register a scheduled ingress source with the schema registry.
+ *
+ * The decorated method's name is the source name (the durable-cursor row and
+ * advisory-lease key); its `function` defaults to the same name.
+ *
+ * @param config - Source configuration
+ * @returns Method decorator
+ */
+export function Source(config: SourceConfig) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy method decorator target
+  return function (_target: any, propertyKey: string, _descriptor: PropertyDescriptor): void {
+    SchemaRegistry.registerSource(
+      propertyKey,
+      config.schedule,
+      config.function ?? propertyKey,
+      config.cursor,
+      config.enabled ?? true,
+      config.runAs,
+      config.options
+    );
+  };
+}


### PR DESCRIPTION
Phase 07 of #573 — the **authoring surface** for scheduled ingress sources. The Phase 06 runtime (PR #586) consumes what these emit. Metadata only; no runtime FFI.

## What's in it (3 commits)

1. **TS `@Source`** — `SchemaRegistry.registerSource` + `SourceDefinition`/`SourceRunAs` types + `sources[]` emission (mirrors the observer path); `@Source({ schedule, function?, cursor?, enabled?, runAs?, options? })` in `sources.ts`, exported from `index.ts`.
2. **Python `@fraiseql.source`** — `register_source` + `_sources` + conditional `sources` emission in `get_schema()` (skip-if-empty, matching Rust + TS); `@fraiseql.source(schedule, function=None, cursor=None, enabled=True, run_as=None, **options)`, exported from `__init__`.
3. **Runnable Model B example** — `examples/sources/poll_orders.connector.ts` (the Deno connector: cursor → HTTP → `fraiseql_query` upsert → advance, with a `ctx` sugar over the raw ops and the `__source_tenant` multi-tenant sugar the Phase 06 executor re-scopes on) + `examples/scheduled_source.ts` (the `@Source` authoring half).

Both SDKs emit JSON matching the Rust `SourceDefinition`: `{ name, schedule, function, cursor?, enabled, options?, run_as: { roles, scopes, tenant? }? }`. Source names are camelCased for TS/Python parity.

## Verification

- ✅ **TS**: vitest (3), `tsc --strict --noEmit`, eslint, tsup build — clean.
- ✅ **Python**: pytest (4) + public-surface + golden-schema (10, no regression), ruff, ty — clean.

The runtime round-trip is already proven by the Phase 06 poller E2E (`fires_a_model_b_connector_end_to_end` vs real PostgreSQL + V8), so this phase is authoring + a reference connector.

**Remaining in #573:** Phase 08 (observability — metrics/logs/status surface + the ingress guide doc), Phase 09 (finalize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)