### PR TITLE
feat(sources): observability — metrics, logs, status, guide (#573 Phase 08)

### DIFF
--- a/crates/fraiseql-cli/src/cli.rs
+++ b/crates/fraiseql-cli/src/cli.rs
@@ -730,6 +730,35 @@ EXAMPLES:
         #[command(subcommand)]
         command: PerfCommands,
     },
+
+    /// List scheduled ingress sources and their durable cursor state (#573)
+    ///
+    /// Reads the compiled schema for each source's schedule and `run_as` ceiling,
+    /// and — when a database is reachable — its cursor value, version, and staleness
+    /// (seconds since the last advance). Leadership and last-fire are not reported
+    /// here (an advisory lock has no visible holder, and the lease is released
+    /// between ticks): watch `fraiseql_source_*` metrics and the poller logs for
+    /// those. Always exits 0 — it is a report.
+    #[command(after_help = "\
+EXAMPLES:
+    fraiseql sources
+    fraiseql sources --schema schema.compiled.json
+    fraiseql sources --db-url postgres://user:pass@host:5432/db
+    fraiseql sources --json")]
+    Sources {
+        /// Path to schema.compiled.json.
+        #[arg(long, default_value = "schema.compiled.json")]
+        schema: std::path::PathBuf,
+
+        /// PostgreSQL URL for cursor reads (defaults to `fraiseql.toml` /
+        /// `DATABASE_URL`). Without one, definitions are listed with no cursor state.
+        #[arg(long)]
+        db_url: Option<String>,
+
+        /// Output machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// `fraiseql perf` subcommands.

--- a/crates/fraiseql-cli/src/commands/mod.rs
+++ b/crates/fraiseql-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod run;
 pub mod sbom;
 pub mod schema;
 pub mod setup;
+pub mod sources;
 pub mod validate;
 pub mod validate_documents;
 pub mod validate_facts;

--- a/crates/fraiseql-cli/src/commands/sources/mod.rs
+++ b/crates/fraiseql-cli/src/commands/sources/mod.rs
@@ -1,0 +1,302 @@
+//! `fraiseql sources` — a read-only status view over scheduled ingress sources
+//! (#573 Phase 08).
+//!
+//! Lists each compiled source with its schedule, `run_as` authority ceiling, and —
+//! when a database is reachable — its durable cursor: the value, the compare-and-swap
+//! version, and how stale the watermark is (seconds since the last advance). It is
+//! the operator's answer to "read its cursor / measure lag"; the fire/skip/error
+//! signals live in the `fraiseql_source_*` Prometheus metrics and the poller's
+//! structured logs, since those are per-firing and per-replica, whereas the cursor is
+//! the durable, cross-replica source of truth for progress.
+//!
+//! Leadership and last-fire are deliberately **not** reported here: a PostgreSQL
+//! advisory lock exposes no holder, the single-firing lease is released between
+//! ticks, and "last fired on this replica" is not "last fired" in a multi-replica
+//! deployment — so the honest, durable signal is the cursor, and single-firing health
+//! is the fleet-wide `fraiseql_source_skips_not_leader_total` metric.
+//!
+//! Architecture mirrors `perf`: a thin PostgreSQL [`reader`] plus pure, unit-tested
+//! merge/format functions, so correctness is covered without a live database.
+
+pub mod reader;
+
+#[cfg(test)]
+mod tests;
+
+use std::{collections::HashMap, path::PathBuf};
+
+use anyhow::{Context, Result};
+use fraiseql_core::schema::{CompiledSchema, SourceDefinition};
+use serde::Serialize;
+
+use self::reader::{CursorRow, SourceCursorReader};
+use crate::commands::migrate::resolve_database_url;
+
+/// Arguments for `fraiseql sources`.
+pub struct SourcesArgs {
+    /// Path to the compiled schema (the source definitions).
+    pub schema:   PathBuf,
+    /// Explicit PostgreSQL URL for cursor reads; falls back to `fraiseql.toml` /
+    /// `DATABASE_URL`. When no URL resolves, definitions are listed without cursor
+    /// state.
+    pub database: Option<String>,
+    /// Emit machine-readable JSON instead of the human report.
+    pub json:     bool,
+}
+
+/// The `run_as` authority ceiling of a source, flattened for display.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RunAsStatus {
+    /// Whether a `run_as` ceiling is configured at all. `false` ⇒ the source is
+    /// fail-closed: its background mutations are denied until a ceiling is granted.
+    pub configured: bool,
+    /// The granted roles (RBAC ceiling).
+    pub roles:      Vec<String>,
+    /// The granted scopes.
+    pub scopes:     Vec<String>,
+    /// The pinned tenant, if any. `None` ⇒ global/system or a per-message
+    /// multi-tenant source.
+    pub tenant:     Option<String>,
+}
+
+/// The durable cursor state of a source, if known.
+#[derive(Debug, Serialize, PartialEq)]
+pub struct CursorStatus {
+    /// `"unknown"` (no database read), `"never_advanced"` (no row yet), or
+    /// `"advanced"` (a watermark exists).
+    pub state:       &'static str,
+    /// The compare-and-swap generation counter (present only when advanced).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version:     Option<i64>,
+    /// The opaque cursor value (present only when advanced).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value:       Option<serde_json::Value>,
+    /// Last-advance timestamp (present only when advanced).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at:  Option<String>,
+    /// Seconds since the last advance — the staleness/lag (present only when
+    /// advanced).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age_seconds: Option<f64>,
+}
+
+impl CursorStatus {
+    /// No database was reachable, so the cursor state is unknown.
+    const fn unknown() -> Self {
+        Self {
+            state:       "unknown",
+            version:     None,
+            value:       None,
+            updated_at:  None,
+            age_seconds: None,
+        }
+    }
+
+    /// The database was read but the source has no cursor row yet.
+    const fn never_advanced() -> Self {
+        Self {
+            state:       "never_advanced",
+            version:     None,
+            value:       None,
+            updated_at:  None,
+            age_seconds: None,
+        }
+    }
+
+    /// A durable watermark exists.
+    fn advanced(row: &CursorRow) -> Self {
+        Self {
+            state:       "advanced",
+            version:     Some(row.version),
+            value:       row.value.clone(),
+            updated_at:  Some(row.updated_at.clone()),
+            age_seconds: Some(row.age_seconds),
+        }
+    }
+}
+
+/// One source's full status: its static definition plus its durable cursor.
+#[derive(Debug, Serialize)]
+pub struct SourceStatus {
+    /// The source name (also the cursor key the runtime advances under).
+    pub name:        String,
+    /// The cron schedule the source fires on.
+    pub schedule:    String,
+    /// The connector function the source runs.
+    pub function:    String,
+    /// Whether the source is enabled (a disabled source is compiled but not
+    /// scheduled).
+    pub enabled:     bool,
+    /// The declared cursor name. Equal to `name` unless an explicit `cursor` was set.
+    pub cursor_name: String,
+    /// The `run_as` authority ceiling.
+    pub run_as:      RunAsStatus,
+    /// The durable cursor state.
+    pub cursor:      CursorStatus,
+}
+
+/// Merge the compiled source definitions with the cursor rows read from the
+/// database into a per-source status list.
+///
+/// `cursors` is `None` when no database was reachable (every cursor is `unknown`),
+/// or `Some(map)` keyed by the source name the runtime advances under — so a source
+/// with no row reads as `never_advanced` and one with a row as `advanced`.
+fn build_status(
+    sources: &[SourceDefinition],
+    cursors: Option<&HashMap<String, CursorRow>>,
+) -> Vec<SourceStatus> {
+    sources
+        .iter()
+        .map(|source| {
+            let cursor = match cursors {
+                None => CursorStatus::unknown(),
+                Some(map) => match map.get(&source.name) {
+                    Some(row) => CursorStatus::advanced(row),
+                    None => CursorStatus::never_advanced(),
+                },
+            };
+            SourceStatus {
+                name: source.name.clone(),
+                schedule: source.schedule.clone(),
+                function: source.function.clone(),
+                enabled: source.enabled,
+                cursor_name: source.cursor_name().to_string(),
+                run_as: run_as_status(source),
+                cursor,
+            }
+        })
+        .collect()
+}
+
+/// Flatten a source's optional `run_as` into a display-ready [`RunAsStatus`].
+fn run_as_status(source: &SourceDefinition) -> RunAsStatus {
+    match &source.run_as {
+        None => RunAsStatus {
+            configured: false,
+            roles:      Vec::new(),
+            scopes:     Vec::new(),
+            tenant:     None,
+        },
+        Some(run_as) => RunAsStatus {
+            configured: true,
+            roles:      run_as.roles.clone(),
+            scopes:     run_as.scopes.clone(),
+            tenant:     run_as.tenant.clone(),
+        },
+    }
+}
+
+/// Render the status list as a human-readable report.
+#[must_use]
+pub fn render_text(statuses: &[SourceStatus], database_connected: bool) -> String {
+    use std::fmt::Write as _;
+
+    if statuses.is_empty() {
+        return "No sources declared in the compiled schema.\n".to_string();
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Sources ({})\n", statuses.len());
+    for status in statuses {
+        let marker = if status.enabled { '●' } else { '○' };
+        let enabled = if status.enabled {
+            "enabled"
+        } else {
+            "DISABLED"
+        };
+        let _ = writeln!(
+            out,
+            "{marker} {name}    schedule {schedule}    {enabled}",
+            name = status.name,
+            schedule = status.schedule,
+        );
+        let _ = writeln!(out, "    function   {}", status.function);
+        let _ = writeln!(out, "    run_as     {}", render_run_as(&status.run_as));
+        let _ =
+            writeln!(out, "    cursor     {}", render_cursor(&status.cursor, database_connected));
+        out.push('\n');
+    }
+    out
+}
+
+/// Render a `run_as` ceiling, calling out the fail-closed (unconfigured) case.
+fn render_run_as(run_as: &RunAsStatus) -> String {
+    if !run_as.configured {
+        return "(none — fail-closed: mutations are denied until a run_as ceiling is granted)"
+            .to_string();
+    }
+    let roles = if run_as.roles.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("{:?}", run_as.roles)
+    };
+    let scopes = if run_as.scopes.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("{:?}", run_as.scopes)
+    };
+    let tenant = run_as.tenant.as_deref().unwrap_or("(per-message / global)");
+    format!("roles={roles} scopes={scopes} tenant={tenant}")
+}
+
+/// Render a cursor's durable state.
+fn render_cursor(cursor: &CursorStatus, database_connected: bool) -> String {
+    match cursor.state {
+        "advanced" => {
+            let version = cursor.version.unwrap_or_default();
+            let age = cursor.age_seconds.unwrap_or_default();
+            let when = cursor.updated_at.as_deref().unwrap_or("");
+            let value =
+                cursor.value.as_ref().map_or_else(|| "null".to_string(), ToString::to_string);
+            format!("v{version} · advanced {age:.0}s ago · {when} · value {value}")
+        },
+        "never_advanced" => "never advanced (no watermark yet)".to_string(),
+        _ if !database_connected => {
+            "(no database connection — pass --db-url to read cursor state)".to_string()
+        },
+        _ => "unknown".to_string(),
+    }
+}
+
+/// Run `fraiseql sources`: load the compiled schema, optionally read cursor state
+/// from the database, and print the merged status as text or JSON.
+///
+/// # Errors
+///
+/// Returns an error if the compiled schema cannot be read/parsed, or if a database
+/// URL resolves but the cursor read fails.
+pub async fn run(args: SourcesArgs) -> Result<()> {
+    let text = std::fs::read_to_string(&args.schema)
+        .with_context(|| format!("cannot read compiled schema {}", args.schema.display()))?;
+    let schema = CompiledSchema::from_json(&text, false).map_err(|e| {
+        anyhow::anyhow!("cannot parse compiled schema {}: {e}", args.schema.display())
+    })?;
+
+    // A database read is best-effort: when no URL resolves, list definitions with
+    // `unknown` cursor state rather than failing — the definitions are still useful.
+    // When a URL *does* resolve, a read failure is a real error (the operator asked
+    // for cursor state).
+    let (cursors, database_connected) = match resolve_database_url(args.database.as_deref()) {
+        Ok(db_url) => {
+            let reader = SourceCursorReader::connect(&db_url)?;
+            let rows = reader.load_cursors().await?;
+            let map: HashMap<String, CursorRow> =
+                rows.into_iter().map(|row| (row.source_name.clone(), row)).collect();
+            (Some(map), true)
+        },
+        Err(_) => (None, false),
+    };
+
+    let statuses = build_status(&schema.sources, cursors.as_ref());
+
+    if args.json {
+        let payload = serde_json::json!({
+            "database_connected": database_connected,
+            "sources": statuses,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        print!("{}", render_text(&statuses, database_connected));
+    }
+    Ok(())
+}

--- a/crates/fraiseql-cli/src/commands/sources/reader.rs
+++ b/crates/fraiseql-cli/src/commands/sources/reader.rs
@@ -1,0 +1,94 @@
+//! The thin PostgreSQL projection behind `fraiseql sources` (#573 Phase 08).
+//!
+//! Reads the durable `_fraiseql_source_cursor` watermark table — the same table the
+//! runtime poller advances — so an operator can see, per source, where its cursor
+//! stands and how stale it is. Deliberately dependency-light (deadpool +
+//! tokio-postgres, mirroring the `perf` reader): all merge/format logic lives in
+//! pure functions in the parent module, so correctness is covered without a live
+//! database.
+
+use anyhow::{Context, Result};
+use deadpool_postgres::{Config, ManagerConfig, Pool, RecyclingMethod, Runtime};
+use tokio_postgres::NoTls;
+
+/// One `_fraiseql_source_cursor` row: a source's durable watermark and its
+/// staleness, computed against the database clock so there is no app↔DB skew.
+pub struct CursorRow {
+    /// The cursor key — the source name the runtime poller advances under.
+    pub source_name: String,
+    /// The opaque cursor value, or `None` if the row exists but holds SQL NULL.
+    pub value:       Option<serde_json::Value>,
+    /// The compare-and-swap generation counter.
+    pub version:     i64,
+    /// Last-advance timestamp, rendered as text (`updated_at::text`).
+    pub updated_at:  String,
+    /// Seconds since the last advance, from the database clock (the staleness/lag).
+    pub age_seconds: f64,
+}
+
+/// A live PostgreSQL connection pool for reading source cursors.
+pub struct SourceCursorReader {
+    pool: Pool,
+}
+
+impl SourceCursorReader {
+    /// Connect to `db_url` (PostgreSQL only) for cursor reads.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `db_url` is not a `postgres://` URL or the pool cannot be
+    /// created. (Connection failures surface lazily on the first query.)
+    pub fn connect(db_url: &str) -> Result<Self> {
+        if !db_url.starts_with("postgres") {
+            anyhow::bail!(
+                "source cursor reads require a PostgreSQL connection URL (postgres://…); got: \
+                 {db_url}"
+            );
+        }
+        let mut cfg = Config::new();
+        cfg.url = Some(db_url.to_string());
+        cfg.manager = Some(ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        });
+        cfg.pool = Some(deadpool_postgres::PoolConfig::new(2));
+        let pool = cfg
+            .create_pool(Some(Runtime::Tokio1), NoTls)
+            .context("failed to create PostgreSQL connection pool for source cursor reads")?;
+        Ok(Self { pool })
+    }
+
+    /// Load every source cursor row.
+    ///
+    /// The age is computed in SQL against the database clock. `cursor_value` (JSONB)
+    /// decodes directly to a [`serde_json::Value`] (the `with-serde_json-1` codec).
+    /// Missing table ⇒ an empty result is *not* silently returned — the error
+    /// surfaces so the operator learns the source subsystem was never initialized.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection or the query fails.
+    pub async fn load_cursors(&self) -> Result<Vec<CursorRow>> {
+        let client = self.pool.get().await.context("failed to acquire DB connection")?;
+        let rows = client
+            .query(
+                "SELECT source_name, cursor_value, version, updated_at::text AS updated_at_text, \
+                 EXTRACT(EPOCH FROM (now() - updated_at))::float8 AS age_seconds \
+                 FROM _fraiseql_source_cursor",
+                &[],
+            )
+            .await
+            .context(
+                "failed to read _fraiseql_source_cursor (is the source subsystem initialized?)",
+            )?;
+        Ok(rows
+            .iter()
+            .map(|row| CursorRow {
+                source_name: row.get("source_name"),
+                value:       row.get("cursor_value"),
+                version:     row.get("version"),
+                updated_at:  row.get("updated_at_text"),
+                age_seconds: row.get("age_seconds"),
+            })
+            .collect())
+    }
+}

--- a/crates/fraiseql-cli/src/commands/sources/tests.rs
+++ b/crates/fraiseql-cli/src/commands/sources/tests.rs
@@ -1,0 +1,133 @@
+//! Tests for the `fraiseql sources` status view.
+//!
+//! The merge (`build_status`) and rendering are pure, so they are covered here
+//! without a database. The [`reader`](super::reader) is a thin PostgreSQL
+//! projection exercised by the CLI integration leg.
+#![allow(clippy::unwrap_used)] // Reason: test module
+
+use std::collections::HashMap;
+
+use fraiseql_core::schema::{RunAs, SourceDefinition};
+use serde_json::json;
+
+use super::{build_status, reader::CursorRow, render_text};
+
+fn cursor_row(source: &str, version: i64, age: f64) -> CursorRow {
+    CursorRow {
+        source_name: source.to_string(),
+        value: Some(json!({ "page": version })),
+        version,
+        updated_at: "2026-07-15T11:32:04+00:00".to_string(),
+        age_seconds: age,
+    }
+}
+
+#[test]
+fn build_status_marks_cursor_unknown_without_a_database() {
+    let sources = vec![SourceDefinition::new("orders", "*/5 * * * *", "pollOrders")];
+    let statuses = build_status(&sources, None);
+
+    assert_eq!(statuses.len(), 1);
+    let status = &statuses[0];
+    assert_eq!(status.name, "orders");
+    assert_eq!(status.schedule, "*/5 * * * *");
+    assert_eq!(status.cursor.state, "unknown");
+    assert!(status.cursor.version.is_none());
+}
+
+#[test]
+fn build_status_reports_never_advanced_when_no_row_exists() {
+    let sources = vec![SourceDefinition::new("orders", "*/5 * * * *", "pollOrders")];
+    // A connected-but-empty database: the map has no row for this source.
+    let cursors: HashMap<String, CursorRow> = HashMap::new();
+
+    let statuses = build_status(&sources, Some(&cursors));
+
+    assert_eq!(statuses[0].cursor.state, "never_advanced");
+}
+
+#[test]
+fn build_status_reports_the_advanced_watermark_and_lag() {
+    let sources = vec![SourceDefinition::new("orders", "*/5 * * * *", "pollOrders")];
+    let mut cursors = HashMap::new();
+    cursors.insert("orders".to_string(), cursor_row("orders", 4, 37.2));
+
+    let statuses = build_status(&sources, Some(&cursors));
+
+    let cursor = &statuses[0].cursor;
+    assert_eq!(cursor.state, "advanced");
+    assert_eq!(cursor.version, Some(4));
+    assert_eq!(cursor.value, Some(json!({ "page": 4 })));
+    assert_eq!(cursor.age_seconds, Some(37.2));
+}
+
+#[test]
+fn build_status_keys_cursors_on_the_source_name_the_runtime_advances_under() {
+    // The declared cursor name differs from the source name, but the runtime poller
+    // advances under the source *name* — so the status must key on the name, not the
+    // declared cursor, or it would always read "never advanced".
+    let sources =
+        vec![SourceDefinition::new("orders", "*/5 * * * *", "pollOrders").with_cursor("shared")];
+    let mut cursors = HashMap::new();
+    cursors.insert("orders".to_string(), cursor_row("orders", 2, 5.0));
+
+    let statuses = build_status(&sources, Some(&cursors));
+
+    assert_eq!(statuses[0].cursor_name, "shared", "the declared cursor is surfaced");
+    assert_eq!(statuses[0].cursor.state, "advanced", "but the lookup keys on the name");
+}
+
+#[test]
+fn build_status_flags_an_unconfigured_run_as_as_fail_closed() {
+    let configured =
+        SourceDefinition::new("orders", "*/5 * * * *", "pollOrders").with_run_as(RunAs {
+            roles:  vec!["order:write".to_string()],
+            scopes: vec![],
+            tenant: None,
+        });
+    let unconfigured = SourceDefinition::new("invoices", "0 * * * *", "pollInvoices");
+
+    let statuses = build_status(&[configured, unconfigured], None);
+
+    assert!(statuses[0].run_as.configured);
+    assert_eq!(statuses[0].run_as.roles, vec!["order:write".to_string()]);
+    assert!(!statuses[1].run_as.configured, "no run_as ⇒ fail-closed");
+}
+
+#[test]
+fn render_text_shows_fail_closed_and_disabled_and_lag() {
+    let sources = vec![
+        SourceDefinition::new("orders", "*/5 * * * *", "pollOrders"),
+        SourceDefinition::new("invoices", "0 * * * *", "pollInvoices").disabled(),
+    ];
+    let mut cursors = HashMap::new();
+    cursors.insert("orders".to_string(), cursor_row("orders", 4, 37.0));
+    let statuses = build_status(&sources, Some(&cursors));
+
+    let text = render_text(&statuses, true);
+
+    assert!(text.contains("Sources (2)"), "header with the count");
+    assert!(text.contains("fail-closed"), "the unconfigured run_as is called out");
+    assert!(text.contains("DISABLED"), "the disabled source is marked");
+    assert!(text.contains("advanced 37s ago"), "the cursor lag is shown");
+    assert!(text.contains("never advanced"), "the un-advanced source is shown");
+}
+
+#[test]
+fn render_text_notes_a_missing_database_connection() {
+    let sources = vec![SourceDefinition::new("orders", "*/5 * * * *", "pollOrders")];
+    let statuses = build_status(&sources, None);
+
+    let text = render_text(&statuses, false);
+
+    assert!(
+        text.contains("no database connection"),
+        "the operator is told cursor state is unread"
+    );
+}
+
+#[test]
+fn render_text_handles_no_sources() {
+    let text = render_text(&[], true);
+    assert!(text.contains("No sources declared"));
+}

--- a/crates/fraiseql-cli/src/runner.rs
+++ b/crates/fraiseql-cli/src/runner.rs
@@ -591,6 +591,19 @@ pub async fn run() {
                 },
             },
         },
