### PR TITLE
fix(core): resolve RLS session vars on Relay node + partial-period aggregate paths (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **RLS session variables now reach the Relay `node(id:)` and partial-period aggregate
+  read paths (#610).** Both paths ran their read without resolving the schema's configured
+  `session_variables`, so a PostgreSQL RLS policy reading `current_setting()` did not
+  constrain them — a cross-tenant read on any Relay `node(id:)` lookup and any aggregate
+  taking the partial-period (`UNION ALL`) branch, both reachable from an ordinary GraphQL
+  request. They now resolve session variables and use the connection-affine
+  `*_with_session` adapter methods, exactly as regular queries, Relay pages, standard
+  aggregates, and mutations already did. (These were the two surviving read-path follow-ups
+  from #329, which was closed after its mutation-path fix shipped; they are fixed here under
+  #610, not by reopening #329.)
+
 - **`fraiseql compile` now surfaces the full error cause chain.** Converter
   failures printed only the top-level context (e.g. `Failed to convert schema to
   compiled format`) with the underlying reason swallowed at every log level and in

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
@@ -221,6 +221,7 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
                     lower_bound,
                     today,
                     query_name,
+                    security_context,
                 )
                 .await;
         }
@@ -277,6 +278,7 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
         lower_bound: chrono::NaiveDate,
         today: chrono::NaiveDate,
         query_name: &str,
+        security_context: Option<&SecurityContext>,
     ) -> Result<serde_json::Value> {
         let branch_plan = crate::runtime::partial_period::determine_branches(
             lower_bound,
@@ -309,15 +311,20 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
             extra_where.as_ref(),
         )?;
 
-        // Execute.
-        // No session vars: the partial-period UNION branch does not thread a
-        // SecurityContext (callers above do), so there is nothing to resolve
-        // session variables from here. RLS for partial-period aggregates over
-        // current_setting()-backed views is a follow-up (#329).
+        // Execute, pinning session variables to the connection so a
+        // `current_setting()`-backed RLS policy constrains the partial-period branch the
+        // same way it constrains the standard aggregate and window paths (#610).
+        let resolved_session_vars = self.resolve_session_vars(security_context)?;
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self
             .ctx
             .adapter
-            .execute_parameterized_aggregate(&union_sql.sql, &union_sql.params)
+            .execute_parameterized_aggregate_with_session(
+                &union_sql.sql,
+                &union_sql.params,
+                &session_pairs,
+            )
             .await?;
 
         // Project and wrap (same as standard path)

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate_tests.rs
@@ -12,6 +12,7 @@ use crate::{
         SqlType, TemporalGrain,
     },
     runtime::{Executor, RuntimeConfig, executor::test_support::CapturingMockAdapter},
+    schema::{SessionVariableMapping, SessionVariableSource, SessionVariablesConfig},
     security::{DefaultRLSPolicy, SecurityContext},
 };
 
@@ -365,6 +366,61 @@ async fn partial_period_with_rls_includes_tenant_in_all_branches() {
             i + 1
         );
     }
