### PR TITLE
chore(functions-platform-maturity): finalize — after:ingest run_as e2e + archaeology

### DIFF
--- a/crates/fraiseql-server/src/routes/after_mutation/tests.rs
+++ b/crates/fraiseql-server/src/routes/after_mutation/tests.rs
@@ -634,6 +634,69 @@ mod query_bridge_wiring {
     }
 
     #[tokio::test]
+    async fn after_ingest_bridge_runs_under_the_run_as_ceiling() {
+        // #594 (ingest half): the same `run_as`→bridge wiring proven above for
+        // after:mutation, but driven by an inbound-message-shaped payload — the
+        // normalized `InboundMessage` a Source adapter puts on the durable spine and
+        // that `spawn_after_ingest` hands to the dispatcher. This bypasses the
+        // Postgres spine (`inbound::spine`, tested separately) and drives `build_host`
+        // directly, exactly as the after:mutation case bypasses the HTTP route: the
+        // dispatched host's `fraiseql_query` write must run under the after:ingest
+        // function's `run_as` ceiling, audited as `system_job:<function-name>`.
+        use fraiseql_functions::{InboundMessage, IngestSource, IngestTrigger};
+
+        let (factory, captured) = recording_factory();
+        let run_as = RunAs {
+            roles:  vec!["ticket_writer".to_string()],
+            scopes: vec!["write:ticket".to_string()],
+            tenant: Some("acme".to_string()),
+        };
+
+        // The event payload an after:ingest function receives: the whole normalized
+        // message rendered by the real `IngestTrigger::build_payload`, so its shape
+        // (`after:ingest:<source>` trigger type, `event_kind = "ingest"`) matches what
+        // the spine dispatches — not a hand-built mutation payload.
+        let message = InboundMessage::new(
+            IngestSource::Webhook {
+                provider: "stripe".to_string(),
+            },
+            "evt_9f8",
+            chrono::Utc::now(),
+        );
+        let payload = IngestTrigger {
+            function_name: "ingestPayment".to_string(),
+            source:        None,
+        }
+        .build_payload(&message);
+        assert_eq!(payload.trigger_type, "after:ingest:webhook:stripe");
+        assert_eq!(payload.event_kind, "ingest");
+
+        // Tag the dispatcher AfterIngest (its DLQ/metrics identity) and drive it.
+        let mut dispatcher = dispatcher(Some(factory), Some(run_as));
+        dispatcher.source = fraiseql_observers::DispatchSource::AfterIngest;
+        let host = dispatcher.build_host("ingestPayment", payload, "ingest-tok-1");
+
+        let value = host
+            .query("mutation { recordPayment(event: \"evt_9f8\") { id } }", serde_json::json!({}))
+            .await
+            .expect("the after:ingest bridge is wired");
+        assert_eq!(value, serde_json::json!({ "data": { "ok": true } }));
+
+        // The write ran under the after:ingest function's ceiling, audited as its
+        // system job — identity carries the granted roles/scopes and the tenant.
+        let identity = captured.lock().unwrap().clone().expect("identity captured");
+        assert_eq!(identity.user_id.0, "system_job:ingestPayment");
+        assert!(identity.has_role("ticket_writer"));
+        assert!(identity.has_scope("write:ticket"));
+        assert_eq!(
+            identity.tenant_id.as_ref().map(|tenant| tenant.0.as_str()),
+            Some("acme"),
+            "the ceiling's tenant scopes the ingest write"
+        );
+        assert_eq!(identity.request_id, "ingest-tok-1", "identity correlates the dispatch token");
+    }
+
+    #[tokio::test]
     async fn a_function_without_run_as_is_fail_closed() {
         // A factory but no `run_as` ⇒ the bridge is wired but runs under an anonymous
         // system_job with no authority: RLS/field-authz deny writes.

--- a/crates/fraiseql-server/tests/graphql_ws_row_visibility_pin_test.rs
+++ b/crates/fraiseql-server/tests/graphql_ws_row_visibility_pin_test.rs
@@ -1,8 +1,8 @@
-//! Row-level visibility conformance for the **live** graphql `/ws` path (#596, phase 06b).
+//! Row-level visibility conformance for the **live** graphql `/ws` path (#596).
 //!
 //! Drives the production `subscription_handler` over a real TCP `WebSocket` (the same
 //! harness as `subscription_ws_e2e_test.rs`). Proves the fix that closed the deliver-all
-//! gap the phase-00 characterization pinned:
+//! gap on the live path:
 //!
 //! - a subscription to a **policy-declaring** entity whose owner identity is **unresolvable**
 //!   (here: an anonymous connection, no enriched `fraiseql.enriched.*` field) is **refused at

--- a/crates/fraiseql-server/tests/subscription_row_visibility_pin_test.rs
+++ b/crates/fraiseql-server/tests/subscription_row_visibility_pin_test.rs
@@ -1,5 +1,5 @@
 //! Row-level visibility regression for the realtime `/realtime/v1` entity-change stream
-//! (#596, phase 06a — the FLIP of the phase-00 characterization).
+//! (#596) — the passing counterpart to the deliver-all characterization it replaced.
 //!
 //! NOTE: this is the *dormant* push path — `RealtimeServer`/`RealtimeState` are never
 //! assembled by any production binary (#605). The *live* graphql `/ws` path is covered by

--- a/docs/architecture/enriched-identity-rls.md
+++ b/docs/architecture/enriched-identity-rls.md
@@ -190,6 +190,11 @@ the subscription rather than silently widening it.
 > tracked separately. The `POST /realtime/v1/broadcast` app-channel pubsub carries no
 > entity after-images and has no row policy.
 
+> **Hot-reload.** Subscription policies are resolved at server start; a policy added or
+> changed via a schema **hot-reload** takes effect on **restart**, not immediately (the
+> subscription subsystem is not yet re-mounted on reload). Change subscription
+> row-visibility policies with a restart. Tracked as a follow-up.
+
 ---
 
 ## Operational notes


### PR DESCRIPTION
## Phase 10 — finalize (functions-platform-maturity train)

Closes out the train. Most of the finalize was verification + issue closeout (done outside a diff); this PR carries the one substantive committed item plus archaeology.

### Committed here
- **after:ingest `run_as`→bridge e2e (#594 ingest half).** `after_ingest_bridge_runs_under_the_run_as_ceiling` drives an inbound-message-shaped payload (real `IngestTrigger::build_payload`, source `webhook:stripe`, `DispatchSource::AfterIngest`) through dispatch to a `fraiseql_query` write and asserts the captured `SecurityContext` is the function's `run_as` ceiling (`system_job:ingestPayment` + roles/scopes/tenant). The after:ingest half now has an **e2e authority proof**, not just a wiring proof — same fidelity as the after:mutation `query_bridge_wiring` case (no Postgres / second isolate; identity is minted at `build_host` from `run_as`).
- **Archaeology.** Removed phase-number refs from the flipped row-visibility pin docstrings; documented the subscription-policy hot-reload limitation.

### Done outside this diff (verification / issue closeout)
- **Issues closed** with landing-PR links: #594 (already), **#595** (cron, #603), **#597** (predicates, #603), **#598** (metrics + DLQ, #603), **#596** (subscription row visibility, #604 + #606), **#602** (service accounts, #607).
- **Follow-ups filed & documented (honest gaps):** **#605** (realtime `/realtime/v1` subsystem is unassembled in prod — productionize or remove; 06a made it fail-closed by construction), **#611** (subscription policies are fixed at server start — not propagated on schema hot-reload).
- **Security audit (new authority surfaces).** Ceilings proven fail-closed on every dispatch path: after:mutation (`query_bridge_wiring`), **after:ingest (new test)**, cron/after:capture (dispatch pins), service bearer (SA ceilingless test). Subscription-policy bypass matrix covered: forged variables, legacy `graphql-ws`, enrichment outage, anonymous → all refuse fail-closed; the dormant realtime seam's fail-closed default is tested (06a).
- **Pins**: the phase-00 characterization pins are all flipped to passing regressions (no `#[ignore]`).

### Train summary
06b (#604) → 06a (#606) → 09B (#607) → this. #596's two push paths closed; service-account identities shipped (ADR-0018, amended); the functions platform (cron/predicates/capture/metrics/DLQ/query-bridge) is observable and authority-bounded end to end.

### Local verification
`make preflight` (fmt/clippy/rustdoc/shell gates) · after:ingest test green (nextest, functions-runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)