### PR TITLE
feat(subscriptions): fail-closed row-level visibility on the live /ws path (#596, phase 06b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Subscription row-level visibility on the live `/ws` path — fail-closed (#596).**
+  Previously any principal authorized to subscribe to an entity over `/ws`
+  (`graphql-transport-ws` / legacy `graphql-ws`) received **every** row's after-images:
+  the subscribe path passed empty RLS conditions, so the push path enforced no row
+  boundary the pull path (GraphQL queries) already did. An entity may now declare a
+  `subscription_policy` (`owner_path` / `identity_field` / `bypass_roles`) in the
+  compiled schema; at subscribe time the server derives a **server-owned** owner
+  condition from the connection's server-resolved enriched identity (#539, the
+  forge-proof `fraiseql.enriched.*` namespace — a client-supplied claim cannot widen
+  it) and enforces it on every delivered event. **Fail-closed:** a policy-declaring
+  subscription whose identity is unresolvable (no enrichment, denial, resolver outage,
+  or anonymous) is **refused at subscribe time**, never delivered unfiltered; a
+  `bypass_roles` role keeps full visibility; an entity with no policy is unchanged. The
+  legacy `graphql-ws` subprotocol routes through the same enforcement and cannot bypass
+  it. The single policy→condition derivation lives in `fraiseql-core` so the pull and
+  push paths consume the same semantics. See
+  `docs/architecture/enriched-identity-rls.md` ("The push path: subscription row
+  visibility").
+
+### Changed
+
+- **`fraiseql_core::runtime::extract_rls_conditions` is now fail-closed (`Result`).**
+  It previously silently dropped any clause shape it could not represent as a flat
+  `field = value` equality ("delivers more events, never fewer") — a deliver-all hole
+  when the conditions gate row visibility (#596). It now returns
+  `Result<Vec<(String, Value)>, String>` and **errors** on a non-`Eq` operator, `Or`,
+  `Not`, or native-column shape, so a caller deriving visibility conditions refuses the
+  subscription rather than widening it. (Public API change; no in-tree callers relied
+  on the fail-open behavior.)
+
 ### Added
 
 - **`fraiseql functions invoke` — a local V8 test harness for function authors.**

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -346,6 +346,7 @@ mod compile_tests {
                 is_error:            false,
                 relay:               false,
                 relationships:       Vec::new(),
+                subscription_policy: None,
             }],
             queries: vec![QueryDefinition {
                 name:                "users".to_string(),
@@ -704,6 +705,7 @@ mod compile_tests {
                 is_error:            false,
                 relay:               false,
                 relationships:       vec![],
+                subscription_policy: None,
             }],
             ..Default::default()
         };

--- a/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
@@ -217,6 +217,7 @@ fn synth_type(name: &str, fields: Vec<FieldDefinition>, desc: &str) -> TypeDefin
         is_error: false,
         relay: false,
         relationships: Vec::new(),
+        subscription_policy: None,
     }
 }
 

--- a/crates/fraiseql-cli/src/schema/converter/mutation_error_union.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mutation_error_union.rs
@@ -157,5 +157,6 @@ fn mutation_error_type() -> TypeDefinition {
         is_error:            true,
         relay:               false,
         relationships:       Vec::new(),
+        subscription_policy: None,
     }
 }

--- a/crates/fraiseql-cli/src/schema/converter/relay.rs
+++ b/crates/fraiseql-cli/src/schema/converter/relay.rs
@@ -112,6 +112,7 @@ pub(super) fn inject_relay_types(schema: &mut CompiledSchema) -> anyhow::Result<
             is_error:            false,
             relay:               false,
             relationships:       Vec::new(),
+            subscription_policy: None,
         };
         schema.types.push(page_info);
     }
@@ -176,6 +177,7 @@ pub(super) fn inject_relay_types(schema: &mut CompiledSchema) -> anyhow::Result<
                 is_error:            false,
                 relay:               false,
                 relationships:       Vec::new(),
+                subscription_policy: None,
             });
         }
 
@@ -214,6 +216,7 @@ pub(super) fn inject_relay_types(schema: &mut CompiledSchema) -> anyhow::Result<
                 is_error:            false,
                 relay:               false,
                 relationships:       Vec::new(),
+                subscription_policy: None,
             });
         }
     }

--- a/crates/fraiseql-cli/src/schema/converter/types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/types.rs
@@ -56,6 +56,7 @@ impl SchemaConverter {
             is_error: intermediate.is_error,
             relay: intermediate.relay,
             relationships: Vec::new(),
+            subscription_policy: None,
         })
     }
 

--- a/crates/fraiseql-cli/src/schema/tests.rs
+++ b/crates/fraiseql-cli/src/schema/tests.rs
@@ -175,6 +175,7 @@ mod database_validator_tests {
             is_error:            false,
             relay:               false,
             relationships:       Vec::new(),
+            subscription_policy: None,
         }
     }
 
@@ -1812,6 +1813,7 @@ mod optimizer_tests {
                 is_error:            false,
                 relay:               false,
                 relationships:       Vec::new(),
+                subscription_policy: None,
             }],
             enums: vec![],
             input_types: vec![],
@@ -1871,6 +1873,7 @@ mod optimizer_tests {
                 is_error:            false,
                 relay:               false,
                 relationships:       Vec::new(),
+                subscription_policy: None,
             }],
             enums: vec![],
             input_types: vec![],
@@ -1940,6 +1943,7 @@ mod optimizer_tests {
                 is_error:            false,
                 relay:               false,
                 relationships:       Vec::new(),
+                subscription_policy: None,
             }],
             enums: vec![],
             input_types: vec![],

--- a/crates/fraiseql-core/src/runtime/subscription/mod.rs
+++ b/crates/fraiseql-core/src/runtime/subscription/mod.rs
@@ -72,33 +72,38 @@ pub use webhook::{WebhookAdapter, WebhookPayload, WebhookTransportConfig};
 /// Backward-compatible type alias — use [`WebhookTransportConfig`] in new code.
 pub type WebhookConfig = WebhookTransportConfig;
 
-/// Extract `(field, value)` equality conditions from an RLS `WhereClause`.
+/// Extract `(field, value)` equality conditions from an RLS `WhereClause`,
+/// **fail-closed**.
 ///
-/// Walks the clause tree and collects all `Field { op: Eq }` nodes.
-/// `And` nodes are recursively flattened. Other clause types (nested `Or`,
-/// non-Eq operators) are ignored — they cannot be represented as simple
-/// field-value pairs and will not filter subscription events.
+/// Walks the clause tree and collects all `Field { op: Eq }` nodes; `And` nodes are
+/// recursively flattened. Any shape that **cannot** be represented as a simple
+/// `field == value` equality — a non-`Eq` operator, `Or`, `Not`, or a `NativeField`
+/// column condition — is a hard **error**, not a silent skip.
 ///
-/// The caller should evaluate the RLS policy at subscribe time and pass
-/// the result through this function to produce conditions for
-/// [`ActiveSubscription::with_rls_conditions`].
+/// This is a security property (#596). Subscription event delivery enforces each
+/// extracted condition against the event data (AND semantics); a condition that is
+/// *dropped* rather than *enforced* silently widens visibility — the subscriber
+/// receives rows the RLS clause was meant to hide. When these conditions derive from a
+/// row-visibility policy or an RLS clause, "deliver more, never fewer" is exactly the
+/// wrong default. So the caller evaluates the policy at subscribe time, passes the
+/// result here, and **refuses the subscription** (rather than delivering unfiltered)
+/// if any part cannot be enforced.
 ///
 /// # Errors
 ///
