### PR TITLE
fix(ci): pass both email test filters to libtest, not cargo

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -634,7 +634,8 @@ func (m *FraiseqlCi) integrationPostgres(ctx context.Context, source *dagger.Dir
 		// poison-skip) + PG e2e (ingest-once / re-poll dedup / UIDVALIDITY reset / two-poller
 		// single-firing — the double-poll bug fix). The email test suite otherwise runs nowhere,
 		// so this is also its first Dagger coverage.
-		"cargo test -p fraiseql-server --features inbound-email --lib inbound::email::source inbound::email::sink -- --test-threads=1",
+		// Both filters go after `--`: cargo accepts a single TESTNAME, libtest ORs several.
+		"cargo test -p fraiseql-server --features inbound-email --lib -- inbound::email::source inbound::email::sink --test-threads=1",
 		// #573 source scheduler (Model B): the SourceQueryExecutor identity/tenant
 		// seam, the SourcePoller build_host composition (cursor round-trip vs PG +
 		// executor reachable via host.query), and the scheduler's schedulable/config


### PR DESCRIPTION
## Summary

The Dagger postgres integration leg has failed on **every dev push since the #573 Phase 07/08 merges** (2026-07-15 ~11:19). Cause: `.dagger/main.go` invoked

```
cargo test -p fraiseql-server --features inbound-email --lib inbound::email::source inbound::email::sink -- --test-threads=1
```

`cargo test` accepts a single positional `TESTNAME`; the second filter aborts with `error: unexpected argument 'inbound::email::sink' found` before any test runs. It was never caught pre-merge because the heavy integration legs only run on push to dev.

## Fix

Move both filters after `--` — libtest ORs multiple positional filters:

```
cargo test -p fraiseql-server --features inbound-email --lib -- inbound::email::source inbound::email::sink --test-threads=1
```

Grepped `.dagger/main.go` for the same pattern; this is the only occurrence.

## Verification
✅ Fixed command run locally against the test PG (fraiseql-573-pg): 8 tests (3 sink + 5 source), all pass, 1358 filtered out
✅ `gofmt -l` clean, `go build ./...` passes in `.dagger/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)