### PR TITLE
fix(observers,cli): admin/observer config dispositions + drift-prevention gate (#612 part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database-layer RLS plus the session variables FraiseQL sets from the identity
   (`resolve_session_variables`, `crates/fraiseql-core/src/runtime/executor/support/security.rs`);
   a worked end-to-end isolation example is tracked in **#628**.
+- **Admin-API and observer config that "succeeded then did nothing" now fails loud
+  (#612, part 2).** The same honest-loud pass applied to the admin/observer surface:
+  - **`[[observers.handlers]]` in `fraiseql.toml` is rejected at compile.** Compiled
+    handlers were never loaded as runtime observers — those come only from the
+    `tb_observer` table / the admin observer API — so a declared handler silently
+    never fired. Define observers in `tb_observer` (or `POST /api/observers`) and
+    remove the block. Loading compiled handlers at boot is tracked in **#631**.
+  - **Creating an observer with an action `type` of `"database"` or `"log"` now
+    returns `400`, not `201`.** The runtime has no dispatcher for those types, so the
+    observer was created and then silently warn-and-skipped at load. The admin API now
+    rejects them at create/update, naming the supported types (`webhook`, `email`,
+    `slack`); real database/log dispatchers are tracked in **#632**.
+  - **The admin observer retry field is `backoff_strategy`, not `backoff`.** The
+    runtime reads `retry_config.backoff_strategy`, so the old DTO field name `backoff`
+    was silently dropped and every observer defaulted to exponential backoff. The field
+    is renamed and both `RetryConfig` structs gained `deny_unknown_fields`, so the dead
+    `backoff` key (or a typo) now fails loud. **Migration:** any `tb_observer.retry_config`
+    JSONB written before this release that carries a `backoff` key must be updated to
+    `backoff_strategy`, or that observer will fail to reload.
 
 ### Changed
 
@@ -358,6 +377,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Webhook observers honor their configured HTTP method (#612 item 12).** The admin
+  API accepted a `method` on webhook actions but the runtime always issued a `POST`.
+  The method is now threaded through dispatch (`PUT`/`PATCH`/… work; default stays
+  `POST`); an unparseable method fails loud rather than silently posting.
+- **Config drift-prevention gate (#612 item M).** A checked-in coverage test walks
+  every leaf of `TomlSchema::default()` (CLI) and `ServerConfig::default()` (server)
+  and asserts each maps to a named consumer in a reviewable manifest — a new config
+  key that no runtime consumes now fails CI at PR time rather than surfacing in a docs
+  pass. This is the durable half of #612: the mechanism whose absence let the whole
+  class accumulate. Paired with the CLI↔server round-trip pins (#6, #9, 5b) that a
+  leaf-walk cannot reach.
+- **Honest docs for two accepted-but-unenforced knobs (#612 items 13/14).** Tenant
+  `max_storage_bytes` is now documented as advisory-only (stored, never enforced — no
+  metering path exists; enforcement tracked in **#633**), and the observer Prometheus
+  metrics registry documents that it is not scraped by the server's `/metrics`
+  (a two-ecosystem split; bridging tracked in **#634**). No behavior change — the
+  surfaces no longer imply a guarantee that isn't there.
 - **A single `[auth]` block now validates on both the CLI compiler and the server (#612).**
   The CLI's `[auth]` schema required the PKCE OAuth-client fields (`discovery_url`,
   `client_id`, `client_secret_env`, `server_redirect_uri`) with `deny_unknown_fields`,

--- a/crates/fraiseql-cli/src/config/toml_schema/mod.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/mod.rs
@@ -362,6 +362,22 @@ impl TomlSchema {
             }
         }
 
+        // #8 [[observers.handlers]]: compiled into `observers_config.handlers` but never
+        // read at runtime — runtime observers are loaded only from the `tb_observer` table
+        // (or the admin observer API), so a TOML-declared handler silently never fires.
+        // (`[observers] enabled` is still consumed as a changelog gate; only the `handlers`
+        // array is inert.)
+        if !self.observers.handlers.is_empty() {
+            anyhow::bail!(
+                "[[observers.handlers]] is accepted but never run: compiled TOML handlers are \
+                 not loaded as runtime observers (those come only from the `tb_observer` table \
+                 or the admin observer API), so a declared handler silently never fires. Define \
+                 observers in `tb_observer` / via `POST /api/observers` and remove the \
+                 [[observers.handlers]] block. Loading compiled handlers at boot is tracked at \
+                 https://github.com/fraiseql/fraiseql/issues/631."
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/fraiseql-cli/tests/config_coverage_manifest_test.rs
+++ b/crates/fraiseql-cli/tests/config_coverage_manifest_test.rs
@@ -1,0 +1,208 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+//! Config-coverage drift gate (#612 item M) — the durable half of the config-drift
+//! train.
+//!
+//! This test exists because #612 was a *class* of defect: config keys the CLI
+//! `TomlSchema` accepts that no runtime consumer honors (they validate, then do
+//! nothing). It walks every leaf key of `TomlSchema::default()` and asserts each
+//! one is accounted for in the checked-in [`MANIFEST`] below, which names — for
+//! every leaf — the consumer that honors it, or records that it is deliberately
+//! **rejected at load** (the honest-loud dispositions from Phase 04/05).
+//!
+//! Adding a new field to `TomlSchema` (or any nested config struct) that is not in
+//! the manifest fails this test at PR time — the drift can no longer reach `dev`
+//! unnoticed. Adding the manifest entry is a deliberate, reviewable act that forces
+//! the author to state who consumes the key (or that it is rejected).
+//!
+//! Limitation: `serde` omits `Option::None` and `skip_serializing_if`-empty fields
+//! from `default()`, so a subtree that is entirely absent by default is not walked
+//! here. The `config_coverage_pin_test.rs` round-trip pins cover the specific
+//! CLI↔server shape pairs (#6, #9, 5b) that this leaf-walk cannot reach.
+
+use fraiseql_cli::config::toml_schema::TomlSchema;
+use serde_json::Value;
+
+/// Every leaf key-path of `TomlSchema::default()` mapped to the subsystem that
+/// consumes it — or the disposition that **rejects** it at load. A leaf not
+/// covered here fails the test (a new top-level section or key can't slip in
+/// unconsumed); a `.*` entry that matches nothing fails too (stale-owner guard).
+///
+/// An entry ending in `.*` claims *section ownership*: it covers every leaf under
+/// that prefix, and names the one subsystem that owns the whole section. Exact
+/// entries are used for the honest-loud **REJECT** keys so their disposition is
+/// documented in one place and a removed rejection is caught. A new *section* or a
+/// new *top-level key* is always gated; a new leaf under an already-owned section
+/// inherits that owner (the CLI↔server shape pairs that a leaf-walk can't verify —
+/// #6, #9, 5b — are pinned separately in `config_coverage_pin_test.rs`).
+const MANIFEST: &[(&str, &str)] = &[
+    // ── Compiled-schema authoring surface (CLI → compiled.json) ──────────────
+    ("schema.*", "compiled schema metadata header (SchemaMetadata → compiled.json)"),
+    ("types", "user schema data — object types (empty by default)"),
+    ("queries", "user schema data — query definitions (empty by default)"),
+    ("mutations", "user schema data — mutation definitions (empty by default)"),
+    ("crud", "compiler CRUD generation (authoring-time codegen input)"),
+    ("hierarchies", "compiler hierarchy generation (authoring-time codegen input)"),
+    ("naming_convention", "compiler naming convention (#400/#410) → recasing"),
+    (
+        "query_defaults.*",
+        "compiled query defaults (limit/offset/order_by/where) → runtime executor",
+    ),
+    ("changelog", "compiled changelog config → server changelog consumer"),
+    ("validation", "compiled schema validation config → server ValidationConfig"),
+    ("subscriptions", "compiled subscription config → server subscription runtime"),
+    ("federation.*", "compiled federation block → server federation (#507/#503)"),
+    (
+        "auth",
+        "server OIDC/JWT auth, reconciled CLI↔server in #612 item 9 (pinned in config_coverage_pin_test)",
+    ),
+    // ── Authoring-time only (consumed by the CLI, never lowered) ─────────────
+    ("debug.*", "CLI/compiler debug flags (compile-time diagnostics)"),
+    ("domain_discovery.*", "CLI domain-discovery of schema files (authoring-time)"),
+    ("includes.*", "CLI multi-file schema includes (authoring-time loader)"),
+    // ── Server runtime surface (compiled → ServerConfig) ─────────────────────
+    ("database.*", "server DB pool + connection (ServerConfig database_url / pool_*)"),
+    ("server.*", "server runtime bind/cors/tls/timeouts (ServerConfig)"),
+    ("rest.*", "fraiseql-server `rest` feature (RestConfig)"),
+    ("mcp.*", "fraiseql-server `mcp` feature (McpConfig)"),
+    // ── Observers: mixed. Backend/enabled consumed; handlers REJECTED (#8) ───
+    (
+        "observers.enabled",
+        "changelog gate — read by converter (compiled observers_config.enabled)",
+    ),
+    ("observers.backend", "runtime observer transport backend (redis/nats/postgres)"),
+    ("observers.redis_url", "runtime observer redis backend URL"),
+    ("observers.nats_url", "runtime observer NATS backend URL"),
+    (
+        "observers.handlers",
+        "REJECTED at load (#8) — not runtime observers; use tb_observer (#631)",
+    ),
+    // ── Security: mixed. Consumed blocks vs the declared-but-unenforced ones ─
+    (
+        "security.rate_limiting",
+        "server RateLimitingSecurityConfig — rate-limit middleware (#609 CIDRs)",
+    ),
+    (
+        "security.token_revocation",
+        "server token_revocation — revoke_all_ttl_secs wired in #612 item 6",
+    ),
+    ("security.error_sanitization", "server error-sanitization layer"),
+    ("security.state_encryption", "server PKCE state encryption"),
+    ("security.pkce", "server PKCE OAuth config"),
+    ("security.persisted_queries_only", "server persisted-queries-only gate (#379)"),
+    ("security.trusted_documents", "server trusted-documents allowlist"),
+    ("security.default_policy", "server default authorization policy"),
+    (
+        "security.enterprise.*",
+        "server enterprise security aggregate (rate-limit/pkce/audit/sanitization)",
+    ),
+    (
+        "security.api_keys",
+        "server static API-key auth; storage != \"env\" REJECTED at load (#7/#627)",
+    ),
+    ("security.rules", "REJECTED at load (#4) — declared-but-unenforced authz (#626)"),
+    (
+        "security.policies",
+        "REJECTED at load (#4) — declared-but-unenforced authz (#626)",
+    ),
+    (
+        "security.field_auth",
+        "REJECTED at load (#4) — declared-but-unenforced authz (#626)",
+    ),
+    // ── Accepted-but-unconsumed sections rejected loud at load (Phase 04) ────
+    ("caching.*", "REJECTED at load (#1) — no compiled/runtime consumer (#623)"),
+    ("analytics.*", "REJECTED at load (#2) — fully inert (#624)"),
+    ("observability.*", "REJECTED at load (#3) — use [metrics]/[tracing] (#625)"),
+];
+
+/// Recursively collect the dotted paths of every leaf in `value`.
+///
+/// A leaf is any value that is not a *non-empty* object: scalars, `null`, arrays,
+/// and empty objects are terminal. This mirrors how a new scalar/section config
+/// key shows up in `default()` serialization.
+fn collect_leaves(value: &Value, prefix: &str, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            for (k, v) in map {
+                let path = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                collect_leaves(v, &path, out);
+            }
+        },
+        _ => out.push(prefix.to_string()),
+    }
+}
+
+/// True if `path` is covered by a manifest entry (exact match, or a `.*` prefix).
+fn is_covered(path: &str) -> bool {
+    MANIFEST.iter().any(|(pattern, _)| {
+        pattern.strip_suffix(".*").map_or(*pattern == path, |prefix| {
+            path == prefix || path.starts_with(&format!("{prefix}."))
+        })
+    })
+}
+
+#[test]
+fn every_toml_schema_leaf_has_a_named_consumer() {
+    let default_json = serde_json::to_value(TomlSchema::default()).unwrap();
+    let mut leaves = Vec::new();
+    collect_leaves(&default_json, "", &mut leaves);
+    leaves.sort();
+    leaves.dedup();
+
+    let uncovered: Vec<&String> = leaves.iter().filter(|p| !is_covered(p)).collect();
+    assert!(
+        uncovered.is_empty(),
+        "TomlSchema has config leaves with no named consumer in the coverage manifest \
+         (#612 item M). Add each to MANIFEST in {} naming who consumes it (or that it is \
+         rejected at load):\n{}",
+        file!(),
+        uncovered
+            .iter()
+            .map(|p| format!("    (\"{p}\", \"<consumer>\"),"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Stale-owner guard: every manifest entry must match at least one real leaf of
+/// `TomlSchema::default()`. A section that is renamed or removed leaves its
+/// manifest entry matching nothing — this catches that so the manifest cannot rot
+/// into claiming consumers for keys that no longer exist.
+#[test]
+fn every_manifest_entry_matches_a_real_leaf() {
+    let default_json = serde_json::to_value(TomlSchema::default()).unwrap();
+    let mut leaves = Vec::new();
+    collect_leaves(&default_json, "", &mut leaves);
+
+    let matches_a_leaf = |pattern: &str| -> bool {
+        pattern.strip_suffix(".*").map_or_else(
+            || leaves.iter().any(|l| l == pattern),
+            |prefix| leaves.iter().any(|l| l == prefix || l.starts_with(&format!("{prefix}."))),
+        )
+    };
+
+    let stale: Vec<&str> =
+        MANIFEST.iter().map(|(p, _)| *p).filter(|p| !matches_a_leaf(p)).collect();
+    assert!(
+        stale.is_empty(),
+        "manifest entries no longer match any TomlSchema leaf: {stale:?}"
+    );
+}
+
+/// The gate itself: a config key that is *not* in the manifest is reported as
+/// uncovered. This is the deliberately-broken fixture — it proves the drift gate
+/// actually catches an unconsumed key rather than silently passing.
+#[test]
+fn an_unmanifested_key_is_flagged_as_uncovered() {
+    assert!(!is_covered("newsection.newkey"), "an unknown section must be uncovered");
+    assert!(
+        !is_covered("security.brand_new_block"),
+        "a new security sub-block must be uncovered"
+    );
+    // And a genuinely-owned key is covered, so the gate is not vacuously strict.
+    assert!(is_covered("schema.name"), "schema.name is owned by the schema.* entry");
+    assert!(is_covered("security.rate_limiting"), "rate_limiting is owned");
+}

--- a/crates/fraiseql-cli/tests/config_coverage_pin_test.rs
+++ b/crates/fraiseql-cli/tests/config_coverage_pin_test.rs
@@ -216,3 +216,42 @@ fn api_keys_non_env_storage_is_rejected_at_compile() {
     .expect("TOML should parse");
     schema.validate().expect("storage = \"env\" must remain valid");
 }
+
+/// #8 `[[observers.handlers]]` — compiled but never run at runtime. Runtime
+/// observers come only from `tb_observer` / the admin observer API, so a
+/// TOML-declared handler silently never fires. Rejected at compile with a pointer
+/// to the load-at-boot follow-up (#631). `[observers] enabled` (a consumed
+/// changelog gate) without handlers must still validate.
+#[test]
+fn compiled_observer_handlers_are_rejected_at_compile() {
+    let err = validate_err(
+        r#"
+        [schema]
+        name = "t"
+
+        [[observers.handlers]]
+        name = "notify"
+        event = "INSERT"
+        action = "webhook"
+        webhook_url = "https://hook.example/x"
+    "#,
+    );
+    assert!(err.contains("[[observers.handlers]]"), "err = {err}");
+    assert!(err.contains("tb_observer"), "err = {err}");
+    assert!(err.contains("/issues/631"), "err = {err}");
+
+    // `[observers] enabled` without handlers is a consumed changelog gate — still valid.
+    let schema = TomlSchema::parse_toml(
+        r#"
+        [schema]
+        name = "t"
+
+        [observers]
+        enabled = true
+    "#,
+    )
+    .expect("TOML should parse");
+    schema
+        .validate()
+        .expect("[observers] enabled without handlers must remain valid");
+}

--- a/crates/fraiseql-observers/examples/job_queue_example.rs
+++ b/crates/fraiseql-observers/examples/job_queue_example.rs
@@ -97,6 +97,7 @@ async fn main() -> fraiseql_observers::Result<()> {
             actions:    vec![ActionConfig::Webhook {
                 url:                Some("https://webhook.example.com/user-created".to_string()),
                 url_env:            None,
+                method:             None,
                 headers:            HashMap::default(),
                 body_template:      None,
                 signing_secret:     None,

--- a/crates/fraiseql-observers/src/actions.rs
+++ b/crates/fraiseql-observers/src/actions.rs
@@ -319,6 +319,9 @@ impl WebhookAction {
 
     /// Execute webhook action
     ///
+    /// `method` is the HTTP verb to use (`None` means `POST`); an unparseable
+    /// method fails loud rather than silently posting (#612 item 12).
+    ///
     /// # Errors
     ///
     /// Returns `ObserverError` if the HTTP request fails or the response is not 2xx.
@@ -326,6 +329,7 @@ impl WebhookAction {
     pub async fn execute(
         &self,
         url: &str,
+        method: Option<&str>,
         headers: &HashMap<String, String>,
         body_template: Option<&str>,
         signing_secret: Option<&str>,
@@ -384,8 +388,18 @@ impl WebhookAction {
                 reason: format!("Failed to serialize webhook body: {e}"),
             })?;
 
-        // Build request
-        let mut request = self.client.post(url);
+        // Build request. `method` defaults to POST; an explicit but unparseable
+        // verb fails loud rather than silently posting (#612 item 12).
+        let http_method =
+            match method {
+                None => reqwest::Method::POST,
+                Some(m) => reqwest::Method::from_bytes(m.to_ascii_uppercase().as_bytes()).map_err(
+                    |_| ObserverError::InvalidActionConfig {
+                        reason: format!("Webhook action has an invalid HTTP method '{m}'"),
+                    },
+                )?,
+            };
+        let mut request = self.client.request(http_method, url);
 
         // Add headers (already validated above), tracking whether the operator
         // set a Content-Type so we don't duplicate it.

--- a/crates/fraiseql-observers/src/actions/tests.rs
+++ b/crates/fraiseql-observers/src/actions/tests.rs
@@ -89,7 +89,7 @@ async fn execute_signs_the_exact_transmitted_bytes() {
 
         let secret = "whsec_gate";
         WebhookAction::new()
-            .execute(&server.uri(), &HashMap::new(), None, Some(secret), &test_event())
+            .execute(&server.uri(), None, &HashMap::new(), None, Some(secret), &test_event())
             .await
             .expect("webhook dispatch should succeed");
 
@@ -125,7 +125,7 @@ async fn execute_without_secret_sends_no_signature_header() {
             .await;
 
         WebhookAction::new()
-            .execute(&server.uri(), &HashMap::new(), None, None, &test_event())
+            .execute(&server.uri(), None, &HashMap::new(), None, None, &test_event())
             .await
             .expect("unsigned webhook dispatch should succeed");
 
@@ -134,6 +134,78 @@ async fn execute_without_secret_sends_no_signature_header() {
         assert!(
             requests[0].headers.get(WEBHOOK_SIGNATURE_HEADER).is_none(),
             "no signature header when signing is not configured"
+        );
+    })
+    .await;
+}
+
+// ── HTTP method threading (#612 item 12) ────────────────────────────────────
+
+#[tokio::test]
+async fn execute_uses_the_configured_http_method() {
+    temp_env::async_with_vars([(ALLOW_INSECURE_ENV, Some("true"))], async {
+        let server = MockServer::start().await;
+        // Only a PUT is mocked; a POST would 404 and fail the dispatch.
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        WebhookAction::new()
+            .execute(&server.uri(), Some("PUT"), &HashMap::new(), None, None, &test_event())
+            .await
+            .expect("webhook dispatch should use PUT and succeed");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method.as_str(), "PUT", "the configured method is used");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn execute_defaults_to_post_when_method_is_none() {
+    temp_env::async_with_vars([(ALLOW_INSECURE_ENV, Some("true"))], async {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        WebhookAction::new()
+            .execute(&server.uri(), None, &HashMap::new(), None, None, &test_event())
+            .await
+            .expect("default method is POST");
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        assert_eq!(requests[0].method.as_str(), "POST");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn execute_rejects_an_invalid_http_method() {
+    temp_env::async_with_vars([(ALLOW_INSECURE_ENV, Some("true"))], async {
+        let server = MockServer::start().await;
+        // No mock mounted: an unparseable method must fail before any request.
+        let err = WebhookAction::new()
+            .execute(
+                &server.uri(),
+                Some("not a method"),
+                &HashMap::new(),
+                None,
+                None,
+                &test_event(),
+            )
+            .await
+            .expect_err("an invalid HTTP method must fail loud, not silently POST");
+        assert!(
+            err.to_string().contains("invalid HTTP method"),
+            "error names the bad method: {err}"
+        );
+        assert!(
+            server.received_requests().await.unwrap_or_default().is_empty(),
+            "no request is sent when the method is invalid"
         );
     })
     .await;

--- a/crates/fraiseql-observers/src/cached_executor/tests.rs
+++ b/crates/fraiseql-observers/src/cached_executor/tests.rs
@@ -140,6 +140,7 @@ fn test_cache_key_generation() {
     let action = ActionConfig::Webhook {
         url:                Some("https://example.com".to_string()),
         url_env:            None,
+        method:             None,
         headers:            std::collections::HashMap::new(),
         body_template:      Some("{}".to_string()),
         signing_secret:     None,

--- a/crates/fraiseql-observers/src/config/runtime.rs
+++ b/crates/fraiseql-observers/src/config/runtime.rs
@@ -183,7 +183,15 @@ impl ObserverDefinition {
 // ============================================================================
 
 /// Retry configuration
+///
+/// `deny_unknown_fields` (#612 item 11): a `retry_config` JSONB carrying a key
+/// the runtime does not read — the pre-#612 admin DTO wrote `backoff` while this
+/// struct reads `backoff_strategy`, so the operator's choice was silently
+/// dropped and every observer defaulted to exponential backoff — now fails loud
+/// at reload rather than being silently ignored. Rows written before the #612
+/// rename (carrying `backoff`) must be updated to `backoff_strategy`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts (default: 3)
     #[serde(default = "default_max_attempts")]
@@ -326,12 +334,20 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ActionConfig {
-    /// HTTP POST webhook to external URL
+    /// HTTP webhook to external URL
     Webhook {
-        /// URL to POST to
+        /// URL to send the request to
         url:                Option<String>,
         /// Environment variable containing the URL
         url_env:            Option<String>,
+        /// HTTP method for the request (`POST` when unset).
+        ///
+        /// Threaded from the admin API's `method` field so a webhook observer can
+        /// `PUT`/`PATCH`/etc. rather than always `POST` (#612 item 12). An absent
+        /// key (older `tb_observer.actions` rows) or `None` means `POST`. An
+        /// unparseable method fails loud at dispatch rather than silently posting.
+        #[serde(default)]
+        method:             Option<String>,
         /// Optional HTTP headers
         ///
         /// `deserialize_with` treats an explicit JSON `null` the same as an

--- a/crates/fraiseql-observers/src/config/tests.rs
+++ b/crates/fraiseql-observers/src/config/tests.rs
@@ -239,6 +239,7 @@ fn test_action_type_names() {
         ActionConfig::Webhook {
             url:                None,
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -267,6 +268,7 @@ fn test_webhook_action_validation() {
     let invalid = ActionConfig::Webhook {
         url:                None,
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      None,
         signing_secret:     None,
@@ -282,6 +284,7 @@ fn test_webhook_action_validation() {
     let valid = ActionConfig::Webhook {
         url:                Some("https://example.com".to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      Some("{}".to_string()),
         signing_secret:     None,
@@ -332,6 +335,7 @@ fn test_webhook_empty_signing_secret_env_is_rejected() {
     let action = ActionConfig::Webhook {
         url:                Some("https://example.com".to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      None,
         signing_secret:     None,
@@ -366,6 +370,7 @@ fn test_webhook_empty_signing_secret_literal_is_rejected() {
     let action = ActionConfig::Webhook {
         url:                Some("https://example.com".to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      None,
         signing_secret:     Some(String::new()),
@@ -383,6 +388,7 @@ fn test_webhook_both_signing_secret_sources_rejected() {
     let action = ActionConfig::Webhook {
         url:                Some("https://example.com".to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      None,
         signing_secret:     Some("whsec_literal".to_string()),

--- a/crates/fraiseql-observers/src/executor/dispatch.rs
+++ b/crates/fraiseql-observers/src/executor/dispatch.rs
@@ -169,6 +169,7 @@ impl ActionDispatcher for DefaultActionDispatcher {
                 ActionConfig::Webhook {
                     url,
                     url_env,
+                    method,
                     headers,
                     body_template,
                     signing_secret,
@@ -188,6 +189,7 @@ impl ActionDispatcher for DefaultActionDispatcher {
                         .webhook_action
                         .execute(
                             &webhook_url,
+                            method.as_deref(),
                             headers,
                             body_template.as_deref(),
                             resolved_secret.as_deref(),

--- a/crates/fraiseql-observers/src/executor/tests.rs
+++ b/crates/fraiseql-observers/src/executor/tests.rs
@@ -345,6 +345,7 @@ fn webhook_action() -> ActionConfig {
     ActionConfig::Webhook {
         url:                Some("https://example.com/hook".to_string()),
         url_env:            None,
+        method:             None,
         headers:            std::collections::HashMap::new(),
         body_template:      None,
         signing_secret:     None,
@@ -773,6 +774,7 @@ async fn test_dispatch_webhook_missing_url_returns_invalid_config() {
     let action = ActionConfig::Webhook {
         url:                None,
         url_env:            None,
+        method:             None,
         headers:            std::collections::HashMap::new(),
         body_template:      None,
         signing_secret:     None,
@@ -794,6 +796,7 @@ async fn test_dispatch_webhook_url_env_var_missing_returns_error_with_var_name()
     let action = ActionConfig::Webhook {
         url:                None,
         url_env:            Some("FRAISEQL_TEST_WEBHOOK_URL_DEFINITELY_NOT_SET".to_string()),
+        method:             None,
         headers:            std::collections::HashMap::new(),
         body_template:      None,
         signing_secret:     None,

--- a/crates/fraiseql-observers/src/job_queue/tests.rs
+++ b/crates/fraiseql-observers/src/job_queue/tests.rs
@@ -169,6 +169,7 @@ mod job_queue_tests {
             ActionConfig::Webhook {
                 url:                Some("http://example.com".to_string()),
                 url_env:            None,
+                method:             None,
                 headers:            std::collections::HashMap::default(),
                 body_template:      None,
                 signing_secret:     None,

--- a/crates/fraiseql-observers/src/lib.rs
+++ b/crates/fraiseql-observers/src/lib.rs
@@ -215,6 +215,7 @@ mod integration_tests {
         let invalid = ActionConfig::Webhook {
             url:                None,
             url_env:            None,
+            method:             None,
             headers:            std::collections::HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -230,6 +231,7 @@ mod integration_tests {
         let valid = ActionConfig::Webhook {
             url:                Some("https://example.com".to_string()),
             url_env:            None,
+            method:             None,
             headers:            std::collections::HashMap::new(),
             body_template:      Some("{}".to_string()),
             signing_secret:     None,

--- a/crates/fraiseql-observers/src/metrics/registry.rs
+++ b/crates/fraiseql-observers/src/metrics/registry.rs
@@ -1,6 +1,19 @@
 //! Prometheus metrics registry for observer system
 //!
 //! This module defines and manages all Prometheus metrics for the observer system.
+//!
+//! # Scrape reachability (#612 item 14)
+//!
+//! These series register into the [`prometheus`] crate's **default global
+//! registry** and are exposed by this crate's own `/metrics` handler
+//! ([`crate::metrics::handler`], which calls `prometheus::gather()`). The
+//! `fraiseql-server` `/metrics` endpoint uses a *different* ecosystem
+//! (`metrics` / `metrics-exporter-prometheus`) and never calls
+//! `prometheus::gather()`, so **it does not scrape these observer metrics** —
+//! even when `observers-enterprise` compiles the series in. To collect observer
+//! metrics today, mount this crate's `/metrics` handler. Bridging the two
+//! registries so the server's `/metrics` also exposes them is tracked at
+//! <https://github.com/fraiseql/fraiseql/issues/634>.
 
 use std::sync::OnceLock;
 

--- a/crates/fraiseql-observers/src/queue/tests.rs
+++ b/crates/fraiseql-observers/src/queue/tests.rs
@@ -20,6 +20,7 @@ mod queue_tests {
             action_config: ActionConfig::Webhook {
                 url:                Some("http://localhost:8000".to_string()),
                 url_env:            None,
+                method:             None,
                 headers:            std::collections::HashMap::new(),
                 body_template:      None,
                 signing_secret:     None,

--- a/crates/fraiseql-observers/src/tests.rs
+++ b/crates/fraiseql-observers/src/tests.rs
@@ -1229,6 +1229,7 @@ mod matcher_tests {
             actions:    vec![ActionConfig::Webhook {
                 url:                Some("https://example.com".to_string()),
                 url_env:            None,
+                method:             None,
                 headers:            HashMap::default(),
                 body_template:      Some("{}".to_string()),
                 signing_secret:     None,

--- a/crates/fraiseql-observers/tests/integration_test.rs
+++ b/crates/fraiseql-observers/tests/integration_test.rs
@@ -111,6 +111,7 @@ fn create_http_action(url: &str) -> ActionConfig {
     ActionConfig::Webhook {
         url:                Some(url.to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::from([(
             "Content-Type".to_string(),
             "application/json".to_string(),

--- a/crates/fraiseql-observers/tests/job_queue_integration.rs
+++ b/crates/fraiseql-observers/tests/job_queue_integration.rs
@@ -113,6 +113,7 @@ fn test_job_creation_with_fixed_backoff() -> Result<()> {
         ActionConfig::Webhook {
             url:                Some("http://example.com/webhook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -139,6 +140,7 @@ fn test_job_creation_with_linear_backoff() -> Result<()> {
         ActionConfig::Webhook {
             url:                Some("http://example.com/webhook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -163,6 +165,7 @@ fn test_job_creation_with_exponential_backoff() -> Result<()> {
         ActionConfig::Webhook {
             url:                Some("http://example.com/webhook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -190,6 +193,7 @@ fn test_job_retry_counting() -> Result<()> {
         ActionConfig::Webhook {
             url:                Some("http://example.com/webhook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -235,6 +239,7 @@ fn test_job_with_webhook_action() -> Result<()> {
         ActionConfig::Webhook {
             url:                Some("http://api.example.com/webhooks/event".to_string()),
             url_env:            None,
+            method:             None,
             headers:            {
                 let mut h = HashMap::new();
                 h.insert("X-API-Key".to_string(), "secret".to_string());
@@ -353,6 +358,7 @@ fn test_backoff_strategies() -> Result<()> {
             ActionConfig::Webhook {
                 url:                Some("http://example.com/webhook".to_string()),
                 url_env:            None,
+                method:             None,
                 headers:            HashMap::new(),
                 body_template:      None,
                 signing_secret:     None,
@@ -381,6 +387,7 @@ fn test_job_lifecycle() -> Result<()> {
         ActionConfig::Webhook {
             url:                Some("http://example.com/webhook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,
@@ -426,6 +433,7 @@ fn test_job_config_combinations() -> Result<()> {
             ActionConfig::Webhook {
                 url:                Some("http://example.com/webhook".to_string()),
                 url_env:            None,
+                method:             None,
                 headers:            HashMap::new(),
                 body_template:      None,
                 signing_secret:     None,

--- a/crates/fraiseql-observers/tests/transport_pipeline_test.rs
+++ b/crates/fraiseql-observers/tests/transport_pipeline_test.rs
@@ -34,6 +34,7 @@ fn make_observer(event_type: &str, entity: &str, condition: Option<&str>) -> Obs
         actions:    vec![ActionConfig::Webhook {
             url:                Some("https://example.com/hook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::default(),
             body_template:      Some("{}".to_string()),
             signing_secret:     None,

--- a/crates/fraiseql-server/src/observers/dlq_handlers/tests.rs
+++ b/crates/fraiseql-server/src/observers/dlq_handlers/tests.rs
@@ -94,6 +94,7 @@ async fn concurrent_retry_dispatches_at_most_once() {
     let action = ActionConfig::Webhook {
         url:                Some("http://localhost/hook".to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      None,
         signing_secret:     None,
@@ -154,6 +155,7 @@ mod dlq_endpoints {
         ActionConfig::Webhook {
             url:                Some("http://localhost/hook".to_string()),
             url_env:            None,
+            method:             None,
             headers:            HashMap::new(),
             body_template:      None,
             signing_secret:     None,

--- a/crates/fraiseql-server/src/observers/handlers.rs
+++ b/crates/fraiseql-server/src/observers/handlers.rs
@@ -4,16 +4,42 @@ use axum::{
     Json,
     extract::{Path, Query, State},
     http::StatusCode,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
 };
 use fraiseql_core::security::SecurityContext;
 use uuid::Uuid;
 
 use super::{
-    CreateObserverRequest, ListObserverLogsQuery, ListObserversQuery, ObserverRepository,
-    PaginatedResponse, UpdateObserverRequest,
+    ActionConfig, CreateObserverRequest, ListObserverLogsQuery, ListObserversQuery,
+    ObserverRepository, PaginatedResponse, UpdateObserverRequest,
 };
 use crate::extractors::OptionalSecurityContext;
+
+/// Reject observer actions whose `type` the runtime cannot dispatch (#612 item 10).
+///
+/// `database`/`log` actions are accepted by the DTO shape but have no runtime
+/// dispatcher, so before this check a create returned 201 and the observer was
+/// then silently warn-and-skipped at load ("success then nothing"). Returns a
+/// `400` response naming the offending type and the supported set, or `None`
+/// when every action is dispatchable.
+pub(super) fn reject_undispatchable_actions(actions: &[ActionConfig]) -> Option<Response> {
+    actions.iter().find(|a| !a.is_runtime_dispatchable()).map(|action| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "Observer action type '{}' has no runtime dispatcher: the observer would be \
+                     created and then silently skipped at load. Supported action types: {}. \
+                     Database/log dispatchers are tracked in \
+                     https://github.com/fraiseql/fraiseql/issues/632.",
+                    action.type_name(),
+                    ActionConfig::RUNTIME_DISPATCHABLE_TYPES.join(", ")
+                )
+            })),
+        )
+            .into_response()
+    })
+}
 
 /// Application state for observer handlers.
 #[derive(Clone)]
@@ -142,6 +168,12 @@ pub async fn create_observer(
             .into_response();
     }
 
+    // Reject action types the runtime cannot dispatch (#612 item 10) — 400 now
+    // rather than 201-then-silently-skipped at load.
+    if let Some(resp) = reject_undispatchable_actions(&request.actions) {
+        return resp;
+    }
+
     // Validate event_type if provided
     if let Some(ref event_type) = request.event_type {
         let valid_types = ["INSERT", "UPDATE", "DELETE", "CUSTOM"];
@@ -197,6 +229,13 @@ pub async fn update_observer(
                 })),
             )
                 .into_response();
+        }
+    }
+
+    // Reject action types the runtime cannot dispatch (#612 item 10).
+    if let Some(ref actions) = request.actions {
+        if let Some(resp) = reject_undispatchable_actions(actions) {
+            return resp;
         }
     }
 

--- a/crates/fraiseql-server/src/observers/mod.rs
+++ b/crates/fraiseql-server/src/observers/mod.rs
@@ -343,16 +343,56 @@ pub enum ActionConfig {
     },
 }
 
+impl ActionConfig {
+    /// Action types the observer runtime can actually dispatch (#612 item 10).
+    ///
+    /// The runtime (`fraiseql_observers`) has wired dispatchers only for these.
+    /// `database` and `log` are accepted by this DTO's shape but have no runtime
+    /// dispatcher, so an observer created with them used to return 201 and then be
+    /// silently warn-and-skipped at runtime load. Creating one is now rejected at
+    /// the API boundary; real `database`/`log` dispatchers are tracked in #632.
+    pub const RUNTIME_DISPATCHABLE_TYPES: &'static [&'static str] = &["webhook", "email", "slack"];
+
+    /// The action `type` discriminant as it appears in the admin API and the
+    /// persisted `actions` JSONB (`webhook`, `email`, `slack`, `database`, `log`).
+    #[must_use]
+    pub const fn type_name(&self) -> &'static str {
+        match self {
+            Self::Webhook { .. } => "webhook",
+            Self::Email { .. } => "email",
+            Self::Slack { .. } => "slack",
+            Self::Database { .. } => "database",
+            Self::Log { .. } => "log",
+        }
+    }
+
+    /// Whether the observer runtime has a wired dispatcher for this action type.
+    #[must_use]
+    pub const fn is_runtime_dispatchable(&self) -> bool {
+        matches!(self, Self::Webhook { .. } | Self::Email { .. } | Self::Slack { .. })
+    }
+}
+
 /// Retry configuration for observer actions.
+///
+/// `deny_unknown_fields` (#612 item 11): the runtime observer's `RetryConfig`
+/// reads `backoff_strategy`, so the pre-#612 DTO field name `backoff` was
+/// silently ignored and every observer defaulted to exponential backoff. The
+/// field is now `backoff_strategy` and an unknown key (the old `backoff`, or a
+/// typo) is rejected at create time rather than silently dropped.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RetryConfig {
     /// Maximum number of retry attempts (default: 3)
     #[serde(default = "default_max_attempts")]
     pub max_attempts: i32,
 
-    /// Backoff strategy: "fixed", "linear", "exponential"
+    /// Backoff strategy: "fixed", "linear", "exponential".
+    ///
+    /// Serialized into the observer's `retry_config` JSONB and consumed by the
+    /// runtime `fraiseql_observers::config::runtime::RetryConfig::backoff_strategy`.
     #[serde(default = "default_backoff")]
-    pub backoff: String,
+    pub backoff_strategy: String,
 
     /// Initial delay in milliseconds (default: 1000)
     #[serde(default = "default_initial_delay")]
@@ -367,7 +407,7 @@ impl Default for RetryConfig {
     fn default() -> Self {
         Self {
             max_attempts:     3,
-            backoff:          "exponential".to_string(),
+            backoff_strategy: "exponential".to_string(),
             initial_delay_ms: 1000,
             max_delay_ms:     60000,
         }

--- a/crates/fraiseql-server/src/observers/runtime/tests.rs
+++ b/crates/fraiseql-server/src/observers/runtime/tests.rs
@@ -25,6 +25,7 @@ fn test_action() -> ActionConfig {
     ActionConfig::Webhook {
         url:                Some("http://localhost/hook".to_string()),
         url_env:            None,
+        method:             None,
         headers:            HashMap::new(),
         body_template:      None,
         signing_secret:     None,

--- a/crates/fraiseql-server/src/observers/tests.rs
+++ b/crates/fraiseql-server/src/observers/tests.rs
@@ -118,7 +118,7 @@ mod repository_tests {
     fn test_retry_config_default() {
         let config = RetryConfig::default();
         assert_eq!(config.max_attempts, 3);
-        assert_eq!(config.backoff, "exponential");
+        assert_eq!(config.backoff_strategy, "exponential");
         assert_eq!(config.initial_delay_ms, 1000);
         assert_eq!(config.max_delay_ms, 60000);
     }
@@ -450,5 +450,120 @@ mod router_construction {
     async fn observer_changelog_routes_constructs() {
         let state = ChangelogState { pool: lazy_pool() };
         let _ = observer_changelog_routes(state);
+    }
+}
+
+mod retry_config_backoff_wire {
+    //! #612 item 11: the admin `RetryConfig` field is `backoff_strategy` (renamed
+    //! from `backoff`), so the persisted `retry_config` JSONB the runtime reads
+    //! carries the key the runtime actually consumes; `deny_unknown_fields` makes
+    //! the dead `backoff` name (or a typo) fail loud instead of silently
+    //! defaulting to exponential backoff.
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+    use fraiseql_observers::{BackoffStrategy, RetryConfig as RuntimeRetryConfig};
+
+    use super::super::RetryConfig as AdminRetryConfig;
+
+    #[test]
+    fn admin_backoff_strategy_round_trips_into_the_runtime() {
+        let admin = AdminRetryConfig {
+            backoff_strategy: "linear".to_string(),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&admin).unwrap();
+        // The persisted JSONB carries `backoff_strategy`, which the runtime reads —
+        // the pre-#612 dead `backoff` key is gone.
+        assert_eq!(json["backoff_strategy"], "linear");
+        assert!(json.get("backoff").is_none(), "the dead `backoff` key is not emitted");
+
+        let runtime: RuntimeRetryConfig = serde_json::from_value(json).unwrap();
+        assert!(
+            matches!(runtime.backoff_strategy, BackoffStrategy::Linear),
+            "the runtime honors the admin-configured strategy instead of defaulting"
+        );
+    }
+
+    #[test]
+    fn admin_dto_rejects_the_dead_backoff_field() {
+        let err =
+            serde_json::from_value::<AdminRetryConfig>(serde_json::json!({ "backoff": "linear" }))
+                .expect_err("the old `backoff` key must be rejected, not silently ignored");
+        assert!(err.to_string().contains("backoff"), "error names the offending key: {err}");
+    }
+
+    #[test]
+    fn runtime_retry_config_rejects_unknown_keys() {
+        let err = serde_json::from_value::<RuntimeRetryConfig>(
+            serde_json::json!({ "backoff": "linear", "backoff_strategy": "linear" }),
+        )
+        .expect_err("an unexpected key must fail loud at reload, not be silently dropped");
+        assert!(err.to_string().contains("backoff"), "{err}");
+    }
+}
+
+mod action_type_dispatch {
+    //! #612 item 10: action types the runtime cannot dispatch are rejected at
+    //! create/update (400) rather than accepted (201) then silently skipped.
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+    use axum::http::StatusCode;
+
+    use super::super::{ActionConfig, handlers::reject_undispatchable_actions};
+
+    fn action(json: serde_json::Value) -> ActionConfig {
+        serde_json::from_value(json).unwrap()
+    }
+
+    #[test]
+    fn webhook_email_slack_are_dispatchable() {
+        for (json, name) in [
+            (serde_json::json!({ "type": "webhook", "url": "https://h/x" }), "webhook"),
+            (
+                serde_json::json!({ "type": "email", "to": "a@b.c", "subject_template": "s", "body_template": "b" }),
+                "email",
+            ),
+            (
+                serde_json::json!({ "type": "slack", "webhook_url": "https://h/x", "message_template": "m" }),
+                "slack",
+            ),
+        ] {
+            let a = action(json);
+            assert_eq!(a.type_name(), name);
+            assert!(a.is_runtime_dispatchable(), "{name} must be dispatchable");
+        }
+    }
+
+    #[test]
+    fn database_and_log_are_not_dispatchable() {
+        for json in [
+            serde_json::json!({ "type": "database", "function_name": "fn_notify" }),
+            serde_json::json!({ "type": "log", "message_template": "m" }),
+        ] {
+            let a = action(json);
+            assert!(!a.is_runtime_dispatchable(), "{} has no runtime dispatcher", a.type_name());
+        }
+    }
+
+    #[test]
+    fn reject_helper_returns_400_for_a_database_action() {
+        let actions = vec![action(serde_json::json!({
+            "type": "database",
+            "function_name": "fn_notify"
+        }))];
+        let resp =
+            reject_undispatchable_actions(&actions).expect("a database action must be rejected");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn reject_helper_passes_all_dispatchable_actions() {
+        let actions = vec![action(
+            serde_json::json!({ "type": "webhook", "url": "https://h/x" }),
+        )];
+        assert!(
+            reject_undispatchable_actions(&actions).is_none(),
+            "a webhook-only action set is accepted"
+        );
     }
 }

--- a/crates/fraiseql-server/src/routes/api/tenant_admin.rs
+++ b/crates/fraiseql-server/src/routes/api/tenant_admin.rs
@@ -63,7 +63,11 @@ pub struct TenantRegistrationRequest {
     /// Maximum concurrent in-flight requests. `None` = unlimited.
     #[serde(default)]
     pub max_concurrent:       Option<u32>,
-    /// Maximum storage in bytes (soft limit). `None` = unlimited.
+    /// Maximum storage in bytes. **Advisory only — accepted and stored but NOT
+    /// enforced** (#612 item 13): FraiseQL has no usage-metering path, so no
+    /// request is ever rejected on the basis of this value. It is retained as an
+    /// operator annotation. Metering + enforcement is tracked at
+    /// <https://github.com/fraiseql/fraiseql/issues/633>. `None` = unset.
     #[serde(default)]
     pub max_storage_bytes:    Option<u64>,
     /// Maximum estimated cost of a single GraphQL operation (#379). `None` = no

--- a/crates/fraiseql-server/src/routes/graphql/tenant_registry.rs
+++ b/crates/fraiseql-server/src/routes/graphql/tenant_registry.rs
@@ -397,9 +397,13 @@ impl<A: DatabaseAdapter> TenantExecutorRegistry<A> {
         }
     }
 
-    /// Returns `true` if the tenant's soft storage quota has been exceeded.
+    /// Returns `true` if the tenant's storage-quota flag has been set.
     ///
-    /// When exceeded, mutations should be rejected (reads still allowed).
+    /// NOTE (#612 item 13): nothing sets this flag in production — there is no
+    /// usage-metering path that measures storage and calls
+    /// [`Self::set_quota_exceeded`], so `max_storage_bytes` is advisory only and
+    /// this always returns `false` outside tests. Metering + enforcement is
+    /// tracked at <https://github.com/fraiseql/fraiseql/issues/633>.
     #[must_use]
     pub fn is_quota_exceeded(&self, key: &str) -> bool {
         self.tenants
@@ -407,7 +411,10 @@ impl<A: DatabaseAdapter> TenantExecutorRegistry<A> {
             .is_some_and(|e| e.value().quota_exceeded.load(Ordering::Relaxed))
     }
 
-    /// Set the quota-exceeded flag for a tenant (called by background task).
+    /// Set the quota-exceeded flag for a tenant.
+    ///
+    /// No production caller exists yet (see [`Self::is_quota_exceeded`]); this is
+    /// the seam a future storage-metering task (#633) would drive.
     pub fn set_quota_exceeded(&self, key: &str, exceeded: bool) {
         if let Some(entry) = self.tenants.get(key) {
             entry.value().quota_exceeded.store(exceeded, Ordering::Relaxed);

--- a/crates/fraiseql-server/tests/config_coverage_manifest_test.rs
+++ b/crates/fraiseql-server/tests/config_coverage_manifest_test.rs
@@ -1,0 +1,168 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+//! Config-coverage drift gate for the server runtime surface (#612 item M).
+//!
+//! The CLI-side twin lives in `fraiseql-cli/tests/config_coverage_manifest_test.rs`
+//! and guards the authoring/compiled surface; this one guards `ServerConfig` — the
+//! runtime config the server initialises from the compiled schema + env overrides.
+//! It walks every leaf of `ServerConfig::default()` and asserts each is owned by a
+//! named subsystem in the checked-in [`MANIFEST`]. A new `ServerConfig` field that
+//! no subsystem consumes (the #612 defect class, server-side) fails at PR time.
+//!
+//! Limitation: `serde` omits `Option::None` / `skip_serializing_if`-empty fields
+//! from `default()`, so an entirely-absent subtree is not walked here.
+
+use fraiseql_server::server_config::ServerConfig;
+use serde_json::Value;
+
+/// Every leaf key-path of `ServerConfig::default()` mapped to its consuming
+/// subsystem. `ServerConfig` uses flat `snake_case` keys, so a trailing `*` is a
+/// plain-prefix glob (`metrics*` owns `metrics_enabled`, `metrics_path`, …); a
+/// bare path is an exact leaf.
+const MANIFEST: &[(&str, &str)] = &[
+    // ── Bind / transport / TLS ───────────────────────────────────────────────
+    ("bind_addr", "server HTTP bind address"),
+    ("cors_enabled", "CORS layer toggle"),
+    ("cors_origins", "CORS allowed origins"),
+    ("compression_enabled", "response compression layer"),
+    ("require_json_content_type", "request content-type guard"),
+    ("tls", "server TLS config (Option — HTTPS listener)"),
+    ("database_tls", "database TLS config (Option)"),
+    // ── Routes / endpoints ───────────────────────────────────────────────────
+    ("graphql_path", "GraphQL route mount path"),
+    ("health_path", "health endpoint path"),
+    ("readiness_path", "readiness endpoint path"),
+    ("introspection_path", "introspection endpoint path"),
+    ("subscription_path", "subscription (WS) route path"),
+    ("playground_path", "GraphQL playground path"),
+    ("playground_enabled", "playground toggle"),
+    ("playground_tool", "playground UI selection (GraphiQL/…)"),
+    ("metrics_json_path", "JSON metrics endpoint path"),
+    // ── Feature toggles ──────────────────────────────────────────────────────
+    ("apq_enabled", "automatic persisted queries"),
+    ("cache_enabled", "query result cache"),
+    ("subscriptions_enabled", "subscriptions runtime toggle"),
+    ("introspection_enabled", "introspection enforcer (#455)"),
+    ("introspection_require_auth", "introspection auth gate"),
+    ("validate_sql_sources", "compile-time SQL-source validation"),
+    // ── Metrics / tracing ────────────────────────────────────────────────────
+    ("metrics*", "server metrics (metrics-exporter-prometheus; enabled/path/token)"),
+    ("tracing_enabled", "OTLP tracing toggle"),
+    ("tracing_service_name", "OTLP service name"),
+    ("otlp_endpoint", "OTLP exporter endpoint (Option)"),
+    ("otlp_export_timeout_secs", "OTLP export timeout"),
+    // ── Admin API ────────────────────────────────────────────────────────────
+    ("admin_api_enabled", "admin API mount toggle"),
+    ("admin_token", "admin API bearer token (Option)"),
+    ("admin_readonly_token", "admin API read-only token (Option)"),
+    ("admin_auth_max_failures", "admin auth brute-force lockout threshold"),
+    ("design_api_require_auth", "design API auth gate"),
+    // ── Auth backends ────────────────────────────────────────────────────────
+    ("auth", "OIDC auth config (fraiseql-core OidcConfig, Option)"),
+    ("auth_hs256", "HS256 JWT auth config (Option)"),
+    ("hmac_secret_env", "HMAC secret env var name (Option)"),
+    ("identity", "enriched-identity resolver config (Option)"),
+    // ── Database pool ────────────────────────────────────────────────────────
+    ("database_url", "primary database connection URL"),
+    ("pool_min_size", "DB pool min size"),
+    ("pool_max_size", "DB pool max size"),
+    ("pool_timeout_secs", "DB pool acquire timeout"),
+    ("pool_tuning", "pool-pressure monitor config (Option)"),
+    // ── Request limits / admission ───────────────────────────────────────────
+    ("max_request_body_bytes", "request body size cap"),
+    ("max_header_count", "request header count cap"),
+    ("max_header_bytes", "request header size cap"),
+    ("max_get_query_bytes", "GET query size cap"),
+    ("request_timeout_secs", "per-request timeout (Option)"),
+    ("shutdown_timeout_secs", "graceful shutdown timeout"),
+    ("admission_control", "admission-control / load-shed config (Option)"),
+    // ── Optional subsystems ──────────────────────────────────────────────────
+    ("rate_limiting", "rate-limit middleware config (Option; #609)"),
+    ("observers", "observer runtime config (Option; `observers` feature)"),
+    ("storage", "object-storage config (Option; #608)"),
+    ("storage_token", "storage admin token (Option)"),
+    ("files", "file-serving config (Option)"),
+    ("usage", "usage-metering config (Option)"),
+    ("tenancy*", "multi-tenant runtime config (tenancy.runtime.enabled)"),
+    (
+        "validation",
+        "schema validation config (Option; fraiseql-core ValidationConfig)",
+    ),
+    ("schema_path", "compiled schema file path"),
+    ("security_contact", "security.txt contact (Option)"),
+];
+
+fn collect_leaves(value: &Value, prefix: &str, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            for (k, v) in map {
+                let path = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                collect_leaves(v, &path, out);
+            }
+        },
+        _ => out.push(prefix.to_string()),
+    }
+}
+
+/// True if `pattern` covers `path`. `foo.*` is a dotted-section prefix; a bare
+/// trailing `*` (`metrics*`) is a plain string prefix for flat `snake_case` keys;
+/// otherwise an exact match.
+fn pattern_covers(pattern: &str, path: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix(".*") {
+        path == prefix || path.starts_with(&format!("{prefix}."))
+    } else if let Some(prefix) = pattern.strip_suffix('*') {
+        path.starts_with(prefix)
+    } else {
+        pattern == path
+    }
+}
+
+fn is_covered(path: &str) -> bool {
+    MANIFEST.iter().any(|(pattern, _)| pattern_covers(pattern, path))
+}
+
+#[test]
+fn every_server_config_leaf_has_a_named_consumer() {
+    let default_json = serde_json::to_value(ServerConfig::default()).unwrap();
+    let mut leaves = Vec::new();
+    collect_leaves(&default_json, "", &mut leaves);
+    leaves.sort();
+    leaves.dedup();
+
+    let uncovered: Vec<&String> = leaves.iter().filter(|p| !is_covered(p)).collect();
+    assert!(
+        uncovered.is_empty(),
+        "ServerConfig has runtime leaves with no named consumer (#612 item M). Add each to \
+         MANIFEST in {} naming who consumes it:\n{}",
+        file!(),
+        uncovered
+            .iter()
+            .map(|p| format!("    (\"{p}\", \"<consumer>\"),"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+#[test]
+fn every_manifest_entry_matches_a_real_leaf() {
+    let default_json = serde_json::to_value(ServerConfig::default()).unwrap();
+    let mut leaves = Vec::new();
+    collect_leaves(&default_json, "", &mut leaves);
+
+    let matches_a_leaf =
+        |pattern: &str| -> bool { leaves.iter().any(|l| pattern_covers(pattern, l)) };
+    let stale: Vec<&str> =
+        MANIFEST.iter().map(|(p, _)| *p).filter(|p| !matches_a_leaf(p)).collect();
+    assert!(
+        stale.is_empty(),
+        "manifest entries no longer match any ServerConfig leaf: {stale:?}"
+    );
+}
+
+#[test]
+fn an_unmanifested_key_is_flagged_as_uncovered() {
+    assert!(!is_covered("brand_new_knob"), "a new server config key must be uncovered");
+}


### PR DESCRIPTION
Phase 05 of the #612 config-drift train — the admin-API/observer surface plus the durable **drift-prevention mechanism** (the train's headline ask). Off updated `dev` (Phase 04 #629 + the #608/#609/#610/auth train all merged).

## WIRE (seam exists, connector-sized)
- **item 12 — webhook method.** Webhook observers now honor their configured HTTP method (was always `POST`); threaded through `WebhookAction::execute` + dispatch; an unparseable method fails loud rather than silently posting. Tests cover PUT, default-POST, invalid-method.
- **item 11 — retry backoff.** The runtime reads `retry_config.backoff_strategy`, so the pre-#612 admin DTO field `backoff` was silently dropped → every observer defaulted to exponential backoff. Renamed the DTO field to `backoff_strategy` and added `deny_unknown_fields` to **both** `RetryConfig` structs so the dead key / a typo fails loud. Round-trip + rejection tests.

## REJECT-loud / document (no seam or not connector-sized) — each files a follow-up
- **item 8** — compiled `[[observers.handlers]]` rejected at compile (never loaded as runtime observers; those come only from `tb_observer` / the admin API). → **#631**
- **item 10** — admin `create`/`update` with an action `type` of `database`/`log` returns **400**, not `201`-then-silently-warn-and-skip; names the supported types. → **#632**
- **item 13** — tenant `max_storage_bytes` documented advisory-only (no metering path exists). → **#633**
- **item 14** — observer Prometheus registry documented as not scraped by the server's `/metrics` (two-ecosystem split). → **#634**

## Mechanism (item M) — the durable half of #612
A checked-in **config-coverage drift gate** walks every leaf of `TomlSchema::default()` (CLI, `fraiseql-cli/tests/config_coverage_manifest_test.rs`) and `ServerConfig::default()` (server, `fraiseql-server/tests/config_coverage_manifest_test.rs`) and asserts each maps to a named consumer in a reviewable manifest — or records that it is rejected at load. A new config key that no runtime consumes now fails CI at PR time (the class of defect #612 was). Includes a deliberately-broken-fixture guard (`an_unmanifested_key_is_flagged_as_uncovered`) and a stale-owner guard. Paired with the CLI↔server round-trip pins (#6, #9, 5b) in `config_coverage_pin_test.rs` that a leaf-walk cannot reach.

## Verification
- `make preflight` — fmt / clippy `--all-targets --all-features -D warnings` / rustdoc `-D warnings` / the shell gates — all green.
- Lib tests: `fraiseql-observers` (548), `fraiseql-server` (1330), `fraiseql-cli` (663); new coverage + reject-pin tests green.

Part of #612. Ships in 2.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)