### PR TITLE
ci(dagger): cap test-leg parallelism to stop --all-features OOM (#615)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -409,11 +409,22 @@ func (m *FraiseqlCi) Test(
 		"echo '### cargo test -p fraiseql-federation --lib --features saga (#429 wired forward exec; SQLite dispatch, no DB)'",
 		"cargo test -p fraiseql-federation --lib --features saga",
 		"echo '### cargo test --doc --all-features'",
-		"cargo test --doc --all-features",
+		// Cap doctest concurrency: `cargo test --doc` spawns one process per doctest,
+		// and the default thread count (= CPU count) OOMs the 31 GiB box on the heavy
+		// --all-features doctest set (arrow doctests were OOM-killed). See the leg-level
+		// CARGO_BUILD_JOBS note below.
+		"cargo test --doc --all-features -- --test-threads=6",
 		"echo \"test OK: workspace suite passed (toolchain " + toolchain + ", testcontainers tests skipped)\"",
 	}, "\n")
 
 	return m.rustBaseFor(toolchain).
+		// The test leg is the only one that runs a full `cargo build --all-features`
+		// PLUS the workspace test + doctest suites in one container. Since the functions
+		// runtime pulled V8 into --all-features (a very memory-heavy compilation unit),
+		// 16 parallel rustc jobs peak over this box's 31 GiB RAM and the OOM killer
+		// takes rustc/doctest processes (bare exit-101, no diagnostic). Cap this leg to
+		// 8 jobs (the other legs stay at the base 16 — they don't OOM). See #615.
+		WithEnvVariable("CARGO_BUILD_JOBS", "8").
 		WithMountedDirectory("/src", source).
 		WithWorkdir("/src").
 		WithMountedCache("/src/target", dag.CacheVolume(targetVol)).


### PR DESCRIPTION
## #615 — dev's `test` leg is red from OOM, not a code bug

The Dagger `test` leg went **green→red exactly at #603** (`026c4e83a`), when the functions runtime pulled **V8** into `--all-features`. V8 is a very memory-heavy compilation unit, so 16 parallel rustc jobs + the default doctest thread count peak over the box's **31 GiB** RAM → the OOM killer takes rustc/doctest processes: a bare `exit status: 101` with **no compiler diagnostic**, and 5 `fraiseql-arrow` doctests reported `FAILED` with no assertion (they pass **17/17 locally** in ~4.6 s). A warm-cache re-run reproduced it — not transient, not a code bug.

### Fix (scoped to the `test` leg only)
The other legs stay at the base `CARGO_BUILD_JOBS=16` — they don't run the full build+test+doctest together and don't OOM.
- **`CARGO_BUILD_JOBS=8`** (from 16) — headroom for V8's compile spike.
- **`cargo test --doc --all-features -- --test-threads=6`** — caps concurrent doctest processes.

### Verification
- `.dagger` Go module builds (`go build ./...`) + `gofmt` clean; `make preflight` green.
- The `test` leg is a **post-merge heavy leg** (doesn't run on PRs), so the cap is confirmed on the **dev run after merge**. If it still OOMs, lower further (jobs 6 / doctest-threads 4) — tracked in #615.

Root-caused during the phase-06/09B/finalize train's post-merge review; the train's own code is clean (17/17 doctests pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)