### PR TITLE
fix(cli): reject accepted-but-unconsumed config; drop dead rate-limit reader (#612 config surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the spine emit (all-or-nothing per poll batch) rather than per-message.
   `fraiseql_functions::migrations::inbound_email_cursor_migration_sql` is removed.
 
+- **Config sections that validated then did nothing are now rejected at compile
+  (#612).** Several `fraiseql.toml` sections the compiler accepted but no runtime
+  consumed now fail loudly at load — the fix-forward "honest-loud over silently-wrong"
+  stance (the v2.7.0 field-encryption precedent) — with a message naming the section
+  and either the real alternative or the tracking issue. Previously each was accepted
+  and silently ignored, so an operator believed it took effect. A schema using any of
+  these now errors; remove the section (or migrate as noted). The rejection runs on
+  **every** compile path, including `--types` (`merge_files`), which skips the rest of
+  `validate()`:
+  - **`[security.rules]` / `[security.policies]` / `[security.field_auth]` (security).**
+    Declared authorization the runtime never enforced — `RuntimeConfig::from_compiled_schema`
+    pins the operation- and field-authorizers to `None`, so any access boundary these
+    blocks implied did not exist. Every deployment carrying them was operating on a
+    false belief; the break *is* the fix. Remove them and enforce authorization at the
+    database layer (RLS policies keyed on the session variables FraiseQL sets from the
+    request identity) until a compiled-schema declarative-authorization engine ships
+    (**#626**).
+  - **`[caching]`** — never lowered into the compiled schema; no runtime honored it (**#623**).
+  - **`[analytics]`** — fully inert (**#624**).
+  - **`[observability]`** — inert on the compiled path; configure metrics under
+    `[metrics]` and tracing under `[tracing]` in `fraiseql.toml` instead (**#625**).
+  - **`[security.api_keys] storage`** — only `"env"` is implemented; `"postgres"`
+    authenticated nothing. Set `storage = "env"` (postgres-backed store: **#627**).
+- **The `multitenant` and `saas` examples stopped compiling until corrected (#612).**
+  Both declared `[[security.rules]]`, and the `multitenant` README + config claimed those
+  rules enforced tenant isolation — a false security claim (the rules were never
+  enforced). The unenforced blocks were removed and the docs corrected to point at
+  database-layer RLS plus the session variables FraiseQL sets from the identity
+  (`resolve_session_variables`, `crates/fraiseql-core/src/runtime/executor/support/security.rs`);
+  a worked end-to-end isolation example is tracked in **#628**.
+
 ### Changed
 
 - **Entity-identity contract: `id: UUID` is canonicalized to `id: ID` (ADR-0017).**
@@ -351,6 +382,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client can paginate and filter. An explicit argument of the same name still wins
   (no duplicates), and Relay connection queries are unchanged (their `first`/`after`/
   `last`/`before` surface is owned by the Relay path).
+- **`security.token_revocation.revoke_all_ttl_secs` now reaches the server (#612).**
+  The server reads this key (default 86400s) to bound how long a `revoke-all` epoch
+  suppresses tokens, and the docs instructed setting it — but the CLI TOML schema lacked
+  the field, so `deny_unknown_fields` rejected any config that set it and it could never
+  take effect. Added to the CLI `[security.token_revocation]` schema; it now serializes
+  into the compiled schema the server already reads.
+- **Removed a dead rate-limiting config reader that silently fed hardcoded defaults
+  (#612).** `fraiseql-auth`'s `SecurityConfigFromSchema` parsed a nested-camelCase
+  `rateLimiting.authStart.maxRequests` shape the compiler never emits (it emits flat
+  snake_case `security.rate_limiting`), so that reader always fell back to hardcoded
+  defaults; its output only fed startup logging/validation before being dropped and
+  never drove runtime limits (those come from the server middleware's live
+  `RateLimitingSecurityConfig`, which reads the flat shape correctly). The dead
+  rate-limiting portion of the reader was removed and a merger→reader round-trip test
+  now pins the flat shape so the two ends cannot drift silently again.
 
 ## [2.11.0] - 2026-07-06
 

--- a/crates/fraiseql-auth/src/lib.rs
+++ b/crates/fraiseql-auth/src/lib.rs
@@ -124,8 +124,8 @@ pub use saml::{
     saml_provider_key, saml_routes, verify_saml_response,
 };
 pub use security_config::{
-    AuditLoggingSettings, ErrorSanitizationSettings, RateLimitingSettings,
-    SecurityConfigFromSchema, StateEncryptionSettings,
+    AuditLoggingSettings, ErrorSanitizationSettings, SecurityConfigFromSchema,
+    StateEncryptionSettings,
 };
 pub use security_init::{
     init_default_security_config, init_security_config, log_security_config,

--- a/crates/fraiseql-auth/src/security_config.rs
+++ b/crates/fraiseql-auth/src/security_config.rs
@@ -8,14 +8,20 @@ use std::env;
 use serde_json::Value as JsonValue;
 
 /// Security configuration loaded from schema.compiled.json
+///
+/// Note: rate limiting is intentionally **not** represented here. The live
+/// rate-limit configuration is read by the server middleware from the compiled
+/// schema's flat `security.rate_limiting` snake_case key
+/// (`fraiseql-server middleware/rate_limit/config.rs`, `RateLimitingSecurityConfig`).
+/// A former nested-camelCase reader on this struct (`rateLimiting.authStart.maxRequests`)
+/// never matched the merger's emitted flat shape, so it silently fed hardcoded
+/// defaults; it was removed under #612 (item 5b) to eliminate that drift.
 #[derive(Debug, Clone)]
 pub struct SecurityConfigFromSchema {
     /// Audit logging configuration
     pub audit_logging:      AuditLoggingSettings,
     /// Error sanitization configuration
     pub error_sanitization: ErrorSanitizationSettings,
-    /// Rate limiting configuration
-    pub rate_limiting:      RateLimitingSettings,
     /// State encryption configuration
     pub state_encryption:   StateEncryptionSettings,
 }
@@ -57,33 +63,6 @@ pub struct ErrorSanitizationSettings {
     pub user_facing_format:     String,
 }
 
-/// Rate-limiting thresholds for each authentication endpoint.
-#[derive(Debug, Clone)]
-pub struct RateLimitingSettings {
-    /// Whether rate limiting is active across all auth endpoints.
-    pub enabled:                    bool,
-    /// Maximum requests to `/auth/start` per IP per window.
-    pub auth_start_max_requests:    u32,
-    /// Window duration (in seconds) for the `/auth/start` rate limit.
-    pub auth_start_window_secs:     u64,
-    /// Maximum requests to `/auth/callback` per IP per window.
-    pub auth_callback_max_requests: u32,
-    /// Window duration (in seconds) for the `/auth/callback` rate limit.
-    pub auth_callback_window_secs:  u64,
-    /// Maximum token refresh requests per user per window.
-    pub auth_refresh_max_requests:  u32,
-    /// Window duration (in seconds) for the `/auth/refresh` rate limit.
-    pub auth_refresh_window_secs:   u64,
-    /// Maximum logout requests per user per window.
-    pub auth_logout_max_requests:   u32,
-    /// Window duration (in seconds) for the `/auth/logout` rate limit.
-    pub auth_logout_window_secs:    u64,
-    /// Maximum failed login attempts per user per window (brute-force protection).
-    pub failed_login_max_requests:  u32,
-    /// Window duration (in seconds) for the failed login rate limit (typically 1 hour).
-    pub failed_login_window_secs:   u64,
-}
-
 /// OAuth state encryption settings loaded from the compiled schema.
 #[derive(Debug, Clone)]
 pub struct StateEncryptionSettings {
@@ -116,19 +95,6 @@ impl Default for SecurityConfigFromSchema {
                 internal_logging:       true,
                 leak_sensitive_details: false,
                 user_facing_format:     "generic".to_string(),
-            },
-            rate_limiting:      RateLimitingSettings {
-                enabled:                    true,
-                auth_start_max_requests:    100,
-                auth_start_window_secs:     60,
-                auth_callback_max_requests: 50,
-                auth_callback_window_secs:  60,
-                auth_refresh_max_requests:  10,
-                auth_refresh_window_secs:   60,
-                auth_logout_max_requests:   20,
-                auth_logout_window_secs:    60,
-                failed_login_max_requests:  5,
-                failed_login_window_secs:   3600,
             },
             state_encryption:   StateEncryptionSettings {
                 enabled:              true,
@@ -185,56 +151,9 @@ impl SecurityConfigFromSchema {
                 .to_string();
         }
 
-        if let Some(rate_limit) = value.get("rateLimiting").and_then(|v| v.as_object()) {
-            config.rate_limiting.enabled =
-                rate_limit.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true);
-
-            #[allow(clippy::cast_possible_truncation)]
-            // Reason: rate-limit maxRequests values are config-bounded within u32
-            if let Some(auth_start) = rate_limit.get("authStart").and_then(|v| v.as_object()) {
-                config.rate_limiting.auth_start_max_requests =
-                    auth_start.get("maxRequests").and_then(|v| v.as_u64()).unwrap_or(100) as u32;
-                config.rate_limiting.auth_start_window_secs =
-                    auth_start.get("windowSecs").and_then(|v| v.as_u64()).unwrap_or(60);
-            }
-
-            #[allow(clippy::cast_possible_truncation)]
-            // Reason: rate-limit maxRequests values are config-bounded within u32
-            if let Some(auth_callback) = rate_limit.get("authCallback").and_then(|v| v.as_object())
-            {
-                config.rate_limiting.auth_callback_max_requests =
-                    auth_callback.get("maxRequests").and_then(|v| v.as_u64()).unwrap_or(50) as u32;
-                config.rate_limiting.auth_callback_window_secs =
-                    auth_callback.get("windowSecs").and_then(|v| v.as_u64()).unwrap_or(60);
-            }
-
-            #[allow(clippy::cast_possible_truncation)]
-            // Reason: rate-limit maxRequests values are config-bounded within u32
-            if let Some(auth_refresh) = rate_limit.get("authRefresh").and_then(|v| v.as_object()) {
-                config.rate_limiting.auth_refresh_max_requests =
-                    auth_refresh.get("maxRequests").and_then(|v| v.as_u64()).unwrap_or(10) as u32;
-                config.rate_limiting.auth_refresh_window_secs =
-                    auth_refresh.get("windowSecs").and_then(|v| v.as_u64()).unwrap_or(60);
-            }
-
-            #[allow(clippy::cast_possible_truncation)]
-            // Reason: rate-limit maxRequests values are config-bounded within u32
-            if let Some(auth_logout) = rate_limit.get("authLogout").and_then(|v| v.as_object()) {
-                config.rate_limiting.auth_logout_max_requests =
-                    auth_logout.get("maxRequests").and_then(|v| v.as_u64()).unwrap_or(20) as u32;
-                config.rate_limiting.auth_logout_window_secs =
-                    auth_logout.get("windowSecs").and_then(|v| v.as_u64()).unwrap_or(60);
-            }
-
-            #[allow(clippy::cast_possible_truncation)]
-            // Reason: rate-limit maxRequests values are config-bounded within u32
-            if let Some(failed_login) = rate_limit.get("failedLogin").and_then(|v| v.as_object()) {
-                config.rate_limiting.failed_login_max_requests =
-                    failed_login.get("maxRequests").and_then(|v| v.as_u64()).unwrap_or(5) as u32;
-                config.rate_limiting.failed_login_window_secs =
-                    failed_login.get("windowSecs").and_then(|v| v.as_u64()).unwrap_or(3600);
-            }
-        }
+        // Rate limiting is read from the compiled schema's flat `security.rate_limiting`
+        // key by the server middleware (`RateLimitingSecurityConfig`), not here. The
+        // former nested-camelCase reader was removed under #612 (item 5b).
 
         if let Some(state_enc) = value.get("stateEncryption").and_then(|v| v.as_object()) {
             config.state_encryption.enabled =
@@ -266,31 +185,8 @@ impl SecurityConfigFromSchema {
             self.audit_logging.log_level = level;
         }
 
-        // Rate limiting
-        if let Ok(val) = env::var("RATE_LIMIT_AUTH_START") {
-            if let Ok(n) = val.parse() {
-                self.rate_limiting.auth_start_max_requests = n;
-            }
-        }
-        if let Ok(val) = env::var("RATE_LIMIT_AUTH_CALLBACK") {
-            if let Ok(n) = val.parse() {
-                self.rate_limiting.auth_callback_max_requests = n;
-            }
-        }
-        if let Ok(val) = env::var("RATE_LIMIT_AUTH_REFRESH") {
-            if let Ok(n) = val.parse() {
-                self.rate_limiting.auth_refresh_max_requests = n;
-            }
-        }
-        if let Ok(val) = env::var("RATE_LIMIT_AUTH_LOGOUT") {
-            if let Ok(n) = val.parse() {
-                self.rate_limiting.auth_logout_max_requests = n;
-            }
-        }
-        if let Ok(val) = env::var("RATE_LIMIT_FAILED_LOGIN") {
-            if let Ok(n) = val.parse() {
-                self.rate_limiting.failed_login_max_requests = n;
-            }
-        }
+        // Rate limiting env overrides (RATE_LIMIT_*) apply to the live server-side
+        // `RateLimitingSecurityConfig`, not to this struct — the nested-camelCase
+        // reader that owned them here was removed under #612 (item 5b).
     }
 }

--- a/crates/fraiseql-auth/src/security_init.rs
+++ b/crates/fraiseql-auth/src/security_init.rs
@@ -186,14 +186,9 @@ pub fn log_security_config(config: &SecurityConfigFromSchema) {
         "Error sanitization configuration"
     );
 
-    info!(
-        rate_limiting_enabled = config.rate_limiting.enabled,
-        auth_start_max = config.rate_limiting.auth_start_max_requests,
-        auth_callback_max = config.rate_limiting.auth_callback_max_requests,
-        auth_refresh_max = config.rate_limiting.auth_refresh_max_requests,
-        failed_login_max = config.rate_limiting.failed_login_max_requests,
-        "Rate limiting configuration"
-    );
+    // Rate-limiting configuration is logged by the server middleware from the live
+    // `RateLimitingSecurityConfig`; the dead reader that logged it here was removed
+    // under #612 (item 5b).
 
     info!(
         state_encryption_enabled = config.state_encryption.enabled,
@@ -219,9 +214,12 @@ pub fn log_security_config(config: &SecurityConfigFromSchema) {
 ///
 /// # Errors
 ///
-/// Returns [`AuthError::ConfigError`] if `leak_sensitive_details` is `true`,
-/// `auth_start_max_requests` is zero when rate limiting is enabled, or
-/// `auth_start_window_secs` is zero when rate limiting is enabled.
+/// Returns [`AuthError::ConfigError`] if `leak_sensitive_details` is `true`.
+///
+/// Note: rate-limit sanity checks (non-zero windows/caps) are enforced by the
+/// server middleware against the live `RateLimitingSecurityConfig`. The checks
+/// that formerly ran here operated on a dead reader fed only hardcoded defaults,
+/// so they validated nothing real and were removed under #612 (item 5b).
 pub fn validate_security_config(config: &SecurityConfigFromSchema) -> Result<()> {
     // Check if sensitive data leaking is disabled (security requirement)
     if config.error_sanitization.leak_sensitive_details {
@@ -229,20 +227,6 @@ pub fn validate_security_config(config: &SecurityConfigFromSchema) -> Result<()>
         return Err(AuthError::ConfigError {
             message: "leak_sensitive_details must be false in production".to_string(),
         });
-    }
-
-    // Check rate limits are reasonable
-    if config.rate_limiting.enabled {
-        if config.rate_limiting.auth_start_max_requests == 0 {
-            return Err(AuthError::ConfigError {
-                message: "auth_start_max_requests must be greater than 0".to_string(),
-            });
-        }
-        if config.rate_limiting.auth_start_window_secs == 0 {
-            return Err(AuthError::ConfigError {
-                message: "auth_start_window_secs must be greater than 0".to_string(),
-            });
-        }
     }
 
     // Check state encryption key size if enabled

--- a/crates/fraiseql-auth/src/tests.rs
+++ b/crates/fraiseql-auth/src/tests.rs
@@ -79,7 +79,6 @@ mod security_config_tests {
         let config = SecurityConfigFromSchema::default();
         assert!(config.audit_logging.enabled);
         assert!(config.error_sanitization.enabled);
-        assert!(config.rate_limiting.enabled);
         assert!(config.state_encryption.enabled);
     }
 
@@ -90,19 +89,11 @@ mod security_config_tests {
                 "enabled": true,
                 "logLevel": "debug",
                 "includeSensitiveData": false
-            },
-            "rateLimiting": {
-                "enabled": true,
-                "authStart": {
-                    "maxRequests": 200,
-                    "windowSecs": 60
-                }
             }
         });
 
         let config = SecurityConfigFromSchema::from_json(&json).expect("Failed to parse");
         assert_eq!(config.audit_logging.log_level, "debug");
-        assert_eq!(config.rate_limiting.auth_start_max_requests, 200);
     }
 
     #[test]
@@ -126,7 +117,6 @@ mod security_init_tests {
         let config = init_default_security_config();
         assert!(config.audit_logging.enabled);
         assert!(config.error_sanitization.enabled);
-        assert!(config.rate_limiting.enabled);
         assert!(config.state_encryption.enabled);
     }
 
@@ -162,13 +152,6 @@ mod security_init_tests {
                 "auditLogging": {
                     "enabled": true,
                     "logLevel": "debug"
-                },
-                "rateLimiting": {
-                    "enabled": true,
-                    "authStart": {
-                        "maxRequests": 200,
-                        "windowSecs": 60
-                    }
                 }
             }
         });
@@ -176,7 +159,6 @@ mod security_init_tests {
         let cfg = init_security_config_from_value(&json)
             .unwrap_or_else(|e| panic!("expected Ok for valid security JSON: {e}"));
         assert_eq!(cfg.audit_logging.log_level, "debug");
-        assert_eq!(cfg.rate_limiting.auth_start_max_requests, 200);
     }
 
     #[test]

--- a/crates/fraiseql-cli/src/config/toml_schema/mod.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/mod.rs
@@ -273,16 +273,110 @@ impl TomlSchema {
         toml::from_str(&expanded).context("Failed to parse TOML schema")
     }
 
+    /// Reject config sections the CLI accepts but no runtime consumes (#612).
+    ///
+    /// Each of these validated-then-did-nothing: the compiler embedded (or silently
+    /// dropped) the section and the server never read it, so an operator who set it
+    /// was misled. Per the fix-forward "honest-loud over silently-wrong" stance, each
+    /// now fails at load with a pointer to the real mechanism or the tracking issue,
+    /// rather than compiling a dishonest configuration. Mirrors the v2.7.0
+    /// field-encryption precedent (refuse rather than run an unsupported config).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of `[security.rules]` / `[security.policies]` /
+    /// `[security.field_auth]` (declared-but-unenforced authorization), `[caching]`,
+    /// `[analytics]`, a non-default `[observability]`, or a non-`env`
+    /// `[security.api_keys] storage` is present.
+    ///
+    /// Called from both [`Self::validate`] and the merger's `merge_values` so that no
+    /// compile path can bypass it — the `--types` path (`merge_files`) deliberately
+    /// skips the rest of `validate()` (queries may reference types from `types.json`),
+    /// but these sections are self-contained and must be rejected there too.
+    pub(crate) fn reject_accepted_but_unconsumed_config(&self) -> Result<()> {
+        // #4 (security-shaped, highest-stakes): declared authorization the runtime does
+        // not enforce. `RuntimeConfig::from_compiled_schema` pins the operation- and
+        // field-authorizers to None, so any access boundary these blocks imply does not
+        // exist. Fail loud rather than let a deployment believe it enforces authz.
+        if !self.security.rules.is_empty()
+            || !self.security.policies.is_empty()
+            || !self.security.field_auth.is_empty()
+        {
+            anyhow::bail!(
+                "[security.rules] / [security.policies] / [security.field_auth] declare \
+                 authorization that the FraiseQL runtime does NOT enforce: the server pins \
+                 the operation- and field-authorizers to None, so the access boundary these \
+                 blocks imply does not exist. Remove the block(s). Enforce authorization at \
+                 the database layer (RLS policies keyed on the session variables FraiseQL \
+                 sets from the request identity) until a compiled-schema declarative \
+                 authorization engine ships — tracked at \
+                 https://github.com/fraiseql/fraiseql/issues/626."
+            );
+        }
+
+        // #1 [caching]: never lowered into the compiled schema and never consumed;
+        // server result caching is configured elsewhere. Reject a configured section.
+        if self.caching.enabled || !self.caching.rules.is_empty() {
+            anyhow::bail!(
+                "[caching] is accepted but not consumed: the compiler does not lower it into \
+                 the compiled schema and no runtime honors it, so `enabled` / \
+                 `[[caching.rules]]` silently do nothing. Remove the [caching] section. \
+                 Declarative per-rule result caching is tracked at \
+                 https://github.com/fraiseql/fraiseql/issues/623."
+            );
+        }
+
+        // #2 [analytics]: fully inert — never merged, never read.
+        if self.analytics.enabled || !self.analytics.queries.is_empty() {
+            anyhow::bail!(
+                "[analytics] is accepted but fully inert: nothing in the compiler or runtime \
+                 consumes it. Remove the [analytics] section. Analytics query definitions are \
+                 tracked at https://github.com/fraiseql/fraiseql/issues/624."
+            );
+        }
+
+        // #3 [observability]: inert on the compiled path — the real metrics/tracing config
+        // lives in the server's runtime `[metrics]` / `[tracing]` sections.
+        if self.observability != ObservabilityConfig::default() {
+            anyhow::bail!(
+                "[observability] is accepted but not consumed on the compiled path. Configure \
+                 metrics under the server's [metrics] section and tracing under [tracing] in \
+                 fraiseql.toml (logging via RUST_LOG / the server log settings), then remove \
+                 [observability]. Alias-vs-remove rationale: \
+                 https://github.com/fraiseql/fraiseql/issues/625."
+            );
+        }
+
+        // #7 [security.api_keys] storage: only `env` (static keys) is implemented; the
+        // server never reads `.storage`, so `postgres` authenticates nothing.
+        if let Some(api_keys) = &self.security.api_keys {
+            if api_keys.storage != "env" {
+                anyhow::bail!(
+                    "[security.api_keys] storage = \"{}\" is not implemented: the server only \
+                     authenticates static `env` keys and never reads a postgres-backed key \
+                     store, so this value authenticates nothing. Set storage = \"env\". A \
+                     postgres-backed API-key store is tracked at \
+                     https://github.com/fraiseql/fraiseql/issues/627.",
+                    api_keys.storage
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Validate schema
     ///
     /// # Errors
     ///
-    /// Returns an error if any query or mutation references an undefined type,
-    /// if a field auth rule references an undefined policy, if a federation
-    /// entity references an undefined type, or if server/database/circuit-breaker
-    /// configuration values are invalid.
+    /// Returns an error if any accepted-but-unconsumed config section is present
+    /// (see `reject_accepted_but_unconsumed_config`), if any query or mutation
+    /// references an undefined type, if a federation entity references an undefined
+    /// type, or if server/database/circuit-breaker configuration values are invalid.
     pub fn validate(&self) -> Result<()> {
         use fraiseql_core::runtime::suggest_similar;
+
+        self.reject_accepted_but_unconsumed_config()?;
 
         let type_names: Vec<&str> = self.types.keys().map(String::as_str).collect();
 
@@ -304,20 +398,6 @@ impl TomlSchema {
                 anyhow::bail!(
                     "Mutation '{mut_name}' references undefined type '{}'{hint}",
                     mut_def.return_type
-                );
-            }
-        }
-
-        // Validate field auth rules reference existing policies
-        for field_auth in &self.security.field_auth {
-            let policy_exists = self.security.policies.iter().any(|p| p.name == field_auth.policy);
-            if !policy_exists {
-                let policy_names: Vec<&str> =
-                    self.security.policies.iter().map(|p| p.name.as_str()).collect();
-                let hint = format_suggestions(suggest_similar(&field_auth.policy, &policy_names));
-                anyhow::bail!(
-                    "Field auth references undefined policy '{}'{hint}",
-                    field_auth.policy
                 );
             }
         }

--- a/crates/fraiseql-cli/src/config/toml_schema/observability.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/observability.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Observability configuration
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ObservabilityConfig {
     /// Enable Prometheus metrics

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -478,20 +478,20 @@ impl Default for TrustedDocumentsConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct TokenRevocationSecurityConfig {
     /// Enable token revocation
-    pub enabled:     bool,
+    pub enabled:             bool,
     /// Backend: `"redis"`, `"postgres"`, or `"memory"`
-    pub backend:     String,
+    pub backend:             String,
     /// Reject JWTs without a `jti` claim when revocation is enabled
     #[serde(default = "default_true")]
-    pub require_jti: bool,
+    pub require_jti:         bool,
     /// If revocation store is unreachable: `false` = reject (fail-closed), `true` = allow
     /// (fail-open)
     #[serde(default)]
-    pub fail_open:   bool,
+    pub fail_open:           bool,
     /// Redis URL for distributed revocation (optional — inherited from `[fraiseql.redis]` if
     /// absent)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub redis_url:   Option<String>,
+    pub redis_url:           Option<String>,
     /// How long (seconds) a `revoke-all` epoch is retained.
     ///
     /// `revoke-all` records a per-user epoch rather than deleting individual tokens, so the

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -492,16 +492,25 @@ pub struct TokenRevocationSecurityConfig {
     /// absent)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redis_url:   Option<String>,
+    /// How long (seconds) a `revoke-all` epoch is retained.
+    ///
+    /// `revoke-all` records a per-user epoch rather than deleting individual tokens, so the
+    /// entry must outlive every token that could have been issued before the revocation.
+    /// Set this **above your maximum access-token lifetime**; once it expires a pre-revocation
+    /// token would resume working (until its own `exp`). Default: 86400 (24h). The server reads
+    /// this value from the compiled schema.
+    pub revoke_all_ttl_secs: u64,
 }
 
 impl Default for TokenRevocationSecurityConfig {
     fn default() -> Self {
         Self {
-            enabled:     false,
-            backend:     "memory".to_string(),
-            require_jti: true,
-            fail_open:   false,
-            redis_url:   None,
+            enabled:             false,
+            backend:             "memory".to_string(),
+            require_jti:         true,
+            fail_open:           false,
+            redis_url:           None,
+            revoke_all_ttl_secs: 86_400,
         }
     }
 }

--- a/crates/fraiseql-cli/src/schema/merger.rs
+++ b/crates/fraiseql-cli/src/schema/merger.rs
@@ -379,6 +379,11 @@ impl SchemaMerger {
     /// Merge JSON types with TOML schema
     #[allow(clippy::cognitive_complexity)] // Reason: deep merge of two schema formats with many field-level transformations
     fn merge_values(types_value: &Value, toml_schema: &TomlSchema) -> Result<IntermediateSchema> {
+        // #612: reject accepted-but-unconsumed config on EVERY compile path. The full
+        // `TomlSchema::validate()` is skipped on the `--types` path (`merge_files`), but
+        // these sections are self-contained and must never compile silently.
+        toml_schema.reject_accepted_but_unconsumed_config()?;
+
         // Typo guard: [queries.defaults] is a common mistake for [query_defaults].
         if toml_schema.queries.contains_key("defaults") {
             anyhow::bail!(

--- a/crates/fraiseql-cli/tests/compiler_runtime_contract.rs
+++ b/crates/fraiseql-cli/tests/compiler_runtime_contract.rs
@@ -178,20 +178,10 @@ required = true
 [security]
 default_policy = "public"
 
-[[security.rules]]
-name = "read_own"
-rule = "user.id == object.owner_id"
-description = "owner read"
-cacheable = true
-cache_ttl_seconds = 300
-
-[[security.policies]]
-name = "admin_only"
-type = "rbac"
-roles = ["admin"]
-strategy = "any"
-description = "admins"
-cache_ttl_seconds = 600
+# Note: [[security.rules]] / [[security.policies]] are intentionally absent —
+# declared-but-unenforced authorization is rejected at compile (#612 item 4 / #626).
+# The emit↔parse contract this test guards is exercised by the remaining security
+# fields (default_policy, enterprise).
 
 [security.enterprise]
 rate_limiting_enabled = true

--- a/crates/fraiseql-cli/tests/config_coverage_pin_test.rs
+++ b/crates/fraiseql-cli/tests/config_coverage_pin_test.rs
@@ -1,0 +1,218 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+//! #612 config-drift pins — the config-file surface (Phase 04).
+//!
+//! One test per disposition target from `config-key-disposition.md` that lives on
+//! the `fraiseql-cli` TOML/merger surface. Each pin asserts the *disposed* behavior:
+//!
+//! - **5b** rate-limiting shape — the merger emits the flat `snake_case` `security.rate_limiting`
+//!   the live server reader consumes (the dead nested-`camelCase` reader was removed in
+//!   `fraiseql-auth`).
+//! - **REJECT** rows (#1 `[caching]`, #2 `[analytics]`, #3 `[observability]`, #4
+//!   `[security.rules/policies/field_auth]`, #7 `[security.api_keys] storage`) — each
+//!   previously-accepted key now fails **loudly at compile** with a targeted message. These replace
+//!   the Phase-00 "accepted silently" characterizations.
+//!
+//! Items #6 (`revoke_all_ttl_secs`) and #9 (`[auth]`) are pinned by their own
+//! landing PRs (#612 commit `3d94331` and PR #622 respectively).
+
+use std::io::Write;
+
+use fraiseql_cli::{config::toml_schema::TomlSchema, schema::merger::SchemaMerger};
+use tempfile::NamedTempFile;
+
+/// Parse a TOML schema and return the error `validate()` produces (panics if it
+/// unexpectedly validates — a REJECT pin must actually reject).
+fn validate_err(toml: &str) -> String {
+    let schema = TomlSchema::parse_toml(toml).expect("TOML should parse");
+    schema
+        .validate()
+        .expect_err("config should be rejected at validate()")
+        .to_string()
+}
+
+/// Write TOML content to a temp file and return the handle (kept alive by caller).
+fn toml_file(content: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+// ---------------------------------------------------------------------------
+// 5b — rate-limiting shape: merger emits flat snake_case that the live reader reads
+// ---------------------------------------------------------------------------
+
+/// The merger lowers `[security.rate_limiting]` into the compiled schema's
+/// `security.rate_limiting` object as **flat `snake_case`** — the exact shape the
+/// server's live `RateLimitingSecurityConfig`
+/// (`fraiseql-server middleware/rate_limit/config.rs`) deserializes. This pins the
+/// contract so the two ends cannot silently drift the way #612 item 5b found (a
+/// nested-`camelCase` reader that never matched and fell back to hardcoded defaults).
+#[test]
+fn rate_limiting_is_emitted_as_flat_snake_case_for_the_live_reader() {
+    let f = toml_file(
+        r#"
+        [schema]
+        name = "test"
+
+        [security.rate_limiting]
+        enabled                 = true
+        auth_start_max_requests = 42
+        auth_start_window_secs  = 77
+        failed_login_max_attempts = 9
+    "#,
+    );
+    let intermediate = SchemaMerger::merge_toml_only(f.path().to_str().unwrap()).unwrap();
+
+    let security = intermediate.security.expect("security section should be emitted");
+    let rate_limiting = security
+        .get("rate_limiting")
+        .expect("compiled schema must carry flat `security.rate_limiting`");
+
+    // Flat snake_case keys carry the configured values (not defaults, not dropped).
+    assert_eq!(rate_limiting.get("enabled").and_then(serde_json::Value::as_bool), Some(true));
+    assert_eq!(
+        rate_limiting.get("auth_start_max_requests").and_then(serde_json::Value::as_u64),
+        Some(42),
+        "the live server reader keys on flat snake_case `auth_start_max_requests`"
+    );
+    assert_eq!(
+        rate_limiting.get("auth_start_window_secs").and_then(serde_json::Value::as_u64),
+        Some(77)
+    );
+    assert_eq!(
+        rate_limiting
+            .get("failed_login_max_attempts")
+            .and_then(serde_json::Value::as_u64),
+        Some(9)
+    );
+
+    // The dead nested-camelCase shape must NOT be what the pipeline emits.
+    assert!(
+        rate_limiting.get("authStart").is_none(),
+        "merger must not emit the nested-camelCase shape the removed reader expected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// REJECT rows — each previously-accepted section now fails loudly at compile
+// ---------------------------------------------------------------------------
+
+/// #4 (highest-stakes): declared-but-unenforced authorization. Any of
+/// `[security.rules]` / `[security.policies]` / `[security.field_auth]` must be
+/// rejected — the runtime pins the authorizers to None, so shipping them is a false
+/// security claim. The error names the blocks, says they are unenforced, and links
+/// the declarative-authz follow-up (#626).
+#[test]
+fn declared_authorization_is_rejected_at_compile() {
+    let err = validate_err(
+        r#"
+        [schema]
+        name = "t"
+
+        [[security.rules]]
+        name = "read_own"
+        rule = "user.id == object.owner_id"
+    "#,
+    );
+    assert!(err.contains("[security.rules]"), "err = {err}");
+    assert!(err.contains("does NOT enforce"), "err = {err}");
+    assert!(err.contains("/issues/626"), "err = {err}");
+
+    // policies and field_auth are rejected on the same footing.
+    assert!(
+        validate_err(
+            r#"
+        [schema]
+        name = "t"
+        [[security.policies]]
+        name = "admin_only"
+        type = "rbac"
+        roles = ["admin"]
+    "#,
+        )
+        .contains("does NOT enforce")
+    );
+}
+
+/// #1 `[caching]` — accepted but never lowered into the compiled schema.
+#[test]
+fn caching_section_is_rejected_at_compile() {
+    let err = validate_err(
+        r#"
+        [schema]
+        name = "t"
+
+        [caching]
+        enabled = true
+        backend = "redis"
+    "#,
+    );
+    assert!(err.contains("[caching]"), "err = {err}");
+    assert!(err.contains("/issues/623"), "err = {err}");
+}
+
+/// #2 `[analytics]` — fully inert.
+#[test]
+fn analytics_section_is_rejected_at_compile() {
+    let err = validate_err(
+        r#"
+        [schema]
+        name = "t"
+
+        [analytics]
+        enabled = true
+    "#,
+    );
+    assert!(err.contains("[analytics]"), "err = {err}");
+    assert!(err.contains("/issues/624"), "err = {err}");
+}
+
+/// #3 `[observability]` — inert on the compiled path; points to `[metrics]`/`[tracing]`.
+#[test]
+fn observability_section_is_rejected_at_compile() {
+    let err = validate_err(
+        r#"
+        [schema]
+        name = "t"
+
+        [observability]
+        prometheus_enabled = true
+    "#,
+    );
+    assert!(err.contains("[observability]"), "err = {err}");
+    assert!(err.contains("[metrics]") && err.contains("[tracing]"), "err = {err}");
+    assert!(err.contains("/issues/625"), "err = {err}");
+}
+
+/// #7 `[security.api_keys] storage` — only `env` is implemented; `postgres` authenticates nothing.
+#[test]
+fn api_keys_non_env_storage_is_rejected_at_compile() {
+    let err = validate_err(
+        r#"
+        [schema]
+        name = "t"
+
+        [security.api_keys]
+        enabled = true
+        storage = "postgres"
+    "#,
+    );
+    assert!(err.contains("[security.api_keys]"), "err = {err}");
+    assert!(err.contains("postgres"), "err = {err}");
+    assert!(err.contains("/issues/627"), "err = {err}");
+
+    // The implemented value (`env`) still validates.
+    let schema = TomlSchema::parse_toml(
+        r#"
+        [schema]
+        name = "t"
+
+        [security.api_keys]
+        enabled = true
+        storage = "env"
+    "#,
+    )
+    .expect("TOML should parse");
+    schema.validate().expect("storage = \"env\" must remain valid");
+}

--- a/crates/fraiseql-cli/tests/diagnostic_snapshots.rs
+++ b/crates/fraiseql-cli/tests/diagnostic_snapshots.rs
@@ -16,9 +16,8 @@ use std::collections::BTreeMap;
 use fraiseql_cli::config::{
     SecurityConfig,
     toml_schema::{
-        AuthorizationPolicy, FederationCircuitBreakerConfig, FederationEntity, FieldAuthRule,
-        MutationDefinition, PerDatabaseCircuitBreakerOverride, QueryDefinition, TomlSchema,
-        TypeDefinition,
+        FederationCircuitBreakerConfig, FederationEntity, MutationDefinition,
+        PerDatabaseCircuitBreakerOverride, QueryDefinition, TomlSchema, TypeDefinition,
     },
 };
 
@@ -115,50 +114,15 @@ fn diagnostic_query_type_typo_suggests_correction() {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Field auth referencing an undefined policy
+// 4 & 5. (removed) Field-auth policy-reference diagnostics.
+//
+// `[security.field_auth]` / `[security.policies]` are now rejected wholesale at
+// load — declared-but-unenforced authorization (#612 item 4 / #626) — so the
+// former "undefined policy" and "did you mean" diagnostics for the field-auth path
+// no longer apply. The rejection is pinned in `config_coverage_pin_test.rs` and
+// `integration_toml_workflow.rs`; the `suggest_similar` machinery stays covered by
+// the query- and federation-undefined diagnostics below.
 // ---------------------------------------------------------------------------
-
-#[test]
-fn diagnostic_field_auth_undefined_policy() {
-    let mut schema = base_schema_with_user();
-    schema.security.field_auth.push(FieldAuthRule {
-        type_name:  "User".to_string(),
-        field_name: "email".to_string(),
-        policy:     "admin_only".to_string(),
-    });
-    // No policies defined — should fail
-
-    let err = schema.validate().unwrap_err();
-    insta::assert_snapshot!(err.to_string());
-}
-
-// ---------------------------------------------------------------------------
-// 5. Field auth policy typo (close to existing policy)
-// ---------------------------------------------------------------------------
-
-#[test]
-fn diagnostic_field_auth_policy_typo_suggests_correction() {
-    let mut schema = base_schema_with_user();
-    schema.security.policies.push(AuthorizationPolicy {
-        name:              "admin_only".to_string(),
-        policy_type:       "RBAC".to_string(),
-        rule:              None,
-        roles:             vec!["admin".to_string()],
-        strategy:          None,
-        attributes:        vec![],
-        description:       None,
-        cache_ttl_seconds: None,
-    });
-    // Typo: "admin_onyl" — edit distance 2 from "admin_only"
-    schema.security.field_auth.push(FieldAuthRule {
-        type_name:  "User".to_string(),
-        field_name: "email".to_string(),
-        policy:     "admin_onyl".to_string(),
-    });
-
-    let err = schema.validate().unwrap_err();
-    insta::assert_snapshot!(err.to_string());
-}
 
 // ---------------------------------------------------------------------------
 // 6. Federation entity referencing an undefined type

--- a/crates/fraiseql-cli/tests/integration_toml_workflow.rs
+++ b/crates/fraiseql-cli/tests/integration_toml_workflow.rs
@@ -296,8 +296,11 @@ audit_logging_enabled = false
     assert!(compiled_value["queries"].is_array(), "queries should be an array, not object");
 }
 
+/// #612 item 4: declaring `[security.rules]` / `[security.policies]` /
+/// `[security.field_auth]` — authorization the runtime does not enforce — must be
+/// rejected at compile rather than embedded as a dishonest, unenforced config.
 #[test]
-fn test_security_config_in_compiled_schema() {
+fn test_declared_authorization_is_rejected_at_compile() {
     let temp_dir = TempDir::new().unwrap();
 
     let types_json = r#"
@@ -371,28 +374,26 @@ audit_logging_enabled = false
         .output()
         .expect("Failed to run compilation");
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        panic!("Compilation failed.\nstdout: {}\nstderr: {}", stdout, stderr);
-    }
-
-    let compiled = fs::read_to_string(&output_path).unwrap();
-    let compiled_value: serde_json::Value = serde_json::from_str(&compiled).unwrap();
-
-    // Verify security section exists and is properly embedded
+    // #612 item 4: `[[security.rules]]` / `[[security.policies]]` /
+    // `[[security.field_auth]]` declare authorization the runtime does not enforce, so
+    // the compile must now FAIL loudly rather than embed a dishonest, unenforced config.
     assert!(
-        compiled_value.get("security").is_some(),
-        "security section missing from compiled schema"
+        !output.status.success(),
+        "compile should reject declared-but-unenforced [security.rules/policies/field_auth]"
     );
-
-    let security = &compiled_value["security"];
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        security.get("default_policy").is_some(),
-        "default_policy missing from security config"
+        stderr.contains("[security.rules]") && stderr.contains("does NOT enforce"),
+        "rejection must name the blocks and explain they are unenforced; got stderr:\n{stderr}"
     );
-    assert!(security.get("rules").is_some(), "rules missing from security config");
-    assert!(security.get("policies").is_some(), "policies missing from security config");
+    assert!(
+        stderr.contains("/issues/626"),
+        "rejection must link the declarative-authz follow-up (#626); got stderr:\n{stderr}"
+    );
+    assert!(
+        !output_path.exists(),
+        "no compiled schema should be written when the config is rejected"
+    );
 }
 
 /// Full CLI compile pipeline with field-level assertions.

--- a/crates/fraiseql-cli/tests/security_config_test.rs
+++ b/crates/fraiseql-cli/tests/security_config_test.rs
@@ -304,3 +304,61 @@ fn test_auth_client_secret_field_rejected() {
         "client_secret in TOML must be rejected — secrets belong in env vars, not config files"
     );
 }
+
+// ---------------------------------------------------------------------------
+// token_revocation.revoke_all_ttl_secs — WIRE (#612 item 6)
+// ---------------------------------------------------------------------------
+// The server reads `security.token_revocation.revoke_all_ttl_secs` (default 86400)
+// and the docs instruct setting it, but the CLI struct lacked the field, so
+// `deny_unknown_fields` rejected it — the value could never reach the server.
+
+// M-612: the field now parses (was rejected by deny_unknown_fields).
+#[test]
+fn test_revoke_all_ttl_secs_parses() {
+    let toml = r"
+        [security.token_revocation]
+        enabled             = true
+        revoke_all_ttl_secs = 172800
+    ";
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    let cfg = schema.security.token_revocation.unwrap();
+    assert_eq!(cfg.revoke_all_ttl_secs, 172_800);
+}
+
+#[test]
+fn test_revoke_all_ttl_secs_defaults_to_86400() {
+    use fraiseql_cli::config::toml_schema::TokenRevocationSecurityConfig;
+    assert_eq!(TokenRevocationSecurityConfig::default().revoke_all_ttl_secs, 86_400);
+}
+
+// M-612: the value reaches the compiled schema (was absent — server used its 86400 default).
+#[test]
+fn test_revoke_all_ttl_secs_reaches_compiled_schema() -> anyhow::Result<()> {
+    use std::fs;
+
+    use fraiseql_cli::schema::SchemaMerger;
+    use tempfile::TempDir;
+
+    let temp = TempDir::new()?;
+    let toml = r#"
+[schema]
+name = "test"
+version = "1.0.0"
+database_target = "postgresql"
+
+[security.token_revocation]
+enabled             = true
+revoke_all_ttl_secs = 172800
+"#;
+    let toml_path = temp.path().join("fraiseql.toml");
+    fs::write(&toml_path, toml)?;
+
+    let schema = SchemaMerger::merge_toml_only(toml_path.to_str().unwrap())?;
+    let security = schema.security.expect("security section present in compiled schema");
+    assert_eq!(
+        security["token_revocation"]["revoke_all_ttl_secs"],
+        serde_json::json!(172_800),
+        "revoke_all_ttl_secs must reach the compiled schema so the server honours it"
+    );
+    Ok(())
+}

--- a/crates/fraiseql-cli/tests/snapshots/diagnostic_snapshots__diagnostic_field_auth_policy_typo_suggests_correction.snap
+++ b/crates/fraiseql-cli/tests/snapshots/diagnostic_snapshots__diagnostic_field_auth_policy_typo_suggests_correction.snap
@@ -1,5 +1,0 @@
----
-source: crates/fraiseql-cli/tests/diagnostic_snapshots.rs
-expression: err.to_string()
----
-Field auth references undefined policy 'admin_onyl'. Did you mean: admin_only?

--- a/crates/fraiseql-cli/tests/snapshots/diagnostic_snapshots__diagnostic_field_auth_undefined_policy.snap
+++ b/crates/fraiseql-cli/tests/snapshots/diagnostic_snapshots__diagnostic_field_auth_undefined_policy.snap
@@ -1,5 +1,0 @@
----
-source: crates/fraiseql-cli/tests/diagnostic_snapshots.rs
-expression: err.to_string()
----
-Field auth references undefined policy 'admin_only'

--- a/crates/fraiseql-server/tests/security_config_runtime_test.rs
+++ b/crates/fraiseql-server/tests/security_config_runtime_test.rs
@@ -6,10 +6,15 @@
 //! 3. Environment variable overrides are applied
 //! 4. Security subsystems are initialized
 //!
+//! Rate limiting is **not** exercised here: the live rate-limit config is read by
+//! the server middleware from the compiled schema's flat `security.rate_limiting`
+//! `snake_case` key (`RateLimitingSecurityConfig`), not by `SecurityConfigFromSchema`.
+//! The nested-`camelCase` reader that used to own it here was removed under #612
+//! (item 5b) because it never matched the merger's emitted shape.
+//!
 //! **Execution engine:** none
 //! **Infrastructure:** none
 //! **Parallelism:** safe
-
 #![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics acceptable
 #[cfg(test)]
 mod tests {
@@ -37,29 +42,6 @@ mod tests {
                     "internalLogging": true,
                     "leakSensitiveDetails": false,
                     "userFacingFormat": "generic"
-                },
-                "rateLimiting": {
-                    "enabled": true,
-                    "authStart": {
-                        "maxRequests": 100,
-                        "windowSecs": 60
-                    },
-                    "authCallback": {
-                        "maxRequests": 50,
-                        "windowSecs": 60
-                    },
-                    "authRefresh": {
-                        "maxRequests": 10,
-                        "windowSecs": 60
-                    },
-                    "authLogout": {
-                        "maxRequests": 20,
-                        "windowSecs": 60
-                    },
-                    "failedLogin": {
-                        "maxRequests": 5,
-                        "windowSecs": 3600
-                    }
                 },
                 "stateEncryption": {
                     "enabled": true,
@@ -93,14 +75,6 @@ mod tests {
         assert!(!cfg.error_sanitization.leak_sensitive_details);
         assert_eq!(cfg.error_sanitization.user_facing_format, "generic");
 
-        // Verify rate limiting settings
-        assert!(cfg.rate_limiting.enabled);
-        assert_eq!(cfg.rate_limiting.auth_start_max_requests, 100);
-        assert_eq!(cfg.rate_limiting.auth_start_window_secs, 60);
-        assert_eq!(cfg.rate_limiting.auth_callback_max_requests, 50);
-        assert_eq!(cfg.rate_limiting.failed_login_max_requests, 5);
-        assert_eq!(cfg.rate_limiting.failed_login_window_secs, 3600);
-
         // Verify state encryption settings
         assert!(cfg.state_encryption.enabled);
         assert_eq!(cfg.state_encryption.algorithm, "chacha20-poly1305");
@@ -117,13 +91,6 @@ mod tests {
                 "auditLogging": {
                     "enabled": true,
                     "logLevel": "debug"
-                },
-                "rateLimiting": {
-                    "enabled": true,
-                    "authStart": {
-                        "maxRequests": 200,
-                        "windowSecs": 120
-                    }
                 }
             }
         }"#;
@@ -133,8 +100,6 @@ mod tests {
             .unwrap_or_else(|e| panic!("Failed to initialize security config from schema: {e}"));
         // Verify custom values were loaded
         assert_eq!(cfg.audit_logging.log_level, "debug");
-        assert_eq!(cfg.rate_limiting.auth_start_max_requests, 200);
-        assert_eq!(cfg.rate_limiting.auth_start_window_secs, 120);
 
         // Verify other values use defaults
         assert!(cfg.audit_logging.enabled);
@@ -170,9 +135,6 @@ mod tests {
         assert!(config.error_sanitization.enabled);
         assert!(config.error_sanitization.generic_messages);
         assert!(!config.error_sanitization.leak_sensitive_details);
-
-        assert!(config.rate_limiting.enabled);
-        assert_eq!(config.rate_limiting.auth_start_max_requests, 100);
 
         assert!(config.state_encryption.enabled);
         assert_eq!(config.state_encryption.algorithm, "chacha20-poly1305");
@@ -212,13 +174,6 @@ mod tests {
                 "errorSanitization": {
                     "enabled": true
                 },
-                "rateLimiting": {
-                    "enabled": true,
-                    "authStart": {
-                        "maxRequests": 150,
-                        "windowSecs": 60
-                    }
-                },
                 "stateEncryption": {
                     "enabled": true,
                     "algorithm": "chacha20-poly1305"
@@ -234,7 +189,6 @@ mod tests {
 
         // Verify custom config values from security section
         assert_eq!(cfg.audit_logging.log_level, "warn");
-        assert_eq!(cfg.rate_limiting.auth_start_max_requests, 150);
     }
 
     #[test]
@@ -259,47 +213,6 @@ mod tests {
 
         // Other settings use defaults
         assert!(cfg.error_sanitization.enabled);
-        assert!(cfg.rate_limiting.enabled);
         assert!(cfg.state_encryption.enabled);
-    }
-
-    #[test]
-    fn test_security_config_rate_limit_windows() {
-        // Test various rate limit window configurations
-        let schema_json = json!({
-            "security": {
-                "rateLimiting": {
-                    "enabled": true,
-                    "authStart": {
-                        "maxRequests": 50,
-                        "windowSecs": 120
-                    },
-                    "authCallback": {
-                        "maxRequests": 25,
-                        "windowSecs": 180
-                    },
-                    "failedLogin": {
-                        "maxRequests": 3,
-                        "windowSecs": 1800
-                    }
-                }
-            }
-        });
-
-        let security_value = schema_json.get("security").unwrap();
-        let config = fraiseql_server::auth::SecurityConfigFromSchema::from_json(security_value);
-
-        let cfg =
-            config.unwrap_or_else(|e| panic!("expected Ok parsing rate limit window config: {e}"));
-
-        // Verify rate limit configuration
-        assert_eq!(cfg.rate_limiting.auth_start_max_requests, 50);
-        assert_eq!(cfg.rate_limiting.auth_start_window_secs, 120);
-
-        assert_eq!(cfg.rate_limiting.auth_callback_max_requests, 25);
-        assert_eq!(cfg.rate_limiting.auth_callback_window_secs, 180);
-
-        assert_eq!(cfg.rate_limiting.failed_login_max_requests, 3);
-        assert_eq!(cfg.rate_limiting.failed_login_window_secs, 1800);
     }
 }

--- a/examples/multitenant/README.md
+++ b/examples/multitenant/README.md
@@ -29,24 +29,34 @@ Organization
 
 ## Tenant isolation
 
-Multi-tenant safety lives in `fraiseql.toml`, not in the views. The schema
-itself is unaware of who is calling — every type carries a `tenantId`
-(`organizationId` for `Tenant`), but nothing scopes a query to one tenant on its
-own. The `[security]` block does that:
+> **Correction (#612).** Earlier revisions of this example claimed
+> `[[security.rules]]` in `fraiseql.toml` scoped each query to the caller's tenant.
+> That was false: FraiseQL does **not** enforce `[security.rules]` at runtime (the
+> operation/field authorizers are pinned to `None` — see #612 / #626). Those blocks
+> compiled but scoped nothing, so they have been removed. Do not rely on
+> `[security.rules]` for isolation.
 
-```toml
-[security]
-default_policy = "authenticated"   # no anonymous access — closes the leak
+Per-tenant isolation must be enforced **at the database layer**. The schema itself
+is unaware of who is calling — every type carries a `tenantId` (`organizationId`
+for `Tenant`), but nothing scopes a query to one tenant on its own.
 
-[[security.rules]]                  # rows scoped to the caller's tenant
-rule = "user.tenant_id == object.tenant_id"
-```
+`default_policy = "authenticated"` closes the anonymous read path (no unauthenticated
+access) — but it does **not** scope rows to a tenant. To scope rows:
 
-Without it, `listTenants` and `listResources` return **every** tenant's rows to
-**any** caller. Treat the `[security]` block as load-bearing: removing it
-re-opens cross-tenant data exposure. The rules above assume the authenticated
-principal carries `tenant_id`/`organization_id` claims; map them from your auth
-provider accordingly.
+1. **Set a session variable from the identity.** FraiseQL resolves configured session
+   variables from the request (JWT claims / headers) and injects them as
+   transaction-scoped PostgreSQL session variables via `set_config()` before each
+   query — see `resolve_session_variables`
+   (`crates/fraiseql-core/src/runtime/executor/support/security.rs`). Map e.g.
+   `app.tenant_id` to the `tenant_id` claim.
+2. **Enforce with RLS.** Define row-level-security policies on the views/tables that
+   read that variable with `current_setting('app.tenant_id')`, so PostgreSQL itself
+   rejects cross-tenant rows.
+
+Without database-layer RLS, `listTenants` and `listResources` return **every**
+tenant's rows to **any** authenticated caller. A worked end-to-end example
+(session-var mapping + RLS policy + a two-tenant proof) is tracked in
+[#628](https://github.com/fraiseql/fraiseql/issues/628).
 
 ## Compiling
 

--- a/examples/multitenant/fraiseql.toml
+++ b/examples/multitenant/fraiseql.toml
@@ -15,22 +15,19 @@ description = "Multi-tenant application with shared core and isolated tenant dom
 name = "multitenant"
 version = "1.0.0"
 
-# Tenant isolation is enforced here, not in the views. Without this block every
-# query (listTenants, listResources, ...) is anonymous and returns every
-# tenant's rows to any caller. default_policy = "authenticated" closes the
-# anonymous read path; the per-tenant rules scope each row to the caller's own
-# tenant/organization. See README.md ("Tenant isolation").
+# Per-tenant isolation is NOT enforced by FraiseQL configuration. `[security.rules]`
+# is declared-but-unenforced — the runtime pins the operation/field authorizers to
+# None (see #612 / #626) — so the two `[[security.rules]]` blocks that used to sit
+# here were removed rather than ship a false security claim (they compiled but scoped
+# nothing). `default_policy = "authenticated"` below only closes the anonymous path;
+# it does NOT scope rows to a tenant.
+#
+# Enforce tenant isolation at the database layer: define RLS policies on the
+# views/tables that read a session variable FraiseQL sets from the request identity.
+# FraiseQL injects configured session variables via `set_config()` before each query
+# (`resolve_session_variables`,
+# crates/fraiseql-core/src/runtime/executor/support/security.rs), and the RLS policy
+# reads it with `current_setting(...)`. A worked end-to-end example (session-var
+# mapping + RLS policy + two-tenant proof) is tracked in #628.
 [security]
 default_policy = "authenticated"
-
-[[security.rules]]
-cacheable = false
-description = "Resources are visible only within the caller's own tenant"
-name = "scope_resources_to_tenant"
-rule = "user.tenant_id == object.tenant_id"
-
-[[security.rules]]
-cacheable = false
-description = "Tenants are visible only within the caller's own organization"
-name = "scope_tenants_to_organization"
-rule = "user.organization_id == object.organization_id"

--- a/examples/saas/README.md
+++ b/examples/saas/README.md
@@ -147,7 +147,10 @@ The new domains are automatically discovered!
 ## Production Considerations
 
 1. **Database**: Each query should have corresponding database views
-2. **Security**: Implement proper authz rules in fraiseql.toml
+2. **Security**: Enforce authorization at the database layer with RLS policies keyed on
+   a session variable FraiseQL sets from the request identity — **not** with
+   `[security.rules]` in `fraiseql.toml`, which is declared-but-unenforced (#612 / #626).
+   See `resolve_session_variables` in fraiseql-core; a worked example is tracked in #628.
 3. **Performance**: Add indexes on accountId for tenant isolation
 4. **Compliance**: Ensure GDPR/data deletion compliance per account
 

--- a/examples/saas/fraiseql.toml
+++ b/examples/saas/fraiseql.toml
@@ -18,17 +18,14 @@ description = "SaaS platform with account management, billing, teams, and integr
 name = "saas"
 version = "1.0.0"
 
+# `[security.rules]` is declared-but-unenforced by the FraiseQL runtime (the
+# operation/field authorizers are pinned to None; see #612 / #626). The two
+# `[[security.rules]]` blocks that used to sit here ("only account owners can modify
+# Account", "only billing admins can manage Subscription") compiled but enforced
+# nothing, so they were removed rather than ship a false authorization claim.
+# `default_policy = "authenticated"` only closes the anonymous path. Enforce
+# per-owner / per-role write rules at the database layer (RLS policies + the session
+# variables FraiseQL sets from the request identity via `set_config()`; see
+# `resolve_session_variables` in fraiseql-core). A worked example is tracked in #628.
 [security]
 default_policy = "authenticated"
-
-[[security.rules]]
-cacheable = false
-description = "Only account owners can modify account settings"
-name = "allow_account_owners"
-rule = "mutation * Account"
-
-[[security.rules]]
-cacheable = false
-description = "Only billing admins can manage subscriptions"
-name = "allow_billing_admin"
-rule = "mutation * Subscription"


### PR DESCRIPTION
Phase 04 of the #612 config-drift train — the **config-file surface** (CLI TOML schema, merger, core runtime). Closes out the `fix/612-config-drift-config-surface` branch (also carries the already-landed #6 `revoke_all_ttl_secs` WIRE commit). Part of the docs-review-fixes sweep (#608/#609/#610/#612).

## Two threads

### 5b — remove the dead rate-limiting reader (`### Fixed`)
`fraiseql-auth`'s `SecurityConfigFromSchema` parsed a nested-camelCase `rateLimiting.authStart.maxRequests` shape the compiler **never emits** — the merger emits flat snake_case `security.rate_limiting`, consumed by the server middleware's live `RateLimitingSecurityConfig`. So that reader always fell back to hardcoded defaults; its output only fed startup logging/validation before being dropped and **never drove runtime limits**. Deleted the rate-limiting portion only (audit / error-sanitization / state-encryption untouched — it's a multi-aspect struct) and pinned the flat shape with a merger emission test so the two ends can't drift silently again.

### REJECT #1/#2/#3/#4/#7 — honest-loud over silently-wrong (`### Breaking`)
Sections the compiler accepted but no runtime consumes now **fail loudly at load**, via a new `TomlSchema::reject_accepted_but_unconsumed_config()` called from **both** `validate()` and `merge_values` — so no compile path (including `--types`, which deliberately skips `validate()`) can bypass it.

| # | Section | Disposition |
|---|---|---|
| **4** | `[security.rules]` / `[security.policies]` / `[security.field_auth]` | **REJECT (security).** Declared authorization the runtime never enforced (`RuntimeConfig::from_compiled_schema` pins the authorizers to `None`). The break *is* the fix — a deployment carrying these believed a boundary existed. Error says remove the block; links **#626**. |
| 1 | `[caching]` | REJECT — never lowered into the compiled schema (**#623**) |
| 2 | `[analytics]` | REJECT — fully inert (**#624**) |
| 3 | `[observability]` | REJECT-with-pointer → `[metrics]` / `[tracing]` (**#625**) |
| 7 | `[security.api_keys] storage` | REJECT `!= "env"` — `"postgres"` authenticated nothing (**#627**) |

## ⚠ Auth-adjacency finding (surfaced + resolved with the maintainer)
The #4 reject broke the `saas` and `multitenant` example compiles — and the **multitenant example's README + config falsely claimed `[security.rules]` enforces tenant isolation** ("without this block every query returns every tenant's rows to any caller"). It never did. Corrected both examples to remove the unenforced blocks and point at the real mechanism: **database-layer RLS + the session variables FraiseQL sets from the request identity** — verified at HEAD (`resolve_session_variables`, `crates/fraiseql-core/src/runtime/executor/support/security.rs:46`; the session-var name is *configurable*, not hardcoded). A worked end-to-end RLS example is tracked separately in **#628** (distinct from the declarative-authz feature #626).

## Tests
- `tests/config_coverage_pin_test.rs`: 5b flat-shape emission pin + 5 REJECT pins (each asserts the message names the key + links its issue).
- Converted `integration_toml_workflow` (now asserts the compile rejects declared authz) and `compiler_runtime_contract` (fixture stripped of the rejected blocks; the emit↔parse contract it guards is unaffected). Dropped 2 obsolete field-auth diagnostic snapshots (the `suggest_similar` machinery stays covered by the query/federation diagnostics).

## Verification
- ✅ `make preflight` — fmt-check (nightly), clippy `--all-targets --all-features -D warnings`, rustdoc `-D warnings`, all shell gates — on the pinned **1.92 MSRV**.
- ✅ `cargo test -p fraiseql-cli` · `-p fraiseql-auth` · server `security_config_runtime_test`.
- Also fixed fmt drift the #6 commit left in `TokenRevocationSecurityConfig`.

## Follow-ups filed
#623 (caching) · #624 (analytics) · #625 ([observability] alias/removal) · **#626 (compiled-schema declarative-authz engine — the important one)** · #627 (postgres API-key store) · #628 (real end-to-end tenant-isolation examples).

Next in the train: Phase 05 (admin-API + observer dispositions #8/#10–#14 + the drift-prevention coverage mechanism), then Phase 06 finalize (#612 closing comment + issue closeout).
