### PR TITLE
feat(realtime): fail-closed row visibility on the dormant realtime seam (#596, phase 06a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/architecture/enriched-identity-rls.md` ("The push path: subscription row
   visibility").
 
+- **Realtime `/realtime/v1` entity-stream seam is fail-closed for policy entities
+  (#596).** This second push subsystem carries entity after-images too but is **not
+  assembled by any production binary** (#605). It now consumes the *same* `fraiseql-core`
+  policy derivation as the `/ws` path, and — the property that matters on a dormant
+  seam — its delivery is fail-closed for a policy-declaring entity: a subscription that
+  reaches delivery without a resolved owner enforcement (`Bypass`/`Scoped`) is **dropped**,
+  and a subscription whose identity is unresolvable is **refused** at subscribe time. So
+  whoever eventually productionizes the subsystem cannot bring it up deliver-all by
+  accident. Issue #605 tracks the productionize-or-remove decision.
+
 ### Changed
 
 - **`fraiseql_core::runtime::extract_rls_conditions` is now fail-closed (`Result`).**

--- a/crates/fraiseql-server/benches/realtime_bench.rs
+++ b/crates/fraiseql-server/benches/realtime_bench.rs
@@ -10,6 +10,7 @@ use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_ma
 use fraiseql_server::realtime::{
     connections::{ConnectionManager, ConnectionState},
     context_hash::{SecurityContextHashInput, security_context_hash},
+    subscription_policy::OwnerEnforcement,
     subscriptions::{SubscriptionDetails, SubscriptionManager},
 };
 
@@ -47,6 +48,7 @@ fn bench_subscription_fanout_lookup(c: &mut Criterion) {
                 event_filter:          None,
                 field_filters:         vec![],
                 security_context_hash: u64::try_from(i % 10).unwrap(),
+                owner_enforcement:     OwnerEnforcement::None,
             };
             let conn_id = format!("conn-{i}");
             mgr.subscribe(&conn_id, "Order", details).unwrap();

--- a/crates/fraiseql-server/src/realtime/delivery.rs
+++ b/crates/fraiseql-server/src/realtime/delivery.rs
@@ -4,7 +4,10 @@
 //! evaluates RLS once per group, applies field filters, and delivers events to
 //! authorized connections.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
@@ -14,6 +17,7 @@ use tracing::{debug, warn};
 
 use super::{
     connections::{ConnectionId, ConnectionManager},
+    subscription_policy::OwnerEnforcement,
     subscriptions::{EventKind, FieldFilter, FilterOperator, SubscriptionManager},
 };
 
@@ -130,27 +134,52 @@ impl ChangeMessage {
 /// Event delivery pipeline that processes entity events and delivers to subscribers.
 pub struct EventDeliveryPipeline {
     /// Subscription manager for looking up who receives what.
-    subscriptions: Arc<SubscriptionManager>,
+    subscriptions:   Arc<SubscriptionManager>,
     /// Connection manager for sending events to connections.
-    connections:   Arc<ConnectionManager>,
+    connections:     Arc<ConnectionManager>,
     /// RLS evaluator for access control.
-    rls_evaluator: Arc<dyn RlsEvaluator>,
+    rls_evaluator:   Arc<dyn RlsEvaluator>,
+    /// Names of entities that declare a row-visibility policy (#596). For these, the
+    /// pipeline is **fail-closed**: a subscription that reaches delivery without an
+    /// explicit [`OwnerEnforcement`] (`Bypass` or `Scoped`) is dropped, so the seam
+    /// cannot come up deliver-all even if a future assembler skips the subscribe-time
+    /// wiring.
+    policy_entities: HashSet<String>,
     /// Receiver for incoming entity events.
-    event_rx:      mpsc::Receiver<EntityEvent>,
+    event_rx:        mpsc::Receiver<EntityEvent>,
 }
 
 impl EventDeliveryPipeline {
-    /// Create a new event delivery pipeline.
+    /// Create a new event delivery pipeline with no row-visibility policies.
     pub fn new(
         subscriptions: Arc<SubscriptionManager>,
         connections: Arc<ConnectionManager>,
         rls_evaluator: Arc<dyn RlsEvaluator>,
         event_rx: mpsc::Receiver<EntityEvent>,
     ) -> Self {
+        Self::with_policy_entities(
+            subscriptions,
+            connections,
+            rls_evaluator,
+            HashSet::new(),
+            event_rx,
+        )
+    }
+
+    /// Create a pipeline that enforces the #596 fail-closed default for the given
+    /// policy-declaring entities.
+    pub fn with_policy_entities(
+        subscriptions: Arc<SubscriptionManager>,
+        connections: Arc<ConnectionManager>,
+        rls_evaluator: Arc<dyn RlsEvaluator>,
+        policy_entities: HashSet<String>,
+        event_rx: mpsc::Receiver<EntityEvent>,
+    ) -> Self {
         Self {
             subscriptions,
             connections,
             rls_evaluator,
+            policy_entities,
             event_rx,
         }
     }
@@ -172,8 +201,13 @@ impl EventDeliveryPipeline {
             return;
         };
 
+        // #596: is this entity governed by a row-visibility policy? If so, delivery is
+        // fail-closed — a subscription without a resolved owner enforcement is dropped.
+        let policy_entity = self.policy_entities.contains(&event.entity);
+
         // Group subscribers by security context hash for RLS coalescing
-        let mut groups: HashMap<u64, Vec<(ConnectionId, Vec<FieldFilter>)>> = HashMap::new();
+        let mut groups: HashMap<u64, Vec<(ConnectionId, Vec<FieldFilter>, OwnerEnforcement)>> =
+            HashMap::new();
         for (conn_id, details) in &subscriber_details {
             // Apply event type filter
             if let Some(filter_kind) = details.event_filter {
@@ -181,10 +215,11 @@ impl EventDeliveryPipeline {
                     continue;
                 }
             }
-            groups
-                .entry(details.security_context_hash)
-                .or_default()
-                .push((conn_id.clone(), details.field_filters.clone()));
+            groups.entry(details.security_context_hash).or_default().push((
+                conn_id.clone(),
+                details.field_filters.clone(),
+                details.owner_enforcement.clone(),
+            ));
         }
 
         // Determine the row to check for RLS (prefer `new`, fall back to `old`)
@@ -210,8 +245,18 @@ impl EventDeliveryPipeline {
             }
 
             // Deliver to each connection in this group
-            for (conn_id, field_filters) in connections {
-                // Apply field filters
+            for (conn_id, field_filters, owner_enforcement) in connections {
+                // #596 fail-closed row visibility for policy-declaring entities.
+                if policy_entity && !owner_enforcement_admits(owner_enforcement, row) {
+                    debug!(
+                        entity = %event.entity,
+                        connection_id = %conn_id,
+                        "row-visibility policy denied event delivery (fail-closed)"
+                    );
+                    continue;
+                }
+
+                // Client-supplied (cooperative) field filters.
                 if !evaluate_field_filters(field_filters, row) {
                     continue;
                 }
@@ -224,6 +269,25 @@ impl EventDeliveryPipeline {
                 }
             }
         }
+    }
+}
+
+/// Whether a policy-declaring entity's event may be delivered to a subscription with the
+/// given [`OwnerEnforcement`] (#596). **Fail-closed:**
+/// - [`OwnerEnforcement::None`] — no enforcement was resolved at subscribe time → **deny** (the
+///   property that keeps a dormant/misassembled seam from delivering everything);
+/// - [`OwnerEnforcement::Bypass`] — a bypass role → allow (full visibility);
+/// - [`OwnerEnforcement::Scoped`] — allow only if the row image is present **and** matches the
+///   server-owned owner filter (a missing image cannot prove ownership → deny; this is why a scoped
+///   subscriber only learns of a DELETE when a pre-image is available).
+#[must_use]
+pub fn owner_enforcement_admits(enforcement: &OwnerEnforcement, row: Option<&Value>) -> bool {
+    match enforcement {
+        OwnerEnforcement::None => false,
+        OwnerEnforcement::Bypass => true,
+        OwnerEnforcement::Scoped(owner_filter) => {
+            row.is_some_and(|r| evaluate_field_filters(std::slice::from_ref(owner_filter), Some(r)))
+        },
     }
 }
 

--- a/crates/fraiseql-server/src/realtime/server.rs
+++ b/crates/fraiseql-server/src/realtime/server.rs
@@ -4,7 +4,11 @@
 //! handles heartbeats and idle timeouts, enforces connection limits, and
 //! processes subscription requests for entity change events.
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{
     extract::{
@@ -21,6 +25,7 @@ use tracing::{debug, info, warn};
 use super::{
     connections::{ConnectionManager, ConnectionState},
     protocol::{ClientMessage, ServerMessage},
+    subscription_policy::{OwnerEnforcement, owner_enforcement},
     subscriptions::{EventKind, SubscriptionDetails, SubscriptionManager, parse_filter},
 };
 
@@ -95,6 +100,32 @@ pub struct TokenInfo {
     pub context_hash: u64,
     /// When the token expires (Unix timestamp in seconds).
     pub expires_at:   i64,
+    /// Server-resolved enriched identity (#539, the `fraiseql.enriched.*` namespace) for
+    /// this connection, consumed by a
+    /// [`SubscriptionPolicy`](super::subscription_policy::SubscriptionPolicy) at subscribe
+    /// time. Empty until a production `TokenValidator` runs enrichment — a step this dormant
+    /// subsystem does not yet have (#605) — so a policy-declaring subscription derives
+    /// **fail-closed** (refused) by default.
+    #[allow(clippy::struct_field_names)] // Reason: mirrors SecurityContext.attributes
+    pub attributes: HashMap<String, serde_json::Value>,
+    /// The connection's roles, consumed for `bypass_roles`.
+    pub roles:        Vec<String>,
+}
+
+impl TokenInfo {
+    /// A token carrying no enriched identity or roles — the shape a validator that has
+    /// not (yet) run #539 enrichment produces. A policy-declaring subscription on such a
+    /// connection is refused (fail-closed).
+    #[must_use]
+    pub fn new(user_id: String, context_hash: u64, expires_at: i64) -> Self {
+        Self {
+            user_id,
+            context_hash,
+            expires_at,
+            attributes: HashMap::new(),
+            roles: Vec::new(),
+        }
+    }
 }
 
 /// Shared state for the realtime `WebSocket` handler.
@@ -109,13 +140,18 @@ pub struct RealtimeState {
 /// The realtime `WebSocket` server.
 pub struct RealtimeServer {
     /// Active connection manager.
-    pub(crate) connections:    Arc<ConnectionManager>,
+    pub(crate) connections:           Arc<ConnectionManager>,
     /// Subscription manager for entity change subscriptions.
-    pub(crate) subscriptions:  Arc<SubscriptionManager>,
+    pub(crate) subscriptions:         Arc<SubscriptionManager>,
     /// Set of entity names that accept realtime subscriptions.
-    pub(crate) known_entities: HashSet<String>,
+    pub(crate) known_entities:        HashSet<String>,
     /// Server configuration.
-    pub(crate) config:         RealtimeConfig,
+    pub(crate) config:                RealtimeConfig,
+    /// Per-entity row-visibility policies (#596), keyed by entity name. A subscription
+    /// to a policy-declaring entity derives a server-owned owner boundary at subscribe
+    /// time and is refused when it is unresolvable (fail-closed).
+    pub(crate) subscription_policies:
+        HashMap<String, super::subscription_policy::SubscriptionPolicy>,
 }
 
 impl RealtimeServer {
@@ -132,6 +168,7 @@ impl RealtimeServer {
             subscriptions: Arc::new(SubscriptionManager::new(max_subs)),
             known_entities: HashSet::new(),
             config,
+            subscription_policies: HashMap::new(),
         }
     }
 
@@ -148,7 +185,20 @@ impl RealtimeServer {
             subscriptions: Arc::new(SubscriptionManager::new(max_subs)),
             known_entities: entities,
             config,
+            subscription_policies: HashMap::new(),
         }
+    }
+
+    /// Attach per-entity row-visibility policies (#596). Builder style so an assembler
+    /// (today: tests; in production see #605) can install policies resolved from the
+    /// compiled schema.
+    #[must_use]
+    pub fn with_subscription_policies(
+        mut self,
+        policies: HashMap<String, super::subscription_policy::SubscriptionPolicy>,
+    ) -> Self {
+        self.subscription_policies = policies;
+        self
     }
 
     /// Returns the number of active connections.
@@ -221,7 +271,6 @@ async fn handle_realtime_connection(
     server: Arc<RealtimeServer>,
     token_info: TokenInfo,
 ) {
-    let context_hash = token_info.context_hash;
     let connection_id = uuid::Uuid::new_v4().to_string();
     let config = &server.config;
 
@@ -339,7 +388,7 @@ async fn handle_realtime_connection(
                                 let reply = handle_subscribe(
                                     &server,
                                     &connection_id,
-                                    context_hash,
+                                    &token_info,
                                     &entity,
                                     &event,
                                     filter.as_deref(),
@@ -393,7 +442,7 @@ async fn handle_realtime_connection(
 fn handle_subscribe(
     server: &RealtimeServer,
     connection_id: &str,
-    context_hash: u64,
+    token_info: &TokenInfo,
     entity: &str,
     event: &str,
     filter: Option<&str>,
@@ -404,6 +453,20 @@ fn handle_subscribe(
             message: format!("unknown entity: {entity}"),
         };
     }
+
+    // #596: resolve the server-owned row-visibility enforcement for this entity from its
+    // policy and the connection's enriched identity. Fail-closed: an unresolvable
+    // identity (the default on this dormant seam, which has no enrichment plumbing —
+    // #605) refuses the subscription rather than delivering every row.
+    let owner_enforcement = match server.subscription_policies.get(entity) {
+        None => OwnerEnforcement::None,
+        Some(policy) => {
+            match owner_enforcement(policy.derive(&token_info.attributes, &token_info.roles)) {
+                Ok(enforcement) => enforcement,
+                Err(reason) => return ServerMessage::Error { message: reason },
+            }
+        },
+    };
 
     // Parse event filter
     let event_filter = if event == "*" {
@@ -428,7 +491,8 @@ fn handle_subscribe(
     let details = SubscriptionDetails {
         event_filter,
         field_filters,
-        security_context_hash: context_hash,
+        security_context_hash: token_info.context_hash,
+        owner_enforcement,
     };
 
     match server.subscriptions.subscribe(connection_id, entity, details) {

--- a/crates/fraiseql-server/src/realtime/subscription_policy.rs
+++ b/crates/fraiseql-server/src/realtime/subscription_policy.rs
@@ -1,120 +1,59 @@
-//! Row-level visibility policies for `/ws` subscription delivery (#596).
+//! Realtime-seam adapter over the shared subscription row-visibility policy (#596).
 //!
-//! The pull path (GraphQL queries) enforces per-row RLS; historically the push path
-//! (`/ws`) did not — any principal authorized to subscribe to an entity received
-//! **every** row's after-images. A [`SubscriptionPolicy`] closes that: at subscribe
-//! time it derives a **server-owned** owner filter from the connection's enriched
-//! identity (#539, the forge-proof `fraiseql.enriched.*` namespace), so a scoped
-//! subscriber only receives rows it owns. It is **fail-closed for declaring
-//! entities**: a policy present but the identity field unresolvable **refuses** the
-//! subscription rather than delivering everything.
+//! The policy type and its derivation live in `fraiseql-core`
+//! ([`fraiseql_core::schema::SubscriptionPolicy`] → [`OwnerCondition`]) so this realtime
+//! entity-stream seam and the graphql `/ws` seam consume **identical** semantics — a
+//! divergence (e.g. `bypass_roles` honored on one path but not the other) would itself
+//! be a visibility bypass. This module only *adapts* the seam-neutral [`OwnerCondition`]
+//! to the realtime delivery matcher's [`FieldFilter`] and defines the per-subscription
+//! [`OwnerEnforcement`] state the delivery pipeline consults.
 //!
-//! The derived filter is a plain equality [`FieldFilter`] enforced by the existing
-//! delivery matcher ([`evaluate_field_filters`](super::delivery::evaluate_field_filters)) —
-//! the owner boundary is one `eq` condition. Entities with no policy keep today's
-//! behavior (no back-compat break). The multi-tenant gate is unchanged and composes
-//! with this (AND). `/realtime/v1` (the app-published channel pubsub) is out of scope.
+//! # Fail-closed on a dormant seam
+//!
+//! This realtime subsystem is **not assembled by any production binary** (see #605).
+//! The one property that must survive is fail-closed-by-construction: a policy-declaring
+//! entity can never come up deliver-all by accident. So delivery denies a policy
+//! entity's events to any subscription that did not resolve an explicit
+//! [`OwnerEnforcement`] (`Bypass` or `Scoped`) at subscribe time — even a future
+//! assembler who skips the subscribe-time wiring cannot leak rows.
 
-use std::collections::HashMap;
-
-use fraiseql_core::security::ENRICHED_NAMESPACE_PREFIX;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+pub use fraiseql_core::schema::{OwnerCondition, SubscriptionPolicy};
 
 use super::subscriptions::{FieldFilter, FilterOperator};
 
-/// An entity's row-visibility policy for `/ws` delivery (#596).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SubscriptionPolicy {
-    /// The single-level JSON path into the after-image holding the owner id
-    /// (e.g. `"$.owner_id"`). Only `$.<field>` is supported — the delivery matcher
-    /// keys on a flat field name.
-    pub owner_path:     String,
-    /// The enriched-identity field (in the `fraiseql.enriched.*` namespace, #539)
-    /// whose value the owner must equal (e.g. `"user_id"`).
-    pub identity_field: String,
-    /// Roles that bypass the policy entirely (full visibility, e.g. `["admin"]`).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub bypass_roles:   Vec<String>,
-}
-
-/// The result of deriving an owner filter for one subscribe request.
-#[derive(Debug, Clone)]
-pub enum OwnerFilterOutcome {
-    /// The principal holds a bypass role — full visibility, no added filter.
+/// Per-subscription row-visibility enforcement for a policy-declaring entity (#596).
+///
+/// Resolved at subscribe time from the entity's [`SubscriptionPolicy`] and the
+/// connection's enriched identity, and stored on the subscription so the delivery
+/// pipeline can enforce it without re-deriving.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum OwnerEnforcement {
+    /// The entity declares no policy — unchanged behavior (the default).
+    #[default]
+    None,
+    /// A bypass role — full visibility for a policy-declaring entity.
     Bypass,
-    /// A server-owned owner filter to enforce (the principal sees only its rows).
-    Filter(FieldFilter),
-    /// **Fail-closed**: the policy applies but the enriched identity is unresolvable
-    /// (no enrichment configured, or a NULL/absent field) — refuse the subscription.
-    Refuse(String),
+    /// Scoped to a server-owned owner filter — the principal sees only its rows.
+    Scoped(FieldFilter),
 }
 
-impl SubscriptionPolicy {
-    /// The flat owner field name the delivery matcher keys on — `owner_path` with a
-    /// leading `$.` stripped.
-    #[must_use]
-    pub fn owner_field(&self) -> &str {
-        self.owner_path.trim_start_matches("$.")
-    }
-
-    /// Validate the policy at load time.
-    ///
-    /// # Errors
-    ///
-    /// - `owner_path` is empty or a nested path (only single-level `$.<field>`).
-    /// - `identity_field` is empty.
-    pub fn validate(&self) -> Result<(), String> {
-        if self.identity_field.is_empty() {
-            return Err("subscription_policy.identity_field must not be empty".to_string());
-        }
-        let field = self.owner_field();
-        if field.is_empty() {
-            return Err("subscription_policy.owner_path must name a field (e.g. \"$.owner_id\")"
-                .to_string());
-        }
-        if field.contains('.') || field.contains('[') {
-            return Err(format!(
-                "subscription_policy.owner_path `{}` must be a single-level `$.<field>` — nested \
-                 paths are not supported by the delivery matcher",
-                self.owner_path
-            ));
-        }
-        Ok(())
-    }
-
-    /// Derive the owner filter for a connection whose enriched identity is `ctx`
-    /// (#596). Bypass role → [`Bypass`]; resolvable identity → an `eq`
-    /// [`Filter`]; otherwise **fail-closed** [`Refuse`].
-    ///
-    /// [`Bypass`]: OwnerFilterOutcome::Bypass
-    /// [`Filter`]: OwnerFilterOutcome::Filter
-    /// [`Refuse`]: OwnerFilterOutcome::Refuse
-    #[must_use]
-    pub fn derive(
-        &self,
-        attributes: &HashMap<String, Value>,
-        roles: &[String],
-    ) -> OwnerFilterOutcome {
-        if self.bypass_roles.iter().any(|bypass| roles.iter().any(|role| role == bypass)) {
-            return OwnerFilterOutcome::Bypass;
-        }
-        // The identity value must come from the server-resolved enriched namespace —
-        // the #539 resolver strips any inbound `fraiseql.*` claims, so this is
-        // forge-proof.
-        let key = format!("{ENRICHED_NAMESPACE_PREFIX}{}", self.identity_field);
-        match attributes.get(&key) {
-            Some(value) if !value.is_null() => OwnerFilterOutcome::Filter(FieldFilter {
-                field:    self.owner_field().to_string(),
-                operator: FilterOperator::Eq,
-                value:    value.clone(),
-            }),
-            _ => OwnerFilterOutcome::Refuse(format!(
-                "subscription refused (fail-closed): enriched identity field `{}` is unresolvable \
-                 — configure `[identity.enrichment]` so the owner boundary can be derived",
-                self.identity_field
-            )),
-        }
+/// Map a derived [`OwnerCondition`] to the realtime seam's [`OwnerEnforcement`], or a
+/// refusal reason.
+///
+/// # Errors
+///
+/// Returns the refusal reason when the condition is [`OwnerCondition::Refuse`] — the
+/// subscribe path turns this into an error and does not register the subscription
+/// (fail-closed).
+pub fn owner_enforcement(condition: OwnerCondition) -> Result<OwnerEnforcement, String> {
+    match condition {
+        OwnerCondition::Bypass => Ok(OwnerEnforcement::Bypass),
+        OwnerCondition::Eq { field, value } => Ok(OwnerEnforcement::Scoped(FieldFilter {
+            field,
+            operator: FilterOperator::Eq,
+            value,
+        })),
+        OwnerCondition::Refuse(reason) => Err(reason),
     }
 }
 

--- a/crates/fraiseql-server/src/realtime/subscription_policy/tests.rs
+++ b/crates/fraiseql-server/src/realtime/subscription_policy/tests.rs
@@ -1,127 +1,44 @@
-//! Tests for the #596 subscription-policy owner-filter derivation — the
-//! security-critical decision logic (bypass / fail-closed refuse / owner eq).
+//! Tests for the realtime-seam adapter (#596). The security-critical derivation
+//! (`bypass` / owner-eq / fail-closed refuse, forge-proof enriched read) is tested in
+//! `fraiseql-core` (`schema::subscription_policy`); here we only assert the
+//! `OwnerCondition` → `OwnerEnforcement` mapping this seam adds.
 #![allow(clippy::unwrap_used, clippy::panic)] // Reason: test module
 
-use fraiseql_core::security::{ENRICHED_NAMESPACE_PREFIX, SecurityContext};
+use fraiseql_core::schema::OwnerCondition;
 
-use super::{OwnerFilterOutcome, SubscriptionPolicy};
+use super::{OwnerEnforcement, owner_enforcement};
 use crate::realtime::subscriptions::FilterOperator;
 
-fn policy() -> SubscriptionPolicy {
-    SubscriptionPolicy {
-        owner_path:     "$.owner_id".to_string(),
-        identity_field: "user_id".to_string(),
-        bypass_roles:   vec!["admin".to_string()],
-    }
-}
-
-/// A base anonymous context; tests add roles / enriched fields as needed.
-fn ctx() -> SecurityContext {
-    let now = chrono::Utc::now();
-    SecurityContext {
-        user_id:          fraiseql_core::types::UserId("u-1".to_string()),
-        roles:            vec![],
-        tenant_id:        None,
-        scopes:           vec![],
-        attributes:       std::collections::HashMap::new(),
-        request_id:       "req-1".to_string(),
-        ip_address:       None,
-        authenticated_at: now,
-        expires_at:       now + chrono::Duration::hours(1),
-        issuer:           None,
-        audience:         None,
-        email:            None,
-        display_name:     None,
-    }
-}
-
-fn with_enriched(mut c: SecurityContext, field: &str, value: serde_json::Value) -> SecurityContext {
-    c.attributes.insert(format!("{ENRICHED_NAMESPACE_PREFIX}{field}"), value);
-    c
+#[test]
+fn bypass_condition_maps_to_bypass_enforcement() {
+    assert_eq!(owner_enforcement(OwnerCondition::Bypass).unwrap(), OwnerEnforcement::Bypass);
 }
 
 #[test]
-fn resolved_identity_yields_an_owner_eq_filter() {
-    let outcome = {
-        let c = with_enriched(ctx(), "user_id", serde_json::json!("alice"));
-        policy().derive(&c.attributes, &c.roles)
-    };
-    match outcome {
-        OwnerFilterOutcome::Filter(filter) => {
+fn eq_condition_maps_to_a_scoped_owner_filter() {
+    let enforcement = owner_enforcement(OwnerCondition::Eq {
+        field: "owner_id".to_string(),
+        value: serde_json::json!("alice"),
+    })
+    .unwrap();
+    match enforcement {
+        OwnerEnforcement::Scoped(filter) => {
             assert_eq!(filter.field, "owner_id");
             assert_eq!(filter.operator, FilterOperator::Eq);
             assert_eq!(filter.value, serde_json::json!("alice"));
         },
-        other => panic!("expected an owner filter, got {other:?}"),
+        other => panic!("expected a scoped owner filter, got {other:?}"),
     }
 }
 
 #[test]
-fn a_bypass_role_grants_full_visibility() {
-    let mut c = with_enriched(ctx(), "user_id", serde_json::json!("alice"));
-    c.roles = vec!["admin".to_string()];
-    assert!(matches!(policy().derive(&c.attributes, &c.roles), OwnerFilterOutcome::Bypass));
+fn refuse_condition_maps_to_an_error() {
+    let err = owner_enforcement(OwnerCondition::Refuse("unresolvable".to_string()))
+        .expect_err("a refusal must not yield an enforcement");
+    assert!(err.contains("unresolvable"));
 }
 
 #[test]
-fn unresolvable_identity_refuses_fail_closed() {
-    // No enrichment configured at all → refuse (not deliver-all).
-    assert!(matches!(
-        {
-            let c = ctx();
-            policy().derive(&c.attributes, &c.roles)
-        },
-        OwnerFilterOutcome::Refuse(_)
-    ));
-
-    // Enrichment present but the specific field is NULL → refuse.
-    let null_field = with_enriched(ctx(), "user_id", serde_json::Value::Null);
-    assert!(matches!(
-        policy().derive(&null_field.attributes, &null_field.roles),
-        OwnerFilterOutcome::Refuse(_)
-    ));
-
-    // A DIFFERENT enriched field present, but not the one the policy names → refuse.
-    let wrong_field = with_enriched(ctx(), "tenant", serde_json::json!("acme"));
-    assert!(matches!(
-        policy().derive(&wrong_field.attributes, &wrong_field.roles),
-        OwnerFilterOutcome::Refuse(_)
-    ));
-}
-
-#[test]
-fn inbound_forged_owner_filter_cannot_widen_visibility() {
-    // The identity value is read ONLY from the server-resolved enriched namespace.
-    // A client that stuffs a plain `user_id` attribute (not the enriched key) does
-    // not influence the derivation — still fail-closed.
-    let mut c = ctx();
-    c.attributes.insert("user_id".to_string(), serde_json::json!("mallory"));
-    assert!(
-        matches!(policy().derive(&c.attributes, &c.roles), OwnerFilterOutcome::Refuse(_)),
-        "a non-enriched (forgeable) attribute must not resolve the owner identity"
-    );
-}
-
-#[test]
-fn validate_rejects_nested_or_empty_paths() {
-    let ok = policy();
-    assert!(ok.validate().is_ok());
-
-    let nested = SubscriptionPolicy {
-        owner_path: "$.a.b".to_string(),
-        ..policy()
-    };
-    assert!(nested.validate().is_err(), "nested paths unsupported");
-
-    let empty_field = SubscriptionPolicy {
-        identity_field: String::new(),
-        ..policy()
-    };
-    assert!(empty_field.validate().is_err());
-
-    let empty_path = SubscriptionPolicy {
-        owner_path: "$.".to_string(),
-        ..policy()
-    };
-    assert!(empty_path.validate().is_err());
+fn default_enforcement_is_none() {
+    assert_eq!(OwnerEnforcement::default(), OwnerEnforcement::None);
 }

--- a/crates/fraiseql-server/src/realtime/subscriptions.rs
+++ b/crates/fraiseql-server/src/realtime/subscriptions.rs
@@ -59,7 +59,7 @@ pub enum FilterOperator {
 }
 
 /// A single field-level filter on subscription events.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldFilter {
     /// Field name to compare.
     pub field:    String,
@@ -131,10 +131,17 @@ pub fn parse_filter(filter_str: &str) -> Result<Vec<FieldFilter>, String> {
 pub struct SubscriptionDetails {
     /// Optional event type filter (None = all events).
     pub event_filter:          Option<EventKind>,
-    /// Field-level filters applied to event payloads.
+    /// Client-supplied field-level filters applied to event payloads (cooperative — a
+    /// client can only narrow its own stream).
     pub field_filters:         Vec<FieldFilter>,
     /// Security context hash for RLS grouping.
     pub security_context_hash: u64,
+    /// Server-owned row-visibility enforcement for a policy-declaring entity (#596),
+    /// resolved at subscribe time. The delivery pipeline **denies** a policy entity's
+    /// events to a subscription left at `OwnerEnforcement::None` — so the seam is
+    /// fail-closed by construction even if a future assembler skips the subscribe-time
+    /// wiring.
+    pub owner_enforcement:     super::subscription_policy::OwnerEnforcement,
 }
 
 /// Thread-safe subscription manager with two-level indexing.

--- a/crates/fraiseql-server/src/realtime/tests.rs
+++ b/crates/fraiseql-server/src/realtime/tests.rs
@@ -48,16 +48,17 @@ impl TokenValidator for TestValidator {
         Box::pin(async move {
             if token.starts_with("valid-") {
                 let user_id = token.strip_prefix("valid-").unwrap_or("unknown").to_owned();
-                Ok(TokenInfo {
-                    user_id:      user_id.clone(),
-                    context_hash: {
-                        use std::hash::{Hash, Hasher};
-                        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                        user_id.hash(&mut hasher);
-                        hasher.finish()
-                    },
-                    expires_at:   chrono::Utc::now().timestamp() + expires_in,
-                })
+                let context_hash = {
+                    use std::hash::{Hash, Hasher};
+                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                    user_id.hash(&mut hasher);
+                    hasher.finish()
+                };
+                Ok(TokenInfo::new(
+                    user_id,
+                    context_hash,
+                    chrono::Utc::now().timestamp() + expires_in,
+                ))
             } else if token == "expired-token" {
                 Err("token expired".to_owned())
             } else {
@@ -377,11 +378,7 @@ impl TokenValidator for NearExpiryValidator {
         Box::pin(async move {
             if token.starts_with("valid-") {
                 let user_id = token.strip_prefix("valid-").unwrap_or("unknown").to_owned();
-                Ok(TokenInfo {
-                    user_id,
-                    context_hash: 42,
-                    expires_at: chrono::Utc::now().timestamp(),
-                })
+                Ok(TokenInfo::new(user_id, 42, chrono::Utc::now().timestamp()))
             } else {
                 Err("invalid".to_owned())
             }
@@ -1650,4 +1647,190 @@ async fn test_realtime_route_does_not_conflict() {
     );
 
     ws.close(None).await.ok();
+}
+
+// ── #596 phase 06a: row-visibility fail-closed on the (dormant) realtime seam ────
+
+/// End-to-end proofs that this seam cannot come up deliver-all for a policy-declaring
+/// entity: an unresolvable identity is **refused** at subscribe time, and a subscription
+/// that reaches delivery without a resolved owner enforcement is **dropped**.
+mod policy_596 {
+    use std::{
+        collections::{HashMap, HashSet},
+        net::SocketAddr,
+        sync::Arc,
+        time::Duration,
+    };
+
+    use axum::{Router, routing::get};
+    use fraiseql_core::schema::SubscriptionPolicy;
+    use futures::StreamExt;
+    use tokio::{net::TcpListener, sync::mpsc};
+    use tokio_tungstenite::connect_async;
+
+    use super::{
+        super::{
+            connections::{ConnectionManager, ConnectionState},
+            delivery::{EntityEvent, EventDeliveryPipeline, EventKindSerde},
+            server::{RealtimeConfig, RealtimeServer, RealtimeState},
+            subscription_policy::OwnerEnforcement,
+            subscriptions::{SubscriptionDetails, SubscriptionManager},
+        },
+        AllowAllRls, TestValidator, make_post_event, next_msg, send_json, ws_url,
+    };
+
+    /// A row policy on `Post`: owner boundary `owner_id == fraiseql.enriched.user_id`.
+    fn post_policy() -> SubscriptionPolicy {
+        SubscriptionPolicy {
+            owner_path:     "$.owner_id".to_string(),
+            identity_field: "user_id".to_string(),
+            bypass_roles:   vec![],
+        }
+    }
+
+    /// Spawn a realtime server + delivery pipeline that both know about the given
+    /// per-entity policies (mirrors `spawn_server_with_delivery`, with policies wired).
+    async fn spawn_with_policies(
+        policies: HashMap<String, SubscriptionPolicy>,
+    ) -> (SocketAddr, mpsc::Sender<EntityEvent>) {
+        let entities: HashSet<String> = policies.keys().cloned().collect();
+        let policy_entities = entities.clone();
+        let server = Arc::new(
+            RealtimeServer::with_entities(RealtimeConfig::default(), entities)
+                .with_subscription_policies(policies),
+        );
+        let (event_tx, event_rx) = mpsc::channel(1000);
+        let pipeline = EventDeliveryPipeline::with_policy_entities(
+            server.subscriptions.clone(),
+            server.connections.clone(),
+            Arc::new(AllowAllRls),
+            policy_entities,
+            event_rx,
+        );
+        tokio::spawn(pipeline.run());
+
+        let state = RealtimeState {
+            server,
+            validator: Arc::new(TestValidator::new()),
+        };
+        let app = Router::new()
+            .route("/realtime/v1", get(super::super::server::ws_handler))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (addr, event_tx)
+    }
+
+    /// The `TestValidator` produces a `TokenInfo` with no enriched identity (there is no
+    /// production enrichment on this dormant seam — #605), so a subscription to a
+    /// policy-declaring entity is refused at subscribe time and never registers.
+    #[tokio::test]
+    async fn subscription_to_policy_entity_refused_without_enriched_identity() {
+        let (addr, event_tx) =
+            spawn_with_policies(HashMap::from([("Post".to_string(), post_policy())])).await;
+
+        let (mut ws, _) = connect_async(ws_url(addr, Some("valid-alice"))).await.unwrap();
+        let _ = next_msg(&mut ws).await; // connected
+
+        send_json(&mut ws, serde_json::json!({ "type": "subscribe", "entity": "Post" })).await;
+        let reply = next_msg(&mut ws).await;
+        assert_eq!(
+            reply["type"], "error",
+            "a policy entity + unresolvable identity must refuse, got {reply}"
+        );
+
+        // Nothing registered, so a published event is delivered to no one.
+        event_tx.send(make_post_event(EventKindSerde::Insert, 42)).await.unwrap();
+        let result = tokio::time::timeout(Duration::from_millis(200), ws.next()).await;
+        assert!(result.is_err(), "a refused subscription must receive no events");
+
+        ws.close(None).await.ok();
+    }
+
+    /// Defense-in-depth: even if a subscription reached the pipeline WITHOUT a resolved
+    /// owner enforcement (a future assembler bypassing the subscribe-time gate), a
+    /// policy-declaring entity's events are dropped for it — never deliver-all.
+    #[tokio::test]
+    async fn pipeline_drops_unenforced_policy_subscription() {
+        let subs = Arc::new(SubscriptionManager::new(1000));
+        let conns = Arc::new(ConnectionManager::new(50, 256));
+        let (event_tx, event_rx) = mpsc::channel(100);
+        let pipeline = EventDeliveryPipeline::with_policy_entities(
+            subs.clone(),
+            conns.clone(),
+            Arc::new(AllowAllRls),
+            HashSet::from(["Post".to_string()]),
+            event_rx,
+        );
+        tokio::spawn(pipeline.run());
+
+        let (mut conn_rx, _ctrl) = conns.insert(ConnectionState::new(
+            "conn-x".to_string(),
+            "user-x".to_string(),
+            7,
+            i64::MAX,
+        ));
+        subs.subscribe(
+            "conn-x",
+            "Post",
+            SubscriptionDetails {
+                event_filter:          None,
+                field_filters:         vec![],
+                security_context_hash: 7,
+                owner_enforcement:     OwnerEnforcement::None,
+            },
+        )
+        .unwrap();
+
+        event_tx.send(make_post_event(EventKindSerde::Insert, 42)).await.unwrap();
+        let result = tokio::time::timeout(Duration::from_millis(200), conn_rx.recv()).await;
+        assert!(
+            result.is_err(),
+            "an unenforced subscription to a policy entity must be dropped (fail-closed)"
+        );
+    }
+
+    /// A `Bypass` enforcement (a bypass role) still receives a policy entity's events.
+    #[tokio::test]
+    async fn pipeline_delivers_to_bypass_subscription() {
+        let subs = Arc::new(SubscriptionManager::new(1000));
+        let conns = Arc::new(ConnectionManager::new(50, 256));
+        let (event_tx, event_rx) = mpsc::channel(100);
+        let pipeline = EventDeliveryPipeline::with_policy_entities(
+            subs.clone(),
+            conns.clone(),
+            Arc::new(AllowAllRls),
+            HashSet::from(["Post".to_string()]),
+            event_rx,
+        );
+        tokio::spawn(pipeline.run());
+
+        let (mut conn_rx, _ctrl) = conns.insert(ConnectionState::new(
+            "conn-b".to_string(),
+            "user-b".to_string(),
+            9,
+            i64::MAX,
+        ));
+        subs.subscribe(
+            "conn-b",
+            "Post",
+            SubscriptionDetails {
+                event_filter:          None,
+                field_filters:         vec![],
+                security_context_hash: 9,
+                owner_enforcement:     OwnerEnforcement::Bypass,
+            },
+        )
+        .unwrap();
+
+        event_tx.send(make_post_event(EventKindSerde::Insert, 42)).await.unwrap();
+        let result = tokio::time::timeout(Duration::from_millis(500), conn_rx.recv()).await;
+        assert!(
+            result.is_ok(),
+            "a bypass-role subscription must receive the policy entity's events"
+        );
+    }
 }

--- a/crates/fraiseql-server/src/server/routing_tests.rs
+++ b/crates/fraiseql-server/src/server/routing_tests.rs
@@ -49,13 +49,7 @@ struct AlwaysOkValidator;
 
 impl TokenValidator for AlwaysOkValidator {
     fn validate<'a>(&'a self, _token: &'a str) -> BoxFuture<'a, Result<TokenInfo, String>> {
-        Box::pin(async move {
-            Ok(TokenInfo {
-                user_id:      "test-user".to_string(),
-                context_hash: 0,
-                expires_at:   i64::MAX,
-            })
-        })
+        Box::pin(async move { Ok(TokenInfo::new("test-user".to_string(), 0, i64::MAX)) })
     }
 }
 

--- a/crates/fraiseql-server/tests/subscription_row_visibility_pin_test.rs
+++ b/crates/fraiseql-server/tests/subscription_row_visibility_pin_test.rs
@@ -1,95 +1,77 @@
-//! Baseline pin for #596 on the **realtime `/realtime/v1` entity-change stream**
-//! (phase 00). NOTE: this is the *dormant* push path — `RealtimeServer`/`RealtimeState`
-//! are never assembled by any production binary (all `.with_realtime(...)` call sites
-//! are tests; there is no production `TokenValidator`). The *live* graphql `/ws` path is
-//! pinned separately in `graphql_ws_row_visibility_pin_test.rs` (`// M-596-WS`).
+//! Row-level visibility regression for the realtime `/realtime/v1` entity-change stream
+//! (#596, phase 06a — the FLIP of the phase-00 characterization).
 //!
-//! Two principals subscribe to the same entity. A row owned by principal B is
-//! delivered to principal A because this pipeline enforces no row boundary:
-//! subscriptions carry client-supplied field filters (cooperative, not a
-//! security boundary) and there is no server-derived owner policy. The
-//! `RlsEvaluator` (`realtime/delivery.rs`) has no non-test implementor, so the delivery
-//! pipeline's RLS hook is permissive by default.
+//! NOTE: this is the *dormant* push path — `RealtimeServer`/`RealtimeState` are never
+//! assembled by any production binary (#605). The *live* graphql `/ws` path is covered by
+//! `graphql_ws_row_visibility_pin_test.rs`. 06a's job on this seam is that it can never
+//! come up deliver-all by accident: for a policy-declaring entity the delivery decision
+//! (`owner_enforcement_admits`) is **fail-closed** — a subscription that did not resolve
+//! an explicit `Bypass`/`Scoped` owner enforcement at subscribe time is denied.
 //!
-//! `// M-596` marks the assertion phase 06a flips: once an entity declares a
-//! `subscription_policy`, principal A must NOT receive principal B's row — and, the
-//! 06a fail-closed deliverable, an *unconfigured* evaluator must deny for a
-//! policy-declaring entity rather than deliver-all.
-//!
-//! This is the focused, infra-free characterization (the realtime subscription manager +
-//! field-filter delivery), not the graphql `/ws` path.
+//! Phase 00 pinned the gap: with no server-side policy, principal A was delivered
+//! principal B's row (`evaluate_field_filters` let it pass). That assertion is now flipped
+//! — the delivery decision denies B's row to a scoped A and denies an unenforced policy
+//! subscription outright. Subscribe-time refusal (the other half — an unresolvable
+//! identity is refused) is covered end-to-end in `realtime::tests`.
 
 #![allow(clippy::unwrap_used)] // Reason: test code
 
 use fraiseql_server::realtime::{
-    delivery::evaluate_field_filters,
-    subscriptions::{SubscriptionDetails, SubscriptionManager},
+    delivery::owner_enforcement_admits,
+    subscription_policy::OwnerEnforcement,
+    subscriptions::{FieldFilter, FilterOperator},
 };
 
-/// A synthetic "connection subscribes without any field filter" — the common
-/// case: the client just asks for an entity's change stream.
-const fn unfiltered_details(context_hash: u64) -> SubscriptionDetails {
-    SubscriptionDetails {
-        event_filter:          None,
-        field_filters:         Vec::new(),
-        security_context_hash: context_hash,
+/// The server-owned owner filter A resolves for a `subscription_policy` on `owner_id`.
+fn a_owner_filter() -> FieldFilter {
+    FieldFilter {
+        field:    "owner_id".to_string(),
+        operator: FilterOperator::Eq,
+        value:    serde_json::json!("A"),
     }
 }
 
 #[test]
-fn pin_596_principal_a_receives_principal_b_row() {
-    let manager = SubscriptionManager::new(1024);
-
-    // Principal A subscribes to `Order`. A's security context hashes to some value;
-    // the manager stores it but derives NO owner condition from it.
-    let principal_a_hash = 0xA;
-    assert!(
-        manager
-            .subscribe("conn-A", "Order", unfiltered_details(principal_a_hash))
-            .unwrap()
-    );
-
-    // A is the sole subscriber to `Order`.
-    let subscribers = manager.get_subscribers("Order").expect("A is subscribed");
-    assert_eq!(subscribers.len(), 1);
-    let (conn_id, details) = &subscribers[0];
-    assert_eq!(conn_id, "conn-A");
-
-    // An `Order` row owned by principal B is inserted. The after-image carries the
-    // owner column, but the delivery path has no policy binding it to A's identity.
+fn m596_unenforced_policy_subscription_is_denied_fail_closed() {
+    // The flip: a subscription to a policy-declaring entity that reached delivery WITHOUT
+    // a resolved owner enforcement (`None`) is denied — never deliver-all. This is what
+    // keeps a future assembler of this dormant seam from coming up permissive.
     let b_row = serde_json::json!({ "id": 42, "owner_id": "B", "status": "approved" });
-
-    // The only gate before delivery is `evaluate_field_filters` — and A supplied
-    // none, so B's row passes. THIS is the #596 gap: A receives B's after-image.
     assert!(
-        evaluate_field_filters(&details.field_filters, Some(&b_row)),
-        "M-596: with no server-side row policy, principal A is delivered principal B's row. \
-         Phase 06 adds a `subscription_policy` that derives an owner condition from A's \
-         enriched identity at subscribe time; when it lands, A must be filtered out here."
+        !owner_enforcement_admits(&OwnerEnforcement::None, Some(&b_row)),
+        "M-596: an unenforced subscription to a policy entity must be denied (was deliver-all)"
     );
+    // Even with no row image at all, `None` denies.
+    assert!(!owner_enforcement_admits(&OwnerEnforcement::None, None));
 }
 
 #[test]
-fn pin_596_client_field_filters_are_cooperative_not_a_boundary() {
-    // A client CAN scope itself with a field filter, but nothing forces it to —
-    // and a malicious client simply omits the filter (previous test) or supplies
-    // one that widens visibility. Demonstrate that the filter is entirely
-    // client-chosen: a filter naming the wrong owner still "passes" its own rows.
-    let details = SubscriptionDetails {
-        event_filter:          None,
-        field_filters:         fraiseql_server::realtime::subscriptions::parse_filter(
-            "owner_id=eq.B",
-        )
-        .unwrap(),
-        security_context_hash: 0xA,
-    };
-    // Principal A (hash 0xA) asks — cooperatively — to see owner B's rows. The
-    // server honors it because field filters are not an authorization boundary.
-    let b_row = serde_json::json!({ "id": 7, "owner_id": "B" });
+fn m596_scoped_subscriber_does_not_receive_another_owners_row() {
+    // The flip of the phase-00 assertion: principal A, scoped to `owner_id = A`, is NOT
+    // delivered principal B's row.
+    let b_row = serde_json::json!({ "id": 42, "owner_id": "B", "status": "approved" });
     assert!(
-        evaluate_field_filters(&details.field_filters, Some(&b_row)),
-        "M-596: field filters are client-supplied and cooperative — a client can request \
-         another principal's rows and the push path will deliver them. Only a server-derived \
-         policy (phase 06) closes this."
+        !owner_enforcement_admits(&OwnerEnforcement::Scoped(a_owner_filter()), Some(&b_row)),
+        "M-596: a scoped subscriber must NOT receive another owner's row"
+    );
+
+    // A's own row IS delivered.
+    let a_row = serde_json::json!({ "id": 7, "owner_id": "A" });
+    assert!(owner_enforcement_admits(
+        &OwnerEnforcement::Scoped(a_owner_filter()),
+        Some(&a_row)
+    ));
+
+    // A DELETE with no owning image cannot prove ownership → denied (scoped clients learn
+    // of a delete only when a pre-image is present).
+    assert!(!owner_enforcement_admits(&OwnerEnforcement::Scoped(a_owner_filter()), None));
+}
+
+#[test]
+fn m596_bypass_role_retains_full_visibility() {
+    let b_row = serde_json::json!({ "id": 42, "owner_id": "B" });
+    assert!(
+        owner_enforcement_admits(&OwnerEnforcement::Bypass, Some(&b_row)),
+        "a bypass role keeps full visibility over a policy entity"
     );
 }


### PR DESCRIPTION
## Phase 06a — hardening the dormant realtime seam (#596)

The realtime `/realtime/v1` entity-change subsystem carries entity after-images and has a row-visibility seam, but **no production binary assembles it** (#605 tracks productionize-or-remove). This PR does the one thing that matters on a dormant path: make it **fail-closed by construction** so it can never come up deliver-all — and unify it on the shared `fraiseql-core` policy derivation 06b landed (the two push paths cannot drift).

Scope is deliberately small: **no** production `TokenValidator`, enrichment plumbing, or subsystem assembly (that is #605's productionization work).

### What changed
- **`realtime::subscription_policy` is now a thin adapter** over `fraiseql_core::schema::{SubscriptionPolicy, OwnerCondition}` — the duplicate policy type + derivation are deleted. It maps the seam-neutral `OwnerCondition` → `OwnerEnforcement {None, Bypass, Scoped}`.
- **`TokenInfo`** carries the connection's enriched `attributes` + `roles` (empty until a production validator runs #539 enrichment — #605). `handle_subscribe` derives the entity's policy and **refuses** an unresolvable identity (fail-closed), else stores the resolved enforcement.
- **`EventDeliveryPipeline` is fail-closed for policy entities**: a subscription that reaches delivery without an explicit `Bypass`/`Scoped` enforcement is **dropped** (`owner_enforcement_admits`). A `Scoped` subscriber never receives another owner's row; a missing row image cannot prove ownership (a scoped client learns of a DELETE only with a pre-image).

### Tests
- **Flipped the `M-596` realtime pin** into a passing regression of the closed behavior (unenforced → deny, scoped → filter B's row, bypass → full, no-image → deny).
- **End-to-end** (`realtime::tests::policy_596`): a policy entity + unresolvable identity is refused at subscribe time and delivers nothing; the pipeline drops an unenforced policy subscription and delivers to a bypass one.
- Adapter unit tests for `OwnerCondition` → `OwnerEnforcement`.

### Local verification
`make preflight` (fmt/clippy/rustdoc/shell gates) · `cargo check --workspace --all-features --all-targets` · realtime module + pin suites green.

### #596 closure
With 06b (merged) + this PR, both push paths that carry after-images honor the row boundary. **#596 can close when this merges** (or on 06b alone if #605 is resolved by *removing* the subsystem — in which case most of this PR's wiring is deleted with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)