### PR TITLE
fix(release): drop dead libssl apt pre-build breaking the aarch64 binary

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,15 @@
-[target.aarch64-unknown-linux-gnu]
-pre-build = [
-  "dpkg --add-architecture arm64",
-  "apt-get update && apt-get install -y libssl-dev:arm64 pkg-config"
-]
+# Cross-compilation configuration for release binaries (see .github/workflows/release.yml).
+#
+# The `fraiseql` binary is pure-Rust and links no external system libraries:
+# TLS is rustls (reqwest -> hyper-rustls -> rustls; no OpenSSL / native-tls) and
+# Postgres is sqlx-postgres / tokio-postgres / deadpool-postgres (no libpq).
+# The only `*-sys` crates are syscall bindings (dirs-sys, inotify-sys,
+# linux-raw-sys) or vendor their own C source (zstd-sys, ring), all built with
+# the aarch64 cross-toolchain already baked into the cross image.
+#
+# Therefore NO target-specific `pre-build` is needed. A previous
+# `apt-get install libssl-dev:arm64 pkg-config` step was vestigial (nothing links
+# libssl) and broke the aarch64 build permanently once the cross image's EOL
+# Ubuntu Xenial apt repos (ports.ubuntu.com) went offline. Do not re-add an apt
+# step unless a genuine system-library dependency is actually introduced — if one
+# is, prefer a vendored/rustls alternative to keep the build apt-free.


### PR DESCRIPTION
## Problem

The `aarch64-unknown-linux-gnu` release binary (release.yml) has been failing at the **pre-build** step: the `cross` image runs `apt-get install libssl-dev:arm64 pkg-config` against its base image's **EOL Ubuntu Xenial** apt repos (`ports.ubuntu.com`), which are offline. `apt-get` fails → the binary is never built or uploaded. This is why the v2.12.0 GitHub Release shipped without an aarch64-linux archive (the other 4 targets built fine).

## Fix

Remove the vestigial apt pre-build from `Cross.toml`. The `fraiseql` binary (`cli,server,postgres`) links **no external system library**:
- TLS is **rustls** (`reqwest` → `hyper-rustls` → `rustls`) — no OpenSSL/native-tls, so `libssl-dev` was never needed.
- Postgres is **sqlx-postgres / tokio-postgres / deadpool-postgres** — no `libpq`.
- The only `*-sys` crates are syscall bindings (`dirs-sys`, `inotify-sys`, `linux-raw-sys`) or vendor their own C source (`zstd-sys`, `ring`), all built with the aarch64 cross-toolchain already baked into the cross image.

With no apt step, the cross build is apt-free and immune to the base image's distro going EOL. `Cross.toml` keeps an inline comment documenting the pure-Rust invariant so the apt step isn't re-added.

## Verification

Ran the exact CI command locally with the fixed `Cross.toml`:

```
cross build --release --target aarch64-unknown-linux-gnu -p fraiseql --features cli,server,postgres
```

→ **succeeds** (previously failed at the apt pre-build), producing a valid stripped **ELF 64-bit ARM aarch64** binary, glibc-linked. The other release targets are unaffected (this file only configures the aarch64 cross target).

Note: this fixes releases **going forward**. The v2.12.0 tag itself checks out the old `Cross.toml`, so its aarch64 archive is backfilled separately from the locally-verified build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)