### PR TITLE
chore(release): prepare v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-07-15
+
 ### Added
 
 - **Scheduled ingress `Source`s — the dual of `Observer` (#573).** A `Source` pulls
@@ -54,6 +56,108 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     CAS version, and staleness.
 
   Opt-in and STABLE-tracked (may evolve). See `docs/architecture/sources.md`.
+
+### Breaking
+
+- **Poll-IMAP email cursor storage removed; email now uses the generic source
+  cursor (#573).** The bespoke `_fraiseql_inbound_email_cursor` table and its
+  `PostgresEmailCursorStore` are deleted with no migration or backfill (there are no
+  IMAP users). The email adapter is reimplemented as the reference native
+  `PullSource` (`ImapSource`) driven by the generic source envelope, and its
+  per-mailbox UID watermark now lives — as opaque JSONB — in the shared
+  `_fraiseql_source_cursor` table (created by the same `init_cursor_store`). This
+  also **fixes a multi-replica double-poll**: each mailbox is now polled under a
+  single-firing advisory lease, so several server replicas poll each mailbox exactly
+  once between them instead of all polling it. Cursor advance is now transactional
+  with the spine emit (all-or-nothing per poll batch) rather than per-message.
+  `fraiseql_functions::migrations::inbound_email_cursor_migration_sql` is removed.
+
+### Changed
+
+- **Entity-identity contract: `id: UUID` is canonicalized to `id: ID` (ADR-0017).**
+  FraiseQL now treats a global `id: ID!` as a first-class invariant consumed
+  uniformly by cascade, Relay `Node`, and federation `@key(fields: "id")` — rather
+  than each subsystem re-deriving identity from heterogeneous id types. The compiler
+  rewrites the Trinity external id (`id: UUID`) to `id: ID` on every output object
+  type. This is **wire-transparent** — a UUID and an `ID` serialize to the same JSON
+  string — so clients are unaffected; only introspection/SDL now reports `id: ID`
+  where it previously reported `id: UUID`. Non-identity ids (a serial `id: Int`, or
+  no `id`) are left as-is and must expose `id: ID` (a UUID surrogate) to use
+  cascade/Relay. See ADR-0017 and `docs/architecture/mutation-response.md`.
+- **All authoring SDKs emit `id: ID` for identity fields (honest at source).** Every
+  FraiseQL SDK that emits `schema.json` now canonicalizes a field named `id` typed as
+  a wire-transparent string (`string`/`str`/`UUID`) to GraphQL `ID`, enforcing the
+  documented convention each SDK already stated. Previously a Trinity surrogate
+  authored as `id: string` leaked `id: String`, which the compiler's identity contract
+  then rejected; the emitted schema is now conformant at the source, so the compiler's
+  `UUID → ID` canonicalization is a backstop rather than the primary mechanism.
+  Covered: **Python, TypeScript, Go, C#, F#, Java, PHP** (fixed + tests green),
+  **Elixir** (fixed + tests, gated by `elixir-sdk.yml` CI), and **Scala** (fixed +
+  tests, gated by a new `scala-sdk.yml` CI workflow — the community SDK previously had
+  none). A numeric `id: Int` is left unchanged. Client/runtime SDKs (Dart, Ruby, Rust,
+  Kotlin, Swift, Node.js, Clojure, Groovy) are unaffected — they consume the API, they
+  don't emit schemas.
+
+### Fixed
+
+- **`fraiseql compile` now surfaces the full error cause chain.** Converter
+  failures printed only the top-level context (e.g. `Failed to convert schema to
+  compiled format`) with the underlying reason swallowed at every log level and in
+  `--json` — the cause was reachable only via the undocumented `--debug` flag, and
+  never in JSON. The CLI now renders the whole `anyhow` source chain in both modes:
+  `  caused by: …` lines in human output and a `"causes": [...]` array in `--json`
+  (additive; `message`/`code` unchanged). Applies to every command, not just
+  `compile`.
+- **Cascade/Relay type synthesis no longer emits a schema that fails its own
+  validator.** Auto-implementing `CascadeNode` (cascade) or `Node` (`relay = true`)
+  on an entity whose `id` was `UUID`/`Int` or absent produced IR that the
+  compiled-schema validator then rejected with a swallowed "missing field 'id'"
+  bail — so a schema that compiled under 2.10 could fail under 2.11 (which began
+  honoring the previously-dropped SDK `cascade` flag) with the real reason hidden.
+  Resolved by the entity-identity contract (see *Changed*): the Trinity `id: UUID`
+  now canonicalizes to `id: ID` and satisfies the interface automatically, and any
+  residual non-identity id (`Int`, absent) fails fast — *before* the `implements`
+  push — with one aggregated, actionable error naming every offending type and the
+  remedy, instead of a swallowed bail.
+- **The compiled-schema validator recognizes interfaces as valid return types.** A
+  query or mutation returning an interface type (narrowed via inline fragments) is
+  now accepted instead of silently failing the type-reference check; every
+  validator rejection also logs a `warn!`, not just the query-return case.
+- **Built-in change-log fields now follow the SDK's camelCase convention by default
+  (#500).** The Python SDK recases every field, operation, and argument it emits to
+  camelCase, but it did not record that convention in the exported schema. The
+  compiler's change-log injection (the #149 audit log) renders its identifiers via the
+  schema's `naming_convention`, which defaulted to `Preserve` — so an exposed
+  `EntityChangeLog` / `TransportCheckpoint` came out in snake_case
+  (`pk_entity_change_log`, `object_type`, `created_at`), the only snake_case corner of
+  an otherwise camelCase API. The camelCase change-log support added in #498 was
+  therefore inert unless the caller hand-injected `naming_convention` into the schema
+  JSON. `get_schema_dict()` (and the registry's `get_schema()`) now emit
+  `naming_convention: "camelCase"`, so a change-log exposed from an SDK-authored schema
+  compiles to camelCase fields with no manual intervention. The SQL contract is
+  unchanged — the runtime still recovers the snake_case JSONB keys via `to_snake_case`.
+- **`auto_params` queries now expose their `where`/`orderBy`/`limit`/`offset` as real
+  GraphQL arguments.** A list query configured with `auto_params` carried those
+  parameters only as compile-time flags — the runtime read them straight from the
+  argument map, but they were never materialised as field arguments. Every consumer
+  that renders from the argument list therefore emitted the query without them:
+  `generate-client typescript` produced a bare, argument-less query and function, and
+  the federation `_service { sdl }` (and `/schema` endpoint) advertised the field with
+  no arguments — so a generated client or a federated gateway could fetch the first
+  page of a collection but could not paginate or filter it (the built-in change-log
+  being the clearest case: its own description documents `where`/`orderBy`/`limit`).
+  `QueryDefinition::graphql_arguments()` now synthesizes those arguments from the
+  `auto_params` flags (`where`/`orderBy` typed as the `JSON` scalar, `limit`/`offset`
+  as `Int`), and the SDL renderer, the TypeScript client generator, and GraphQL
+  introspection all render through it — so the three stay consistent and a generated
+  client can paginate and filter. An explicit argument of the same name still wins
+  (no duplicates), and Relay connection queries are unchanged (their `first`/`after`/
+  `last`/`before` surface is owned by the Relay path).
+
+## [2.11.0] - 2026-07-06
+
+### Added
+
 - **Typed, enforced GraphQL cascade (cascade hardening).** The `cascade`
   feature — a mutation returning every entity it affected, per the graphql-cascade
   spec — is rebuilt from a verbatim JSONB passthrough into a first-class, enforced
@@ -64,11 +168,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   updatedFields }` whose `cascade: CascadeUpdates` carries `updated`
   (`[UpdatedEntity!]!`), `deleted` (`[DeletedEntity!]!`), `metadata`
   (`CascadeMetadata!`), and `invalidations` (`[QueryInvalidation!]!`) — a
-  `CascadeNode` interface (`id: ID!`) is auto-implemented on every queryable entity
-  (the Trinity `id: UUID` canonicalizes to `id: ID` per the entity-identity contract,
-  ADR-0017; a non-identity id fails fast with an aggregated, actionable error) so
-  cascade entities are selectable via inline fragments. At runtime every cascade
-  entity is
+  `CascadeNode` interface is auto-implemented on every queryable entity so cascade
+  entities are selectable via inline fragments. At runtime every cascade entity is
   projected to camelCase and run through the field-level authorizer (#423) exactly
   like a queried entity; cascade is selection-gated (never injected unrequested);
   the response is bounded by `RuntimeConfig.cascade_limits` (max affected entities →
@@ -412,19 +513,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- **Poll-IMAP email cursor storage removed; email now uses the generic source
-  cursor (#573).** The bespoke `_fraiseql_inbound_email_cursor` table and its
-  `PostgresEmailCursorStore` are deleted with no migration or backfill (there are no
-  IMAP users). The email adapter is reimplemented as the reference native
-  `PullSource` (`ImapSource`) driven by the generic source envelope, and its
-  per-mailbox UID watermark now lives — as opaque JSONB — in the shared
-  `_fraiseql_source_cursor` table (created by the same `init_cursor_store`). This
-  also **fixes a multi-replica double-poll**: each mailbox is now polled under a
-  single-firing advisory lease, so several server replicas poll each mailbox exactly
-  once between them instead of all polling it. Cursor advance is now transactional
-  with the spine emit (all-or-nothing per poll batch) rather than per-message.
-  `fraiseql_functions::migrations::inbound_email_cursor_migration_sql` is removed.
-
 - **Cascade is now typed, selection-gated, and enforced (cascade hardening).**
   Cascade was previously injected verbatim into *every* mutation response, unrequested
   and undeclared. Now: (1) only mutations with `cascade=True` expose it, and they
@@ -440,29 +528,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Entity-identity contract: `id: UUID` is canonicalized to `id: ID` (ADR-0017).**
-  FraiseQL now treats a global `id: ID!` as a first-class invariant consumed
-  uniformly by cascade, Relay `Node`, and federation `@key(fields: "id")` — rather
-  than each subsystem re-deriving identity from heterogeneous id types. The compiler
-  rewrites the Trinity external id (`id: UUID`) to `id: ID` on every output object
-  type. This is **wire-transparent** — a UUID and an `ID` serialize to the same JSON
-  string — so clients are unaffected; only introspection/SDL now reports `id: ID`
-  where it previously reported `id: UUID`. Non-identity ids (a serial `id: Int`, or
-  no `id`) are left as-is and must expose `id: ID` (a UUID surrogate) to use
-  cascade/Relay. See ADR-0017 and `docs/architecture/mutation-response.md`.
-- **All authoring SDKs emit `id: ID` for identity fields (honest at source).** Every
-  FraiseQL SDK that emits `schema.json` now canonicalizes a field named `id` typed as
-  a wire-transparent string (`string`/`str`/`UUID`) to GraphQL `ID`, enforcing the
-  documented convention each SDK already stated. Previously a Trinity surrogate
-  authored as `id: string` leaked `id: String`, which the compiler's identity contract
-  then rejected; the emitted schema is now conformant at the source, so the compiler's
-  `UUID → ID` canonicalization is a backstop rather than the primary mechanism.
-  Covered: **Python, TypeScript, Go, C#, F#, Java, PHP** (fixed + tests green),
-  **Elixir** (fixed + tests, gated by `elixir-sdk.yml` CI), and **Scala** (fixed +
-  tests, gated by a new `scala-sdk.yml` CI workflow — the community SDK previously had
-  none). A numeric `id: Int` is left unchanged. Client/runtime SDKs (Dart, Ruby, Rust,
-  Kotlin, Swift, Node.js, Clojure, Groovy) are unaffected — they consume the API, they
-  don't emit schemas.
 - **Inbound email config renamed: `[imap.<name>]` → `[mailbox.<name>.imap]` (breaking).**
   A connected mail account now has one section, `[mailbox.<name>]`, carrying both its
   poll-IMAP *receive* half (`[mailbox.<name>.imap]`) and its SMTP *send* half
@@ -517,29 +582,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`fraiseql compile` now surfaces the full error cause chain.** Converter
-  failures printed only the top-level context (e.g. `Failed to convert schema to
-  compiled format`) with the underlying reason swallowed at every log level and in
-  `--json` — the cause was reachable only via the undocumented `--debug` flag, and
-  never in JSON. The CLI now renders the whole `anyhow` source chain in both modes:
-  `  caused by: …` lines in human output and a `"causes": [...]` array in `--json`
-  (additive; `message`/`code` unchanged). Applies to every command, not just
-  `compile`.
-- **Cascade/Relay type synthesis no longer emits a schema that fails its own
-  validator.** Auto-implementing `CascadeNode` (cascade) or `Node` (`relay = true`)
-  on an entity whose `id` was `UUID`/`Int` or absent produced IR that the
-  compiled-schema validator then rejected with a swallowed "missing field 'id'"
-  bail — so a schema that compiled under 2.10 could fail under 2.11 (which began
-  honoring the previously-dropped SDK `cascade` flag) with the real reason hidden.
-  Resolved by the entity-identity contract (see *Changed*): the Trinity `id: UUID`
-  now canonicalizes to `id: ID` and satisfies the interface automatically, and any
-  residual non-identity id (`Int`, absent) fails fast — *before* the `implements`
-  push — with one aggregated, actionable error naming every offending type and the
-  remedy, instead of a swallowed bail.
-- **The compiled-schema validator recognizes interfaces as valid return types.** A
-  query or mutation returning an interface type (narrowed via inline fragments) is
-  now accepted instead of silently failing the type-reference check; every
-  validator rejection also logs a `warn!`, not just the query-return case.
 - **Native-column `WHERE` filters no longer 500 on a camelCase argument (#540).**
   A filter argument on a native (real-column) field emitted the camelCase argument
   name verbatim as the SQL column — `comments(postId: …)` became `WHERE postId = …`,
@@ -620,36 +662,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   de-duplicated, matching the claim names already honoured by the observer-admin RBAC
   engine. The claims continue to be forwarded into `attributes` for RLS / session-var
   injection — the two surfaces are independent. (#503)
-- **Built-in change-log fields now follow the SDK's camelCase convention by default
-  (#500).** The Python SDK recases every field, operation, and argument it emits to
-  camelCase, but it did not record that convention in the exported schema. The
-  compiler's change-log injection (the #149 audit log) renders its identifiers via the
-  schema's `naming_convention`, which defaulted to `Preserve` — so an exposed
-  `EntityChangeLog` / `TransportCheckpoint` came out in snake_case
-  (`pk_entity_change_log`, `object_type`, `created_at`), the only snake_case corner of
-  an otherwise camelCase API. The camelCase change-log support added in #498 was
-  therefore inert unless the caller hand-injected `naming_convention` into the schema
-  JSON. `get_schema_dict()` (and the registry's `get_schema()`) now emit
-  `naming_convention: "camelCase"`, so a change-log exposed from an SDK-authored schema
-  compiles to camelCase fields with no manual intervention. The SQL contract is
-  unchanged — the runtime still recovers the snake_case JSONB keys via `to_snake_case`.
-- **`auto_params` queries now expose their `where`/`orderBy`/`limit`/`offset` as real
-  GraphQL arguments.** A list query configured with `auto_params` carried those
-  parameters only as compile-time flags — the runtime read them straight from the
-  argument map, but they were never materialised as field arguments. Every consumer
-  that renders from the argument list therefore emitted the query without them:
-  `generate-client typescript` produced a bare, argument-less query and function, and
-  the federation `_service { sdl }` (and `/schema` endpoint) advertised the field with
-  no arguments — so a generated client or a federated gateway could fetch the first
-  page of a collection but could not paginate or filter it (the built-in change-log
-  being the clearest case: its own description documents `where`/`orderBy`/`limit`).
-  `QueryDefinition::graphql_arguments()` now synthesizes those arguments from the
-  `auto_params` flags (`where`/`orderBy` typed as the `JSON` scalar, `limit`/`offset`
-  as `Int`), and the SDL renderer, the TypeScript client generator, and GraphQL
-  introspection all render through it — so the three stay consistent and a generated
-  client can paginate and filter. An explicit argument of the same name still wins
-  (no duplicates), and Relay connection queries are unchanged (their `first`/`after`/
-  `last`/`before` surface is owned by the Relay path).
 - **Federation SDL: scalar names are consistent and `*WhereInput` types are valid.**
   Two residual `_service` SDL gaps that the type-closure fix exposed: (1) the `scalar`
   declaration walk canonicalised names (`DateTime`) while fields rendered them verbatim

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "fraiseql-arrow",
  "fraiseql-cli",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-arrow"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-auth"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cdc-sinks"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "async-nats",
  "chrono",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cli"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-codegen"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "fraiseql-core",
  "fraiseql-error",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-core"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-db"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-error"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "axum",
  "serde",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-federation"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-functions"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-observers"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "arrow",
  "async-nats",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-secrets"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-server"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-storage"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-support"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "testcontainers",
  "testcontainers-modules",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-utils"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "async-trait",
  "fraiseql-core",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-webhooks"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-wire"
-version = "2.10.0"
+version = "2.12.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,26 +63,26 @@ dashmap = "6.1"
 deadpool = "0.12"
 deadpool-postgres = "0.14"
 # Internal crates
-fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.10.0"}
-fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.10.0"}
+fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.12.0"}
+fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.12.0"}
 # Deliberately loose floor (2.3.0, not the current 2.7.0): fraiseql-server takes
 # fraiseql-cli as a dev-dependency while fraiseql-cli depends on fraiseql-server,
 # a publish cycle. A floor equal to the unpublished current version breaks the
 # first `cargo publish` of the cut (the sibling isn't on crates.io yet). Keep this
 # floor loose — see the v2.4.0 release lessons. Do NOT bump it to match the others.
 fraiseql-cli = {path = "crates/fraiseql-cli", version = "2.3.0"}
-fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.10.0"}
-fraiseql-core = {path = "crates/fraiseql-core", version = "2.10.0", default-features = false}
-fraiseql-db = {path = "crates/fraiseql-db", version = "2.10.0", default-features = false}
-fraiseql-error = {path = "crates/fraiseql-error", version = "2.10.0", default-features = false}
-fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.10.0"}
-fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.10.0"}
-fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.10.0"}
-fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.10.0"}
-fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.10.0"}
-fraiseql-server = {path = "crates/fraiseql-server", version = "2.10.0"}
-fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.10.0"}
-fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.10.0"}
+fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.12.0"}
+fraiseql-core = {path = "crates/fraiseql-core", version = "2.12.0", default-features = false}
+fraiseql-db = {path = "crates/fraiseql-db", version = "2.12.0", default-features = false}
+fraiseql-error = {path = "crates/fraiseql-error", version = "2.12.0", default-features = false}
+fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.12.0"}
+fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.12.0"}
+fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.12.0"}
+fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.12.0"}
+fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.12.0"}
+fraiseql-server = {path = "crates/fraiseql-server", version = "2.12.0"}
+fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.12.0"}
+fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.12.0"}
 futures = "0.3"
 graphql-parser = "0.4"
 hex = "0.4"
@@ -350,4 +350,4 @@ keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
 rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
-version = "2.10.0"
+version = "2.12.0"

--- a/crates/fraiseql-arrow/fuzz/Cargo.toml
+++ b/crates/fraiseql-arrow/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-arrow-fuzz"
 publish = false
-version = "2.10.0"
+version = "2.12.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-auth-fuzz"
-version = "2.10.0"
+version = "2.12.0"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-core/fuzz/Cargo.toml
+++ b/crates/fraiseql-core/fuzz/Cargo.toml
@@ -51,7 +51,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-core-fuzz"
 publish = false
-version = "2.10.0"
+version = "2.12.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-db/fuzz/Cargo.toml
+++ b/crates/fraiseql-db/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-db-fuzz"
 publish = false
-version = "2.10.0"
+version = "2.12.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-federation/fuzz/Cargo.toml
+++ b/crates/fraiseql-federation/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ path = "../../fraiseql-error"
 edition = "2021"
 name = "fraiseql-federation-fuzz"
 publish = false
-version = "2.10.0"
+version = "2.12.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-secrets/fuzz/Cargo.toml
+++ b/crates/fraiseql-secrets/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-secrets-fuzz"
-version = "2.10.0"
+version = "2.12.0"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-server/fuzz/Cargo.toml
+++ b/crates/fraiseql-server/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-server-fuzz"
 publish = false
-version = "2.10.0"
+version = "2.12.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-wire/fuzz/Cargo.toml
+++ b/crates/fraiseql-wire/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-wire-fuzz"
 publish = false
-version = "2.10.0"
+version = "2.12.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdks/official/fraiseql-python/pyproject.toml
+++ b/sdks/official/fraiseql-python/pyproject.toml
@@ -38,7 +38,7 @@ license = {text = "MIT"}
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.10.0"
+version = "2.12.0"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]

--- a/sdks/official/fraiseql-python/src/fraiseql/__init__.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/__init__.py
@@ -79,7 +79,7 @@ input = input_decorator
 interface = interface_decorator
 union = union_decorator
 
-__version__ = "2.10.0"
+__version__ = "2.12.0"
 
 __all__ = [
     "ID",

--- a/sdks/official/fraiseql-rust/Cargo.toml
+++ b/sdks/official/fraiseql-rust/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["graphql", "authorization", "rbac", "schema"]
 license = "Apache-2.0"
 name = "fraiseql-rust"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "2.10.0"
+version = "2.12.0"
 
 [[test]]
 name = "integration_test"

--- a/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
+++ b/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-client"
-version = "2.10.0"
+version = "2.12.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Async HTTP client for FraiseQL GraphQL servers"

--- a/sdks/official/fraiseql-typescript/package-lock.json
+++ b/sdks/official/fraiseql-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fraiseql",
-  "version": "2.10.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fraiseql",
-      "version": "2.10.0",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/sdks/official/fraiseql-typescript/package.json
+++ b/sdks/official/fraiseql-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fraiseql",
-  "version": "2.10.0",
+  "version": "2.12.0",
   "description": "FraiseQL v2 - Compiled GraphQL execution engine (schema authoring + HTTP client)",
   "repository": {
     "type": "git",

--- a/sdks/official/fraiseql-typescript/src/index.ts
+++ b/sdks/official/fraiseql-typescript/src/index.ts
@@ -32,7 +32,7 @@
  * @packageDocumentation
  */
 
-export const version = "2.10.0";
+export const version = "2.12.0";
 
 // Export type system
 export { typeToGraphQL, extractFieldInfo, extractFunctionSignature } from "./types";


### PR DESCRIPTION
## Summary

Cuts **v2.12.0** from `dev` and repairs a CHANGELOG regression left by the v2.11.0 release.

**New in v2.12.0** (the 50 commits since `v2.11.0`):
- **`Source` — scheduled/idempotent ingress (#573)**, the dual of `Observer`, shipped end to end (coordination cursor + advisory-lease single-firing, Model A native `PullSource` / Model B Deno connector, least-privilege `run_as` identity, TS/Python authoring, opt-in `sources` server feature, metrics + `fraiseql sources` CLI). Email is reimplemented as the reference source (**breaking**: `_fraiseql_inbound_email_cursor` removed — no IMAP users).
- **ADR-0017 `id: ID` entity-identity contract** — the CLI canonicalizes Trinity `id: UUID → id: ID` (wire-transparent) and every authoring SDK emits it at source (incl. repaired Scala/Elixir SDKs, now CI-gated).
- **Fixes**: `auto_params` queries expose `where`/`orderBy`/`limit`/`offset` as real GraphQL args (#499); built-in change-log follows the SDK's camelCase (#500); `fraiseql compile` surfaces the full error cause chain; cascade/Relay type synthesis no longer emits a schema that fails its own validator; interface return types accepted.

**CHANGELOG repair.** v2.11.0 was tagged from a one-commit side branch whose `chore(release): prepare v2.11.0` commit (version bump + `## [2.11.0]` heading) was **never merged back to `dev`**. As a result `dev` was still on `2.10.0` in code and the entire v2.11.0 body was stranded in `[Unreleased]`. This PR restores the `## [2.11.0] - 2026-07-06` heading (content verified byte-identical to the tag) and re-applies the version bump on `dev`, so the tree and the published tags finally agree.

## Verification
- ✅ `cargo check --workspace` passes; `Cargo.lock` synced to 2.12.0
- ✅ CHANGELOG reconstruction proven lossless: `[2.11.0]` bullets identical to the `v2.11.0` tag; `[2.12.0]` ∪ `[2.11.0]` = the prior `[Unreleased]` set (9 + 43 = 52, none lost/added)
- ✅ Heading order Unreleased → 2.12.0 → 2.11.0 → 2.10.0, clean boundaries
- CI preflight + security are the required gates on this PR

The tag `v2.12.0` will be created on the `dev` merge commit (not this branch) after CI is green, followed by `make release-validate VERSION=2.12.0` before pushing the tag — so the release-prep commit lands on `dev` this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)