### PR TITLE
fix(cli): reconcile [auth] so one block validates on both CLI and server (#612 item 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A single `[auth]` block now validates on both the CLI compiler and the server (#612).**
+  The CLI's `[auth]` schema required the PKCE OAuth-client fields (`discovery_url`,
+  `client_id`, `client_secret_env`, `server_redirect_uri`) with `deny_unknown_fields`,
+  while the server's OIDC config — read from the **same** `fraiseql.toml` — expects
+  `issuer`. So a JWT-validation block (`[auth] issuer = "…"`) failed `fraiseql compile`,
+  and no single `[auth]` could satisfy both tools. `[auth]` now accepts a **JWT-validation
+  group** (`issuer` + optional `audience`) and a **PKCE OAuth-client group** (the four
+  client fields), each validated as a coherent unit (client group is all-four-or-none;
+  `audience` requires `issuer`; an empty `[auth]` is a load error). The PKCE server-login
+  flow is **not yet functional on the compiled path** — the compiled schema carries no
+  `auth`/`auth_endpoints` blob for the server's `OidcServerClient`, and the CLI never
+  emitted one — so a *complete* client group is now **rejected at compile time with a
+  pointer to #621** instead of being silently accepted (the item-4 precedent: declared-but-
+  unenforced auth fails loud). The previously-false operator instructions that told
+  operators to configure those four fields (`builder.rs` startup error, the Auth0 and SAML
+  integration guides) are corrected to say so. JWT validation is unaffected.
+
 - **`fraiseql compile` now surfaces the full error cause chain.** Converter
   failures printed only the top-level context (e.g. `Failed to convert schema to
   compiled format`) with the underlying reason swallowed at every log level and in

--- a/crates/fraiseql-cli/src/config/toml_schema/mod.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/mod.rs
@@ -421,6 +421,13 @@ impl TomlSchema {
             }
         }
 
+        // Validate the [auth] block's group structure (#612 item 9): JWT group
+        // (issuer/audience) is functional; a PKCE client group is all-four-or-none and
+        // a complete one is rejected (not yet functional on the compiled path — #621).
+        if let Some(auth) = &self.auth {
+            auth.validate()?;
+        }
+
         Ok(())
     }
 

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -510,14 +510,13 @@ impl Default for TokenRevocationSecurityConfig {
 ///
 /// Two independent groups may be configured, together or separately:
 ///
-/// - **JWT validation** — `issuer` (required for this group), `audience` (optional).
-///   The server consumes these to validate incoming bearer tokens. Accepted and
-///   functional.
-/// - **PKCE OAuth client** (server-side login) — `discovery_url`, `client_id`,
-///   `client_secret_env`, `server_redirect_uri`, configured all four together.
-///   **Not yet functional on the compiled path (tracked in #621):** the compiled
-///   schema carries no `auth`/`auth_endpoints` for the server to consume, so a complete
-///   client group is *rejected at compile time* rather than silently accepted.
+/// - **JWT validation** — `issuer` (required for this group), `audience` (optional). The server
+///   consumes these to validate incoming bearer tokens. Accepted and functional.
+/// - **PKCE OAuth client** (server-side login) — `discovery_url`, `client_id`, `client_secret_env`,
+///   `server_redirect_uri`, configured all four together. **Not yet functional on the compiled path
+///   (tracked in #621):** the compiled schema carries no `auth`/`auth_endpoints` for the server to
+///   consume, so a complete client group is *rejected at compile time* rather than silently
+///   accepted.
 ///
 /// At least one group must be present; an empty `[auth]` is a load error. The client
 /// secret itself must never appear here — `client_secret_env` names the environment

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -506,32 +506,115 @@ impl Default for TokenRevocationSecurityConfig {
     }
 }
 
-/// OAuth2 client configuration for server-side PKCE flows.
+/// OIDC configuration for `[auth]`.
 ///
-/// The client secret is intentionally absent — use `client_secret_env` to
-/// name the environment variable that holds the secret at runtime.
+/// Two independent groups may be configured, together or separately:
+///
+/// - **JWT validation** — `issuer` (required for this group), `audience` (optional).
+///   The server consumes these to validate incoming bearer tokens. Accepted and
+///   functional.
+/// - **PKCE OAuth client** (server-side login) — `discovery_url`, `client_id`,
+///   `client_secret_env`, `server_redirect_uri`, configured all four together.
+///   **Not yet functional on the compiled path (tracked in #621):** the compiled
+///   schema carries no `auth`/`auth_endpoints` for the server to consume, so a complete
+///   client group is *rejected at compile time* rather than silently accepted.
+///
+/// At least one group must be present; an empty `[auth]` is a load error. The client
+/// secret itself must never appear here — `client_secret_env` names the environment
+/// variable that holds it.
 ///
 /// ```toml
 /// [auth]