+
+        Commands::Sources {
+            schema,
+            db_url,
+            json,
+        } => {
+            commands::sources::run(commands::sources::SourcesArgs {
+                schema,
+                database: db_url,
+                json,
+            })
+            .await
+        },
     };
 
     if let Err(e) = result {

--- a/crates/fraiseql-cli/tests/sources_against_db.rs
+++ b/crates/fraiseql-cli/tests/sources_against_db.rs
@@ -1,0 +1,98 @@
+//! Live-PostgreSQL integration test for the `fraiseql sources` cursor reader (#573).
+//!
+//! It installs the real `_fraiseql_source_cursor` table from the shipped observers
+//! migration, seeds a known advanced watermark, and asserts
+//! [`SourceCursorReader::load_cursors`] decodes every column — the opaque JSONB
+//! value, the compare-and-swap version, the `updated_at` text, and the DB-clock lag.
+//!
+//! Self-skips when no `DATABASE_URL` is set. Like every CLI `*_against_db` test this
+//! is **local-only** verification — no Dagger leg runs the CLI against a live DB. Run
+//! against the warm dev database:
+//!
+//! ```bash
+//! DATABASE_URL=postgres://fraiseql_test:fraiseql_test_password@localhost:5433/test_fraiseql \
+//!   cargo test -p fraiseql-cli --features test-postgres --test sources_against_db
+//! ```
+
+#![cfg(feature = "test-postgres")]
+#![allow(clippy::unwrap_used, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use fraiseql_cli::commands::sources::reader::{CursorRow, SourceCursorReader};
+use fraiseql_observers::migrations::source_cursor_sql;
+
+/// A source name unique to this test so leftover rows in the shared throwaway DB
+/// (e.g. from the server poller tests) never collide with the assertions.
+const SEEDED: &str = "against-db-orders";
+/// A second seeded source with a NULL cursor value, to prove the reader tolerates it.
+const SEEDED_NULL: &str = "against-db-null-value";
+
+/// Install the cursor table from the shipped migration and seed known rows.
+async fn provision(url: &str) -> Option<tokio_postgres::Client> {
+    let (client, conn) = match tokio_postgres::connect(url, tokio_postgres::NoTls).await {
+        Ok(pair) => pair,
+        Err(e) => {
+            eprintln!("skipping #573 sources reader test: {e}");
+            return None;
+        },
+    };
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    // Idempotent DDL from the shipped migration (matches the runtime store's init).
+    client.batch_execute(source_cursor_sql()).await.unwrap();
+    client
+        .batch_execute(&format!(
+            "INSERT INTO _fraiseql_source_cursor (source_name, cursor_value, version, updated_at) \
+             VALUES ('{SEEDED}', '{{\"page\": 4}}'::jsonb, 4, now() - interval '30 seconds'), \
+                    ('{SEEDED_NULL}', NULL, 2, now()) \
+             ON CONFLICT (source_name) DO UPDATE \
+               SET cursor_value = EXCLUDED.cursor_value, version = EXCLUDED.version, \
+                   updated_at = EXCLUDED.updated_at;"
+        ))
+        .await
+        .unwrap();
+
+    Some(client)
+}
+
+fn find<'a>(rows: &'a [CursorRow], source: &str) -> &'a CursorRow {
+    rows.iter().find(|r| r.source_name == source).expect("seeded source present")
+}
+
+#[tokio::test]
+async fn reader_decodes_the_advanced_watermark_and_lag() {
+    let Some(url) = fraiseql_test_support::try_database_url() else {
+        return;
+    };
+    if provision(&url).await.is_none() {
+        return;
+    }
+
+    let reader = SourceCursorReader::connect(&url).expect("connect source cursor reader");
+    let rows = reader.load_cursors().await.expect("load cursors");
+
+    // The advanced row: opaque JSONB value + version + a positive DB-clock lag.
+    let orders = find(&rows, SEEDED);
+    assert_eq!(orders.version, 4);
+    assert_eq!(orders.value, Some(serde_json::json!({ "page": 4 })));
+    assert!(
+        orders.age_seconds >= 25.0,
+        "≈30s of lag from the DB clock: {}",
+        orders.age_seconds
+    );
+    assert!(!orders.updated_at.is_empty(), "updated_at decodes to text");
+
+    // A row with a SQL NULL cursor value decodes to `None`, not an error.
+    let null_value = find(&rows, SEEDED_NULL);
+    assert_eq!(null_value.version, 2);
+    assert_eq!(null_value.value, None);
+}
+
+#[tokio::test]
+async fn non_postgres_url_is_rejected() {
+    assert!(
+        SourceCursorReader::connect("mysql://localhost/db").is_err(),
+        "non-postgres URL rejected"
+    );
+}