+}
+
+/// A partial-period schema with session variables configured, so
+/// `resolve_session_vars` produces `app.tenant_id` from the security context.
+fn schema_with_partial_period_and_session_vars() -> crate::schema::CompiledSchema {
+    let mut schema = schema_with_partial_period();
+    schema.session_variables = SessionVariablesConfig {
+        variables:         vec![SessionVariableMapping {
+            name:   "app.tenant_id".to_string(),
+            source: SessionVariableSource::Jwt {
+                claim: "tenant_id".to_string(),
+            },
+        }],
+        inject_started_at: false,
+    };
+    schema
+}
+
+// M-610: the partial-period aggregate branch must resolve session variables so a
+// PostgreSQL current_setting()-backed RLS policy constrains it — the same way the
+// standard aggregate path and the window path already do. Before the fix this branch
+// called the non-session aggregate method, so no session variables reached the
+// connection (cross-tenant read on any aggregate taking the partial-period branch).
+#[tokio::test]
+async fn partial_period_aggregate_resolves_session_variables() {
+    let schema = schema_with_partial_period_and_session_vars();
+    let adapter = Arc::new(CapturingMockAdapter::new(vec![]));
+    let executor = Executor::new(schema, adapter.clone());
+
+    let ctx = tenant_security_context("tenant-abc");
+    let vars = serde_json::json!({
+        "table": "tf_events",
+        "aggregates": [{"count": {}}],
+        "where": {"period_start_gte": "2020-01-15"}
+    });
+    executor
+        .execute_with_security("{ events_aggregate }", Some(&vars), &ctx)
+        .await
+        .unwrap();
+
+    // Confirm the partial-period branch was actually exercised.
+    let sql = adapter.captured_aggregate_sql().expect("SQL should be captured");
+    assert!(sql.contains("UNION ALL"), "test must exercise the partial-period path: {sql}");
+
+    let session_vars = adapter
+        .captured_aggregate_session_vars()
+        .expect("partial-period branch must call the session-aware aggregate method");
+    let tenant =
+        session_vars.iter().find(|(k, _)| k == "app.tenant_id").map(|(_, v)| v.as_str());
+    assert_eq!(
+        tenant,
+        Some("tenant-abc"),
+        "partial-period aggregate must resolve the caller's tenant into session variables for \
+         current_setting()-backed RLS; got: {session_vars:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate_tests.rs
@@ -413,8 +413,7 @@ async fn partial_period_aggregate_resolves_session_variables() {
     let session_vars = adapter
         .captured_aggregate_session_vars()
         .expect("partial-period branch must call the session-aware aggregate method");
-    let tenant =
-        session_vars.iter().find(|(k, _)| k == "app.tenant_id").map(|(_, v)| v.as_str());
+    let tenant = session_vars.iter().find(|(k, _)| k == "app.tenant_id").map(|(_, v)| v.as_str());
     assert_eq!(
         tenant,
         Some("tenant-abc"),

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -36,7 +36,10 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
     /// Returns an empty vec when there is no security context or no session
     /// variables are configured; the adapter treats an empty slice as "no
     /// session variables" with zero overhead.
-    fn resolve_session_vars(
+    ///
+    /// `pub(super)` so the sibling `query_relay` impl of the same `QueryRunner` can
+    /// reuse it for the node-lookup path (#610).
+    pub(super) fn resolve_session_vars(
         &self,
         security_context: Option<&SecurityContext>,
     ) -> Result<Vec<(String, String)>> {

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_relay.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_relay.rs
@@ -565,21 +565,28 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             None
         };
 
-        // 6. Execute the query (limit 1) with projection.
-        // The FraiseQL `rls_policy` and `inject_params` gates are enforced above as an
-        // explicit WHERE filter. Session variables are not resolved here, so DB-side
-        // `current_setting()`-backed RLS on the node path remains a follow-up (#329).
+        // 6. Execute the query (limit 1) with projection, pinning session variables to
+        // the read's connection so a PostgreSQL `current_setting()`-backed RLS policy
+        // constrains the node lookup the same way it constrains regular queries and Relay
+        // pages (#610). The FraiseQL `rls_policy` and `inject_params` gates are enforced
+        // above as an explicit WHERE filter.
+        let resolved_session_vars = self.resolve_session_vars(security_context)?;
+        let session_pairs: Vec<(&str, &str)> =
+            resolved_session_vars.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
         let rows = self
             .ctx
             .adapter
-            .execute_with_projection_arc(&crate::db::ProjectionRequest {
-                view:         &sql_source,
-                projection:   projection_hint.as_ref(),
-                where_clause: Some(&where_clause),
-                order_by:     None,
-                limit:        Some(1),
-                offset:       None,
-            })
+            .execute_with_projection_arc_with_session(
+                &crate::db::ProjectionRequest {
+                    view:         &sql_source,
+                    projection:   projection_hint.as_ref(),
+                    where_clause: Some(&where_clause),
+                    order_by:     None,
+                    limit:        Some(1),
+                    offset:       None,
+                },
+                &session_pairs,
+            )
             .await?;
 
         // 7. Return the first matching row (or null).

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
@@ -671,6 +671,52 @@ mod session_variables {
             "no session variables must be passed when no session_variables are configured"
         );
     }
+
+    /// A node-resolvable variant of [`schema_with_session_vars`]: the Relay `node(id:)`
+    /// path resolves the type by name from `schema.types`, so the `User` type must be
+    /// registered (the list-query-only `test_schema` does not register it).
+    fn node_schema_with_session_vars() -> CompiledSchema {
+        let mut schema = schema_with_session_vars();
+        schema.types.push({
+            let mut t = TypeDefinition::new("User", "v_user");
+            t.fields = vec![
+                FieldDefinition::new("id", FieldType::String),
+                FieldDefinition::new("name", FieldType::String),
+            ];
+            t
+        });
+        schema
+    }
+
+    // M-610: the Relay node(id:) lookup must resolve session variables so a PostgreSQL
+    // current_setting()-backed RLS policy constrains it — the same way regular queries
+    // (test_session_variables_injected_on_read_query, above) and Relay pages already do.
+    // Before the fix the node path called the non-session projection method, so no
+    // session variables reached the connection (cross-tenant read on any leaked node id).
+    #[tokio::test]
+    async fn test_session_variables_injected_on_node_lookup() {
+        let schema = node_schema_with_session_vars();
+        let adapter = Arc::new(SessionVarCapturingAdapter::new(mock_user_results()));
+        let executor = Executor::new(schema, adapter.clone());
+
+        let node_id = crate::runtime::relay::encode_node_id(
+            "User",
+            "11111111-1111-1111-1111-111111111111",
+        );
+        let query = format!("{{ node(id: \"{node_id}\") {{ id name }} }}");
+
+        let ctx = security_ctx_with_tenant(); // tenant-abc
+        executor.execute_with_security(&query, None, &ctx).await.unwrap();
+
+        let pairs = adapter.captured_pairs();
+        let tenant = pairs.iter().find(|(k, _)| k == "app.tenant_id").map(|(_, v)| v.as_str());
+        assert_eq!(
+            tenant,
+            Some("tenant-abc"),
+            "node(id:) lookup must resolve the caller's tenant into session variables for \
+             current_setting()-backed RLS; got: {pairs:?}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
@@ -699,10 +699,8 @@ mod session_variables {
         let adapter = Arc::new(SessionVarCapturingAdapter::new(mock_user_results()));
         let executor = Executor::new(schema, adapter.clone());
 
-        let node_id = crate::runtime::relay::encode_node_id(
-            "User",
-            "11111111-1111-1111-1111-111111111111",
-        );
+        let node_id =
+            crate::runtime::relay::encode_node_id("User", "11111111-1111-1111-1111-111111111111");
         let query = format!("{{ node(id: \"{node_id}\") {{ id name }} }}");
 
         let ctx = security_ctx_with_tenant(); // tenant-abc

--- a/crates/fraiseql-core/src/runtime/executor/test_support.rs
+++ b/crates/fraiseql-core/src/runtime/executor/test_support.rs
@@ -26,12 +26,12 @@ use crate::{
 /// Capturing mock that records the WHERE clause and limit/offset it receives.
 /// Used to verify parameter threading from executor to adapter.
 pub struct CapturingMockAdapter {
-    pub mock_results:              Vec<JsonbValue>,
-    pub captured_where:            std::sync::Mutex<Option<WhereClause>>,
-    pub captured_limit:            std::sync::Mutex<Option<u32>>,
-    pub captured_offset:           std::sync::Mutex<Option<u32>>,
-    pub captured_aggregate_sql:    std::sync::Mutex<Option<String>>,
-    pub captured_aggregate_params: std::sync::Mutex<Option<Vec<serde_json::Value>>>,
+    pub mock_results:                    Vec<JsonbValue>,
+    pub captured_where:                  std::sync::Mutex<Option<WhereClause>>,
+    pub captured_limit:                  std::sync::Mutex<Option<u32>>,
+    pub captured_offset:                 std::sync::Mutex<Option<u32>>,
+    pub captured_aggregate_sql:          std::sync::Mutex<Option<String>>,
+    pub captured_aggregate_params:       std::sync::Mutex<Option<Vec<serde_json::Value>>>,
     pub captured_aggregate_session_vars: std::sync::Mutex<Option<Vec<(String, String)>>>,
 }
 

--- a/crates/fraiseql-core/src/runtime/executor/test_support.rs
+++ b/crates/fraiseql-core/src/runtime/executor/test_support.rs
@@ -32,6 +32,7 @@ pub struct CapturingMockAdapter {
     pub captured_offset:           std::sync::Mutex<Option<u32>>,
     pub captured_aggregate_sql:    std::sync::Mutex<Option<String>>,
     pub captured_aggregate_params: std::sync::Mutex<Option<Vec<serde_json::Value>>>,
+    pub captured_aggregate_session_vars: std::sync::Mutex<Option<Vec<(String, String)>>>,
 }
 
 impl CapturingMockAdapter {
@@ -43,6 +44,7 @@ impl CapturingMockAdapter {
             captured_offset: std::sync::Mutex::new(None),
             captured_aggregate_sql: std::sync::Mutex::new(None),
             captured_aggregate_params: std::sync::Mutex::new(None),
+            captured_aggregate_session_vars: std::sync::Mutex::new(None),
         }
     }
 
@@ -65,6 +67,13 @@ impl CapturingMockAdapter {
     #[allow(dead_code)] // Reason: available for future aggregate RLS param verification tests
     pub fn captured_aggregate_params(&self) -> Option<Vec<serde_json::Value>> {
         self.captured_aggregate_params.lock().unwrap().clone()
+    }
+
+    /// The session variables the last `_with_session` aggregate call received.
+    /// `None` means the non-session `execute_parameterized_aggregate` was called
+    /// (no session variables reached the connection) — the #610 partial-period gap.
+    pub fn captured_aggregate_session_vars(&self) -> Option<Vec<(String, String)>> {
+        self.captured_aggregate_session_vars.lock().unwrap().clone()
     }
 }
 
@@ -130,6 +139,18 @@ impl DatabaseAdapter for CapturingMockAdapter {
         *self.captured_aggregate_sql.lock().unwrap() = Some(sql.to_string());
         *self.captured_aggregate_params.lock().unwrap() = Some(params.to_vec());
         Ok(vec![])
+    }
+
+    async fn execute_parameterized_aggregate_with_session(
+        &self,
+        sql: &str,
+        params: &[serde_json::Value],
+        session_vars: &[(&str, &str)],
+    ) -> Result<Vec<std::collections::HashMap<String, serde_json::Value>>> {
+        *self.captured_aggregate_session_vars.lock().unwrap() =
+            Some(session_vars.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect());
+        // Delegate so SQL/params capture stays identical to the non-session path.
+        self.execute_parameterized_aggregate(sql, params).await
     }
 
     async fn execute_function_call(


### PR DESCRIPTION
## Summary

Closes the third of the docs-review-fixes set (#610). Two read paths executed their
database read **without** resolving the schema's configured `session_variables`, so a
PostgreSQL RLS policy backed by `current_setting()` did **not** constrain them:

- the Relay **`node(id:)`** lookup, and
- the **partial-period aggregate** branch (the `UNION ALL` fine/coarse split).

Both are reachable from an ordinary GraphQL request, so for a deployment whose tenant
boundary is a `current_setting()`-backed RLS policy this was a **cross-tenant read**. Every
other read path (regular queries, Relay pages, standard aggregates) and mutations already
threaded session variables; these two were the surviving read-path follow-ups honestly
commented `#329`, but #329 was **closed** after its mutation-path fix shipped — nothing
surfaced them.

## Scope (not overstated)

This is **not** "RLS is off on these paths." FraiseQL's own `rls_policy` / `inject_params`
gates are still enforced as an explicit WHERE filter. The specific gap: the two paths did
not set the connection's session variables, so `current_setting()`-backed **database** RLS
policies could not read them.

## What changed (both fixes are connector-sized; every method used already existed)

- **Site 1 — `query_relay.rs::execute_node_query`:** resolve session vars and call
  `execute_with_projection_arc_with_session`. No signature change (the `SecurityContext`
  was already a parameter). `QueryRunner::resolve_session_vars` widened `fn` → `pub(super)`
  so the sibling `query_relay` impl of the same struct can reuse it.
- **Site 2 — `aggregate.rs::execute_partial_period_aggregate`:** gains a `security_context`
  param, threaded from its sole caller `execute_aggregate_query`, then resolves + calls
  `execute_parameterized_aggregate_with_session`.
- Both stale `#329` comments re-homed to **#610**. The `cache/adapter/mod.rs:794` fail-safe
  comment (a different, still-open concern) is **intentionally untouched**.

## Tests (RED → GREEN, `// M-610` pins ship with the fix)

- Node path: `test_session_variables_injected_on_node_lookup` — the lookup now captures the
  caller's tenant (`app.tenant_id = tenant-abc`) into session variables (was empty).
- Aggregate path: `partial_period_aggregate_resolves_session_variables` — the partial-period
  branch now calls the session-aware method with the caller's tenant (was the non-session
  method). `CapturingMockAdapter` extended to capture aggregate session vars.
- Both assert **value-level** tenant scoping (the mock-achievable form of the two-tenant
  conformance; a live `current_setting()` test belongs in the DB integration leg).
- No regressions: existing `node_authz` (7) and `aggregate_rls_tests` pass unchanged.

## Verification

- ✅ `cargo test -p fraiseql-core --lib`
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- ✅ `make lint-tests-layout`

## #329 note

Not reopened — its scope ("session variables never reach *mutation* SQL functions") was met
and shipped. These two read-path misses are fixed here under #610. A closing comment will be
posted on #329 in Phase 06 so a future reader of the old code comments finds the trail.

Targets **2.13.0** (`[Unreleased]`). Independent of the #608/#609/#612 phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)