-/// This function is infallible — unsupported clause shapes are silently
-/// skipped, which is a safe default (fewer conditions = more events
-/// delivered, never fewer).
-#[must_use]
-pub fn extract_rls_conditions(clause: &crate::db::WhereClause) -> Vec<(String, serde_json::Value)> {
+/// Returns a description of the first unenforceable clause shape encountered.
+pub fn extract_rls_conditions(
+    clause: &crate::db::WhereClause,
+) -> Result<Vec<(String, serde_json::Value)>, String> {
     let mut conditions = Vec::new();
-    collect_eq_conditions(clause, &mut conditions);
-    conditions
+    collect_eq_conditions(clause, &mut conditions)?;
+    Ok(conditions)
 }
 
 fn collect_eq_conditions(
     clause: &crate::db::WhereClause,
     out: &mut Vec<(String, serde_json::Value)>,
-) {
+) -> Result<(), String> {
     use crate::db::{WhereClause, WhereOperator};
     match clause {
         WhereClause::Field {
@@ -110,16 +115,27 @@ fn collect_eq_conditions(
             if let Some(field) = path.last() {
                 out.push((field.clone(), value.clone()));
             }
+            Ok(())
         },
         WhereClause::And(clauses) => {
             for c in clauses {
-                collect_eq_conditions(c, out);
+                collect_eq_conditions(c, out)?;
             }
+            Ok(())
         },
-        _ => {
-            // Or, Not, non-Eq operators — cannot be represented as simple field-value pairs.
-            // Safe default: skip (delivers more events, never fewer).
-        },
+        WhereClause::Field { path, operator, .. } => Err(format!(
+            "row-visibility condition on `{}` uses operator `{operator:?}`; only `Eq` can be \
+             enforced on the pushed event stream — refusing the subscription rather than \
+             delivering unfiltered rows (#596)",
+            path.last().map_or("<field>", String::as_str),
+        )),
+        // `Or`, `Not`, and `NativeField` (a native-column condition that does not map to
+        // a JSONB event-data key) cannot be enforced as event-stream equality — refuse
+        // rather than silently widen.
+        _ => Err("row-visibility clause uses an `Or`/`Not`/native-column shape that cannot be \
+                  enforced as event-stream equality — refusing the subscription rather than \
+                  delivering unfiltered rows (#596)"
+            .to_string()),
     }
 }
 

--- a/crates/fraiseql-core/src/runtime/subscription/tests.rs
+++ b/crates/fraiseql-core/src/runtime/subscription/tests.rs
@@ -1090,18 +1090,20 @@ fn test_extract_rls_conditions_from_where_clause() {
         },
     ]);
 
-    let conditions = extract_rls_conditions(&clause);
+    let conditions = extract_rls_conditions(&clause).expect("an all-Eq And tree extracts cleanly");
     assert_eq!(conditions.len(), 2);
     assert_eq!(conditions[0], ("tenant_id".to_string(), serde_json::json!("abc")));
     assert_eq!(conditions[1], ("author_id".to_string(), serde_json::json!("user-1")));
 }
 
 #[test]
-fn test_extract_rls_conditions_ignores_non_eq() {
+fn test_extract_rls_conditions_refuses_non_eq_fail_closed() {
     use super::super::extract_rls_conditions;
     use crate::db::{WhereClause, WhereOperator};
 
-    // Only Eq conditions are extracted; Gt is skipped.
+    // A non-Eq operator cannot be enforced on the event stream. Fail-closed (#596):
+    // refuse rather than silently dropping the `score > 100` bound and delivering rows
+    // it was meant to hide.
     let clause = WhereClause::And(vec![
         WhereClause::Field {
             path:     vec!["tenant_id".to_string()],
@@ -1115,9 +1117,17 @@ fn test_extract_rls_conditions_ignores_non_eq() {
         },
     ]);
 
-    let conditions = extract_rls_conditions(&clause);
-    assert_eq!(conditions.len(), 1, "only Eq conditions should be extracted");
-    assert_eq!(conditions[0].0, "tenant_id");
+    let err = extract_rls_conditions(&clause)
+        .expect_err("a non-Eq condition must refuse, not silently widen");
+    assert!(err.contains("score"), "the error names the offending field: {err}");
+
+    // `Or` is likewise unenforceable as flat equality → refuse.
+    let or_clause = WhereClause::Or(vec![WhereClause::Field {
+        path:     vec!["tenant_id".to_string()],
+        operator: WhereOperator::Eq,
+        value:    serde_json::json!("abc"),
+    }]);
+    assert!(extract_rls_conditions(&or_clause).is_err(), "Or shape must refuse");
 }
 
 // ── C20: Subscription RBAC error variants ────────────────────────────────

--- a/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema_domain.rs
@@ -592,6 +592,15 @@ impl CompiledSchema {
             if !type_names.insert(type_def.name.as_str()) {
                 errors.push(format!("Duplicate type name: {}", type_def.name));
             }
+
+            // Validate a declared subscription row-visibility policy (#596): a malformed
+            // `owner_path`/`identity_field` is a load-time error, not a silent
+            // deliver-all at subscribe time.
+            if let Some(policy) = &type_def.subscription_policy {
+                if let Err(e) = policy.validate() {
+                    errors.push(format!("Type '{}': {e}", type_def.name));
+                }
+            }
         }
 
         // Check for duplicate query names

--- a/crates/fraiseql-core/src/schema/compiled/tests.rs
+++ b/crates/fraiseql-core/src/schema/compiled/tests.rs
@@ -344,6 +344,7 @@ fn make_type_def(name: &str) -> TypeDefinition {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
     }
 }
 

--- a/crates/fraiseql-core/src/schema/dependency_graph/tests.rs
+++ b/crates/fraiseql-core/src/schema/dependency_graph/tests.rs
@@ -23,6 +23,7 @@ fn make_type(name: &str, fields: Vec<(&str, FieldType)>) -> TypeDefinition {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
     }
 }
 
