### PR TITLE
fix(core): repair TypeDefinition doctest broken by subscription_policy field

### DIFF
--- a/crates/fraiseql-core/src/schema/graphql_type_defs.rs
+++ b/crates/fraiseql-core/src/schema/graphql_type_defs.rs
@@ -37,6 +37,7 @@ use crate::validation::ValidationRule;
 ///     is_error: false,
 ///     relay: false,
 ///     relationships: Vec::new(),
+///     subscription_policy: None,
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

The `Dagger — test` leg has been red on `dev`. One root cause is a **deterministic doctest compile failure**, independent of the known runner-side (llama.cpp) resource issue:

```
error[E0063]: missing field `subscription_policy` in initializer of `TypeDefinition`
  --> crates/fraiseql-core/src/schema/graphql_type_defs.rs:26:17
...
test result: FAILED. 242 passed; 1 failed; ...
error: doctest failed, to rerun pass `-p fraiseql-core --doc`
```

`subscription_policy: Option<SubscriptionPolicy>` was added to `TypeDefinition` for #596, but the struct's own doc-comment example still constructed the literal without it. Because `TypeDefinition` is a plain (non-`#[non_exhaustive]`) struct, the example no longer compiles.

## Why it slipped through

`make preflight` runs `cargo doc` (which builds documentation but does **not** compile/run doctests). Only `cargo test --doc --all-features` — exercised solely by the heavy `Dagger — test` leg — catches it. That leg has been red for an unrelated runner reason, masking this regression.

## Fix

Add `subscription_policy: None` to the `TypeDefinition` doctest example.

## Verification

- `cargo test -p fraiseql-core --doc` (CORE_FEATURES) — the `TypeDefinition (line 22)` doctest now passes (7/7 in that file).
- `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)