### PR TITLE
chore(sources): finalize scheduled ingress (#573 Phase 09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Least-privilege identity for scheduled sources (#573, in progress).** A
-  scheduled `Source` runs its background mutations under an explicit, configured
-  authority *ceiling*, not an anonymous or unbounded identity. A source's compiled
-  definition gains an optional `run_as` (`{ roles, scopes, tenant? }`); at runtime
-  its mutations execute under a new `SecurityContext::system_job(...)` — the first
-  use of the `ActorType::SystemJob` principal — carrying exactly those roles/scopes.
-  **Fail-closed:** a source with no `run_as` runs with no authority, so RLS/field
-  authorization deny its writes until an operator grants a ceiling. `run_as.tenant`
-  scopes a single-tenant or global source; multi-tenant sources leave it unset and
-  re-scope each write per message. The compiler validates `run_as` (blank
-  role/scope/tenant → error; a ceiling granting nothing → fail-closed warning). See
-  `.phases/573-source-ingress/DESIGN.md` §7 (D6).
+- **Scheduled ingress `Source`s — the dual of `Observer` (#573).** A `Source` pulls
+  from an external system on a schedule and drives the results into the database via
+  mutations, resuming from a durable cursor with at-least-once delivery — the ingress
+  counterpart to an observer's egress. The primitive ships end to end:
+  - **Coordination.** A durable opaque cursor store (`_fraiseql_source_cursor`, one
+    row per source) advanced by a monotonic **compare-and-swap** so a stale writer can
+    never regress the watermark; deny-by-default RLS + `REVOKE … FROM PUBLIC`, the
+    cursor value stored as opaque JSONB (written only via parameterized binds, never
+    assembled into SQL text). A single-firing **advisory-lease runner** (lock key = a
+    stable `SHA-256` of the source name) so a source scheduled on N replicas fires on
+    exactly one.
+  - **Two execution models, one envelope.** *Model A* — a native Rust `PullSource`
+    (`poll() → batch`): the framework spine-dedups each message and advances the
+    cursor **in the same transaction** as the ingest writes (atomic, no reprocess
+    window). *Model B* — a handler-driven **Deno connector** (`ctx.cursor` → fetch →
+    `ctx.query` mutate → `ctx.advance`); the envelope supplies single-firing, the
+    cursor, and observability. The poll-IMAP email adapter is reimplemented as the
+    reference Model A source (see Breaking).
+  - **Least-privilege identity, fail-closed.** A source's mutations run under an
+    explicit authority *ceiling* — `run_as` (`{ roles, scopes, tenant? }`) on the
+    compiled definition — carried at runtime by a new
+    `SecurityContext::system_job(...)` (the first use of the `ActorType::SystemJob`
+    principal, recorded for audit, never an authorization input). A source with no
+    `run_as` runs with no authority: RLS and field authorization deny its writes until
+    an operator grants a ceiling. `run_as.tenant` scopes a single-tenant or global
+    source; a multi-tenant source leaves it unset and re-scopes each write to a
+    per-message tenant, and a source already pinned to a tenant cannot forge writes for
+    another. Outbound fetches inherit the deny-by-default SSRF allowlist (no bypass).
+  - **Authoring.** `@Source({ schedule, cursor, runAs })` (TypeScript) and
+    `@fraiseql.source(...)` (Python) compile to a `sources` array in the schema; the
+    compiler validates the cron expression, unique source/cursor names, and `run_as`.
+  - **Server.** An opt-in `sources` cargo feature spawns one poller per enabled source
+    on the functions-subsystem lifecycle (`[sources]` TOML + `FRAISEQL_SOURCES_*` env
+    overrides, env > TOML > default), drains gracefully on shutdown, and warns loudly
+    if `[sources]` is configured while the feature is off.
+  - **Observability.** Prometheus metrics `fraiseql_source_fires_total{source,result}`,
+    `fraiseql_source_skips_not_leader_total{source}`, and
+    `fraiseql_source_run_duration_seconds{source}` (under the `metrics` feature);
+    structured fire/skip/error logs carrying the source and a per-firing idempotency
+    token (HMAC-signed when a server secret is configured; payload logging opt-in via
+    `[sources] log_payloads`); and a read-only `fraiseql sources` CLI that lists each
+    source's schedule, `run_as` ceiling, and — with a database URL — its cursor value,
+    CAS version, and staleness.
+
+  Opt-in and STABLE-tracked (may evolve). See `docs/architecture/sources.md`.
 - **Typed, enforced GraphQL cascade (cascade hardening).** The `cascade`
   feature — a mutation returning every entity it affected, per the graphql-cascade
   spec — is rebuilt from a verbatim JSONB passthrough into a first-class, enforced

--- a/crates/fraiseql-cli/src/commands/sources/mod.rs
+++ b/crates/fraiseql-cli/src/commands/sources/mod.rs
@@ -1,5 +1,5 @@
 //! `fraiseql sources` — a read-only status view over scheduled ingress sources
-//! (#573 Phase 08).
+//! (#573).
 //!
 //! Lists each compiled source with its schedule, `run_as` authority ceiling, and —
 //! when a database is reachable — its durable cursor: the value, the compare-and-swap

--- a/crates/fraiseql-cli/src/commands/sources/reader.rs
+++ b/crates/fraiseql-cli/src/commands/sources/reader.rs
@@ -1,4 +1,4 @@
-//! The thin PostgreSQL projection behind `fraiseql sources` (#573 Phase 08).
+//! The thin PostgreSQL projection behind `fraiseql sources` (#573).
 //!
 //! Reads the durable `_fraiseql_source_cursor` watermark table — the same table the
 //! runtime poller advances — so an operator can see, per source, where its cursor

--- a/crates/fraiseql-core/src/schema/source_types.rs
+++ b/crates/fraiseql-core/src/schema/source_types.rs
@@ -53,7 +53,7 @@ pub struct SourceDefinition {
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub options: serde_json::Value,
 
-    /// The authority this source's background mutations run under (#573 D6) — its
+    /// The authority this source's background mutations run under (#573) — its
     /// `run_as` *ceiling*. Absent ⇒ **fail-closed**: the source runs with no
     /// roles/scopes/tenant and can write nothing. See [`identity`](Self::identity).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -61,7 +61,7 @@ pub struct SourceDefinition {
 }
 
 /// The least-privilege authority ceiling a scheduled source's background mutations
-/// run under (#573 D6) — the source's `run_as`.
+/// run under (#573) — the source's `run_as`.
 ///
 /// This is a *ceiling*: the source can never exceed these `roles`/`scopes`. It is
 /// authored on `@source`/`@fraiseql.source` and compiled into
@@ -135,7 +135,7 @@ impl SourceDefinition {
         self
     }
 
-    /// Set the [`run_as`](Self::run_as) authority ceiling (#573 D6).
+    /// Set the [`run_as`](Self::run_as) authority ceiling (#573).
     #[must_use]
     pub fn with_run_as(mut self, run_as: RunAs) -> Self {
         self.run_as = Some(run_as);
@@ -143,7 +143,7 @@ impl SourceDefinition {
     }
 
     /// The background [`SecurityContext`](crate::security::SecurityContext) this
-    /// source's mutations run under (#573 D6).
+    /// source's mutations run under (#573).
     ///
     /// Built from [`run_as`](Self::run_as) via
     /// [`SecurityContext::system_job`](crate::security::SecurityContext::system_job);
@@ -177,7 +177,7 @@ impl SourceDefinition {
     }
 
     /// The `cron:<schedule>` trigger type this source desugars to — the sugar-over-
-    /// cron binding (decision D1). The runtime schedules [`function`](Self::function)
+    /// cron binding. The runtime schedules [`function`](Self::function)
     /// on it.
     #[must_use]
     pub fn cron_trigger(&self) -> String {

--- a/crates/fraiseql-core/src/security/tests.rs
+++ b/crates/fraiseql-core/src/security/tests.rs
@@ -3843,7 +3843,7 @@ mod actor_context_tests {
 }
 
 /// `SecurityContext::system_job` — the background/system identity for scheduled
-/// sources and other server-initiated work (#573 D6). The first (and, at
+/// sources and other server-initiated work (#573). The first (and, at
 /// introduction, only) construction of [`ActorType::SystemJob`].
 mod system_job_tests {
     use crate::{

--- a/crates/fraiseql-functions/src/triggers/source/tests.rs
+++ b/crates/fraiseql-functions/src/triggers/source/tests.rs
@@ -1,7 +1,7 @@
 //! Pure (no-database) unit tests for the source scheduling envelope, using an
 //! in-memory cursor store, a canned pull source, and a recording ingest sink. The
 //! transactional emit+advance atomicity and cross-replica single-firing are proven
-//! against real Postgres where the server sink lives (Phase 03).
+//! against real Postgres where the server sink lives.
 #![allow(clippy::unwrap_used)] // Reason: test module
 
 use std::sync::{Arc, Mutex};

--- a/crates/fraiseql-observers/src/source/runner.rs
+++ b/crates/fraiseql-observers/src/source/runner.rs
@@ -3,7 +3,7 @@
 //! Wraps the (previously unwired) [`CheckpointLease`] advisory lease so a source
 //! scheduled on N replicas fires on one. The runner acquires the lease keyed on
 //! the source name, runs the closure while holding it, then **releases
-//! explicitly** — Phase 00 characterization proved that dropping the lease does
+//! explicitly** — characterization tests proved that dropping the lease does
 //! *not* free a PostgreSQL session advisory lock (its pooled connection stays
 //! alive), so drop-based RAII is not enough on the happy path; only a dead
 //! connection (a real crash) releases via the session ending, which is the

--- a/crates/fraiseql-server/src/inbound/email/sink.rs
+++ b/crates/fraiseql-server/src/inbound/email/sink.rs
@@ -3,7 +3,7 @@
 //! The generic source envelope ([`fraiseql_functions::run_source_once`]) hands each
 //! polled batch here. In one transaction this emits every message onto the durable
 //! spine (dedup by `Message-ID`) and advances the cursor — atomically, so a crash
-//! leaves writes and watermark consistent (decision D3). Once committed, it runs
+//! leaves writes and watermark consistent. Once committed, it runs
 //! the email-specific post-ingest work for each *genuinely new* message: delivery
 //! correlation (bounces / challenges → send-status / suppression) first — it is not
 //! idempotent, so a redelivery must not re-run it — then the `after:ingest:email`

--- a/crates/fraiseql-server/src/sources/executor.rs
+++ b/crates/fraiseql-server/src/sources/executor.rs
@@ -1,4 +1,4 @@
-//! The query-executor bridge for scheduled sources (#573 D6, Phase 06 Step 2).
+//! The query-executor bridge for scheduled sources (#573).
 //!
 //! A Model B source's Deno connector issues mutations via `fraiseql_query`, which
 //! reaches the host as [`HostContext::query`](fraiseql_functions::HostContext::query)
@@ -6,7 +6,7 @@
 //! Production dispatch never wired one, so a connector's `host.query()` failed with
 //! "query executor not configured". [`SourceQueryExecutor`] is that missing bridge:
 //! it wraps the server's [`Executor`] and runs each query/mutation under the
-//! source's **`run_as` identity** (a `SystemJob` [`SecurityContext`], D6).
+//! source's **`run_as` identity** (a `SystemJob` [`SecurityContext`]).
 //!
 //! Two properties matter:
 //!
@@ -28,17 +28,17 @@ use fraiseql_functions::host::live::QueryExecutor;
 use serde_json::Value;
 
 /// Reserved GraphQL variable a multi-tenant source sets to scope one write to a
-/// tenant (#573 D6).
+/// tenant (#573).
 ///
 /// It is stripped from the variables before the query runs, so it never reaches the
-/// mutation itself. The Phase 07 SDK surfaces it ergonomically (e.g.
+/// mutation itself. The SDK surfaces it ergonomically (e.g.
 /// `ctx.query(mutation, vars, { tenant })`); this constant is the wire contract both
 /// sides agree on.
 pub const SOURCE_TENANT_VAR: &str = "__source_tenant";
 
 /// Adapts the server's [`Executor`] to the functions
 /// [`QueryExecutor`](fraiseql_functions::host::live::QueryExecutor) so a scheduled
-/// source's mutations run under its `run_as` identity (#573 D6).
+/// source's mutations run under its `run_as` identity (#573).
 pub struct SourceQueryExecutor<A: DatabaseAdapter> {
     /// The hot-reloadable executor — the exact handle the request path uses, so a
     /// schema swap is reflected on the next firing (loaded per call).

--- a/crates/fraiseql-server/src/sources/executor/tests.rs
+++ b/crates/fraiseql-server/src/sources/executor/tests.rs
@@ -3,7 +3,7 @@
 //!
 //! The live `execute_query` round-trip (a connector actually mutating through the
 //! server `Executor`) is exercised end-to-end by the scheduler integration test
-//! against real PostgreSQL (Phase 06 Step 3); here we pin the identity/variable
+//! against real PostgreSQL; here we pin the identity/variable
 //! logic that has no database dependency.
 #![allow(clippy::unwrap_used)] // Reason: test module
 

--- a/crates/fraiseql-server/src/sources/metrics.rs
+++ b/crates/fraiseql-server/src/sources/metrics.rs
@@ -1,4 +1,4 @@
-//! Prometheus metrics for scheduled ingress sources (#573 Phase 08).
+//! Prometheus metrics for scheduled ingress sources (#573).
 //!
 //! Emitted through the lightweight [`metrics`] facade — the same mechanism
 //! `fraiseql-wire` uses for its per-entity counters and histograms, and the only

--- a/crates/fraiseql-server/src/sources/mod.rs
+++ b/crates/fraiseql-server/src/sources/mod.rs
@@ -7,13 +7,13 @@
 //!
 //! - [`SourceQueryExecutor`] — the [`QueryExecutor`](fraiseql_functions::host::live::QueryExecutor)
 //!   bridge that lets a source's `fraiseql_query` mutations execute against the server's
-//!   [`Executor`](fraiseql_core::runtime::Executor) under the source's `run_as` identity (#573 D6).
+//!   [`Executor`](fraiseql_core::runtime::Executor) under the source's `run_as` identity.
 //! - [`SourcePoller`] — the per-source scheduler loop: cron-tick → single-firing lease → a cursor +
 //!   executor host → invoke the Deno connector.
 //!
 //! Native pull sources (poll-IMAP email) run under the `inbound-email` feature
-//! independently; lifecycle wiring (reading `sources` from the compiled schema and
-//! spawning a poller per enabled source) lands in Phase 06 Step 4.
+//! independently. Lifecycle wiring — reading `sources` from the compiled schema and
+//! spawning a poller per enabled source — is assembled by [`build_source_pollers`].
 
 mod executor;
 mod metrics;

--- a/crates/fraiseql-server/src/sources/poller.rs
+++ b/crates/fraiseql-server/src/sources/poller.rs
@@ -1,9 +1,9 @@
-//! The per-source scheduler loop (#573 D6, Phase 06 Step 3).
+//! The per-source scheduler loop (#573).
 //!
 //! One [`SourcePoller`] drives one Model B (Deno) source: on its cron schedule it
 //! fires the connector, single-firing across replicas via the advisory lease, under
-//! a host bound to both the source's durable cursor (Phase 04) and its `run_as`
-//! query executor (Step 2). It is the Model B analogue of the poll-IMAP
+//! a host bound to both the source's durable cursor and its `run_as`
+//! query executor. It is the Model B analogue of the poll-IMAP
 //! `MailboxPoller` — cron-tick instead of a fixed interval, and a Deno guest with a
 //! cursor + executor host instead of a native `PullSource`.
 //!
@@ -38,34 +38,39 @@ use super::metrics;
 /// a compiled [`SourceDefinition`](fraiseql_core::schema::SourceDefinition).
 pub struct SourcePoller {
     /// The source name — the cursor row and advisory-lease key.
-    source_name:  String,
+    source_name:     String,
     /// The parsed cron schedule the source fires on.
-    schedule:     CronSchedule,
+    schedule:        CronSchedule,
     /// The Deno connector module to invoke.
-    module:       FunctionModule,
+    module:          FunctionModule,
     /// The runtime-agnostic function observer that dispatches the module.
-    observer:     Arc<FunctionObserver>,
+    observer:        Arc<FunctionObserver>,
     /// The durable cursor store, bound onto each firing's host.
-    cursor_store: PostgresSourceCursorStore,
+    cursor_store:    PostgresSourceCursorStore,
     /// The query-executor bridge (the source's `run_as` identity), bound onto each
     /// firing's host. A trait object so the lifecycle passes a `SourceQueryExecutor`
     /// while tests pass a stub.
-    executor:     Arc<dyn QueryExecutor>,
+    executor:        Arc<dyn QueryExecutor>,
     /// The single-firing runner (advisory lease keyed on the source name).
-    runner:       LeaseGuardedRunner,
+    runner:          LeaseGuardedRunner,
     /// Host config (SSRF allowlist, timeouts) for the connector's outbound I/O.
-    host_config:  HostContextConfig,
+    host_config:     HostContextConfig,
     /// Guest resource limits.
-    limits:       ResourceLimits,
+    limits:          ResourceLimits,
+    /// The HMAC subkey that signs each firing's idempotency token, from the server
+    /// HMAC secret. `Some` ⇒ the token is unforgeable, matching every other dispatch
+    /// path (`after:mutation` / `after:ingest`); `None` ⇒ an unsigned digest (the
+    /// zero-config default).
+    idempotency_key: Option<Arc<[u8]>>,
     /// Whether to log the trigger payload on each firing (default off). Off-by-default
     /// mirrors the observer `log_payloads` gate: even though a source's trigger
     /// payload carries only schedule context — the external data the connector fetches
     /// never reaches the poller — payload logging stays opt-in for a uniform PII stance.
-    log_payloads: bool,
+    log_payloads:    bool,
     /// In-memory fire-window state (the durable cursor is the real resume point, so
     /// missed-fire catch-up across restarts is unnecessary — the next fire resumes
     /// from the cursor).
-    state:        CronExecutionState,
+    state:           CronExecutionState,
 }
 
 impl SourcePoller {
@@ -85,6 +90,7 @@ impl SourcePoller {
         runner: LeaseGuardedRunner,
         host_config: HostContextConfig,
         limits: ResourceLimits,
+        idempotency_key: Option<Arc<[u8]>>,
         log_payloads: bool,
     ) -> Self {
         Self {
@@ -97,6 +103,7 @@ impl SourcePoller {
             runner,
             host_config,
             limits,
+            idempotency_key,
             log_payloads,
             state: CronExecutionState::new(),
         }
@@ -107,10 +114,12 @@ impl SourcePoller {
     /// scheduled tick has its own correlation id threaded through the metrics-adjacent
     /// logs and made available to the connector via `ctx.idempotencyToken` for
     /// idempotent writes. Never wall-clock/random *at the token site* — derived from
-    /// the already-built payload so a resume re-derives the same value.
+    /// the already-built payload so a resume re-derives the same value. Signed with
+    /// the server HMAC subkey when one is configured (matching `after:mutation` /
+    /// `after:ingest`), otherwise an unsigned digest.
     fn idempotency_token(&self, payload: &EventPayload) -> String {
         derive_idempotency_token(
-            None,
+            self.idempotency_key.as_deref(),
             DispatchSource::Source,
             &self.module.name,
             &payload.trigger_type,
@@ -139,7 +148,7 @@ impl SourcePoller {
     /// replica leads), or ran with the guest's own result. An acquire failure is
     /// logged and reported as a skip (the guest did not run this tick).
     ///
-    /// This is the observability seam (#573 Phase 08): it meters every firing
+    /// This is the observability seam (#573): it meters every firing
     /// (`fraiseql_source_fires_total` / `_run_duration_seconds` / `_skips_not_leader_total`)
     /// and emits the structured fire/skip/error logs — all with the `source` and the
     /// per-firing `idempotency_token` — so the whole per-outcome record lives here

--- a/crates/fraiseql-server/src/sources/poller/tests.rs
+++ b/crates/fraiseql-server/src/sources/poller/tests.rs
@@ -5,8 +5,7 @@
 //!   that one firing's host reaches *both* the durable cursor (vs real PostgreSQL) *and* the
 //!   `run_as` executor — without a V8 guest, so it runs in the PG integration leg. The full Model B
 //!   guest-through-poller round-trip (a Deno connector reading its cursor, mutating via
-//!   `fraiseql_query`, advancing) is a local-only V8 test landing with the runnable example in
-//!   Phase 07.
+//!   `fraiseql_query`, advancing) is a local-only V8 test that ships with the runnable example.
 #![allow(clippy::unwrap_used)] // Reason: test module
 #![allow(clippy::print_stderr)] // Reason: skip diagnostic when no backing Postgres
 #![allow(clippy::large_futures)] // Reason: a test future holds a poller + runtime; stack size is irrelevant in a #[tokio::test]
@@ -36,6 +35,50 @@ fn source_payload_carries_the_trigger_context() {
     assert_eq!(payload.event_kind, "scheduled");
     assert_eq!(payload.data["source"], "orders");
     assert_eq!(payload.data["schedule"], "*/5 * * * *");
+}
+
+/// The per-firing idempotency token is signed with the server HMAC subkey when one
+/// is configured — the poller threads `idempotency_key` through rather than
+/// hard-coding the unsigned digest, so a source's token is as unforgeable as every
+/// other dispatch path's. A lazy pool never connects (this derives tokens, it does
+/// not query) — `#[tokio::test]` only because `connect_lazy` needs a runtime handle.
+#[tokio::test]
+async fn idempotency_token_is_signed_when_a_key_is_configured() {
+    let pool = PgPool::connect_lazy("postgres://localhost/unused").unwrap();
+    let build = |key: Option<Arc<[u8]>>| {
+        SourcePoller::new(
+            "orders",
+            CronSchedule::parse("*/5 * * * *").unwrap(),
+            FunctionModule::from_source("connector".to_string(), String::new(), RuntimeType::Deno),
+            Arc::new(FunctionObserver::new()),
+            PostgresSourceCursorStore::new(pool.clone()),
+            StubExecutor::new(json!(null)),
+            LeaseGuardedRunner::in_process("orders"),
+            HostContextConfig::default(),
+            ResourceLimits::default(),
+            key,
+            false,
+        )
+    };
+    let payload = build_source_payload("orders", "*/5 * * * *", Utc::now());
+
+    let unsigned = build(None).idempotency_token(&payload);
+    let secret: Arc<[u8]> = Arc::from(b"server-hmac-secret".as_slice());
+    let signed = build(Some(Arc::clone(&secret))).idempotency_token(&payload);
+
+    // The key changes the token: it is threaded through, not ignored.
+    assert_ne!(unsigned, signed);
+    // The signed form is exactly the keyed HMAC over the firing's stable identity.
+    let expected = fraiseql_observers::derive_idempotency_token(
+        Some(&secret),
+        fraiseql_observers::DispatchSource::Source,
+        "connector",
+        &payload.trigger_type,
+        &payload.data,
+    );
+    assert_eq!(signed, expected);
+    // Both forms honour the 32-hex-char (128-bit) token contract.
+    assert_eq!(unsigned.len(), 32);
 }
 
 /// A query executor that returns a canned response and records the query it saw, so
@@ -86,6 +129,7 @@ fn poller(pool: &PgPool, source: &str, executor: Arc<dyn QueryExecutor>) -> Sour
         LeaseGuardedRunner::in_process(source),
         HostContextConfig::default(),
         ResourceLimits::default(),
+        None,
         false,
     )
 }
@@ -189,6 +233,7 @@ async fn fires_a_model_b_connector_end_to_end() {
         LeaseGuardedRunner::in_process(source),
         HostContextConfig::default(),
         ResourceLimits::default(),
+        None,
         false,
     );
 

--- a/crates/fraiseql-server/src/sources/scheduler.rs
+++ b/crates/fraiseql-server/src/sources/scheduler.rs
@@ -1,4 +1,4 @@
-//! Assembling the source scheduler from the compiled schema (#573 Phase 06 Step 4).
+//! Assembling the source scheduler from the compiled schema (#573).
 //!
 //! [`build_source_pollers`] turns the compiled `sources` array into one
 //! [`SourcePoller`] per enabled Model B source, resolving each source's function
@@ -130,7 +130,7 @@ pub fn build_source_pollers<A: DatabaseAdapter + Send + Sync + 'static>(
     schedulable(sources, &hooks.module_registry)
         .into_iter()
         .map(|(source, module, schedule)| {
-            // The source's mutations run under its run_as ceiling (D6); the
+            // The source's mutations run under its run_as ceiling; the
             // request-id correlates the source in the audit envelope.
             let identity = source.identity(source.name.as_str());
             let query_executor: Arc<dyn QueryExecutor> =
@@ -145,6 +145,7 @@ pub fn build_source_pollers<A: DatabaseAdapter + Send + Sync + 'static>(
                 LeaseGuardedRunner::postgres(db_pool.clone(), source.name.clone()),
                 host_config.clone(),
                 limits.clone(),
+                hooks.idempotency_key.clone(),
                 log_payloads,
             )
         })

--- a/crates/fraiseql-server/src/sources/scheduler/tests.rs
+++ b/crates/fraiseql-server/src/sources/scheduler/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for the source-scheduler assembly: the pure `schedulable` filter and the
 //! env-overridable config resolution. The full poller-wiring (`build_source_pollers`)
-//! is exercised by the lifecycle integration and Step 3's `build_host` composition.
+//! is exercised by the lifecycle integration and the poller's `build_host` composition.
 #![allow(clippy::unwrap_used)] // Reason: test module
 
 use std::collections::HashMap;

--- a/sdks/official/fraiseql-python/src/fraiseql/decorators.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/decorators.py
@@ -1278,7 +1278,7 @@ def source(
         function: The bound Deno connector name; defaults to the source name.
         cursor: Optional distinct cursor name (defaults to the source name).
         enabled: Whether the source is scheduled (default ``True``).
-        run_as: Optional least-privilege authority ceiling (#573 D6):
+        run_as: Optional least-privilege authority ceiling (#573):
             ``{"roles": [...], "scopes": [...], "tenant": "..."}``. Absent ⇒
             fail-closed (the source's mutations are RLS/authz-denied).
         **options: Connector-specific options, opaque to the framework.

--- a/sdks/official/fraiseql-python/src/fraiseql/registry.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/registry.py
@@ -424,7 +424,7 @@ class SchemaRegistry:
             function: The bound Deno connector name; defaults to the source name.
             cursor: Optional distinct cursor name (defaults to the source name).
             enabled: Whether the source is scheduled (default ``True``).
-            run_as: Optional least-privilege authority ceiling (#573 D6):
+            run_as: Optional least-privilege authority ceiling (#573):
                 ``{"roles": [...], "scopes": [...], "tenant": "..."}``.
             options: Optional connector-specific options, opaque to the framework.
         """

--- a/sdks/official/fraiseql-typescript/examples/scheduled_source.ts
+++ b/sdks/official/fraiseql-typescript/examples/scheduled_source.ts
@@ -35,7 +35,7 @@ class OrderSources {
    * Every 5 minutes, run the `pollOrders` connector to ingest new orders.
    *
    * `runAs` is the least-privilege ceiling the connector's mutations execute under
-   * (#573 D6): here it may only write orders. Omit `runAs` and the source is
+   * (#573): here it may only write orders. Omit `runAs` and the source is
    * fail-closed (its mutations are RLS/authz-denied) until you grant one.
    *
    * `function` defaults to the method name (`pollOrders`) — the Deno connector.

--- a/sdks/official/fraiseql-typescript/src/registry.ts
+++ b/sdks/official/fraiseql-typescript/src/registry.ts
@@ -228,7 +228,7 @@ export interface UnionDefinition {
 
 /**
  * The `run_as` authority ceiling a scheduled source's background mutations run
- * under (#573 D6). Absent ⇒ the source runs fail-closed (no roles/scopes/tenant →
+ * under (#573). Absent ⇒ the source runs fail-closed (no roles/scopes/tenant →
  * RLS/authz deny). `tenant` scopes a single-tenant or global source; a multi-tenant
  * source leaves it unset and re-scopes each write per message at runtime.
  */
@@ -731,7 +731,7 @@ export class SchemaRegistry {
    * @param fn - The bound Deno connector function name.
    * @param cursor - Optional distinct cursor name (defaults to the source name).
    * @param enabled - Whether the source is scheduled (default true).
-   * @param runAs - Optional least-privilege authority ceiling (#573 D6).
+   * @param runAs - Optional least-privilege authority ceiling (#573).
    * @param options - Optional connector-specific options, opaque to the framework.
    */
   static registerSource(

--- a/sdks/official/fraiseql-typescript/src/sources.ts
+++ b/sdks/official/fraiseql-typescript/src/sources.ts
@@ -32,7 +32,7 @@ interface SourceConfig {
   cursor?: string;
   /** Whether the source is scheduled. Default `true`. */
   enabled?: boolean;
-  /** Least-privilege authority ceiling for the source's mutations (#573 D6). */
+  /** Least-privilege authority ceiling for the source's mutations (#573). */
   runAs?: SourceRunAs;
   /** Connector-specific options, opaque to the framework. */
   options?: Record<string, unknown>;


### PR DESCRIPTION
## Phase 09 — Finalize `#573` scheduled ingress `Source`

The runtime (Phases 00–08) is already shipped to `dev`. This is the ship-ready
gate: QC review, security audit, archaeology removal, and CHANGELOG — behind the
opt-in `sources` feature (STABLE-tracked-may-evolve).

### Security fix (the one substantive code change)

The QC/security audit found that `SourcePoller` hard-coded `None` for the
idempotency HMAC key, so a source's per-firing token was an **unsigned SHA-256
digest even when the server had an HMAC secret configured** — unlike every other
dispatch path (`after:mutation` / `after:ingest`, which thread the configured
key). The token is guest-exposed (`ctx.idempotencyToken`), so it should be
unforgeable whenever a secret exists.

Fixed by threading `hooks.idempotency_key` (already in scope at
`build_source_pollers`) through `SourcePoller` → `derive_idempotency_token`.
No key configured ⇒ unchanged (unsigned digest, the zero-config default). A pure
regression test (`idempotency_token_is_signed_when_a_key_is_configured`) pins it.

### Security audit — DESIGN §6 checklist, all verified

| Item | Result |
|---|---|
| SSRF allowlist, no bypass | Source host inherits the deny-by-default allowlist via `HostContextConfig`; only `allowed_domains` is set, `..default()` keeps the audited validator. |
| Cursor/lease RLS + `REVOKE FROM PUBLIC` + tenant isolation | Migration 13: `ENABLE` RLS (owner-exempt), deny-by-default read policy, `REVOKE ALL … FROM PUBLIC`, `tenant_id` RLS stamp. |
| Opaque JSONB cursor never in SQL text | All writes bind the value as `$2::jsonb`; CAS via a monotonic `version` so a stale writer can't regress. |
| Lock key collision-resistant | First 8 bytes of `SHA-256(source_name)` — stable across replicas, unique per validated name. |
| HMAC idempotency | **Fixed** — keyed when a secret is configured. |
| `run_as` fail-closed | Unset ⇒ empty roles/scopes/tenant ⇒ RBAC + tenant-RLS deny; `ActorType::SystemJob` is audit-only (no authz branch keys on it); a tenant-pinned source can't forge another tenant's writes. |

### QC review

`PullSource` envelope + `ctx.cursor`/`advance` ergonomics, at-least-once /
overlap edge cases, and Model A transactional advance (email sink: emit + advance
in one tx, cursor-race → rollback, post-commit correlate/dispatch only for
genuinely-new messages) all reviewed and sound. No unnecessary complexity.
One documented-acceptable edge: a panic inside the run closure skips explicit
lease release and relies on connection-death crash-safety (mirrors `MailboxPoller`;
a session advisory lock can't be released from `Drop` anyway) — no regression.

### Archaeology & docs

- Stripped `Phase N` / `Step M` / `D1`/`D3`/`D6` design-plan markers from shipped
  doc comments (observers/functions/server/core/cli + TS/Python SDKs); kept the
  permanent `#573` issue references. `.phases/` stays gitignored.
- Rewrote the `### Added` #573 CHANGELOG entry from the in-progress identity-only
  slice into a complete Source-primitive description; dropped the
  `.phases/DESIGN.md` pointer for `docs/architecture/sources.md`. The `### Breaking`
  (email cursor removal) was already present.

### Verification

- ✅ `make preflight` (fmt, ~9 shell gates, lint-unwrap, rustdoc `-D warnings --all-features`, clippy `--all-targets --all-features -D warnings`)
- ✅ `cargo test -p fraiseql-server --features sources` — 16 non-V8 sources tests + the V8 connector E2E (isolated) green
- ✅ release-smoke boots `--features sources` against a source-declaring fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