@@ -432,6 +433,7 @@ fn test_interface_dependencies() {
             is_error:            false,
             relay:               false,
             relationships:       vec![],
+            subscription_policy: None,
         }],
         interfaces: vec![InterfaceDefinition {
             name:        "Node".to_string(),

--- a/crates/fraiseql-core/src/schema/graphql_type_defs.rs
+++ b/crates/fraiseql-core/src/schema/graphql_type_defs.rs
@@ -99,6 +99,16 @@ pub struct TypeDefinition {
     /// Relationships to other types (used by REST resource embedding).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub relationships: Vec<super::config_types::Relationship>,
+
+    /// Row-level visibility policy for subscription delivery (#596).
+    ///
+    /// When set, a subscription whose events carry this type's after-images derives a
+    /// server-owned owner condition from the connection's enriched identity at subscribe
+    /// time (see [`SubscriptionPolicy`](super::SubscriptionPolicy)). Fail-closed:
+    /// declaring the policy but being unable to resolve the identity refuses the
+    /// subscription rather than delivering every row. `None` keeps today's behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subscription_policy: Option<super::SubscriptionPolicy>,
 }
 
 pub(super) fn default_jsonb_column() -> String {
@@ -121,7 +131,15 @@ impl TypeDefinition {
             is_error:            false,
             relay:               false,
             relationships:       Vec::new(),
+            subscription_policy: None,
         }
+    }
+
+    /// Set the subscription row-visibility policy (#596).
+    #[must_use]
+    pub fn with_subscription_policy(mut self, policy: super::SubscriptionPolicy) -> Self {
+        self.subscription_policy = Some(policy);
+        self
     }
 
     /// Add a field to this type.

--- a/crates/fraiseql-core/src/schema/introspection/tests.rs
+++ b/crates/fraiseql-core/src/schema/introspection/tests.rs
@@ -227,6 +227,7 @@ fn test_deprecated_field_introspection() {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
         fields:              vec![
             FieldDefinition::new("id", FieldType::Id),
             FieldDefinition {
@@ -482,6 +483,7 @@ fn test_interface_introspection() {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
         fields:              vec![
             FieldDefinition::new("id", FieldType::Id),
             FieldDefinition::new("name", FieldType::String),
@@ -499,6 +501,7 @@ fn test_interface_introspection() {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
         fields:              vec![
             FieldDefinition::new("id", FieldType::Id),
             FieldDefinition::new("title", FieldType::String),
@@ -564,6 +567,7 @@ fn test_type_implements_interface() {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
         fields:              vec![
             FieldDefinition::new("id", FieldType::Id),
             FieldDefinition::new("createdAt", FieldType::DateTime),

--- a/crates/fraiseql-core/src/schema/mod.rs
+++ b/crates/fraiseql-core/src/schema/mod.rs
@@ -59,6 +59,7 @@ pub mod security_config;
 mod source_probe;
 mod source_types;
 mod subscribable_ddl;
+mod subscription_policy;
 mod subscription_types;
 
 pub use changelog::inject_changelog;
@@ -99,6 +100,7 @@ pub use security_config::{
 pub use source_probe::{SourceKind, SourceProbe, sql_source_probes};
 pub use source_types::{RunAs, SourceDefinition};
 pub use subscribable_ddl::generate_capture_trigger_ddl;
+pub use subscription_policy::{OwnerCondition, SubscriptionPolicy};
 pub use subscription_types::{
     FilterOperator, StaticFilterCondition, SubscriptionDefinition, SubscriptionFilter,
 };

--- a/crates/fraiseql-core/src/schema/subscription_policy.rs
+++ b/crates/fraiseql-core/src/schema/subscription_policy.rs
@@ -1,0 +1,144 @@
+//! Row-level visibility policy for subscription delivery (#596).
+//!
+//! The pull path (GraphQL queries) enforces per-row RLS; historically the push paths
+//! (subscriptions) did not — any principal authorized to subscribe to an entity
+//! received **every** row's after-images. A [`SubscriptionPolicy`] closes that: at
+//! subscribe time it derives a **server-owned** owner condition from the connection's
+//! enriched identity (#539, the forge-proof `fraiseql.enriched.*` namespace), so a
+//! scoped subscriber only receives rows it owns.
+//!
+//! # One derivation, two seams
+//!
+//! [`SubscriptionPolicy::derive`] returns a seam-neutral [`OwnerCondition`]. Both push
+//! seams are thin adapters over this single function:
+//! - the graphql `/ws` path maps [`OwnerCondition::Eq`] to a `(field, value)` RLS condition on
+//!   `subscribe_with_rls`;
+//! - the realtime entity-stream maps it to a server-owned equality `FieldFilter`.
+//!
+//! Keeping the semantics (owner-path resolution, `bypass_roles`, unresolvable-identity
+//! refusal) in *one* place is a security property: if the two seams grew their own
+//! interpretations they would drift, and a divergence — e.g. `bypass_roles` honored on
+//! one path but not the other — is itself a visibility bypass.
+//!
+//! It is **fail-closed for declaring entities**: a policy present but the identity field
+//! unresolvable (no enrichment configured, NULL/absent field) yields
+//! [`OwnerCondition::Refuse`], which the seam turns into a refused subscription rather
+//! than delivering everything.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::security::ENRICHED_NAMESPACE_PREFIX;
+
+/// An entity's row-visibility policy for subscription delivery (#596).
+///
+/// Declared per entity in the compiled schema
+/// ([`TypeDefinition::subscription_policy`](super::TypeDefinition)):
+///
+/// ```jsonc
+/// "subscription_policy": {
+///   "owner_path": "$.owner_id",      // single-level path into the after-image
+///   "identity_field": "user_id",     // the fraiseql.enriched.* field (#539)
+///   "bypass_roles": ["admin"]        // roles that get full visibility
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionPolicy {
+    /// The single-level JSON path into the after-image holding the owner id
+    /// (e.g. `"$.owner_id"`). Only `$.<field>` is supported — the delivery matchers
+    /// key on a flat field name.
+    pub owner_path:     String,
+    /// The enriched-identity field (in the `fraiseql.enriched.*` namespace, #539)
+    /// whose value the owner must equal (e.g. `"user_id"`).
+    pub identity_field: String,
+    /// Roles that bypass the policy entirely (full visibility, e.g. `["admin"]`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bypass_roles:   Vec<String>,
+}
+
+/// The server-owned owner condition derived for one subscribe request — seam-neutral.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OwnerCondition {
+    /// The principal holds a bypass role — full visibility, no added condition.
+    Bypass,
+    /// A server-owned equality condition: the principal sees only rows where
+    /// `field == value`.
+    Eq {
+        /// The flat owner field name (the delivery matcher keys on it).
+        field: String,
+        /// The principal's server-resolved identity value.
+        value: Value,
+    },
+    /// **Fail-closed**: the policy applies but the enriched identity is unresolvable
+    /// (no enrichment configured, or a NULL/absent field) — refuse the subscription.
+    Refuse(String),
+}
+
+impl SubscriptionPolicy {
+    /// The flat owner field name the delivery matchers key on — `owner_path` with a
+    /// leading `$.` stripped.
+    #[must_use]
+    pub fn owner_field(&self) -> &str {
+        self.owner_path.trim_start_matches("$.")
+    }
+
+    /// Validate the policy at load time.
+    ///
+    /// # Errors
+    ///
+    /// - `owner_path` is empty or a nested path (only single-level `$.<field>`).
+    /// - `identity_field` is empty.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.identity_field.is_empty() {
+            return Err("subscription_policy.identity_field must not be empty".to_string());
+        }
+        let field = self.owner_field();
+        if field.is_empty() {
+            return Err("subscription_policy.owner_path must name a field (e.g. \"$.owner_id\")"
+                .to_string());
+        }
+        if field.contains('.') || field.contains('[') {
+            return Err(format!(
+                "subscription_policy.owner_path `{}` must be a single-level `$.<field>` — nested \
+                 paths are not supported by the delivery matchers",
+                self.owner_path
+            ));
+        }
+        Ok(())
+    }
+
+    /// Derive the owner condition for a connection whose enriched identity is in
+    /// `attributes` and whose roles are `roles` (#596). Bypass role →
+    /// [`Bypass`](OwnerCondition::Bypass); a resolvable identity →
+    /// [`Eq`](OwnerCondition::Eq); otherwise **fail-closed**
+    /// [`Refuse`](OwnerCondition::Refuse).
+    ///
+    /// The identity value is read **only** from the server-resolved
+    /// `fraiseql.enriched.*` namespace — the #539 resolver strips any inbound
+    /// `fraiseql.*` claims, so a client-supplied plain attribute cannot widen
+    /// visibility.
+    #[must_use]
+    pub fn derive(&self, attributes: &HashMap<String, Value>, roles: &[String]) -> OwnerCondition {
+        if self.bypass_roles.iter().any(|bypass| roles.iter().any(|role| role == bypass)) {
+            return OwnerCondition::Bypass;
+        }
+        let key = format!("{ENRICHED_NAMESPACE_PREFIX}{}", self.identity_field);
+        match attributes.get(&key) {
+            Some(value) if !value.is_null() => OwnerCondition::Eq {
+                field: self.owner_field().to_string(),
+                value: value.clone(),
+            },
+            _ => OwnerCondition::Refuse(format!(
+                "subscription refused (fail-closed): enriched identity field `{}` is unresolvable \
+                 — configure `[identity.enrichment]` so the owner boundary can be derived",
+                self.identity_field
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-core/src/schema/subscription_policy/tests.rs
+++ b/crates/fraiseql-core/src/schema/subscription_policy/tests.rs
@@ -1,0 +1,94 @@
+//! Tests for the #596 subscription-policy owner-condition derivation — the
+//! security-critical decision logic (bypass / fail-closed refuse / owner eq).
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test module
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use super::{OwnerCondition, SubscriptionPolicy};
+use crate::security::ENRICHED_NAMESPACE_PREFIX;
+
+fn policy() -> SubscriptionPolicy {
+    SubscriptionPolicy {
+        owner_path:     "$.owner_id".to_string(),
+        identity_field: "user_id".to_string(),
+        bypass_roles:   vec!["admin".to_string()],
+    }
+}
+
+/// Attributes carrying one server-resolved enriched field.
+fn enriched(field: &str, value: Value) -> HashMap<String, Value> {
+    let mut m = HashMap::new();
+    m.insert(format!("{ENRICHED_NAMESPACE_PREFIX}{field}"), value);
+    m
+}
+
+#[test]
+fn resolved_identity_yields_an_owner_eq_condition() {
+    let attrs = enriched("user_id", serde_json::json!("alice"));
+    match policy().derive(&attrs, &[]) {
+        OwnerCondition::Eq { field, value } => {
+            assert_eq!(field, "owner_id");
+            assert_eq!(value, serde_json::json!("alice"));
+        },
+        other => panic!("expected an owner eq condition, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_bypass_role_grants_full_visibility() {
+    let attrs = enriched("user_id", serde_json::json!("alice"));
+    let roles = vec!["admin".to_string()];
+    assert!(matches!(policy().derive(&attrs, &roles), OwnerCondition::Bypass));
+}
+
+#[test]
+fn unresolvable_identity_refuses_fail_closed() {
+    // No enrichment configured at all → refuse (not deliver-all).
+    assert!(matches!(policy().derive(&HashMap::new(), &[]), OwnerCondition::Refuse(_)));
+
+    // Enrichment present but the specific field is NULL → refuse.
+    let null_field = enriched("user_id", Value::Null);
+    assert!(matches!(policy().derive(&null_field, &[]), OwnerCondition::Refuse(_)));
+
+    // A DIFFERENT enriched field present, but not the one the policy names → refuse.
+    let wrong_field = enriched("tenant", serde_json::json!("acme"));
+    assert!(matches!(policy().derive(&wrong_field, &[]), OwnerCondition::Refuse(_)));
+}
+
+#[test]
+fn inbound_forged_attribute_cannot_widen_visibility() {
+    // The identity value is read ONLY from the server-resolved enriched namespace.
+    // A client that stuffs a plain `user_id` attribute (not the enriched key) does not
+    // influence the derivation — still fail-closed.
+    let mut attrs = HashMap::new();
+    attrs.insert("user_id".to_string(), serde_json::json!("mallory"));
+    assert!(
+        matches!(policy().derive(&attrs, &[]), OwnerCondition::Refuse(_)),
+        "a non-enriched (forgeable) attribute must not resolve the owner identity"
+    );
+}
+
+#[test]
+fn validate_rejects_nested_or_empty_paths() {
+    assert!(policy().validate().is_ok());
+
+    let nested = SubscriptionPolicy {
+        owner_path: "$.a.b".to_string(),
+        ..policy()
+    };
+    assert!(nested.validate().is_err(), "nested paths unsupported");
+
+    let empty_field = SubscriptionPolicy {
+        identity_field: String::new(),
+        ..policy()
+    };
+    assert!(empty_field.validate().is_err());
+
+    let empty_path = SubscriptionPolicy {
+        owner_path: "$.".to_string(),
+        ..policy()
+    };
+    assert!(empty_path.validate().is_err());
+}

--- a/crates/fraiseql-core/tests/security/e2e_field_rbac_pipeline.rs
+++ b/crates/fraiseql-core/tests/security/e2e_field_rbac_pipeline.rs
@@ -142,6 +142,7 @@ fn create_user_type_with_scopes() -> TypeDefinition {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
     }
 }
 

--- a/crates/fraiseql-core/tests/security/integration_executor_field_rbac.rs
+++ b/crates/fraiseql-core/tests/security/integration_executor_field_rbac.rs
@@ -118,6 +118,7 @@ fn create_post_type_with_scopes() -> TypeDefinition {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
     }
 }
 

--- a/crates/fraiseql-core/tests/security/integration_field_rbac_errors.rs
+++ b/crates/fraiseql-core/tests/security/integration_field_rbac_errors.rs
@@ -132,6 +132,7 @@ fn create_schema_with_mixed_fields() -> CompiledSchema {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
     };
 
     let mut security_config = SecurityConfig::new();

--- a/crates/fraiseql-core/tests/security/integration_field_rbac_runtime.rs
+++ b/crates/fraiseql-core/tests/security/integration_field_rbac_runtime.rs
@@ -90,6 +90,7 @@ fn create_schema_with_scoped_fields() -> CompiledSchema {
         is_error:            false,
         relay:               false,
         relationships:       vec![],
+        subscription_policy: None,
     };
 
     let mut security_config = SecurityConfig::new();

--- a/crates/fraiseql-server/src/routes/subscriptions.rs
+++ b/crates/fraiseql-server/src/routes/subscriptions.rs
@@ -48,6 +48,7 @@ use fraiseql_core::{
             SubscribePayload,
         },
     },
+    schema::{CompiledSchema, OwnerCondition, SubscriptionPolicy},
     security::{Authorizer, OperationKind, SecurityContext, authorizer::enforce_authz},
 };
 use futures::{SinkExt, StreamExt};
@@ -142,6 +143,19 @@ pub struct SubscriptionState {
     /// delivery to a connection whose tenant is suspended is paused. `None` until
     /// a host binary installs a multi-tenant registry.
     pub tenant_status_source: Option<Arc<dyn TenantStatusSource>>,
+    /// Per-subscription-field row-visibility policies (#596), keyed by subscription
+    /// field name, resolved at mount time from the target entity's compiled
+    /// `subscription_policy`. A subscription named here derives a **server-owned** owner
+    /// condition from the connection's enriched identity at subscribe time — fail-closed
+    /// when the identity is unresolvable. A subscription with no policy keeps today's
+    /// behavior (no back-compat break).
+    pub subscription_policies: Arc<HashMap<String, SubscriptionPolicy>>,
+    /// Enriched-identity resolver (#539). When set, the connection's `SecurityContext`
+    /// is enriched at subscribe time (only for policy-declaring subscriptions) so the
+    /// `fraiseql.enriched.*` owner field is server-resolved, never client-asserted.
+    /// `None` disables enrichment — a policy-declaring subscription then fails closed.
+    #[cfg(feature = "auth")]
+    pub identity_resolver: Option<Arc<crate::identity::IdentityResolver>>,
 }
 
 impl SubscriptionState {
@@ -156,7 +170,34 @@ impl SubscriptionState {
             strict_tenant_validation: false,
             authorizer: None,
             tenant_status_source: None,
+            subscription_policies: Arc::new(HashMap::new()),
+            #[cfg(feature = "auth")]
+            identity_resolver: None,
         }
+    }
+
+    /// Install the per-subscription row-visibility policies (#596). Typically built by
+    /// [`build_subscription_policies`] from the compiled schema at mount time.
+    #[must_use]
+    pub fn with_subscription_policies(
+        mut self,
+        policies: Arc<HashMap<String, SubscriptionPolicy>>,
+    ) -> Self {
+        self.subscription_policies = policies;
+        self
+    }
+
+    /// Install the enriched-identity resolver (#539) used to derive row-visibility owner
+    /// boundaries at subscribe time. `None` leaves policy-declaring subscriptions
+    /// fail-closed (refused).
+    #[cfg(feature = "auth")]
+    #[must_use]
+    pub fn with_identity_resolver(
+        mut self,
+        resolver: Option<Arc<crate::identity::IdentityResolver>>,
+    ) -> Self {
+        self.identity_resolver = resolver;
+        self
     }
 
     /// Install the tenant-status source (M-tenant-ws-suspended). When set, new
@@ -219,6 +260,89 @@ impl SubscriptionState {
     pub fn with_remote_subscription_fields(mut self, fields: HashMap<String, String>) -> Self {
         self.remote_subscription_fields = Arc::new(fields);
         self
+    }
+}
+
+/// Build the per-subscription row-visibility policy map (#596) from the compiled schema.
+///
+/// For each subscription field, resolve its target entity's `subscription_policy` (if
+/// any) and key it by the subscription field name. The `/ws` handler consults this map
+/// at subscribe time; an entry means "derive a server-owned owner condition and refuse
+/// if the identity is unresolvable", absence means "unchanged behavior".
+#[must_use]
+pub fn build_subscription_policies(schema: &CompiledSchema) -> HashMap<String, SubscriptionPolicy> {
+    let mut policies = HashMap::new();
+    for sub in &schema.subscriptions {
+        if let Some(type_def) = schema.types.iter().find(|t| t.name.as_str() == sub.return_type) {
+            if let Some(policy) = &type_def.subscription_policy {
+                policies.insert(sub.name.clone(), policy.clone());
+            }
+        }
+    }
+    policies
+}
+
+/// Resolve the server-owned RLS conditions to enforce for a subscribe request (#596).
+///
+/// - `Ok(vec![])` — the subscription declares no policy (back-compat) **or** the principal holds a
+///   bypass role (full visibility);
+/// - `Ok(vec![(owner_field, identity_value)])` — a scoped subscriber sees only its rows;
+/// - `Err(reason)` — the policy applies but the identity is unresolvable; the caller **refuses**
+///   the subscription (fail-closed, never deliver-all).
+async fn resolve_subscription_rls(
+    state: &SubscriptionState,
+    subscription_name: &str,
+    principal: Option<&SecurityContext>,
+) -> Result<Vec<(String, serde_json::Value)>, String> {
+    let Some(policy) = state.subscription_policies.get(subscription_name) else {
+        return Ok(Vec::new());
+    };
+
+    // Enrich a copy of the principal so the owner boundary derives from the
+    // server-resolved `fraiseql.enriched.*` namespace, never a client claim. A failed
+    // or absent enrichment leaves the enriched field unresolvable → the derivation
+    // refuses below (fail-closed). Enrichment runs only for policy-declaring
+    // subscriptions, so unscoped streams pay nothing.
+    #[cfg(feature = "auth")]
+    let enriched = enrich_principal(state, principal).await;
+    #[cfg(feature = "auth")]
+    let effective = enriched.as_ref().or(principal);
+    #[cfg(not(feature = "auth"))]
+    let effective = principal;
+
+    derive_policy_conditions(policy, effective)
+}
+
+/// Enrich a clone of the principal's `SecurityContext` (#539). Best-effort: on a denial
+/// or resolver outage the enriched fields are simply absent, so a policy-declaring
+/// subscription fails closed at derivation. Returns `None` when there is no principal
+/// or no resolver configured.
+#[cfg(feature = "auth")]
+async fn enrich_principal(
+    state: &SubscriptionState,
+    principal: Option<&SecurityContext>,
+) -> Option<SecurityContext> {
+    let resolver = state.identity_resolver.as_ref()?;
+    let mut ctx = principal?.clone();
+    let _ = crate::identity::enrich_security_context(resolver, &mut ctx).await;
+    Some(ctx)
+}
+
+/// Adapt a policy's seam-neutral [`OwnerCondition`] to the `/ws` seam's `(field, value)`
+/// condition channel (#596). Fail-closed: `Refuse` → `Err`. A `None` principal (or one
+/// lacking the enriched field) derives to `Refuse`, so anonymous subscribers cannot see
+/// a policy-scoped entity's rows.
+fn derive_policy_conditions(
+    policy: &SubscriptionPolicy,
+    principal: Option<&SecurityContext>,
+) -> Result<Vec<(String, serde_json::Value)>, String> {
+    let empty = HashMap::new();
+    let attributes = principal.map_or(&empty, |ctx| &ctx.attributes);
+    let roles: &[String] = principal.map_or(&[], |ctx| ctx.roles.as_slice());
+    match policy.derive(attributes, roles) {
+        OwnerCondition::Bypass => Ok(Vec::new()),
+        OwnerCondition::Eq { field, value } => Ok(vec![(field, value)]),
+        OwnerCondition::Refuse(reason) => Err(reason),
     }
 }
 
@@ -816,18 +940,51 @@ async fn handle_client_message(
                 }
             }
 
+            // #596: derive the server-owned row-visibility condition for this
+            // subscription from the target entity's `subscription_policy`. Fail-closed —
+            // a policy that applies but whose identity is unresolvable refuses the
+            // subscription rather than falling back to delivering every row.
+            let rls_conditions = match resolve_subscription_rls(
+                state,
+                &subscription_name,
+                principal,
+            )
+            .await
+            {
+                Ok(conditions) => conditions,
+                Err(reason) => {
+                    WS_SUBSCRIPTIONS_REJECTED.fetch_add(1, Ordering::Relaxed);
+                    warn!(
+                        connection_id = %connection_id,
+                        subscription = %subscription_name,
+                        "Row-visibility policy refused the subscription (fail-closed)"
+                    );
+                    let error = ServerMessage::error(
+                        &op_id,
+                        vec![GraphQLError::with_code(reason, "SUBSCRIPTION_REFUSED")],
+                    );
+                    if let Err(send_err) = send_server_message(codec, sender, error).await {
+                        debug!(connection_id = %connection_id, error = %send_err, "Could not send row-visibility refusal to client");
+                    }
+                    return Ok(());
+                },
+            };
+
             // Build context with server-resolved tenant_id
             let mut context = serde_json::json!({});
             if let Some(tid) = tenant_id {
                 context["tenant_id"] = serde_json::Value::String(tid.to_string());
             }
 
-            // Subscribe locally (field is owned by this subgraph)
-            match state.manager.subscribe(
+            // Subscribe locally (field is owned by this subgraph). The server-owned
+            // `rls_conditions` (#596) are enforced on every delivered event (AND
+            // semantics) and cannot be overridden by client-supplied variables/filters.
+            match state.manager.subscribe_with_rls(
                 &subscription_name,
                 context,
                 variables_value,
                 connection_id,
+                rls_conditions,
             ) {
                 Ok(sub_id) => {
                     active_operations.insert(op_id.clone(), sub_id);

--- a/crates/fraiseql-server/src/routes/subscriptions/tests.rs
+++ b/crates/fraiseql-server/src/routes/subscriptions/tests.rs
@@ -103,6 +103,124 @@ fn no_tenant_sources_resolves_to_none() {
     assert!(resolved.is_none());
 }
 
+/// Row-level visibility policy derivation on the `/ws` seam (#596). Exercises the
+/// security-critical adapter (`derive_policy_conditions`) and the mount-time policy-map
+/// builder (`build_subscription_policies`) directly — the same enforcement point both
+/// WS subprotocols route through in `handle_client_message`.
+mod row_visibility_596 {
+    use fraiseql_core::{
+        schema::{SubscriptionDefinition, SubscriptionPolicy, TypeDefinition},
+        security::ENRICHED_NAMESPACE_PREFIX,
+    };
+
+    use super::{
+        super::{build_subscription_policies, derive_policy_conditions},
+        *,
+    };
+
+    fn policy() -> SubscriptionPolicy {
+        SubscriptionPolicy {
+            owner_path:     "$.owner_id".to_string(),
+            identity_field: "user_id".to_string(),
+            bypass_roles:   vec!["admin".to_string()],
+        }
+    }
+
+    /// A `SecurityContext` for user `sub`, with optional server-resolved enriched fields
+    /// and roles.
+    fn principal(sub: &str, enriched: &[(&str, &str)], roles: &[&str]) -> SecurityContext {
+        let mut attributes = HashMap::new();
+        for (field, value) in enriched {
+            attributes.insert(
+                format!("{ENRICHED_NAMESPACE_PREFIX}{field}"),
+                serde_json::Value::String((*value).to_string()),
+            );
+        }
+        SecurityContext {
+            user_id: UserId::new(sub),
+            roles: roles.iter().map(|r| (*r).to_string()).collect(),
+            tenant_id: None,
+            scopes: vec![],
+            attributes,
+            request_id: "req-596".to_string(),
+            ip_address: None,
+            authenticated_at: Utc::now(),
+            expires_at: Utc::now(),
+            issuer: None,
+            audience: None,
+            email: None,
+            display_name: None,
+        }
+    }
+
+    #[test]
+    fn resolvable_identity_yields_a_server_owned_owner_condition() {
+        let ctx = principal("alice", &[("user_id", "alice")], &[]);
+        let conds =
+            derive_policy_conditions(&policy(), Some(&ctx)).expect("resolvable → conditions");
+        assert_eq!(conds, vec![("owner_id".to_string(), serde_json::json!("alice"))]);
+    }
+
+    #[test]
+    fn bypass_role_gets_full_visibility_no_condition() {
+        let ctx = principal("root", &[("user_id", "root")], &["admin"]);
+        let conds = derive_policy_conditions(&policy(), Some(&ctx)).expect("bypass → ok");
+        assert!(conds.is_empty(), "a bypass role adds no owner condition (full visibility)");
+    }
+
+    #[test]
+    fn anonymous_subscriber_is_refused_fail_closed() {
+        // No principal at all → cannot resolve the owner → refuse (never deliver-all).
+        assert!(
+            derive_policy_conditions(&policy(), None).is_err(),
+            "an anonymous subscriber must be refused for a policy-declaring entity"
+        );
+    }
+
+    #[test]
+    fn enrichment_outage_or_missing_field_is_refused_fail_closed() {
+        // Authenticated principal, but enrichment produced no `user_id` field (outage,
+        // denial, or NULL) → refuse rather than deliver every row.
+        let ctx = principal("alice", &[], &[]);
+        assert!(
+            derive_policy_conditions(&policy(), Some(&ctx)).is_err(),
+            "an unresolvable enriched identity must refuse the subscription"
+        );
+    }
+
+    #[test]
+    fn forged_plain_attribute_cannot_widen_visibility() {
+        // A client that smuggles a plain (non-enriched) `user_id` attribute must not
+        // resolve the owner — the derivation reads ONLY the server-resolved
+        // `fraiseql.enriched.*` namespace.
+        let mut ctx = principal("mallory", &[], &[]);
+        ctx.attributes.insert("user_id".to_string(), serde_json::json!("victim"));
+        assert!(
+            derive_policy_conditions(&policy(), Some(&ctx)).is_err(),
+            "a forgeable plain attribute must not resolve the owner identity"
+        );
+    }
+
+    #[test]
+    fn build_map_keys_policies_by_subscription_field() {
+        let schema = CompiledSchema {
+            types: vec![
+                TypeDefinition::new("Order", "v_order").with_subscription_policy(policy()),
+                TypeDefinition::new("Ping", "v_ping"), // no policy
+            ],
+            subscriptions: vec![
+                SubscriptionDefinition::new("orderUpdated", "Order"),
+                SubscriptionDefinition::new("pinged", "Ping"),
+            ],
+            ..Default::default()
+        };
+        let map = build_subscription_policies(&schema);
+        assert!(map.contains_key("orderUpdated"), "policy-declaring entity is mapped");
+        assert!(!map.contains_key("pinged"), "an entity without a policy is not mapped");
+        assert_eq!(map.len(), 1);
+    }
+}
+
 /// `create_next_message` wire-contract (#425): the Change-Spine envelope rides in
 /// the graphql-transport-ws `extensions.changeSpine` slot, leaving `data` untouched;
 /// events without an envelope keep the plain payload.

--- a/crates/fraiseql-server/src/server/routing/admin.rs
+++ b/crates/fraiseql-server/src/server/routing/admin.rs
@@ -300,13 +300,21 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         // validation from the schema's RLS configuration (#331).
         let strict_tenant_validation = self.executor.schema().has_rls_configured();
 
-        #[allow(unused_mut)] // Reason: `mut` is needed when the federation feature is enabled
+        // #596: row-level visibility policies, resolved once from the compiled schema.
+        let subscription_policies = Arc::new(
+            crate::routes::subscriptions::build_subscription_policies(self.executor.schema()),
+        );
+
+        #[allow(unused_mut)]
+        // Reason: `mut` is needed when the federation/auth features are enabled
         let mut subscription_state = SubscriptionState::new(self.subscription_manager.clone())
             .with_lifecycle(self.subscription_lifecycle.clone())
             .with_max_subscriptions(self.max_subscriptions_per_connection)
             .with_tenant_context(state.domain_registry().clone(), strict_tenant_validation)
             // #422: enforce the operation-level authorizer (if any) at subscribe-time.
             .with_authorizer(self.executor.config().authorizer.clone())
+            // #596: server-owned row-visibility policies (fail-closed at subscribe time).
+            .with_subscription_policies(subscription_policies)
             // M-tenant-ws-suspended: reject subscribes / pause delivery for a
             // suspended tenant, mirroring the GraphQL data plane's 503.
             .with_tenant_status_source(
@@ -314,6 +322,15 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                     .tenant_registry()
                     .map(|r| Arc::clone(r) as Arc<dyn crate::routes::graphql::TenantStatusSource>),
             );
+
+        // #596/#539: hand the subscription path the enriched-identity resolver so a
+        // policy-declaring subscription derives its owner boundary server-side. Mirrors
+        // the GraphQL handler's `AppState.identity_resolver`.
+        #[cfg(feature = "auth")]
+        {
+            subscription_state =
+                subscription_state.with_identity_resolver(state.identity_resolver.clone());
+        }
 
         #[cfg(feature = "federation")]
         if !remote_sub_fields.is_empty() {

--- a/crates/fraiseql-server/tests/graphql_ws_row_visibility_pin_test.rs
+++ b/crates/fraiseql-server/tests/graphql_ws_row_visibility_pin_test.rs
@@ -1,0 +1,269 @@
+//! Row-level visibility conformance for the **live** graphql `/ws` path (#596, phase 06b).
+//!
+//! Drives the production `subscription_handler` over a real TCP `WebSocket` (the same
+//! harness as `subscription_ws_e2e_test.rs`). Proves the fix that closed the deliver-all
+//! gap the phase-00 characterization pinned:
+//!
+//! - a subscription to a **policy-declaring** entity whose owner identity is **unresolvable**
+//!   (here: an anonymous connection, no enriched `fraiseql.enriched.*` field) is **refused at
+//!   subscribe time** — it never registers and never delivers a row (fail-closed);
+//! - the **legacy `graphql-ws`** subprotocol cannot bypass the enforcement (same refusal), because
+//!   the derivation lives in the protocol-agnostic message handler;
+//! - a subscription to an entity with **no policy** still registers (no back-compat break).
+//!
+//! Owner-equality filtering for a *resolvable* identity (A sees only A's rows), bypass
+//! roles, and forged-attribute refusal are unit-tested against the derivation adapter in
+//! `routes/subscriptions/tests.rs` (they need an enriched `SecurityContext`, which the
+//! anonymous e2e path deliberately does not carry); the delivery mechanism itself — a
+//! server-owned owner condition filtering foreign rows — is asserted here at the manager
+//! level in `manager_mechanism`.
+
+#![allow(clippy::unwrap_used, clippy::missing_panics_doc)] // Reason: test code
+
+use std::sync::Arc;
+
+use fraiseql_core::{
+    runtime::subscription::SubscriptionManager,
+    schema::{CompiledSchema, SubscriptionDefinition, SubscriptionPolicy, TypeDefinition},
+};
+use fraiseql_server::routes::subscriptions::{
+    SubscriptionState, build_subscription_policies, subscription_handler,
+};
+use futures::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{self, client::IntoClientRequest},
+};
+
+type WsSink = futures::stream::SplitSink<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    tungstenite::Message,
+>;
+type WsStream = futures::stream::SplitStream<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+>;
+
+/// A single-tenant schema whose `Order` entity declares an owner row policy, plus a
+/// `Ping` entity with none.
+fn policy_schema() -> CompiledSchema {
+    let mut schema = CompiledSchema::new();
+    schema
+        .types
+        .push(TypeDefinition::new("Order", "v_order").with_subscription_policy(
+            SubscriptionPolicy {
+                owner_path:     "$.owner_id".to_string(),
+                identity_field: "user_id".to_string(),
+                bypass_roles:   vec![],
+            },
+        ));
+    schema.types.push(TypeDefinition::new("Ping", "v_ping"));
+    schema.subscriptions.push(SubscriptionDefinition::new("orderCreated", "Order"));
+    schema.subscriptions.push(SubscriptionDefinition::new("pinged", "Ping"));
+    schema
+}
+
+/// Spawn an axum server exposing only `/ws` → `subscription_handler`; return its URL.
+async fn spawn_ws_server(state: SubscriptionState) -> String {
+    let app = axum::Router::new()
+        .route("/ws", axum::routing::get(subscription_handler))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("ws://{addr}/ws")
+}
+
+/// Connect with an optional `Sec-WebSocket-Protocol` (None → default transport-ws).
+async fn connect(url: &str, subprotocol: Option<&str>) -> (WsSink, WsStream) {
+    let mut request = url.into_client_request().unwrap();
+    if let Some(proto) = subprotocol {
+        request.headers_mut().insert(
+            "sec-websocket-protocol",
+            tungstenite::http::HeaderValue::from_str(proto).unwrap(),
+        );
+    }
+    let (ws_stream, _) = connect_async(request).await.expect("WebSocket connect failed");
+    ws_stream.split()
+}
+
+async fn send_json(ws: &mut WsSink, value: serde_json::Value) {
+    ws.send(tungstenite::Message::Text(serde_json::to_string(&value).unwrap().into()))
+        .await
+        .unwrap();
+}
+
+/// Receive the next control/data frame, skipping keepalives (`ping` for transport-ws,
+/// `ka` for legacy graphql-ws).
+async fn recv_json(ws: &mut WsStream) -> serde_json::Value {
+    loop {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+            .await
+            .expect("timed out")
+            .expect("stream ended")
+            .expect("ws error");
+        if let tungstenite::Message::Text(text) = msg {
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            // Skip keepalives (`ping` for transport-ws, `ka` for legacy graphql-ws).
+            let kind = value.get("type").and_then(|t| t.as_str());
+            if kind != Some("ping") && kind != Some("ka") {
+                return value;
+            }
+        }
+    }
+}
+
+fn policy_state() -> (Arc<SubscriptionManager>, SubscriptionState) {
+    let schema = policy_schema();
+    let policies = Arc::new(build_subscription_policies(&schema));
+    let manager = Arc::new(SubscriptionManager::new(Arc::new(schema)));
+    let state = SubscriptionState::new(manager.clone()).with_subscription_policies(policies);
+    (manager, state)
+}
+
+/// A policy-declaring subscription with an unresolvable identity (anonymous) is refused
+/// at subscribe time — the #596 gap the phase-00 pin characterized, now closed.
+#[tokio::test]
+async fn ws_596_policy_scoped_subscription_refused_for_unresolvable_identity() {
+    let (manager, state) = policy_state();
+    let url = spawn_ws_server(state).await;
+    let (mut sink, mut stream) = connect(&url, None).await;
+
+    send_json(&mut sink, json!({ "type": "connection_init" })).await;
+    assert_eq!(recv_json(&mut stream).await["type"], "connection_ack");
+
+    send_json(
+        &mut sink,
+        json!({
+            "type": "subscribe",
+            "id": "op_scoped",
+            "payload": { "query": "subscription { orderCreated { id status } }" }
+        }),
+    )
+    .await;
+
+    let frame = recv_json(&mut stream).await;
+    assert_eq!(frame["type"], "error", "unresolvable identity must refuse, got {frame}");
+    assert_eq!(frame["id"], "op_scoped");
+
+    // Fail-closed: the subscription must NOT register — it can never deliver a row.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eq!(
+        manager.subscription_count(),
+        0,
+        "a refused policy subscription must not register (never deliver-all)"
+    );
+}
+
+/// The legacy `graphql-ws` subprotocol (`start` instead of `subscribe`) routes through
+/// the same protocol-agnostic enforcement — it cannot bypass the policy.
+#[tokio::test]
+async fn ws_596_legacy_graphql_ws_cannot_bypass_policy() {
+    let (manager, state) = policy_state();
+    let url = spawn_ws_server(state).await;
+    let (mut sink, mut stream) = connect(&url, Some("graphql-ws")).await;
+
+    send_json(&mut sink, json!({ "type": "connection_init" })).await;
+    assert_eq!(recv_json(&mut stream).await["type"], "connection_ack");
+
+    // Legacy clients open a subscription with `start`, remapped to `subscribe` server-side.
+    send_json(
+        &mut sink,
+        json!({
+            "type": "start",
+            "id": "op_legacy",
+            "payload": { "query": "subscription { orderCreated { id status } }" }
+        }),
+    )
+    .await;
+
+    let frame = recv_json(&mut stream).await;
+    assert_eq!(frame["type"], "error", "legacy graphql-ws must also refuse, got {frame}");
+    assert_eq!(frame["id"], "op_legacy");
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eq!(
+        manager.subscription_count(),
+        0,
+        "legacy graphql-ws must not be able to establish a deliver-all subscription"
+    );
+}
+
+/// An entity with **no** subscription policy is unaffected — the subscription registers
+/// as before (no back-compat break).
+#[tokio::test]
+async fn ws_596_unpolicied_subscription_still_registers() {
+    let (manager, state) = policy_state();
+    let url = spawn_ws_server(state).await;
+    let (mut sink, mut stream) = connect(&url, None).await;
+
+    send_json(&mut sink, json!({ "type": "connection_init" })).await;
+    assert_eq!(recv_json(&mut stream).await["type"], "connection_ack");
+
+    send_json(
+        &mut sink,
+        json!({
+            "type": "subscribe",
+            "id": "op_open",
+            "payload": { "query": "subscription { pinged { id } }" }
+        }),
+    )
+    .await;
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    while manager.subscription_count() != 1 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "a policy-free subscription must register unchanged"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+/// The delivery mechanism the fix rides: a server-owned `(owner_id = A)` condition
+/// filters principal B's row out of A's stream. (The route derives this condition from
+/// the enriched identity; that derivation is unit-tested separately.)
+mod manager_mechanism {
+    use fraiseql_core::{
+        runtime::subscription::{SubscriptionEvent, SubscriptionOperation},
+        schema::{CompiledSchema, SubscriptionDefinition},
+    };
+
+    use super::{Arc, SubscriptionManager};
+
+    #[test]
+    fn owner_condition_filters_a_foreign_owners_row_even_with_forged_variables() {
+        let schema = Arc::new(CompiledSchema {
+            subscriptions: vec![SubscriptionDefinition::new("orderUpdated", "Order")],
+            ..Default::default()
+        });
+        let manager = SubscriptionManager::new(schema);
+
+        // A subscribes; the server derives `owner_id = A`. The client also forges a
+        // variable naming owner B — it cannot widen visibility (server condition ANDs).
+        manager
+            .subscribe_with_rls(
+                "orderUpdated",
+                serde_json::json!({}),
+                serde_json::json!({ "owner_id": "B" }), // forged client variable
+                "conn-A",
+                vec![("owner_id".to_string(), serde_json::json!("A"))],
+            )
+            .unwrap();
+
+        let b_row = SubscriptionEvent::new(
+            "Order",
+            "ord_42",
+            SubscriptionOperation::Update,
+            serde_json::json!({ "id": "ord_42", "owner_id": "B", "status": "approved" }),
+        );
+        assert_eq!(
+            manager.publish_event(b_row),
+            0,
+            "the server-owned owner condition filters B's row from A's stream"
+        );
+    }
+}

--- a/crates/fraiseql-server/tests/subscription_row_visibility_pin_test.rs
+++ b/crates/fraiseql-server/tests/subscription_row_visibility_pin_test.rs
@@ -1,18 +1,23 @@
-//! Baseline pin for #596: `/ws` fan-out ignores row-level visibility (phase 00).
+//! Baseline pin for #596 on the **realtime `/realtime/v1` entity-change stream**
+//! (phase 00). NOTE: this is the *dormant* push path — `RealtimeServer`/`RealtimeState`
+//! are never assembled by any production binary (all `.with_realtime(...)` call sites
+//! are tests; there is no production `TokenValidator`). The *live* graphql `/ws` path is
+//! pinned separately in `graphql_ws_row_visibility_pin_test.rs` (`// M-596-WS`).
 //!
 //! Two principals subscribe to the same entity. A row owned by principal B is
-//! delivered to principal A because the push path enforces no row boundary:
+//! delivered to principal A because this pipeline enforces no row boundary:
 //! subscriptions carry client-supplied field filters (cooperative, not a
 //! security boundary) and there is no server-derived owner policy. The
-//! production `RlsEvaluator` has no non-test implementor, so the delivery
-//! pipeline's RLS hook is effectively permissive by default.
+//! `RlsEvaluator` (`realtime/delivery.rs`) has no non-test implementor, so the delivery
+//! pipeline's RLS hook is permissive by default.
 //!
-//! `// M-596` marks the assertion phase 06 flips: once an entity declares a
-//! `subscription_policy`, principal A must NOT receive principal B's row.
+//! `// M-596` marks the assertion phase 06a flips: once an entity declares a
+//! `subscription_policy`, principal A must NOT receive principal B's row — and, the
+//! 06a fail-closed deliverable, an *unconfigured* evaluator must deny for a
+//! policy-declaring entity rather than deliver-all.
 //!
-//! This is the focused, infra-free characterization (subscription manager +
-//! field-filter delivery). The full two-principal WS+DB conformance test lands
-//! in phase 06 next to the cascade two-tenant test.
+//! This is the focused, infra-free characterization (the realtime subscription manager +
+//! field-filter delivery), not the graphql `/ws` path.
 
 #![allow(clippy::unwrap_used)] // Reason: test code
 

--- a/docs/architecture/enriched-identity-rls.md
+++ b/docs/architecture/enriched-identity-rls.md
@@ -141,6 +141,57 @@ an existence oracle over the actor table.
 
 ---
 
+## The push path: subscription row visibility (#596)
+
+The pull path (GraphQL queries) enforces per-row RLS. The **push path** — live
+subscriptions over `/ws` (`graphql-transport-ws` / legacy `graphql-ws`) — historically
+did not: any principal authorized to subscribe to an entity received **every** row's
+after-images. It now consumes the *same* enriched identity fields, so the two paths
+share one boundary.
+
+An entity declares a row policy in the compiled schema:
+
+```jsonc
+"subscription_policy": {
+  "owner_path": "$.owner_id",     // single-level path into the after-image
+  "identity_field": "user_id",    // the fraiseql.enriched.* field resolved here
+  "bypass_roles": ["admin"]       // roles that get full visibility
+}
+```
+
+At subscribe time the server derives a **server-owned** owner condition from the
+connection's enriched identity and enforces it on every delivered event (AND semantics
+with any tenant gate and client filters — a client filter can only *narrow*):
+
+- **Resolvable identity** → the subscription is scoped to `owner_path == <enriched
+  identity_field>`. The value is read **only** from the `fraiseql.enriched.*`
+  namespace, so a client-supplied claim or subscribe variable cannot widen it.
+- **`bypass_roles` role** → full visibility, no added condition.
+- **Unresolvable identity** (no enrichment configured, a denial, a resolver outage, a
+  NULL field, or an anonymous connection) → the subscription is **refused at subscribe
+  time** — fail-closed, never delivered unfiltered.
+- **No policy** on the entity → unchanged behavior (no back-compat break).
+
+The single policy→condition derivation lives in `fraiseql-core`
+(`schema::SubscriptionPolicy::derive` → `OwnerCondition`), so the push seam and any
+future seam consume identical semantics; a divergence — e.g. `bypass_roles` honored on
+one path but not the other — would itself be a bypass. `extract_rls_conditions` is
+fail-closed for the same reason: a clause shape it cannot enforce as equality refuses
+the subscription rather than silently widening it.
+
+> **DELETE events / pre-images.** The policy evaluates on whichever image the event
+> carries; a scoped subscriber only learns of a delete when the change stream includes
+> the row's owning image (i.e. `pre_image` is enabled for the entity). This is the
+> fail-closed default — a scoped client is never shown a row it does not own, even a
+> deleted one.
+
+> **Realtime `/realtime/v1` entity stream.** A second (opt-in, not assembled by the
+> stock server) push subsystem carries entity after-images too; its policy hardening is
+> tracked separately. The `POST /realtime/v1/broadcast` app-channel pubsub carries no
+> entity after-images and has no row policy.
+
+---
+
 ## Operational notes
 
 - **Provision actors out-of-band.** Under `enabled = true`, every authenticated


### PR DESCRIPTION
## Phase 06b — the live `/ws` fix (#596)

The production-mounted `/ws` subscription path (`graphql-transport-ws` / legacy `graphql-ws`) delivered **every** row's after-images to any authorized subscriber — it subscribed with empty RLS conditions, so the push path enforced no row boundary the pull path (GraphQL queries) already did. This closes that on the **live** path.

### What changed

**fraiseql-core (shared foundation)**
- `schema::SubscriptionPolicy` (`owner_path` / `identity_field` / `bypass_roles`) + a seam-neutral `OwnerCondition::{Bypass, Eq, Refuse}` derivation. **One** derivation both push seams adapt over, so the paths can't drift (a `bypass_roles` divergence would itself be a bypass).
- `TypeDefinition.subscription_policy` compiled-schema field + load-time `validate`.
- `extract_rls_conditions` is now **fail-closed** (`Result`): a clause shape it cannot enforce as equality (`non-Eq`, `Or`, `Not`, native-column) **errors** instead of silently widening. Public-API change; no in-tree callers relied on the fail-open behavior.

**fraiseql-server (the `/ws` seam)**
- `SubscriptionState` gains the per-subscription policy map (built from the compiled schema at mount) + the `#539` enriched-identity resolver.
- At subscribe time a policy-declaring subscription derives a **server-owned** owner condition from the connection's server-resolved `fraiseql.enriched.*` identity (a client claim/variable can't widen it) and enforces it via `subscribe_with_rls`.
- **Fail-closed**: unresolvable identity (anonymous / no enrichment / denial / resolver outage) → the subscription is **refused at subscribe time**, never delivered unfiltered. `bypass_roles` → full visibility. No policy → unchanged.
- Legacy `graphql-ws` routes through the same protocol-agnostic enforcement — it cannot bypass.

### Tests
- **Route-level e2e** over a real WebSocket (`graphql_ws_row_visibility_pin_test.rs`): a policy-scoped subscribe is refused for an unresolvable identity over **both** `graphql-transport-ws` and **legacy `graphql-ws`**; an unpolicied subscription still registers.
- **Derivation unit tests** (`routes/subscriptions/tests.rs`): resolvable→eq, bypass→full, anonymous / enrichment-outage / forged-attribute → refuse; policy-map builder.
- **Core**: policy derivation + fail-closed `extract_rls_conditions`.
- Flipped the graphql-path characterization pin to assert the closed behavior; corrected the realtime pin's scope doc.

### Local verification
`make preflight` (fmt/clippy/rustdoc/shell gates) · `cargo check --workspace --all-features --all-targets` · `cargo-deny` · fraiseql-core + fraiseql-server lib suites + WS e2e green.

### Scope note
This is the **live** push path. A second push subsystem — the realtime `/realtime/v1` entity stream — carries after-images too but is **not assembled by any production binary** (no production `TokenValidator`; all `.with_realtime(...)` call sites are tests). Its policy hardening is **phase 06a** (rescoped to a fail-closed default), and the "unassembled subsystem" itself is being filed as a separate *productionize-or-remove* issue. **#596 closes only when 06b + 06a both land** (or on 06b alone if the realtime subsystem is removed). The `POST /realtime/v1/broadcast` channel pubsub carries no after-images and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)