### PR TITLE
chore(core): reconcile rls_policy doc + remove #612 train archaeology (#612 finalize)

### DIFF
--- a/crates/fraiseql-cli/tests/config_coverage_manifest_test.rs
+++ b/crates/fraiseql-cli/tests/config_coverage_manifest_test.rs
@@ -7,7 +7,7 @@
 //! nothing). It walks every leaf key of `TomlSchema::default()` and asserts each
 //! one is accounted for in the checked-in [`MANIFEST`] below, which names — for
 //! every leaf — the consumer that honors it, or records that it is deliberately
-//! **rejected at load** (the honest-loud dispositions from Phase 04/05).
+//! **rejected at load** (the honest-loud #612 dispositions).
 //!
 //! Adding a new field to `TomlSchema` (or any nested config struct) that is not in
 //! the manifest fails this test at PR time — the drift can no longer reach `dev`
@@ -108,7 +108,7 @@ const MANIFEST: &[(&str, &str)] = &[
         "security.field_auth",
         "REJECTED at load (#4) — declared-but-unenforced authz (#626)",
     ),
-    // ── Accepted-but-unconsumed sections rejected loud at load (Phase 04) ────
+    // ── Accepted-but-unconsumed sections rejected loud at load (#612) ────────
     ("caching.*", "REJECTED at load (#1) — no compiled/runtime consumer (#623)"),
     ("analytics.*", "REJECTED at load (#2) — fully inert (#624)"),
     ("observability.*", "REJECTED at load (#3) — use [metrics]/[tracing] (#625)"),

--- a/crates/fraiseql-cli/tests/config_coverage_pin_test.rs
+++ b/crates/fraiseql-cli/tests/config_coverage_pin_test.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
-//! #612 config-drift pins — the config-file surface (Phase 04).
+//! #612 config-drift pins — the config-file surface.
 //!
 //! One test per disposition target from `config-key-disposition.md` that lives on
 //! the `fraiseql-cli` TOML/merger surface. Each pin asserts the *disposed* behavior:
@@ -9,8 +9,8 @@
 //!   `fraiseql-auth`).
 //! - **REJECT** rows (#1 `[caching]`, #2 `[analytics]`, #3 `[observability]`, #4
 //!   `[security.rules/policies/field_auth]`, #7 `[security.api_keys] storage`) — each
-//!   previously-accepted key now fails **loudly at compile** with a targeted message. These replace
-//!   the Phase-00 "accepted silently" characterizations.
+//!   previously-accepted key now fails **loudly at compile** with a targeted message, replacing the
+//!   earlier "accepted silently" behavior.
 //!
 //! Items #6 (`revoke_all_ttl_secs`) and #9 (`[auth]`) are pinned by their own
 //! landing PRs (#612 commit `3d94331` and PR #622 respectively).