-/// discovery_url       = "https://accounts.google.com"
-/// client_id           = "my-fraiseql-client"
-/// client_secret_env   = "OIDC_CLIENT_SECRET"
-/// server_redirect_uri = "https://api.example.com/auth/callback"
+/// issuer   = "https://accounts.google.com"
+/// audience = "my-api"
 /// ```
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct OidcClientConfig {
-    /// OIDC provider discovery URL (e.g. `"https://accounts.google.com"`).
-    /// Used to fetch `authorization_endpoint` and `token_endpoint` at compile time.
-    pub discovery_url:       String,
-    /// OAuth2 `client_id` registered with the provider.
-    pub client_id:           String,
-    /// Name of the environment variable that holds the client secret.
+    /// OIDC issuer URL for JWT validation (e.g. `"https://accounts.google.com"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer:              Option<String>,
+    /// Expected `aud` claim for JWT validation (optional; only meaningful with `issuer`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audience:            Option<String>,
+    /// PKCE: OIDC provider discovery URL. **Not yet functional (#621).**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery_url:       Option<String>,
+    /// PKCE: OAuth2 `client_id` registered with the provider. **Not yet functional (#621).**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id:           Option<String>,
+    /// PKCE: name of the environment variable that holds the client secret.
     /// The secret itself must never appear in TOML or the compiled schema.
-    pub client_secret_env:   String,
-    /// The full URL of this server's `/auth/callback` endpoint,
-    /// e.g. `"https://api.example.com/auth/callback"`.
-    pub server_redirect_uri: String,
+    /// **Not yet functional (#621).**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret_env:   Option<String>,
+    /// PKCE: the full URL of this server's `/auth/callback` endpoint.
+    /// **Not yet functional (#621).**
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_redirect_uri: Option<String>,
+}
+
+impl OidcClientConfig {
+    /// Validate the `[auth]` group structure (#612 item 9).
+    ///
+    /// The JWT group (`issuer` + optional `audience`) is accepted and functional. The
+    /// PKCE client group is all-four-or-none, and a *complete* client group is rejected
+    /// — it is not yet functional on the compiled path (#621), so it is refused rather
+    /// than silently accepted. At least one group must be present.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error naming the specific problem: an incomplete client group (with the
+    /// missing fields), a complete-but-unsupported client group, `audience` without
+    /// `issuer`, or an empty `[auth]` block.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let client_fields = [
+            ("discovery_url", self.discovery_url.is_some()),
+            ("client_id", self.client_id.is_some()),
+            ("client_secret_env", self.client_secret_env.is_some()),
+            ("server_redirect_uri", self.server_redirect_uri.is_some()),
+        ];
+        let client_set = client_fields.iter().filter(|(_, set)| *set).count();
+        let has_client_group = client_set > 0;
+        let has_jwt_group = self.issuer.is_some();
+
+        if has_client_group && client_set < client_fields.len() {
+            let missing: Vec<&str> =
+                client_fields.iter().filter(|(_, set)| !*set).map(|(name, _)| *name).collect();
+            anyhow::bail!(
+                "[auth] PKCE OAuth-client config is incomplete: discovery_url, client_id, \
+                 client_secret_env, and server_redirect_uri must be set together (missing: {}).",
+                missing.join(", ")
+            );
+        }
+
+        if has_client_group {
+            // client_set == 4 here (all-or-none enforced above).
+            anyhow::bail!(
+                "[auth] PKCE OAuth-client config (discovery_url, client_id, client_secret_env, \
+                 server_redirect_uri) is recognized but not yet functional on the compiled path: \
+                 the compiled schema carries no auth/auth_endpoints for the server to consume. \
+                 Remove these fields and use [auth] issuer/audience for JWT validation, or track \
+                 the wiring in #621."
+            );
+        }
+
+        if self.audience.is_some() && !has_jwt_group {
+            anyhow::bail!(
+                "[auth] audience is set but issuer is not. JWT validation requires issuer — \
+                 add issuer, or remove audience."
+            );
+        }
+
+        if !has_jwt_group {
+            anyhow::bail!(
+                "[auth] is empty. Configure JWT validation with issuer (audience optional). \
+                 An empty [auth] block does nothing."
+            );
+        }
+
+        Ok(())
+    }
 }
 
 fn default_true() -> bool {

--- a/crates/fraiseql-cli/tests/security_config_test.rs
+++ b/crates/fraiseql-cli/tests/security_config_test.rs
@@ -238,16 +238,56 @@ fn test_existing_enterprise_field_not_broken() {
 // OidcClientConfig / [auth]
 // ---------------------------------------------------------------------------
 
+// #612 item 9: the CLI [auth] schema and the server's OidcConfig read the same
+// fraiseql.toml [auth], but the CLI's old schema (required PKCE client fields +
+// deny_unknown_fields) rejected a JWT-only block, so a single valid [auth] could not
+// exist. The union schema accepts the JWT group (issuer/audience) — functional — while
+// a complete PKCE client group is rejected loud (not yet functional on the compiled
+// path — #621), never silently accepted.
+
+// M-612: a JWT-only [auth] block now compiles (was rejected — this is the item-9 fix).
 #[test]
-fn test_auth_config_parses() {
+fn test_auth_jwt_only_compiles() {
     let toml = r#"
         [schema]
         name = "test"
         version = "1.0.0"
         database_target = "postgresql"
 
-        [database]
-        url = "postgresql://localhost/test"
+        [auth]
+        issuer   = "https://accounts.google.com"
+        audience = "my-api"
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    schema.validate().expect("a JWT-validation [auth] block must compile");
+    let auth = schema.auth.expect("auth section should be present");
+    assert_eq!(auth.issuer.as_deref(), Some("https://accounts.google.com"));
+    assert_eq!(auth.audience.as_deref(), Some("my-api"));
+}
+
+#[test]
+fn test_auth_issuer_without_audience_compiles() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [auth]
+        issuer = "https://accounts.example.com"
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    schema.validate().expect("issuer alone is a valid JWT [auth] block");
+}
+
+// M-612: a complete PKCE client group is rejected loud (recognized, not yet functional).
+#[test]
+fn test_auth_complete_client_group_rejected_loud() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
 
         [auth]
         discovery_url       = "https://accounts.google.com"
@@ -256,11 +296,63 @@ fn test_auth_config_parses() {
         server_redirect_uri = "https://api.example.com/auth/callback"
     "#;
     let schema: TomlSchema = toml::from_str(toml).unwrap();
-    let auth = schema.auth.expect("auth section should be present");
-    assert_eq!(auth.discovery_url, "https://accounts.google.com");
-    assert_eq!(auth.client_id, "my-client-id");
-    assert_eq!(auth.client_secret_env, "OIDC_CLIENT_SECRET");
-    assert_eq!(auth.server_redirect_uri, "https://api.example.com/auth/callback");
+    let err = schema.validate().expect_err("a complete PKCE client group must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("not yet functional"), "explains why it is rejected: {msg}");
+    assert!(msg.contains("#621"), "points at the tracking follow-up: {msg}");
+}
+
+#[test]
+fn test_auth_partial_client_group_rejected_names_missing() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [auth]
+        issuer        = "https://accounts.example.com"
+        discovery_url = "https://accounts.example.com"
+        client_id     = "my-client-id"
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    let err = schema.validate().expect_err("an incomplete PKCE client group must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("incomplete"), "flags the incomplete group: {msg}");
+    assert!(msg.contains("client_secret_env"), "names a missing field: {msg}");
+    assert!(msg.contains("server_redirect_uri"), "names a missing field: {msg}");
+}
+
+#[test]
+fn test_auth_empty_block_rejected() {
+    // A present-but-empty [auth] table configures nothing and must not pass silently.
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [auth]
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    let err = schema.validate().expect_err("an empty [auth] block must be rejected");
+    assert!(err.to_string().contains("empty"), "explains the empty block: {err}");
+}
+
+#[test]
+fn test_auth_audience_without_issuer_rejected() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [auth]
+        audience = "my-api"
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    let err = schema.validate().expect_err("audience without issuer must be rejected");
+    assert!(err.to_string().contains("issuer"), "explains issuer is required: {err}");
 }
 
 #[test]

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -361,14 +361,15 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             Some(service)
         };
 
-        // Warn if PKCE is configured but [auth] is missing (no OidcServerClient).
+        // Warn if PKCE is configured but no OidcServerClient could be built.
         #[cfg(feature = "auth")]
         if pkce_store.is_some() && oidc_server_client.is_none() {
             tracing::error!(
-                "pkce.enabled = true but [auth] is not configured or OIDC client init failed. \
-                 Auth routes (/auth/start, /auth/callback) will NOT be mounted. \
-                 Add [auth] with discovery_url, client_id, client_secret_env, and \
-                 server_redirect_uri to fraiseql.toml and recompile the schema."
+                "pkce.enabled = true but no OIDC client is available. Auth routes \
+                 (/auth/start, /auth/callback) will NOT be mounted. Building an \
+                 OidcServerClient from the compiled schema's [auth] block is not yet \
+                 functional (the compiled schema carries no auth/auth_endpoints) — \
+                 tracked in #621."
             );
         }
 

--- a/docs/auth/auth0.md
+++ b/docs/auth/auth0.md
@@ -1,7 +1,17 @@
 # Auth0 with FraiseQL
 
-Auth0 is an OIDC-compliant provider that works with FraiseQL's existing PKCE
-authentication flow **without any code changes**. This guide covers configuration.
+Auth0 is an OIDC-compliant provider that works with FraiseQL's PKCE
+authentication flow. This guide covers configuration.
+
+> **⚠️ Status (#621):** The compiled-path PKCE `[auth]` **server-login** flow shown
+> below (`discovery_url` / `client_id` / `client_secret_env` / `server_redirect_uri`)
+> is **not yet functional** — the compiled schema does not carry the `[auth]` block or
+> the cached OIDC endpoints the server needs to build an `OidcServerClient`, so
+> `fraiseql compile` currently **rejects** a complete `[auth]` client group. Wiring it
+> end-to-end is tracked in
+> [#621](https://github.com/fraiseql/fraiseql/issues/621). **JWT validation** via
+> `[auth] issuer = "…"` (validating Auth0-issued bearer tokens) is unaffected and works
+> today.
 
 ## Prerequisites
 

--- a/docs/auth/saml-sso.md
+++ b/docs/auth/saml-sso.md
@@ -114,6 +114,14 @@ The identity proxy:
 
 FraiseQL points its `[auth]` configuration at the proxy's OIDC endpoint.
 
+> **⚠️ Status (#621):** The compiled-path PKCE `[auth]` **server-login** blocks below
+> (`discovery_url` / `client_id` / `client_secret_env` / `server_redirect_uri`) are
+> **not yet functional** — the compiled schema does not carry the `[auth]` block or the
+> cached OIDC endpoints the server needs, so `fraiseql compile` currently **rejects** a
+> complete `[auth]` client group. Wiring it end-to-end is tracked in
+> [#621](https://github.com/fraiseql/fraiseql/issues/621). **JWT validation** via
+> `[auth] issuer = "…"` (validating tokens the proxy issues) is unaffected and works today.
+
 ## Recommended proxies
 
 | Proxy | Hosting | Best for |


### PR DESCRIPTION
## Summary

#612 item 9. The CLI's `[auth]` schema (`OidcClientConfig`) required the four PKCE
OAuth-client fields with `deny_unknown_fields`, while the server's `OidcConfig` — read
from the **same** `fraiseql.toml` — expects `issuer`. A JWT-validation block
(`[auth] issuer = "…"`) therefore failed `fraiseql compile`, and **no single `[auth]`
block could satisfy both tools**.

Tracing the data flow at HEAD surfaced a second, deeper finding (a documented auth path
that never worked): the compiled-path PKCE server-login flow is **non-functional**.
`OidcServerClient::from_compiled_schema` reads `schema_json["auth"]`, but `CompiledSchema`
has no `auth` field (so `to_value` never emits `["auth"]`), the merger never serializes
`[auth]`, and the CLI never fetches/caches the `auth_endpoints` the client also needs.

## Disposition (decided with the reviewer)

**JWT group functional, PKCE client group reject-loud** — the item-4 precedent (declared-
but-unenforced auth fails loud, never silently accepted). This closes the filed symptom
without hand-building a *new* accepted-but-unconsumed key.

- `[auth]` is a union of two coherent groups, validated in `TomlSchema::validate`:
  - **JWT validation** — `issuer` (+ optional `audience`). Accepted and functional (fixes
    the item-9 bug: a JWT-only `[auth]` now compiles).
  - **PKCE OAuth client** — the four client fields, **all-four-or-none**. A *complete*
    client group is **rejected at compile time with a pointer to #621**; an incomplete one
    names the missing fields; `audience`-without-`issuer` and an empty `[auth]` both error.
  - `deny_unknown_fields` kept — `client_secret` is still rejected (secrets never in TOML).
- Corrected the **false operator instructions** that told operators to configure those four
  fields: the `builder.rs` startup error and the **Auth0 / SAML integration guides**.

## Not in this PR (tracked in #621)

The full PKCE-compiled-path wire — additive `auth` on `CompiledSchema` (fraiseql-core) +
`IntermediateSchema` + converter + merger emit, **and** the `auth_endpoints`
fetch-strategy design (compile-time IdP fetch vs fetch-at-boot — an ADR-shaped decision).
These are one feature; the plumbing has no value without the endpoints answer. When #621
lands, the client-group rejection lifts and configs written against the documented fields
start working.

## Tests (`// M-612`)

`test_auth_jwt_only_compiles`, `test_auth_issuer_without_audience_compiles`,
`test_auth_complete_client_group_rejected_loud` (asserts the #621 pointer),
`test_auth_partial_client_group_rejected_names_missing`, `test_auth_empty_block_rejected`,
`test_auth_audience_without_issuer_rejected`; existing `test_auth_client_secret_field_rejected`
still green.

## Verification

- ✅ `cargo test -p fraiseql-cli`
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`

Part of the #612 config-drift work; independent PR per the item-9 disposition. Targets
2.13.0 (`[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)