--- a/crates/fraiseql-functions/src/host/live/mod.rs
+++ b/crates/fraiseql-functions/src/host/live/mod.rs
@@ -583,6 +583,10 @@ impl HostContext for LiveHostContext {
             .await
             .map_err(|error| fraiseql_error::FraiseQLError::database(error.to_string()))?;
         if applied {
+            // Value-free by design: the opaque cursor can carry external-influenced
+            // data, so the watermark movement is logged without its contents (#573
+            // Phase 08 observability).
+            tracing::debug!(source = %binding.source_name, "source cursor advanced");
             Ok(())
         } else {
             Err(fraiseql_error::FraiseQLError::database(

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -76,11 +76,12 @@ ipnet = {version = "2", features = ["serde"]}
 # Authentication (JWT, OAuth, OIDC)
 jsonwebtoken = {version = "10", features = ["rust_crypto"]}
 # Metrics (optional). The server emits its own metrics via hand-rolled atomics
-# (see metrics_server.rs); the `metrics` *facade* crate is only needed to install
-# a recorder so transitive crates' (e.g. fraiseql-wire) facade emissions are
-# captured — that recorder is installed via metrics-exporter-prometheus, which
-# pulls a matching `metrics` 0.24 transitively. The previous direct `metrics` 0.22
-# pin was unreferenced and conflicted with the exporter's 0.24 (audit H45).
+# (see metrics_server.rs). The `metrics` *facade* crate is a direct dep so the
+# server can emit its own facade metrics (the scheduled-source metrics, #573 Phase
+# 08) alongside transitive crates' (e.g. fraiseql-wire) emissions; all are captured
+# by the recorder installed via metrics-exporter-prometheus (which pulls a matching
+# `metrics` 0.24) and appended to `/metrics` under the `metrics` feature (audit H45).
+metrics = "0.24"
 metrics-exporter-prometheus = {version = "0.18", optional = true}
 # OpenTelemetry (optional) — versions must match tracing-opentelemetry 0.33
 opentelemetry = {version = "0.32", optional = true}
@@ -149,9 +150,6 @@ criterion = {version = "0.5", features = ["async_tokio"]}
 # Test-only: construct an AuthenticatedUser (expires_at) for the introspection
 # gate e2e (#453). chrono is already a normal dependency; pinned by the workspace.
 chrono = {workspace = true}
-# `metrics` facade, test-only: lets the recorder-scrape test emit a facade metric
-# and assert it renders (the production server does not emit facade metrics — H45).
-metrics = "0.24"
 fraiseql-auth = {workspace = true}
 fraiseql-cli = {workspace = true}
 fraiseql-federation = {workspace = true, features = ["test-utils"]}

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -262,6 +262,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                         hooks.as_ref(),
                         &host_config,
                         &fraiseql_functions::ResourceLimits::default(),
+                        sources_config.log_payloads,
                     );
                     let started = pollers.len();
                     for poller in pollers {

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -725,6 +725,15 @@ pub struct SourcesConfig {
     /// Deny-by-default: empty permits no outbound host.
     #[serde(default)]
     pub allowed_domains: Vec<String>,
+
+    /// Log each firing's trigger payload at debug (default: `false`).
+    ///
+    /// Off-by-default mirrors the observer `log_payloads` gate. A source's trigger
+    /// payload carries only schedule context (the external data the connector fetches
+    /// never reaches the poller), so the risk is low — but payload logging stays an
+    /// operator opt-in for a uniform PII stance.
+    #[serde(default)]
+    pub log_payloads: bool,
 }
 
 #[cfg(feature = "sources")]
@@ -733,6 +742,7 @@ impl Default for SourcesConfig {
         Self {
             enabled:         true,
             allowed_domains: Vec::new(),
+            log_payloads:    false,
         }
     }
 }

--- a/crates/fraiseql-server/src/sources/metrics.rs
+++ b/crates/fraiseql-server/src/sources/metrics.rs
@@ -1,0 +1,57 @@
+//! Prometheus metrics for scheduled ingress sources (#573 Phase 08).
+//!
+//! Emitted through the lightweight [`metrics`] facade — the same mechanism
+//! `fraiseql-wire` uses for its per-entity counters and histograms, and the only
+//! idiom in the workspace that natively supports the per-source labels and the
+//! run-duration histogram a source needs. Emissions are captured by the global
+//! Prometheus recorder installed at startup
+//! ([`crate::metrics_recorder`]) and appended to the `/metrics` endpoint, so
+//! **they surface only when the server is built with the `metrics` feature and
+//! metrics are enabled** (the same boundary as the wire metrics). The macro calls
+//! themselves are cheap no-ops when no recorder is installed, so this module needs
+//! no feature gate of its own.
+//!
+//! Three metrics, all driven from [`SourcePoller::fire_once`](super::SourcePoller):
+//!
+//! - `fraiseql_source_fires_total{source, result}` — a source firing that ran to completion
+//!   (`result="ok"`) or whose connector returned an error (`result="error"`). A failed firing
+//!   re-runs from the last committed cursor on the next tick (at-least-once), so `result="error"`
+//!   is the source-failure signal — there is no separate source dead-letter queue.
+//! - `fraiseql_source_skips_not_leader_total{source}` — a tick this replica skipped because another
+//!   replica held the single-firing lease. The fleet-wide health of the cross-replica coordination.
+//! - `fraiseql_source_run_duration_seconds{source}` — wall-clock of a firing that ran (skips are
+//!   not recorded — a skip is near-instant and not a run).
+
+use metrics::{counter, histogram};
+
+/// `fraiseql_source_fires_total{source, result}` — firings that ran, by outcome.
+const FIRES_TOTAL: &str = "fraiseql_source_fires_total";
+/// `fraiseql_source_skips_not_leader_total{source}` — ticks skipped (not leader).
+const SKIPS_NOT_LEADER_TOTAL: &str = "fraiseql_source_skips_not_leader_total";
+/// `fraiseql_source_run_duration_seconds{source}` — run wall-clock, seconds.
+const RUN_DURATION_SECONDS: &str = "fraiseql_source_run_duration_seconds";
+
+/// The `result` label for a firing that ran: the connector completed.
+pub const RESULT_OK: &str = "ok";
+/// The `result` label for a firing that ran but whose connector returned an error.
+pub const RESULT_ERROR: &str = "error";
+
+/// Record that `source` fired and ran to completion with the given `result`
+/// (`"ok"` or `"error"`), taking `duration_seconds` of wall-clock.
+///
+/// One call covers both the fire counter and the run-duration histogram — the two
+/// only ever move together (a run has an outcome and a duration), so pairing them
+/// keeps the caller from recording one without the other.
+pub fn record_fire(source: &str, result: &str, duration_seconds: f64) {
+    counter!(FIRES_TOTAL, "source" => source.to_string(), "result" => result.to_string())
+        .increment(1);
+    histogram!(RUN_DURATION_SECONDS, "source" => source.to_string()).record(duration_seconds);
+}
+
+/// Record that `source` skipped a tick because another replica held the lease.
+pub fn record_skip_not_leader(source: &str) {
+    counter!(SKIPS_NOT_LEADER_TOTAL, "source" => source.to_string()).increment(1);
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-server/src/sources/metrics/tests.rs
+++ b/crates/fraiseql-server/src/sources/metrics/tests.rs
@@ -1,0 +1,31 @@
+//! Tests for the source metrics facade emitters.
+//!
+//! Following the `fraiseql-wire` metrics precedent, the emitters are exercised for
+//! "does not panic" (the facade macro is a no-op without an installed recorder, so
+//! there is nothing to snapshot in a unit test) plus a guard on the metric *names*,
+//! which are a stable wire contract dashboards depend on.
+
+use super::{
+    FIRES_TOTAL, RESULT_ERROR, RESULT_OK, RUN_DURATION_SECONDS, SKIPS_NOT_LEADER_TOTAL,
+    record_fire, record_skip_not_leader,
+};
+
+#[test]
+fn metric_names_are_the_expected_wire_contract() {
+    assert_eq!(FIRES_TOTAL, "fraiseql_source_fires_total");
+    assert_eq!(SKIPS_NOT_LEADER_TOTAL, "fraiseql_source_skips_not_leader_total");
+    assert_eq!(RUN_DURATION_SECONDS, "fraiseql_source_run_duration_seconds");
+    assert_eq!(RESULT_OK, "ok");
+    assert_eq!(RESULT_ERROR, "error");
+}
+
+#[test]
+fn record_fire_does_not_panic_for_either_result() {
+    record_fire("orders", RESULT_OK, 0.25);
+    record_fire("orders", RESULT_ERROR, 1.5);
+}
+
+#[test]
+fn record_skip_not_leader_does_not_panic() {
+    record_skip_not_leader("orders");
+}

--- a/crates/fraiseql-server/src/sources/mod.rs
+++ b/crates/fraiseql-server/src/sources/mod.rs
@@ -16,6 +16,7 @@
 //! spawning a poller per enabled source) lands in Phase 06 Step 4.
 
 mod executor;
+mod metrics;
 mod poller;
 mod scheduler;
 

--- a/crates/fraiseql-server/src/sources/poller.rs
+++ b/crates/fraiseql-server/src/sources/poller.rs
@@ -12,7 +12,10 @@
 //! fire-and-forget `NoopHostContext` path with the leased, cursor+executor host a
 //! source needs to read its watermark and mutate.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use chrono::{DateTime, Utc};
 use fraiseql_functions::{
@@ -23,8 +26,13 @@ use fraiseql_functions::{
     },
     triggers::{CronExecutionState, CronSchedule},
 };
-use fraiseql_observers::{LeaseGuardedRunner, PostgresSourceCursorStore, RunOutcome};
+use fraiseql_observers::{
+    DispatchSource, LeaseGuardedRunner, PostgresSourceCursorStore, RunOutcome,
+    derive_idempotency_token,
+};
 use tracing::{debug, info, warn};
+
+use super::metrics;
 
 /// The collaborators one [`SourcePoller`] drives — assembled by the lifecycle from
 /// a compiled [`SourceDefinition`](fraiseql_core::schema::SourceDefinition).
@@ -49,6 +57,11 @@ pub struct SourcePoller {
     host_config:  HostContextConfig,
     /// Guest resource limits.
     limits:       ResourceLimits,
+    /// Whether to log the trigger payload on each firing (default off). Off-by-default
+    /// mirrors the observer `log_payloads` gate: even though a source's trigger
+    /// payload carries only schedule context — the external data the connector fetches
+    /// never reaches the poller — payload logging stays opt-in for a uniform PII stance.
+    log_payloads: bool,
     /// In-memory fire-window state (the durable cursor is the real resume point, so
     /// missed-fire catch-up across restarts is unnecessary — the next fire resumes
     /// from the cursor).
@@ -72,6 +85,7 @@ impl SourcePoller {
         runner: LeaseGuardedRunner,
         host_config: HostContextConfig,
         limits: ResourceLimits,
+        log_payloads: bool,
     ) -> Self {
         Self {
             source_name: source_name.into(),
@@ -83,42 +97,121 @@ impl SourcePoller {
             runner,
             host_config,
             limits,
+            log_payloads,
             state: CronExecutionState::new(),
         }
     }
 
+    /// The per-firing idempotency token: a stable hash of the source's identity and
+    /// this firing's trigger payload (which carries the scheduled instant), so each
+    /// scheduled tick has its own correlation id threaded through the metrics-adjacent
+    /// logs and made available to the connector via `ctx.idempotencyToken` for
+    /// idempotent writes. Never wall-clock/random *at the token site* — derived from
+    /// the already-built payload so a resume re-derives the same value.
+    fn idempotency_token(&self, payload: &EventPayload) -> String {
+        derive_idempotency_token(
+            None,
+            DispatchSource::Source,
+            &self.module.name,
+            &payload.trigger_type,
+            &payload.data,
+        )
+    }
+
     /// Build the Model B host for one firing: a live host bound to the source's
-    /// durable cursor *and* its `run_as` executor, so the guest can read/advance its
-    /// watermark and issue `fraiseql_query` mutations.
-    fn build_host(&self, payload: EventPayload) -> Arc<dyn DynHostContext> {
+    /// durable cursor, its `run_as` executor, and this firing's idempotency token, so
+    /// the guest can read/advance its watermark, issue `fraiseql_query` mutations, and
+    /// key idempotent writes.
+    fn build_host(
+        &self,
+        payload: EventPayload,
+        idempotency_token: &str,
+    ) -> Arc<dyn DynHostContext> {
         Arc::new(
             LiveHostContext::new(payload, self.host_config.clone())
                 .with_source_cursor(self.source_name.clone(), self.cursor_store.clone())
-                .with_executor(Arc::clone(&self.executor)),
+                .with_executor(Arc::clone(&self.executor))
+                .with_idempotency_token(idempotency_token.to_string()),
         )
     }
 
     /// Fire the source once, under the lease. Returns the outcome: skipped (another
     /// replica leads), or ran with the guest's own result. An acquire failure is
     /// logged and reported as a skip (the guest did not run this tick).
+    ///
+    /// This is the observability seam (#573 Phase 08): it meters every firing
+    /// (`fraiseql_source_fires_total` / `_run_duration_seconds` / `_skips_not_leader_total`)
+    /// and emits the structured fire/skip/error logs — all with the `source` and the
+    /// per-firing `idempotency_token` — so the whole per-outcome record lives here
+    /// rather than being split with the caller.
     async fn fire_once(
         &self,
         now: DateTime<Utc>,
     ) -> RunOutcome<fraiseql_error::Result<FunctionResult>> {
         let payload = build_source_payload(&self.source_name, &self.schedule.expression, now);
+        let token = self.idempotency_token(&payload);
+        if self.log_payloads {
+            debug!(
+                source = %self.source_name,
+                idempotency_token = %token,
+                payload = %payload.data,
+                "source firing (payload logging enabled)"
+            );
+        }
+        let started = Instant::now();
         let attempt = self
             .runner
             .run(|| async {
-                let host = self.build_host(payload.clone());
+                let host = self.build_host(payload.clone(), &token);
                 self.observer
                     .invoke_with_context(&self.module, payload.clone(), host, self.limits.clone())
                     .await
             })
             .await;
+        let elapsed = started.elapsed().as_secs_f64();
         match attempt {
-            Ok(outcome) => outcome,
+            Ok(RunOutcome::Ran(result)) => {
+                let label = match &result {
+                    Ok(_) => metrics::RESULT_OK,
+                    Err(_) => metrics::RESULT_ERROR,
+                };
+                metrics::record_fire(&self.source_name, label, elapsed);
+                match &result {
+                    Ok(_) => info!(
+                        source = %self.source_name,
+                        idempotency_token = %token,
+                        duration_ms = elapsed * 1000.0,
+                        "source fired"
+                    ),
+                    Err(error) => warn!(
+                        source = %self.source_name,
+                        idempotency_token = %token,
+                        duration_ms = elapsed * 1000.0,
+                        %error,
+                        "source invocation failed — re-runs from the last cursor next tick"
+                    ),
+                }
+                RunOutcome::Ran(result)
+            },
+            Ok(RunOutcome::SkippedNotLeader) => {
+                metrics::record_skip_not_leader(&self.source_name);
+                debug!(
+                    source = %self.source_name,
+                    idempotency_token = %token,
+                    "source skipped — another replica leads"
+                );
+                RunOutcome::SkippedNotLeader
+            },
             Err(error) => {
-                warn!(source = %self.source_name, %error, "source lease acquire failed — skipping tick");
+                // A lease *acquire* error is a DB fault, not "another replica leads",
+                // so it is not counted in skips_not_leader (which would then spike
+                // misleadingly during a database outage) — the warn log carries it.
+                warn!(
+                    source = %self.source_name,
+                    idempotency_token = %token,
+                    %error,
+                    "source lease acquire failed — skipping tick"
+                );
                 RunOutcome::SkippedNotLeader
             },
         }
@@ -144,17 +237,8 @@ impl SourcePoller {
                 continue;
             }
             self.state.record_execution(now);
-            match self.fire_once(now).await {
-                RunOutcome::Ran(Ok(_)) => {
-                    info!(source = %self.source_name, "source fired");
-                },
-                RunOutcome::Ran(Err(error)) => {
-                    warn!(source = %self.source_name, %error, "source invocation failed");
-                },
-                RunOutcome::SkippedNotLeader => {
-                    debug!(source = %self.source_name, "source skipped — another replica leads");
-                },
-            }
+            // `fire_once` owns the per-outcome metrics and structured logs.
+            let _ = self.fire_once(now).await;
         }
     }
 }

--- a/crates/fraiseql-server/src/sources/poller/tests.rs
+++ b/crates/fraiseql-server/src/sources/poller/tests.rs
@@ -86,6 +86,7 @@ fn poller(pool: &PgPool, source: &str, executor: Arc<dyn QueryExecutor>) -> Sour
         LeaseGuardedRunner::in_process(source),
         HostContextConfig::default(),
         ResourceLimits::default(),
+        false,
     )
 }
 
@@ -106,7 +107,7 @@ async fn build_host_binds_both_the_cursor_and_the_executor() {
 
     let executor = StubExecutor::new(json!({ "data": { "createOrder": { "status": "ok" } } }));
     let poller = poller(&pool, source, executor.clone());
-    let host = poller.build_host(build_source_payload(source, "*/5 * * * *", Utc::now()));
+    let host = poller.build_host(build_source_payload(source, "*/5 * * * *", Utc::now()), "tok");
 
     // The cursor is bound: it round-trips through the host against real Postgres.
     assert!(host.cursor().await.unwrap().is_none(), "a fresh source has no cursor");
@@ -188,6 +189,7 @@ async fn fires_a_model_b_connector_end_to_end() {
         LeaseGuardedRunner::in_process(source),
         HostContextConfig::default(),
         ResourceLimits::default(),
+        false,
     );
 
     let outcome = poller.fire_once(chrono::Utc::now()).await;

--- a/crates/fraiseql-server/src/sources/scheduler.rs
+++ b/crates/fraiseql-server/src/sources/scheduler.rs
@@ -115,6 +115,9 @@ fn schedulable<'a>(
 /// returned poller's [`run_forever`](SourcePoller::run_forever) on the server's
 /// `JoinSet`; the shared `_fraiseql_source_cursor` table must already be
 /// initialized.
+// Reason: a wiring seam whose args are each a distinct runtime collaborator; a
+// params struct would relocate the same fields without reducing coupling.
+#[allow(clippy::too_many_arguments)]
 pub fn build_source_pollers<A: DatabaseAdapter + Send + Sync + 'static>(
     sources: &[SourceDefinition],
     db_pool: &sqlx::PgPool,
@@ -122,6 +125,7 @@ pub fn build_source_pollers<A: DatabaseAdapter + Send + Sync + 'static>(
     hooks: &BeforeMutationHooks,
     host_config: &HostContextConfig,
     limits: &ResourceLimits,
+    log_payloads: bool,
 ) -> Vec<SourcePoller> {
     schedulable(sources, &hooks.module_registry)
         .into_iter()
@@ -141,6 +145,7 @@ pub fn build_source_pollers<A: DatabaseAdapter + Send + Sync + 'static>(
                 LeaseGuardedRunner::postgres(db_pool.clone(), source.name.clone()),
                 host_config.clone(),
                 limits.clone(),
+                log_payloads,
             )
         })
         .collect()

--- a/crates/fraiseql-server/src/sources/scheduler/tests.rs
+++ b/crates/fraiseql-server/src/sources/scheduler/tests.rs
@@ -50,10 +50,12 @@ fn enabled_resolves_env_over_config() {
     let on = SourcesConfig {
         enabled:         true,
         allowed_domains: vec![],
+        log_payloads:    false,
     };
     let off = SourcesConfig {
         enabled:         false,
         allowed_domains: vec![],
+        log_payloads:    false,
     };
 
     // No env → the config value.
@@ -72,6 +74,7 @@ fn host_config_allowlist_resolves_env_over_config() {
     let config = SourcesConfig {
         enabled:         true,
         allowed_domains: vec!["from-toml.example".to_string()],
+        log_payloads:    false,
     };
 
     // No env → the config allowlist.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,6 +17,7 @@ This directory contains the authoritative architecture documentation for FraiseQ
 | Understand analytics fact table design and caching | [../modules/fact-table.md](../modules/fact-table.md) |
 | Understand the streaming wire protocol engine | [wire-protocol.md](wire-protocol.md) |
 | Understand inbound webhooks vs. outbound observers | [webhooks.md](webhooks.md) |
+| Understand scheduled ingress sources (the dual of observers) | [sources.md](sources.md) |
 | Resolve identity from your own DB for RLS (not token claims) | [enriched-identity-rls.md](enriched-identity-rls.md) |
 | Understand operational concerns (schema lifecycle, idempotency) | [../operations/](../operations/) |
 | See which features each database supports | [../database-compatibility.md](../database-compatibility.md) |

--- a/docs/architecture/inbound-email.md
+++ b/docs/architecture/inbound-email.md
@@ -1,10 +1,11 @@
 # Inbound Email (Poll-IMAP) Architecture
 
-The poll-IMAP email adapter is the first **pull** inbound source. It rides the
-inbound-ingestion primitive (see [webhooks.md](webhooks.md) for the push side and
-the shared spine): an external message becomes a normalized `InboundMessage` on a
-durable spine that `after:ingest:email` functions consume — the same path the
-webhook adapter uses, with a different transport at the edge.
+The poll-IMAP email adapter is the reference **Model A** native `PullSource` — the
+first pull inbound source. It rides the scheduled-ingress `Source` primitive (see
+[sources.md](sources.md) for the generic envelope and [webhooks.md](webhooks.md) for
+the push side and the shared spine): an external message becomes a normalized
+`InboundMessage` on a durable spine that `after:ingest:email` functions consume — the
+same path the webhook adapter uses, with a different transport at the edge.
 
 It is opt-in behind the `inbound-email` Cargo feature.
 
@@ -106,7 +107,11 @@ that could form a mail loop.
 ## Cursor semantics (at-least-once)
 
 The only state kept between polls is, per mailbox, the IMAP `UIDVALIDITY` last
-seen and the highest `UID` already ingested (`_fraiseql_inbound_email_cursor`).
+seen and the highest `UID` already ingested. Since the email adapter was reshaped as
+the reference Model A `PullSource`, that `{uid_validity, last_uid}` state is serialized
+as the opaque JSONB cursor value in the generic `_fraiseql_source_cursor` table (keyed
+on the mailbox name), so the framework treats it as opaque and the email adapter no
+longer keeps a bespoke cursor table.
 
 - Each poll fetches `UID (last_uid + 1):*` under the mailbox's *current*
   `UIDVALIDITY`.

--- a/docs/architecture/sources.md
+++ b/docs/architecture/sources.md
@@ -1,0 +1,211 @@
+# Sources (Scheduled Ingress) Architecture
+
+A **`Source`** is the dual of an observer. An observer is *egress* — "the database
+changed, tell the world." A source is *ingress* — "on a schedule, fetch the world and
+drive the results into the database via mutations," resuming from a durable cursor with
+at-least-once delivery.
+
+It is opt-in behind the `sources` Cargo feature and, like observers, is
+STABLE-tracked-may-evolve.
+
+```text
+                    ┌──────────── scheduling envelope (generic) ────────────┐
+ cron schedule ───► │ lease.acquire()  →  load cursor                       │
+ (per source)       │   ├─ Model A: PullSource::poll() → spine → advance    │ (txn)
+                    │   └─ Model B: run connector(ctx: cursor/fetch/mutate) │
+                    │ release lease → metrics / logs                        │
+                    └───────────────────────────────────────────────────────┘
+```
+
+The scheduling / single-firing / cursor / observability **envelope** is generic. What
+runs inside it is one of two models (below). This is what makes the primitive
+expandable: a native source and a user's TypeScript connector are the same primitive
+with a different body.
+
+---
+
+## Two execution models
+
+Authoring is Python/TypeScript; **runtime is pure Rust, no FFI** — so a source's
+connector body runs in the Deno functions runtime (`functions-runtime-deno`, the same
+mechanism behind `after:mutation` / `after:ingest` / `cron:` functions), not in
+Python. The `@source` decorator is authoring *metadata* only: it compiles, it does not
+execute.
+
+- **Model A — framework-driven (native Rust `PullSource`).** `poll(ctx) -> PullBatch`
+  returns normalized `InboundMessage`s plus the advanced cursor; the framework
+  spine-dedups each message, dispatches the existing `after:ingest` path, and advances
+  the cursor **transactionally**. The poll-IMAP email adapter is the reference Model A
+  source — see [inbound-email.md](inbound-email.md). Best isolation and testability; the
+  framework owns idempotency.
+
+- **Model B — handler-driven (Deno connector).** The connector drives the loop itself:
+  `ctx.cursor` → `fraiseql_http_request` (fetch) → `fraiseql_query` (mutate) →
+  `ctx.advance`. The envelope still supplies single-firing, the cursor store, the
+  `run_as` identity, and observability. **This is the connectors-are-user-code path** —
+  the boundary is deliberate: a connector is ordinary user TypeScript, sandboxed in the
+  Deno runtime under an SSRF allowlist and a bounded `run_as` authority ceiling, not
+  trusted first-party infrastructure.
+
+Both share the **same** scheduling / lease / cursor / observability envelope.
+
+---
+
+## Contracts
+
+- **At-least-once, cursor-gated.** Run → writes commit → cursor advances. A crash
+  before the advance is safe: the next run re-fetches from the old watermark.
+- **Transactional advance is the default for Model A.** The native `PullSource` cursor
+  advance participates in the **same transaction** as the ingest writes, so each batch
+  is atomic (writes + watermark, or neither) — no reprocess window. Model B (Deno)
+  advances after-commit, because its `fraiseql_query` calls are independent
+  transactions.
+- **Exactly-once business writes are the connector author's job.** The framework
+  guarantees at-least-once delivery plus a stable per-firing `idempotencyToken`; it does
+  **not** dedupe your domain rows. Write idempotently — natural keys, upserts,
+  `ON CONFLICT`. This is the one contract most connectors get wrong, so it bears
+  repeating: a source *will* occasionally re-deliver a batch (retry, failover,
+  `UIDVALIDITY` reset), and only idempotent writes make that harmless.
+
+---
+
+## Single-firing across replicas
+
+A source scheduled on N replicas must fire on exactly one. Each firing runs under a
+PostgreSQL advisory lease keyed on a collision-resistant stable hash of the source name
+(`LeaseGuardedRunner`): the replica that acquires the lease runs the connector while
+holding it, then releases explicitly; the others skip the tick. Within a replica a
+source never overlaps itself (the tick is skipped if the previous run is still going).
+
+The lease is **held for the run and released between ticks** — it is *not* a
+steady-state leader election. So "which replica is the leader" is not an observable
+property (a PostgreSQL advisory lock exposes no holder); the health signal is the
+`fraiseql_source_skips_not_leader_total` metric, which counts, per replica, the ticks a
+replica yielded to another.
+
+---
+
+## Identity — `run_as` (fail-closed)
+
+A scheduled source has no request and no JWT, yet its Model B connector's
+`fraiseql_query` mutations must run under *some* `SecurityContext` — which governs
+operation/field authorization, RLS, and the change-log tenant stamp. A source therefore
+runs under an explicit, per-source, least-privilege **authority ceiling**:
+
+```
+run_as = { roles: [...], scopes: [...], tenant?: "..." }
+```
+
+- **Fail-closed.** A source with **no** `run_as` runs with no authority — the anonymous
+  context — so RLS and field authorization deny its writes until an operator grants a
+  ceiling. Granting authority is a deliberate act, never a default.
+- **The ceiling is static; the tenant is per-message.** `run_as.tenant` pins a
+  single-tenant or global source. A **multi-tenant** source (one `stripe_sync` → many
+  tenants) leaves `tenant` unset and scopes each write to the message's tenant at
+  runtime — only the connector knows which tenant a fetched record belongs to. A source
+  already pinned to a tenant cannot forge writes for another.
+- Built on `SecurityContext::system_job(...)` (`ActorType::SystemJob`) — an audit-only,
+  never-token-derived background principal. The `SystemJob` actor is not itself an
+  authorization input; authority comes solely from the configured roles/scopes.
+
+---
+
+## Configuration & feature surface
+
+- **Cargo feature `sources`** (opt-in, mirrors `inbound`) on `fraiseql-server`; the
+  default binary stays lean. A compiled schema that declares sources while the feature
+  is off boots with a loud warning and no scheduler.
+- **`[sources]` TOML** — operator-facing runtime tuning, overridable by environment
+  (env > TOML > default):
+
+  ```toml
+  [sources]
+  enabled = true            # FRAISEQL_SOURCES_ENABLED — global on/off
+  allowed_domains = [       # FRAISEQL_SOURCES_ALLOWED_DOMAINS (comma-separated)
+    "api.example.com",      # SSRF allowlist for connectors' outbound fetches;
+  ]                         # deny-by-default — empty permits no outbound host
+  log_payloads = false      # log each firing's trigger payload at debug (opt-in)
+  ```
+
+- **Per-source definitions come from the compiled schema** (authoring), mirroring the
+  observers split: `name`, `schedule` (cron), `function`, `enabled`, `cursor`, and
+  `run_as` live in the `sources` array of `schema.compiled.json`, not in operator TOML.
+
+---
+
+## Authoring surface
+
+The decorator is metadata only — it emits a `sources` entry, it never runs.
+
+```typescript
+// TypeScript
+@Source({ schedule: "*/5 * * * *", cursor: "orders", runAs: { roles: ["order:write"] } })
+```
+
+```python
+# Python
+@fraiseql.source(schedule="*/5 * * * *", cursor="orders", run_as={"roles": ["order:write"]})
+```
+
+The connector body (Model B) is a separate `.ts` handler bound by name; see the runnable
+`sdks/official/fraiseql-typescript/examples/sources/poll_orders.connector.ts` for the
+`ctx.cursor` → fetch → `ctx.query` upsert → `ctx.advance` loop and the
+`ctx.query(mutation, vars, { tenant })` per-message tenant sugar.
+
+---
+
+## Observability
+
+A source is operable — you can see it fire, measure lag, read its cursor, and find
+failures — through three surfaces:
+
+**Metrics** (Prometheus facade; exported when the server is built with the `metrics`
+feature, like the wire metrics). Emitted per firing from the poller:
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `fraiseql_source_fires_total` | counter | `source`, `result` | A firing that ran, by outcome (`ok` / `error`). A failed firing re-runs from the last cursor next tick — `result="error"` is the source-failure signal; there is no separate source DLQ. |
+| `fraiseql_source_skips_not_leader_total` | counter | `source` | Ticks this replica skipped because another replica held the lease (cross-replica single-firing health). |
+| `fraiseql_source_run_duration_seconds` | histogram | `source` | Wall-clock of a firing that ran. |
+
+**Structured logs** — every firing logs `fire` / `skip` / `error` with the `source` and
+the per-firing `idempotency_token` (the connector reads the same token via the
+`Deno.core.ops.fraiseql_idempotency_token()` host op, to key idempotent writes); a
+successful `ctx.advance` logs a value-free "cursor advanced" line (the opaque cursor
+value is never logged). The trigger payload is logged only when `[sources] log_payloads`
+is enabled.
+
+**Read-only status surface** — `fraiseql sources` lists every compiled source with its
+schedule, `run_as` ceiling, and — against a database — its durable cursor: value,
+version, and staleness (seconds since the last advance, the lag signal).
+
+```console
+$ fraiseql sources --db-url postgres://…
+Sources (2)
+
+● orders    schedule */5 * * * *    enabled
+    function   pollOrders
+    run_as     roles=["order:write"] scopes=[] tenant=(per-message / global)
+    cursor     v4 · advanced 37s ago · 2026-07-15T12:07:01+00:00 · value {"page":4}
+
+○ invoices    schedule 0 * * * *    DISABLED
+    function   pollInvoices
+    run_as     (none — fail-closed: mutations are denied until a run_as ceiling is granted)
+    cursor     never advanced (no watermark yet)
+```
+
+Add `--json` for a machine-readable snapshot. The cursor is the durable, cross-replica
+source of truth for progress; the metrics and logs are the per-firing, per-replica
+signal — together they answer "is this source healthy."
+
+---
+
+## See Also
+
+- [inbound-email.md](inbound-email.md) — the poll-IMAP email adapter, the reference
+  Model A native `PullSource`.
+- [functions.md](functions.md) — the Deno functions runtime, the `after:ingest` host
+  surface, and durable dispatch (retry + dead-letter) that Model A sources reuse.
+- [webhooks.md](webhooks.md) — the push side of inbound ingestion and the shared
+  `InboundMessage` spine; a future fast-follow folds the webhook path under the same
+  `Source` umbrella.


### PR DESCRIPTION
Phase 08 of #573 (scheduled ingress `Source`). Makes a source **operable**: see it fire, measure lag, read its cursor, find failures. Builds on Phase 06 (server integration, #586) and Phase 07 (SDKs + example, #587).

## What shipped

**Metrics** (`sources/metrics.rs`) — the `metrics` facade, the idiom `fraiseql-wire` uses and the only one with native per-source labels + a duration histogram. Emitted from `SourcePoller::fire_once`:
- `fraiseql_source_fires_total{source, result}` — `result` is `ok`/`error`
- `fraiseql_source_skips_not_leader_total{source}` — cross-replica single-firing health
- `fraiseql_source_run_duration_seconds{source}` — histogram, recorded only when the source ran

Exported on `/metrics` under the `metrics` feature (same boundary as the wire metrics). `metrics` moved from a dev-dep to a normal dep of `fraiseql-server`.

**No `source_dlq_depth`** — a Model B source is guest-driven; a failed firing is `result="error"` and re-runs from the last committed cursor next tick (at-least-once). There is no source DLQ, so a depth gauge would be structurally always-0 and misleading.

**Structured logs** — consolidated into `fire_once` (where the token + duration + result live): `fire`/`skip`/`error` with `source`, a per-firing `idempotency_token` (bound to the host via `.with_idempotency_token`, so the connector reads it and the pre-existing `after:ingest` executor gap's token now flows), and `duration_ms`. `advance_cursor` logs a value-free "cursor advanced" line (the opaque value is never logged). Trigger-payload logging gated behind a new `SourcesConfig.log_payloads` (default off; observers precedent).

**Status surface** — a `fraiseql sources` CLI command (chosen over an HTTP endpoint: the server is generic over `DatabaseAdapter` with no raw `PgPool` in `AppState`, whereas the CLI already has the `doctor`/`perf` schema-load + `PgCatalog` pattern). Lists each source's schedule, `run_as` ceiling (fail-closed called out), and — with `--db-url` — its cursor value/version/`updated_at`/age from `_fraiseql_source_cursor`. `--json` for machines. **Leader/last-fire deliberately not reported** — an advisory lock has no visible holder and the lease is released between ticks; those are the `skips_not_leader` metric + logs' job, the cursor is the durable cross-replica progress signal.

**Docs** — new ingress guide `docs/architecture/sources.md` (registered in the architecture nav), mirroring `inbound-email.md`/`functions.md`. Also fixed `inbound-email.md`'s stale `_fraiseql_inbound_email_cursor` reference (Phase 03 replaced it with the generic `_fraiseql_source_cursor`).

## Verification
- `make preflight` green (fmt + clippy `--all-targets --all-features -D warnings` + rustdoc + all policy gates)
- `cargo test -p fraiseql-server --features sources,metrics` (sources + config, 92 pass)
- `cargo test -p fraiseql-cli --lib` (663) + help snapshots (22) + local-only `sources_against_db` reader test (2, vs real PG)
- `fraiseql sources` verified end-to-end against PostgreSQL 16
- `cargo deny check bans` clean (single `ordered-float`; `metrics-util` was rejected precisely because its `DebuggingRecorder` pulls a second `ordered-float`, so the facade emitters are tested wire-style)

Deno/V8 paths remain local-only (CI compiles but excludes execution). Next: Phase 09 (finalize — QC, security review, CHANGELOG, release gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)