### PR TITLE
fix(security): make trusted_proxy_cidrs reachable on the compiled path (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whoever eventually productionizes the subsystem cannot bring it up deliver-all by
   accident. Issue #605 tracks the productionize-or-remove decision.
 
+- **Rate-limiting proxy-trust mitigation is reachable on the compiled path (#609).**
+  `trust_proxy_headers = true` was settable in `[security.rate_limiting]`, but its safety
+  valve `trusted_proxy_cidrs` was not — the CLI schema lacked the field and
+  `deny_unknown_fields` rejected it, so the only reachable posture trusted
+  `X-Forwarded-For` from **every** proxy IP. Any client could then spoof its address to
+  bypass per-IP rate limiting or poison IP-derived logging — the mitigation the docs
+  recommend could not be applied. The field is now accepted on the compiled path,
+  **validated as CIDR notation at compile time** (a malformed range fails `fraiseql
+  compile`, not server boot), and carried through to the runtime the server already
+  honours (`extract_real_ip`). The permissive posture is now **explicit**:
+  `trusted_proxy_cidrs = ["0.0.0.0/0"]` says "trust every proxy" on purpose.
+  **Deprecation:** `trust_proxy_headers = true` with an empty or omitted CIDR list still
+  boots but now warns that it will **refuse to boot in 2.14** (#618); set
+  `trusted_proxy_cidrs` to your proxy ranges, or `["0.0.0.0/0"]` to keep trusting every
+  proxy explicitly.
+
 ### Changed
 
 - **`fraiseql_core::runtime::extract_rls_conditions` is now fail-closed (`Result`).**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,7 @@ dependencies = [
  "http-body-util",
  "indexmap 2.14.0",
  "insta",
+ "ipnet",
  "notify",
  "predicates",
  "regex",

--- a/crates/fraiseql-cli/Cargo.toml
+++ b/crates/fraiseql-cli/Cargo.toml
@@ -40,6 +40,9 @@ fraiseql-server = {workspace = true, optional = true, features = ["cli"]}
 axum = {workspace = true, optional = true}
 glob = "0.3"
 hex = {workspace = true}
+# CIDR parsing to validate [security.rate_limiting] trusted_proxy_cidrs at compile
+# time (#609) — same parser the server uses, so compile rejects what boot would.
+ipnet = "2"
 reqwest = {workspace = true}
 # Serialization
 indexmap = {workspace = true}

--- a/crates/fraiseql-cli/src/config/toml_schema/mod.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/mod.rs
@@ -421,6 +421,23 @@ impl TomlSchema {
             }
         }
 
+        // Validate trusted_proxy_cidrs are parseable CIDR ranges (#609). The server
+        // parses these into `ipnet::IpNet`; catching a bad value here surfaces the
+        // error where the operator is authoring rather than at server boot.
+        if let Some(rate_limiting) = &self.security.rate_limiting {
+            if let Some(cidrs) = &rate_limiting.trusted_proxy_cidrs {
+                for cidr in cidrs {
+                    if cidr.parse::<ipnet::IpNet>().is_err() {
+                        anyhow::bail!(
+                            "[security.rate_limiting] trusted_proxy_cidrs contains an invalid \
+                             CIDR range '{cidr}'. Use CIDR notation such as \"10.0.0.0/8\", or \
+                             \"0.0.0.0/0\" to trust every proxy IP explicitly."
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -230,6 +230,18 @@ pub struct RateLimitingSecurityConfig {
     /// Enabling without a trusted proxy allows clients to spoof their IP address.
     #[serde(default)]
     pub trust_proxy_headers: bool,
+    /// CIDR ranges trusted as proxy IPs (e.g. `["10.0.0.0/8", "172.16.0.0/12"]`).
+    ///
+    /// When set and `trust_proxy_headers = true`, `X-Forwarded-For` is only honoured
+    /// when the direct connection IP falls within one of these ranges — requests from
+    /// outside them use the connection IP directly, preventing clients from spoofing
+    /// their address. Use `["0.0.0.0/0"]` to trust every proxy IP explicitly.
+    ///
+    /// When omitted with `trust_proxy_headers = true`, all proxy IPs are trusted
+    /// (less secure — the server emits a startup warning). CIDR strings are validated
+    /// at compile time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trusted_proxy_cidrs: Option<Vec<String>>,
 }
 
 impl Default for RateLimitingSecurityConfig {
@@ -251,6 +263,7 @@ impl Default for RateLimitingSecurityConfig {
             failed_login_lockout_secs: 900,
             redis_url: None,
             trust_proxy_headers: false,
+            trusted_proxy_cidrs: None,
         }
     }
 }

--- a/crates/fraiseql-cli/tests/security_config_test.rs
+++ b/crates/fraiseql-cli/tests/security_config_test.rs
@@ -304,3 +304,112 @@ fn test_auth_client_secret_field_rejected() {
         "client_secret in TOML must be rejected — secrets belong in env vars, not config files"
     );
 }
+
+// ---------------------------------------------------------------------------
+// trusted_proxy_cidrs — the X-Forwarded-For safety valve (#609)
+// ---------------------------------------------------------------------------
+// Before the fix the CLI `RateLimitingSecurityConfig` lacked this field, so
+// `deny_unknown_fields` rejected it: the mitigation the docs recommend for
+// `trust_proxy_headers = true` was unsettable on the compiled path.
+
+// M-609: the block now parses (was rejected by deny_unknown_fields).
+#[test]
+fn test_trusted_proxy_cidrs_parses_into_schema() {
+    let toml = r#"
+        [security.rate_limiting]
+        enabled             = true
+        trust_proxy_headers = true
+        trusted_proxy_cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    let cfg = schema.security.rate_limiting.unwrap();
+    assert!(cfg.trust_proxy_headers);
+    assert_eq!(
+        cfg.trusted_proxy_cidrs,
+        Some(vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()])
+    );
+}
+
+#[test]
+fn test_trusted_proxy_cidrs_default_none() {
+    let toml = r"
+        [security.rate_limiting]
+        enabled = true
+    ";
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    assert_eq!(schema.security.rate_limiting.unwrap().trusted_proxy_cidrs, None);
+}
+
+// M-609: the value survives end-to-end into the compiled schema (was dropped —
+// the compiled `security.rate_limiting` carried no `trusted_proxy_cidrs` key).
+#[test]
+fn test_trusted_proxy_cidrs_reach_compiled_schema() -> anyhow::Result<()> {
+    use std::fs;
+
+    use fraiseql_cli::schema::SchemaMerger;
+    use tempfile::TempDir;
+
+    let temp = TempDir::new()?;
+    let toml = r#"
+[schema]
+name = "test"
+version = "1.0.0"
+database_target = "postgresql"
+
+[security.rate_limiting]
+enabled             = true
+trust_proxy_headers = true
+trusted_proxy_cidrs = ["10.0.0.0/8"]
+"#;
+    let toml_path = temp.path().join("fraiseql.toml");
+    fs::write(&toml_path, toml)?;
+
+    let schema = SchemaMerger::merge_toml_only(toml_path.to_str().unwrap())?;
+    let security = schema.security.expect("security section present in compiled schema");
+    assert_eq!(
+        security["rate_limiting"]["trusted_proxy_cidrs"],
+        serde_json::json!(["10.0.0.0/8"]),
+        "trusted_proxy_cidrs must survive into the compiled schema so the server can honour it"
+    );
+    Ok(())
+}
+
+// M-609: a malformed CIDR fails `fraiseql compile` (validate) with a clear message,
+// not silently at server boot. The server parses these strings into `ipnet::IpNet`;
+// validating at compile time surfaces the error where the operator is authoring.
+#[test]
+fn test_malformed_trusted_proxy_cidr_fails_validation() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [security.rate_limiting]
+        enabled             = true
+        trust_proxy_headers = true
+        trusted_proxy_cidrs = ["not-a-cidr"]
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    let err = schema.validate().expect_err("a malformed CIDR must fail validation");
+    let msg = err.to_string();
+    assert!(msg.contains("not-a-cidr"), "error names the offending value: {msg}");
+    assert!(msg.contains("trusted_proxy_cidrs"), "error names the field: {msg}");
+}
+
+#[test]
+fn test_valid_trusted_proxy_cidrs_pass_validation() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [security.rate_limiting]
+        enabled             = true
+        trust_proxy_headers = true
+        trusted_proxy_cidrs = ["10.0.0.0/8", "0.0.0.0/0", "::1/128"]
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    schema.validate().expect("valid IPv4/IPv6 CIDR ranges pass validation");
+}

--- a/crates/fraiseql-server/src/server/initialization.rs
+++ b/crates/fraiseql-server/src/server/initialization.rs
@@ -239,14 +239,12 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         )?;
 
         // Warn when trust_proxy_headers is enabled without restricting which IPs are
-        // trusted proxies — any client can then spoof X-Forwarded-For.
-        if sec.trust_proxy_headers && sec.trusted_proxy_cidrs.as_ref().is_none_or(Vec::is_empty) {
-            warn!(
-                "Rate limiter: trust_proxy_headers = true but trusted_proxy_cidrs is not set. \
-                 Any client can spoof X-Forwarded-For and bypass per-IP rate limits. \
-                 Set trusted_proxy_cidrs in [security.rate_limiting] to restrict which \
-                 proxy IPs are trusted (e.g. [\"10.0.0.0/8\"] for internal load balancers)."
-            );
+        // trusted proxies — any client can then spoof X-Forwarded-For (#609). Explicit
+        // ["0.0.0.0/0"] opts into trust-all deliberately and does not warn.
+        if let Some(msg) =
+            proxy_trust_startup_warning(sec.trust_proxy_headers, sec.trusted_proxy_cidrs.as_deref())
+        {
+            warn!("{msg}");
         }
 
         let config = crate::middleware::RateLimitConfig::from_security_config(&sec);
@@ -672,6 +670,36 @@ pub(super) fn failed_login_lockout_check(
          edge proxy. Per-IP / per-endpoint rate limits still apply."
     );
     Ok(())
+}
+
+/// Startup warning for an unrestricted `X-Forwarded-For` trust posture (#609).
+///
+/// Returns the warning to emit when `trust_proxy_headers` is enabled but no CIDR
+/// range restricts which direct peers may set `X-Forwarded-For` — the trust-every-proxy
+/// posture, where any client can spoof its IP and bypass per-IP rate limiting. Returns
+/// `None` when the configuration is safe: proxy trust off, or a **non-empty** CIDR list —
+/// including `["0.0.0.0/0"]`, the sanctioned way to say "trust every proxy" on purpose,
+/// which is a valid CIDR that `extract_real_ip` already treats as trust-all.
+///
+/// Empty-by-omission warns and carries a deprecation notice: trusting all proxies
+/// implicitly is scheduled to refuse boot in 2.14 (#618). An operator who writes
+/// `["0.0.0.0/0"]` opted in deliberately, so the list is non-empty and this does not fire.
+pub(super) fn proxy_trust_startup_warning(
+    trust_proxy_headers: bool,
+    trusted_proxy_cidrs: Option<&[String]>,
+) -> Option<&'static str> {
+    if trust_proxy_headers && trusted_proxy_cidrs.is_none_or(<[String]>::is_empty) {
+        Some(
+            "Rate limiter: trust_proxy_headers = true but trusted_proxy_cidrs is not set. \
+             Any client can spoof X-Forwarded-For and bypass per-IP rate limits. Set \
+             trusted_proxy_cidrs in [security.rate_limiting] to your proxy ranges (e.g. \
+             [\"10.0.0.0/8\"] for internal load balancers), or [\"0.0.0.0/0\"] to keep \
+             trusting every proxy explicitly. DEPRECATED: trusting all proxies by omission \
+             will refuse to boot in 2.14 (#618).",
+        )
+    } else {
+        None
+    }
 }
 
 // ── Observer transport selection (#350) ──────────────────────────────────────

--- a/crates/fraiseql-server/src/server/tests.rs
+++ b/crates/fraiseql-server/src/server/tests.rs
@@ -263,6 +263,44 @@ mod initialization_tests {
         assert!(failed_login_lockout_check(5, 60, false).is_ok());
     }
 
+    // #609: trusting X-Forwarded-For from all proxies (empty CIDR list) warns with a
+    // 2.14 refuse-to-boot deprecation notice (#618); an explicit ["0.0.0.0/0"] opt-in
+    // does not warn.
+    use super::super::initialization::proxy_trust_startup_warning;
+
+    #[test]
+    fn proxy_trust_all_by_omission_warns_with_deprecation() {
+        let msg = proxy_trust_startup_warning(true, None)
+            .expect("trust_proxy_headers = true with no CIDRs must warn");
+        assert!(msg.contains("DEPRECATED"), "carries the deprecation notice: {msg}");
+        assert!(msg.contains("2.14"), "names the refuse-to-boot version: {msg}");
+        assert!(msg.contains("#618"), "links the follow-up issue: {msg}");
+    }
+
+    #[test]
+    fn proxy_trust_empty_list_warns() {
+        assert!(proxy_trust_startup_warning(true, Some(&[])).is_some());
+    }
+
+    #[test]
+    fn proxy_trust_explicit_trust_all_does_not_warn() {
+        // ["0.0.0.0/0"] is the sanctioned explicit opt-in — a deliberate, non-empty
+        // list, so the deprecation warning must not fire.
+        let cidrs = vec!["0.0.0.0/0".to_string()];
+        assert!(proxy_trust_startup_warning(true, Some(&cidrs)).is_none());
+    }
+
+    #[test]
+    fn proxy_trust_restricted_cidrs_do_not_warn() {
+        let cidrs = vec!["10.0.0.0/8".to_string()];
+        assert!(proxy_trust_startup_warning(true, Some(&cidrs)).is_none());
+    }
+
+    #[test]
+    fn proxy_trust_disabled_does_not_warn() {
+        assert!(proxy_trust_startup_warning(false, None).is_none());
+    }
+
     // #350: a configured non-Postgres observer transport that cannot run must fail
     // loud (refuse boot in production), never silently fall back to PostgreSQL.
     #[cfg(feature = "observers")]

--- a/docs/guides/production-security-checklist.md
+++ b/docs/guides/production-security-checklist.md
@@ -25,7 +25,7 @@ A checklist for hardening FraiseQL deployments. Review each item before going li
 ## Network
 
 - [ ] Terminate TLS at a reverse proxy / load balancer — FraiseQL serves plaintext and **refuses to boot** if the `[tls]` section is set
-- [ ] Configure trusted proxy headers for accurate client IP extraction
+- [ ] Configure trusted proxy headers for accurate client IP extraction — set `trust_proxy_headers = true` **and** `trusted_proxy_cidrs` to your proxy ranges (e.g. `["10.0.0.0/8"]`) in `[security.rate_limiting]`. Without the CIDR restriction any client can spoof `X-Forwarded-For` to bypass per-IP rate limiting; use `["0.0.0.0/0"]` only to trust every proxy on purpose
 - [ ] Restrict admin endpoints to internal networks or VPN
 - [ ] Set CORS origins explicitly (avoid `*` in production)
 


### PR DESCRIPTION
## Summary

Closes the second of the docs-review-fixes set (#609). `trust_proxy_headers = true` was
settable in `[security.rate_limiting]`, but its documented safety valve
`trusted_proxy_cidrs` was **not** — the CLI schema lacked the field and
`deny_unknown_fields` rejected it. The only reachable posture trusted `X-Forwarded-For`
from **every** proxy IP, so any client could spoof its address to bypass per-IP rate
limiting or poison IP-derived logging. The server side already honoured the field
(`extract_real_ip`, `from_security_config`, `initialization.rs` re-hydration); **only the
CLI struct was missing**, so the fix is almost entirely additive plumbing.

## What changed

- **Field + passthrough.** Add `trusted_proxy_cidrs: Option<Vec<String>>` to the CLI
  `RateLimitingSecurityConfig` + `Default`. The merger already serializes the whole
  struct, so the value now reaches the compiled schema and the server re-hydrates it into
  `RateLimitConfig.trusted_proxy_cidrs`. (`skip_serializing_if` mirrors the sibling
  `requests_per_second_per_user` — no churn to existing compiled JSON when unset.)
- **Compile-time CIDR validation.** `TomlSchema::validate()` parses each entry with the
  same `ipnet::IpNet` parser the server uses, so a malformed range fails `fraiseql
  compile` with a clear message instead of at server boot.
- **Staged deprecation (per the resolved gate: warn now, refuse in 2.14).** The
  empty-CIDR + `trust_proxy_headers` startup warning now carries a 2.14 refuse-to-boot
  notice (**#618**). `trusted_proxy_cidrs = ["0.0.0.0/0"]` is the sanctioned **explicit**
  trust-all opt-in and does **not** warn (it is a non-empty list). The warning decision is
  extracted into `proxy_trust_startup_warning()` and unit-tested.
- **Docs** + CHANGELOG `### Security`.

## Tests (RED → GREEN, `// M-609` pins ship with the fix)

- CLI: block parses (was rejected); value reaches the compiled schema via `SchemaMerger`;
  malformed CIDR fails `validate()`; valid IPv4/IPv6 pass.
- Server: `["0.0.0.0/0"]` does not warn; empty/omitted warns with the 2.14 deprecation
  line and links #618; disabled/restricted do not warn.

## Verification

- ✅ `cargo test -p fraiseql-cli` (full) / `cargo test -p fraiseql-server --lib` (proxy_trust + rate_limit)
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- ✅ `cargo deny check bans` (single `ipnet` version; lockfile only adds the dependent)

## Follow-up

- **#618** — 2.14 refuse-to-boot on empty-CIDR + trust-proxy (the deprecation this PR references).

Targets **2.13.0** (`[Unreleased]`). Independent of the #608/#610/#612 phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)