### PR TITLE
fix(storage): private-bucket downloads are not shared-cacheable (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Private-bucket downloads are no longer advertised as shared-cacheable (#608).**
+  Every storage download was served `Cache-Control: public, max-age=3600` regardless
+  of the bucket's access mode. For a `Private` bucket this defeated the per-request
+  RLS check (`can_read`) that ran immediately before it: any shared cache on the path
+  (CDN, reverse proxy, corporate forward proxy) was told the response was public and
+  could store it and serve the private object to unauthenticated third parties for up
+  to an hour, and revocation did not take effect until the entry expired. Downloads
+  now branch on access mode — a `Private` bucket serves `Cache-Control: private,
+  no-store` (per-row `can_read` cannot be represented by a URL-keyed shared cache, so
+  the object must not be stored at all); a `PublicRead` bucket is unchanged (`public,
+  max-age=3600`). Only shared-cache-fronted deployments were exposed; direct-to-server
+  deployments were unaffected.
+
 - **Subscription row-level visibility on the live `/ws` path — fail-closed (#596).**
   Previously any principal authorized to subscribe to an entity over `/ws`
   (`graphql-transport-ws` / legacy `graphql-ws`) received **every** row's after-images:

--- a/crates/fraiseql-storage/src/routes/mod.rs
+++ b/crates/fraiseql-storage/src/routes/mod.rs
@@ -329,12 +329,18 @@ async fn get_handler(
                     headers.insert(header::ETAG, val);
                 }
             }
-            headers.insert(
-                header::CACHE_CONTROL,
-                "public, max-age=3600"
-                    .parse()
-                    .expect("static ASCII header value parses as HeaderValue"),
-            );
+            // #608: branch the cache directive on the bucket's access mode. A
+            // `Private` object's per-request RLS decision (`can_read`, above) is
+            // per-row, so a URL-keyed shared cache (CDN/reverse/forward proxy)
+            // cannot represent the boundary — advertising `public` would let it
+            // store the private object and serve it to unauthenticated third
+            // parties, and would delay revocation for up to `max-age`. `no-store`
+            // is the conservative directive; `PublicRead` stays publicly cacheable.
+            let cache_control = match bucket.access {
+                crate::config::BucketAccess::Private => "private, no-store",
+                crate::config::BucketAccess::PublicRead => "public, max-age=3600",
+            };
+            headers.insert(header::CACHE_CONTROL, HeaderValue::from_static(cache_control));
             // #337: defang stored content. `nosniff` stops browsers from
             // MIME-sniffing the body into an executable type. The default
             // `attachment` disposition forces a download rather than inline

--- a/crates/fraiseql-storage/src/routes/tests.rs
+++ b/crates/fraiseql-storage/src/routes/tests.rs
@@ -300,6 +300,71 @@ async fn test_download_sets_nosniff_and_attachment_for_html() {
 }
 
 #[tokio::test]
+async fn private_bucket_download_is_not_shared_cacheable() {
+    // #608: a Private-bucket download passes the per-request RLS check, then must NOT be
+    // advertised as publicly cacheable. A shared cache (CDN / reverse or forward proxy) told
+    // `public, max-age=3600` may store the private object and serve it to unauthenticated third
+    // parties for an hour, defeating the `can_read` check that ran immediately before. `can_read`
+    // is per-row, so a URL-keyed shared cache cannot represent the boundary → `private, no-store`.
+    let (state, _keep) = test_state("private-files", BucketAccess::Private).await;
+
+    // The owner uploads, then downloads their own object (RLS allows the owner on a Private
+    // bucket).
+    let app = authenticated_router(state.clone());
+    let upload = Request::builder()
+        .method("PUT")
+        .uri("/storage/v1/object/private-files/secret.txt")
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from("classified"))
+        .unwrap();
+    assert_eq!(app.oneshot(upload).await.unwrap().status(), StatusCode::OK);
+
+    let app = authenticated_router(state);
+    let download = Request::builder()
+        .method("GET")
+        .uri("/storage/v1/object/private-files/secret.txt")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(download).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(header::CACHE_CONTROL).and_then(|v| v.to_str().ok()),
+        Some("private, no-store"),
+        "a Private-bucket download must not be advertised as shared-cacheable (#608)",
+    );
+}
+
+#[tokio::test]
+async fn public_read_bucket_download_stays_publicly_cacheable() {
+    // #608 guard: the fix must not regress the public path. A PublicRead download stays
+    // `public, max-age=3600` — public read is cacheable by definition.
+    let (state, _keep) = test_state("public-files", BucketAccess::PublicRead).await;
+
+    let app = authenticated_router(state.clone());
+    let upload = Request::builder()
+        .method("PUT")
+        .uri("/storage/v1/object/public-files/logo.png")
+        .header(header::CONTENT_TYPE, "image/png")
+        .body(Body::from("PNGDATA"))
+        .unwrap();
+    assert_eq!(app.oneshot(upload).await.unwrap().status(), StatusCode::OK);
+
+    let app = authenticated_router(state);
+    let download = Request::builder()
+        .method("GET")
+        .uri("/storage/v1/object/public-files/logo.png")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(download).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(header::CACHE_CONTROL).and_then(|v| v.to_str().ok()),
+        Some("public, max-age=3600"),
+        "PublicRead downloads remain publicly cacheable (#608 must not regress the public path)",
+    );
+}
+
+#[tokio::test]
 async fn test_serve_inline_bucket_renders_safe_types_but_attaches_dangerous_ones() {
     // #337: a bucket may opt into inline rendering, but content types that can
     // execute as active content are still served as attachments.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -33,6 +33,15 @@ switching between providers via configuration.
 - **Path validation**: Upload paths are validated against traversal attacks.
   The `validate_socket_dir` pattern rejects `..` components.
 - **Size limits**: Configurable per-file and per-request size limits.
+- **Download cache directives**: a download's `Cache-Control` depends on the
+  bucket's access mode. A `Private` bucket serves `Cache-Control: private,
+  no-store` — its per-request RLS decision (`can_read`) is per-row, so a
+  shared cache (CDN / reverse or forward proxy) keyed on the URL cannot
+  represent the boundary and must never store the object. A `PublicRead`
+  bucket serves `Cache-Control: public, max-age=3600`, since public read is
+  cacheable by definition. (Fixed in #608: previously every download was
+  served `public`, which let a shared cache serve a private object to
+  unauthenticated clients for up to an hour.)
 
 ## Transforms (Optional)
 


### PR DESCRIPTION
## Summary

Storage downloads were served `Cache-Control: public, max-age=3600` unconditionally, with no branch on the bucket's access mode (`crates/fraiseql-storage/src/routes/mod.rs`). For a **`Private`** bucket this defeated the per-request RLS check (`can_read`) that ran immediately before it: any shared cache on the path — CDN, reverse proxy, corporate forward proxy — was told the private object was `public` and could store it and serve it to **unauthenticated third parties** for up to an hour. Revocation also did not take effect until the cache entry expired.

Because `can_read` is per-row, two users can legitimately get different answers for the same bucket+key URL, so a URL-keyed shared cache cannot represent the boundary — `no-store` is the conservative directive for private objects.

Only shared-cache-fronted deployments were exposed; direct-to-server deployments were unaffected.

## Change

`get_handler` now branches the directive on `bucket.access`:

| Access | `Cache-Control` |
|---|---|
| `Private` | `private, no-store` (was `public, max-age=3600`) |
| `PublicRead` | `public, max-age=3600` (unchanged) |

The `match` is exhaustive over the `#[non_exhaustive]` `BucketAccess` **in-crate**, so a future access variant forces a compile error here rather than silently mis-caching. It mirrors the existing `list_handler` precedent that already branches on `bucket.access`.

The `private, no-cache` alternative (keeps browser re-download semantics for large artifacts while still barring shared caches) was considered and deferred: this is the security fix, so it ships the unambiguously-safe `no-store`; switching this one match arm later is a trivial, separable follow-up if bandwidth for large artifacts becomes a concern.

## Tests

- `private_bucket_download_is_not_shared_cacheable` — a `Private` download now asserts `private, no-store`.
- `public_read_bucket_download_stays_publicly_cacheable` — guards the public path against regression.

## Verification

- ✅ `cargo clippy -p fraiseql-storage --all-targets --all-features -- -D warnings` clean
- ✅ `cargo test -p fraiseql-storage` (lib 80 passed incl. 2 new pins; doctests green)
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc -p fraiseql-storage --all-features --no-deps` clean
- ✅ `cargo +nightly fmt` applied

Closes #608.

This is the first PR of the docs-review-sweep fix train (#608, #609, #610, #612); #609/#610/#612 follow in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