--- a/crates/fraiseql-cli/tests/security_config_test.rs
+++ b/crates/fraiseql-cli/tests/security_config_test.rs
@@ -245,7 +245,7 @@ fn test_existing_enterprise_field_not_broken() {
 // a complete PKCE client group is rejected loud (not yet functional on the compiled
 // path — #621), never silently accepted.
 
-// M-612: a JWT-only [auth] block now compiles (was rejected — this is the item-9 fix).
+// a JWT-only [auth] block now compiles (was rejected — this is the item-9 fix).
 #[test]
 fn test_auth_jwt_only_compiles() {
     let toml = r#"
@@ -280,7 +280,7 @@ fn test_auth_issuer_without_audience_compiles() {
     schema.validate().expect("issuer alone is a valid JWT [auth] block");
 }
 
-// M-612: a complete PKCE client group is rejected loud (recognized, not yet functional).
+// a complete PKCE client group is rejected loud (recognized, not yet functional).
 #[test]
 fn test_auth_complete_client_group_rejected_loud() {
     let toml = r#"
@@ -404,7 +404,7 @@ fn test_auth_client_secret_field_rejected() {
 // and the docs instruct setting it, but the CLI struct lacked the field, so
 // `deny_unknown_fields` rejected it — the value could never reach the server.
 
-// M-612: the field now parses (was rejected by deny_unknown_fields).
+// the field now parses (was rejected by deny_unknown_fields).
 #[test]
 fn test_revoke_all_ttl_secs_parses() {
     let toml = r"
@@ -423,7 +423,7 @@ fn test_revoke_all_ttl_secs_defaults_to_86400() {
     assert_eq!(TokenRevocationSecurityConfig::default().revoke_all_ttl_secs, 86_400);
 }
 
-// M-612: the value reaches the compiled schema (was absent — server used its 86400 default).
+// the value reaches the compiled schema (was absent — server used its 86400 default).
 #[test]
 fn test_revoke_all_ttl_secs_reaches_compiled_schema() -> anyhow::Result<()> {
     use std::fs;
@@ -462,7 +462,7 @@ revoke_all_ttl_secs = 172800
 // `deny_unknown_fields` rejected it: the mitigation the docs recommend for
 // `trust_proxy_headers = true` was unsettable on the compiled path.
 
-// M-609: the block now parses (was rejected by deny_unknown_fields).
+// the block now parses (was rejected by deny_unknown_fields).
 #[test]
 fn test_trusted_proxy_cidrs_parses_into_schema() {
     let toml = r#"
@@ -490,7 +490,7 @@ fn test_trusted_proxy_cidrs_default_none() {
     assert_eq!(schema.security.rate_limiting.unwrap().trusted_proxy_cidrs, None);
 }
 
-// M-609: the value survives end-to-end into the compiled schema (was dropped —
+// the value survives end-to-end into the compiled schema (was dropped —
 // the compiled `security.rate_limiting` carried no `trusted_proxy_cidrs` key).
 #[test]
 fn test_trusted_proxy_cidrs_reach_compiled_schema() -> anyhow::Result<()> {
@@ -524,7 +524,7 @@ trusted_proxy_cidrs = ["10.0.0.0/8"]
     Ok(())
 }
 
-// M-609: a malformed CIDR fails `fraiseql compile` (validate) with a clear message,
+// a malformed CIDR fails `fraiseql compile` (validate) with a clear message,
 // not silently at server boot. The server parses these strings into `ipnet::IpNet`;
 // validating at compile time surfaces the error where the operator is authoring.
 #[test]

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate_tests.rs
@@ -384,7 +384,7 @@ fn schema_with_partial_period_and_session_vars() -> crate::schema::CompiledSchem
     schema
 }
 
-// M-610: the partial-period aggregate branch must resolve session variables so a
+// the partial-period aggregate branch must resolve session variables so a
 // PostgreSQL current_setting()-backed RLS policy constrains it — the same way the
 // standard aggregate path and the window path already do. Before the fix this branch
 // called the non-session aggregate method, so no session variables reached the

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_tests.rs
@@ -688,7 +688,7 @@ mod session_variables {
         schema
     }
 
-    // M-610: the Relay node(id:) lookup must resolve session variables so a PostgreSQL
+    // the Relay node(id:) lookup must resolve session variables so a PostgreSQL
     // current_setting()-backed RLS policy constrains it — the same way regular queries
     // (test_session_variables_injected_on_read_query, above) and Relay pages already do.
     // Before the fix the node path called the non-session projection method, so no

--- a/crates/fraiseql-core/src/security/rls_policy.rs
+++ b/crates/fraiseql-core/src/security/rls_policy.rs
@@ -1,63 +1,32 @@
 //! Row-Level Security (RLS) Policy Evaluation
 //!
-//! This module provides the trait for evaluating RLS rules at runtime.
+//! This module provides the [`RLSPolicy`] trait — the runtime seam that *would*
+//! compose an RLS filter into a query's WHERE clause from the requesting
+//! `SecurityContext`.
 //!
-//! RLS rules are defined in fraiseql.toml at authoring time and compiled into
-//! schema.compiled.json. At runtime, the executor evaluates these rules using
-//! the `SecurityContext` to determine what rows a user can access.
+//! # Status: not wired to a compiled-schema config (#612 item 4)
 //!
-//! # Architecture
+//! **There is no compiled-schema declarative-authorization engine yet.**
+//! `RuntimeConfig::from_compiled_schema` pins the operation- and field-authorizers
+//! to `None`, and no code path constructs a [`CompiledRLSPolicy`] from a compiled
+//! schema. The `[[security.rules]]` / `[[security.policies]]` / `[security.field_auth]`
+//! TOML sections that a reader might expect to feed this trait are **rejected at
+//! compile time** (`TomlSchema::reject_accepted_but_unconsumed_config`) rather than
+//! silently accepted — declaring an authorization boundary the runtime does not
+//! enforce is a false security claim, so the compiler fails loud and points here.
 //!
-//! ```text
-//! fraiseql.toml (authoring)
-//!     ├── [[security.policies]]          # Define policies
-//!     └── [[security.rules]]             # Define RLS rules
-//!     ↓
-//! schema.compiled.json (compiled)
-//!     ├── "policies": [...]              # Serialized policies
-//!     └── "rules": [...]                 # Serialized rules
-//!     ↓
-//! Executor.execute_regular_query()       # Runtime
-//!     ├── SecurityContext (user info)
-//!     └── RLSPolicy::evaluate()          # Evaluate rules
-//!     ↓
-//! WHERE clause composition
-//!     └── WhereClause::And([user_where, rls_filter])
-//! ```
+//! This trait and its evaluators are therefore *infrastructure for the future
+//! engine*, exercised by unit tests, not a shipping config surface. Building the
+//! compiled-schema declarative-authz engine that populates it is tracked in
+//! **[#626](https://github.com/fraiseql/fraiseql/issues/626)**.
 //!
-//! # Example RLS Rules (in fraiseql.toml)
+//! # Enforce authorization today
 //!
-//! ```toml
-//! # Users can only read their own posts
-//! [[security.rules]]
-//! name = "own_posts_only"
-//! rule = "user.id == object.author_id"
-//! cacheable = true
-//! cache_ttl_seconds = 300
-//!
-//! # Admins can read everything
-//! [[security.rules]]
-//! name = "admin_can_read_all"
-//! rule = "user.roles includes 'admin'"
-//! cacheable = false
-//! ```
-//!
-//! # Example RLS Policies (in fraiseql.toml)
-//!
-//! ```toml
-//! [[security.policies]]
-//! name = "read_own_posts"
-//! type = "rls"
-//! rules = ["own_posts_only"]
-//! description = "Users can only read their own posts"
-//!
-//! [[security.policies]]
-//! name = "admin_access"
-//! type = "rbac"
-//! roles = ["admin"]
-//! strategy = "any"
-//! description = "Admins have full access"
-//! ```
+//! Enforce row-level access at the **database layer** — PostgreSQL RLS policies
+//! keyed on the session variables FraiseQL sets from the request identity
+//! (`resolve_session_variables` →
+//! `crates/fraiseql-core/src/runtime/executor/support/security.rs`). That path is
+//! real and load-bearing; a compiled `[[security.rules]]` block is not.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
Phase 06 (finalize) of the #612 config-drift train — non-behavioral cleanup. The issue closeouts and the #612 disposition-summary comment are posted on merge.

## Changes
- **`fraiseql-core::security::rls_policy` module doc reconciled.** It described `[[security.rules]]`/`[[security.policies]]` as a working `fraiseql.toml` → compiled → runtime RLS feature. That is false: `RuntimeConfig::from_compiled_schema` pins the authorizers to `None`, and those TOML sections are now **rejected at load** (#612 item 4). The doc now states the trait is infrastructure for the future declarative-authz engine (**#626**) and points operators at database-layer RLS (the session variables FraiseQL sets from identity) for enforcement today.
- **Archaeology removed.** Stripped the Phase-00 `// M-608/M-609/M-610/M-612` characterization markers (the pins are now real regression tests); softened the internal plan-phase references ("Phase 04/05", "Phase-00") in the #612 config-coverage/pin test docs.

CHANGELOG audit: the docs-review entries are already correctly bucketed under `[Unreleased]` — `### Security` (#608, #609), `### Fixed` (#610, #612 wire/reconcile/mechanism), `### Breaking` (#612 rejects). Consolidating the accumulated `[Unreleased]` subsections into a single `2.13.0` section is the release-prep step.

## Verification
- `cargo clippy --all-targets --all-features -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc` (rls_policy intra-doc links resolve), fmt clean.

Closes the code half of #612 (part of the docs-review-fixes train; ships in 2.13.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)