### PR TITLE
chore(release): prepare 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-07-17
+
 ### Security
 
 - **Private-bucket downloads are no longer advertised as shared-cacheable (#608).**
@@ -236,6 +238,129 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `inbound-email`, `metrics`, `run-server`) mirroring the `observers` precedent, plus
   a `release-full` bundle.
 
+### Breaking
+
+- **Config sections that validated then did nothing are now rejected at compile
+  (#612).** Several `fraiseql.toml` sections the compiler accepted but no runtime
+  consumed now fail loudly at load — the fix-forward "honest-loud over silently-wrong"
+  stance (the v2.7.0 field-encryption precedent) — with a message naming the section
+  and either the real alternative or the tracking issue. Previously each was accepted
+  and silently ignored, so an operator believed it took effect. A schema using any of
+  these now errors; remove the section (or migrate as noted). The rejection runs on
+  **every** compile path, including `--types` (`merge_files`), which skips the rest of
+  `validate()`:
+  - **`[security.rules]` / `[security.policies]` / `[security.field_auth]` (security).**
+    Declared authorization the runtime never enforced — `RuntimeConfig::from_compiled_schema`
+    pins the operation- and field-authorizers to `None`, so any access boundary these
+    blocks implied did not exist. Every deployment carrying them was operating on a
+    false belief; the break *is* the fix. Remove them and enforce authorization at the
+    database layer (RLS policies keyed on the session variables FraiseQL sets from the
+    request identity) until a compiled-schema declarative-authorization engine ships
+    (**#626**).
+  - **`[caching]`** — never lowered into the compiled schema; no runtime honored it (**#623**).
+  - **`[analytics]`** — fully inert (**#624**).
+  - **`[observability]`** — inert on the compiled path; configure metrics under
+    `[metrics]` and tracing under `[tracing]` in `fraiseql.toml` instead (**#625**).
+  - **`[security.api_keys] storage`** — only `"env"` is implemented; `"postgres"`
+    authenticated nothing. Set `storage = "env"` (postgres-backed store: **#627**).
+
+- **The `multitenant` and `saas` examples stopped compiling until corrected (#612).**
+  Both declared `[[security.rules]]`, and the `multitenant` README + config claimed those
+  rules enforced tenant isolation — a false security claim (the rules were never
+  enforced). The unenforced blocks were removed and the docs corrected to point at
+  database-layer RLS plus the session variables FraiseQL sets from the identity
+  (`resolve_session_variables`, `crates/fraiseql-core/src/runtime/executor/support/security.rs`);
+  a worked end-to-end isolation example is tracked in **#628**.
+
+- **Admin-API and observer config that "succeeded then did nothing" now fails loud
+  (#612, part 2).** The same honest-loud pass applied to the admin/observer surface:
+  - **`[[observers.handlers]]` in `fraiseql.toml` is rejected at compile.** Compiled
+    handlers were never loaded as runtime observers — those come only from the
+    `tb_observer` table / the admin observer API — so a declared handler silently
+    never fired. Define observers in `tb_observer` (or `POST /api/observers`) and
+    remove the block. Loading compiled handlers at boot is tracked in **#631**.
+  - **Creating an observer with an action `type` of `"database"` or `"log"` now
+    returns `400`, not `201`.** The runtime has no dispatcher for those types, so the
+    observer was created and then silently warn-and-skipped at load. The admin API now
+    rejects them at create/update, naming the supported types (`webhook`, `email`,
+    `slack`); real database/log dispatchers are tracked in **#632**.
+  - **The admin observer retry field is `backoff_strategy`, not `backoff`.** The
+    runtime reads `retry_config.backoff_strategy`, so the old DTO field name `backoff`
+    was silently dropped and every observer defaulted to exponential backoff. The field
+    is renamed and both `RetryConfig` structs gained `deny_unknown_fields`, so the dead
+    `backoff` key (or a typo) now fails loud. **Migration:** any `tb_observer.retry_config`
+    JSONB written before this release that carries a `backoff` key must be updated to
+    `backoff_strategy`, or that observer will fail to reload.
+
+### Fixed
+
+- **Webhook observers honor their configured HTTP method (#612 item 12).** The admin
+  API accepted a `method` on webhook actions but the runtime always issued a `POST`.
+  The method is now threaded through dispatch (`PUT`/`PATCH`/… work; default stays
+  `POST`); an unparseable method fails loud rather than silently posting.
+
+- **Config drift-prevention gate (#612 item M).** A checked-in coverage test walks
+  every leaf of `TomlSchema::default()` (CLI) and `ServerConfig::default()` (server)
+  and asserts each maps to a named consumer in a reviewable manifest — a new config
+  key that no runtime consumes now fails CI at PR time rather than surfacing in a docs
+  pass. This is the durable half of #612: the mechanism whose absence let the whole
+  class accumulate. Paired with the CLI↔server round-trip pins (#6, #9, 5b) that a
+  leaf-walk cannot reach.
+
+- **Honest docs for two accepted-but-unenforced knobs (#612 items 13/14).** Tenant
+  `max_storage_bytes` is now documented as advisory-only (stored, never enforced — no
+  metering path exists; enforcement tracked in **#633**), and the observer Prometheus
+  metrics registry documents that it is not scraped by the server's `/metrics`
+  (a two-ecosystem split; bridging tracked in **#634**). No behavior change — the
+  surfaces no longer imply a guarantee that isn't there.
+
+- **A single `[auth]` block now validates on both the CLI compiler and the server (#612).**
+  The CLI's `[auth]` schema required the PKCE OAuth-client fields (`discovery_url`,
+  `client_id`, `client_secret_env`, `server_redirect_uri`) with `deny_unknown_fields`,
+  while the server's OIDC config — read from the **same** `fraiseql.toml` — expects
+  `issuer`. So a JWT-validation block (`[auth] issuer = "…"`) failed `fraiseql compile`,
+  and no single `[auth]` could satisfy both tools. `[auth]` now accepts a **JWT-validation
+  group** (`issuer` + optional `audience`) and a **PKCE OAuth-client group** (the four
+  client fields), each validated as a coherent unit (client group is all-four-or-none;
+  `audience` requires `issuer`; an empty `[auth]` is a load error). The PKCE server-login
+  flow is **not yet functional on the compiled path** — the compiled schema carries no
+  `auth`/`auth_endpoints` blob for the server's `OidcServerClient`, and the CLI never
+  emitted one — so a *complete* client group is now **rejected at compile time with a
+  pointer to #621** instead of being silently accepted (the item-4 precedent: declared-but-
+  unenforced auth fails loud). The previously-false operator instructions that told
+  operators to configure those four fields (`builder.rs` startup error, the Auth0 and SAML
+  integration guides) are corrected to say so. JWT validation is unaffected.
+
+- **RLS session variables now reach the Relay `node(id:)` and partial-period aggregate
+  read paths (#610).** Both paths ran their read without resolving the schema's configured
+  `session_variables`, so a PostgreSQL RLS policy reading `current_setting()` did not
+  constrain them — a cross-tenant read on any Relay `node(id:)` lookup and any aggregate
+  taking the partial-period (`UNION ALL`) branch, both reachable from an ordinary GraphQL
+  request. They now resolve session variables and use the connection-affine
+  `*_with_session` adapter methods, exactly as regular queries, Relay pages, standard
+  aggregates, and mutations already did. (These were the two surviving read-path follow-ups
+  from #329, which was closed after its mutation-path fix shipped; they are fixed here under
+  #610, not by reopening #329.)
+
+- **`security.token_revocation.revoke_all_ttl_secs` now reaches the server (#612).**
+  The server reads this key (default 86400s) to bound how long a `revoke-all` epoch
+  suppresses tokens, and the docs instructed setting it — but the CLI TOML schema lacked
+  the field, so `deny_unknown_fields` rejected any config that set it and it could never
+  take effect. Added to the CLI `[security.token_revocation]` schema; it now serializes
+  into the compiled schema the server already reads.
+
+- **Removed a dead rate-limiting config reader that silently fed hardcoded defaults
+  (#612).** `fraiseql-auth`'s `SecurityConfigFromSchema` parsed a nested-camelCase
+  `rateLimiting.authStart.maxRequests` shape the compiler never emits (it emits flat
+  snake_case `security.rate_limiting`), so that reader always fell back to hardcoded
+  defaults; its output only fed startup logging/validation before being dropped and
+  never drove runtime limits (those come from the server middleware's live
+  `RateLimitingSecurityConfig`, which reads the flat shape correctly). The dead
+  rate-limiting portion of the reader was removed and a merger→reader round-trip test
+  now pins the flat shape so the two ends cannot drift silently again.
+
+## [2.12.0] - 2026-07-15
+
 ### Added
 
 - **Scheduled ingress `Source`s — the dual of `Observer` (#573).** A `Source` pulls
@@ -299,56 +424,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the spine emit (all-or-nothing per poll batch) rather than per-message.
   `fraiseql_functions::migrations::inbound_email_cursor_migration_sql` is removed.
 
-- **Config sections that validated then did nothing are now rejected at compile
-  (#612).** Several `fraiseql.toml` sections the compiler accepted but no runtime
-  consumed now fail loudly at load — the fix-forward "honest-loud over silently-wrong"
-  stance (the v2.7.0 field-encryption precedent) — with a message naming the section
-  and either the real alternative or the tracking issue. Previously each was accepted
-  and silently ignored, so an operator believed it took effect. A schema using any of
-  these now errors; remove the section (or migrate as noted). The rejection runs on
-  **every** compile path, including `--types` (`merge_files`), which skips the rest of
-  `validate()`:
-  - **`[security.rules]` / `[security.policies]` / `[security.field_auth]` (security).**
-    Declared authorization the runtime never enforced — `RuntimeConfig::from_compiled_schema`
-    pins the operation- and field-authorizers to `None`, so any access boundary these
-    blocks implied did not exist. Every deployment carrying them was operating on a
-    false belief; the break *is* the fix. Remove them and enforce authorization at the
-    database layer (RLS policies keyed on the session variables FraiseQL sets from the
-    request identity) until a compiled-schema declarative-authorization engine ships
-    (**#626**).
-  - **`[caching]`** — never lowered into the compiled schema; no runtime honored it (**#623**).
-  - **`[analytics]`** — fully inert (**#624**).
-  - **`[observability]`** — inert on the compiled path; configure metrics under
-    `[metrics]` and tracing under `[tracing]` in `fraiseql.toml` instead (**#625**).
-  - **`[security.api_keys] storage`** — only `"env"` is implemented; `"postgres"`
-    authenticated nothing. Set `storage = "env"` (postgres-backed store: **#627**).
-- **The `multitenant` and `saas` examples stopped compiling until corrected (#612).**
-  Both declared `[[security.rules]]`, and the `multitenant` README + config claimed those
-  rules enforced tenant isolation — a false security claim (the rules were never
-  enforced). The unenforced blocks were removed and the docs corrected to point at
-  database-layer RLS plus the session variables FraiseQL sets from the identity
-  (`resolve_session_variables`, `crates/fraiseql-core/src/runtime/executor/support/security.rs`);
-  a worked end-to-end isolation example is tracked in **#628**.
-- **Admin-API and observer config that "succeeded then did nothing" now fails loud
-  (#612, part 2).** The same honest-loud pass applied to the admin/observer surface:
-  - **`[[observers.handlers]]` in `fraiseql.toml` is rejected at compile.** Compiled
-    handlers were never loaded as runtime observers — those come only from the
-    `tb_observer` table / the admin observer API — so a declared handler silently
-    never fired. Define observers in `tb_observer` (or `POST /api/observers`) and
-    remove the block. Loading compiled handlers at boot is tracked in **#631**.
-  - **Creating an observer with an action `type` of `"database"` or `"log"` now
-    returns `400`, not `201`.** The runtime has no dispatcher for those types, so the
-    observer was created and then silently warn-and-skipped at load. The admin API now
-    rejects them at create/update, naming the supported types (`webhook`, `email`,
-    `slack`); real database/log dispatchers are tracked in **#632**.
-  - **The admin observer retry field is `backoff_strategy`, not `backoff`.** The
-    runtime reads `retry_config.backoff_strategy`, so the old DTO field name `backoff`
-    was silently dropped and every observer defaulted to exponential backoff. The field
-    is renamed and both `RetryConfig` structs gained `deny_unknown_fields`, so the dead
-    `backoff` key (or a typo) now fails loud. **Migration:** any `tb_observer.retry_config`
-    JSONB written before this release that carries a `backoff` key must be updated to
-    `backoff_strategy`, or that observer will fail to reload.
-
 ### Changed
 
 - **Entity-identity contract: `id: UUID` is canonicalized to `id: ID` (ADR-0017).**
@@ -376,51 +451,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   don't emit schemas.
 
 ### Fixed
-
-- **Webhook observers honor their configured HTTP method (#612 item 12).** The admin
-  API accepted a `method` on webhook actions but the runtime always issued a `POST`.
-  The method is now threaded through dispatch (`PUT`/`PATCH`/… work; default stays
-  `POST`); an unparseable method fails loud rather than silently posting.
-- **Config drift-prevention gate (#612 item M).** A checked-in coverage test walks
-  every leaf of `TomlSchema::default()` (CLI) and `ServerConfig::default()` (server)
-  and asserts each maps to a named consumer in a reviewable manifest — a new config
-  key that no runtime consumes now fails CI at PR time rather than surfacing in a docs
-  pass. This is the durable half of #612: the mechanism whose absence let the whole
-  class accumulate. Paired with the CLI↔server round-trip pins (#6, #9, 5b) that a
-  leaf-walk cannot reach.
-- **Honest docs for two accepted-but-unenforced knobs (#612 items 13/14).** Tenant
-  `max_storage_bytes` is now documented as advisory-only (stored, never enforced — no
-  metering path exists; enforcement tracked in **#633**), and the observer Prometheus
-  metrics registry documents that it is not scraped by the server's `/metrics`
-  (a two-ecosystem split; bridging tracked in **#634**). No behavior change — the
-  surfaces no longer imply a guarantee that isn't there.
-- **A single `[auth]` block now validates on both the CLI compiler and the server (#612).**
-  The CLI's `[auth]` schema required the PKCE OAuth-client fields (`discovery_url`,
-  `client_id`, `client_secret_env`, `server_redirect_uri`) with `deny_unknown_fields`,
-  while the server's OIDC config — read from the **same** `fraiseql.toml` — expects
-  `issuer`. So a JWT-validation block (`[auth] issuer = "…"`) failed `fraiseql compile`,
-  and no single `[auth]` could satisfy both tools. `[auth]` now accepts a **JWT-validation
-  group** (`issuer` + optional `audience`) and a **PKCE OAuth-client group** (the four
-  client fields), each validated as a coherent unit (client group is all-four-or-none;
-  `audience` requires `issuer`; an empty `[auth]` is a load error). The PKCE server-login
-  flow is **not yet functional on the compiled path** — the compiled schema carries no
-  `auth`/`auth_endpoints` blob for the server's `OidcServerClient`, and the CLI never
-  emitted one — so a *complete* client group is now **rejected at compile time with a
-  pointer to #621** instead of being silently accepted (the item-4 precedent: declared-but-
-  unenforced auth fails loud). The previously-false operator instructions that told
-  operators to configure those four fields (`builder.rs` startup error, the Auth0 and SAML
-  integration guides) are corrected to say so. JWT validation is unaffected.
-
-- **RLS session variables now reach the Relay `node(id:)` and partial-period aggregate
-  read paths (#610).** Both paths ran their read without resolving the schema's configured
-  `session_variables`, so a PostgreSQL RLS policy reading `current_setting()` did not
-  constrain them — a cross-tenant read on any Relay `node(id:)` lookup and any aggregate
-  taking the partial-period (`UNION ALL`) branch, both reachable from an ordinary GraphQL
-  request. They now resolve session variables and use the connection-affine
-  `*_with_session` adapter methods, exactly as regular queries, Relay pages, standard
-  aggregates, and mutations already did. (These were the two surviving read-path follow-ups
-  from #329, which was closed after its mutation-path fix shipped; they are fixed here under
-  #610, not by reopening #329.)
 
 - **`fraiseql compile` now surfaces the full error cause chain.** Converter
   failures printed only the top-level context (e.g. `Failed to convert schema to
@@ -475,21 +505,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client can paginate and filter. An explicit argument of the same name still wins
   (no duplicates), and Relay connection queries are unchanged (their `first`/`after`/
   `last`/`before` surface is owned by the Relay path).
-- **`security.token_revocation.revoke_all_ttl_secs` now reaches the server (#612).**
-  The server reads this key (default 86400s) to bound how long a `revoke-all` epoch
-  suppresses tokens, and the docs instructed setting it — but the CLI TOML schema lacked
-  the field, so `deny_unknown_fields` rejected any config that set it and it could never
-  take effect. Added to the CLI `[security.token_revocation]` schema; it now serializes
-  into the compiled schema the server already reads.
-- **Removed a dead rate-limiting config reader that silently fed hardcoded defaults
-  (#612).** `fraiseql-auth`'s `SecurityConfigFromSchema` parsed a nested-camelCase
-  `rateLimiting.authStart.maxRequests` shape the compiler never emits (it emits flat
-  snake_case `security.rate_limiting`), so that reader always fell back to hardcoded
-  defaults; its output only fed startup logging/validation before being dropped and
-  never drove runtime limits (those come from the server middleware's live
-  `RateLimitingSecurityConfig`, which reads the flat shape correctly). The dead
-  rate-limiting portion of the reader was removed and a merger→reader round-trip test
-  now pins the flat shape so the two ends cannot drift silently again.
 
 ## [2.11.0] - 2026-07-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "fraiseql-arrow",
  "fraiseql-cli",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-arrow"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-auth"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cdc-sinks"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "async-nats",
  "chrono",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cli"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-codegen"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "fraiseql-core",
  "fraiseql-error",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-core"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-db"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-error"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "axum",
  "serde",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-federation"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-functions"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-observers"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "arrow",
  "async-nats",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-secrets"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-server"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-storage"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-support"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "testcontainers",
  "testcontainers-modules",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-utils"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "async-trait",
  "fraiseql-core",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-webhooks"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4220,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-wire"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,26 +63,26 @@ dashmap = "6.1"
 deadpool = "0.12"
 deadpool-postgres = "0.14"
 # Internal crates
-fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.12.0"}
-fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.12.0"}
+fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.13.0"}
+fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.13.0"}
 # Deliberately loose floor (2.3.0, not the current 2.7.0): fraiseql-server takes
 # fraiseql-cli as a dev-dependency while fraiseql-cli depends on fraiseql-server,
 # a publish cycle. A floor equal to the unpublished current version breaks the
 # first `cargo publish` of the cut (the sibling isn't on crates.io yet). Keep this
 # floor loose — see the v2.4.0 release lessons. Do NOT bump it to match the others.
 fraiseql-cli = {path = "crates/fraiseql-cli", version = "2.3.0"}
-fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.12.0"}
-fraiseql-core = {path = "crates/fraiseql-core", version = "2.12.0", default-features = false}
-fraiseql-db = {path = "crates/fraiseql-db", version = "2.12.0", default-features = false}
-fraiseql-error = {path = "crates/fraiseql-error", version = "2.12.0", default-features = false}
-fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.12.0"}
-fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.12.0"}
-fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.12.0"}
-fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.12.0"}
-fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.12.0"}
-fraiseql-server = {path = "crates/fraiseql-server", version = "2.12.0"}
-fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.12.0"}
-fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.12.0"}
+fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.13.0"}
+fraiseql-core = {path = "crates/fraiseql-core", version = "2.13.0", default-features = false}
+fraiseql-db = {path = "crates/fraiseql-db", version = "2.13.0", default-features = false}
+fraiseql-error = {path = "crates/fraiseql-error", version = "2.13.0", default-features = false}
+fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.13.0"}
+fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.13.0"}
+fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.13.0"}
+fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.13.0"}
+fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.13.0"}
+fraiseql-server = {path = "crates/fraiseql-server", version = "2.13.0"}
+fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.13.0"}
+fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.13.0"}
 futures = "0.3"
 graphql-parser = "0.4"
 hex = "0.4"
@@ -350,4 +350,4 @@ keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
 rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
-version = "2.12.0"
+version = "2.13.0"

--- a/crates/fraiseql-arrow/fuzz/Cargo.toml
+++ b/crates/fraiseql-arrow/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-arrow-fuzz"
 publish = false
-version = "2.12.0"
+version = "2.13.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-auth-fuzz"
-version = "2.12.0"
+version = "2.13.0"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-core/fuzz/Cargo.toml
+++ b/crates/fraiseql-core/fuzz/Cargo.toml
@@ -51,7 +51,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-core-fuzz"
 publish = false
-version = "2.12.0"
+version = "2.13.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-db/fuzz/Cargo.toml
+++ b/crates/fraiseql-db/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-db-fuzz"
 publish = false
-version = "2.12.0"
+version = "2.13.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-federation/fuzz/Cargo.toml
+++ b/crates/fraiseql-federation/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ path = "../../fraiseql-error"
 edition = "2021"
 name = "fraiseql-federation-fuzz"
 publish = false
-version = "2.12.0"
+version = "2.13.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-secrets/fuzz/Cargo.toml
+++ b/crates/fraiseql-secrets/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-secrets-fuzz"
-version = "2.12.0"
+version = "2.13.0"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-server/fuzz/Cargo.toml
+++ b/crates/fraiseql-server/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-server-fuzz"
 publish = false
-version = "2.12.0"
+version = "2.13.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-wire/fuzz/Cargo.toml
+++ b/crates/fraiseql-wire/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-wire-fuzz"
 publish = false
-version = "2.12.0"
+version = "2.13.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdks/official/fraiseql-python/pyproject.toml
+++ b/sdks/official/fraiseql-python/pyproject.toml
@@ -38,7 +38,7 @@ license = {text = "MIT"}
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.12.0"
+version = "2.13.0"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]

--- a/sdks/official/fraiseql-python/src/fraiseql/__init__.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/__init__.py
@@ -79,7 +79,7 @@ input = input_decorator
 interface = interface_decorator
 union = union_decorator
 
-__version__ = "2.12.0"
+__version__ = "2.13.0"
 
 __all__ = [
     "ID",

--- a/sdks/official/fraiseql-rust/Cargo.toml
+++ b/sdks/official/fraiseql-rust/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["graphql", "authorization", "rbac", "schema"]
 license = "Apache-2.0"
 name = "fraiseql-rust"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "2.12.0"
+version = "2.13.0"
 
 [[test]]
 name = "integration_test"

--- a/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
+++ b/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-client"
-version = "2.12.0"
+version = "2.13.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Async HTTP client for FraiseQL GraphQL servers"

--- a/sdks/official/fraiseql-typescript/package-lock.json
+++ b/sdks/official/fraiseql-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fraiseql",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fraiseql",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/sdks/official/fraiseql-typescript/package.json
+++ b/sdks/official/fraiseql-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fraiseql",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "FraiseQL v2 - Compiled GraphQL execution engine (schema authoring + HTTP client)",
   "repository": {
     "type": "git",

--- a/sdks/official/fraiseql-typescript/src/index.ts
+++ b/sdks/official/fraiseql-typescript/src/index.ts
@@ -32,7 +32,7 @@
  * @packageDocumentation
  */
 
-export const version = "2.12.0";
+export const version = "2.13.0";
 
 // Export type system
 export { typeToGraphQL, extractFieldInfo, extractFunctionSignature } from "./types";


### PR DESCRIPTION
Release prep for **2.13.0**. Merge lands the prep commit on `dev`; the tag will go on the `dev` merge commit (per the v2.11.0 lesson) **after** an explicit go.

## CHANGELOG
- New `## [2.13.0] - 2026-07-17` — two trains: **functions-platform-maturity** (service accounts, `functions invoke`, DLQ #598, `after:capture` #366, `when` #597, cron, write-back, `-full` binaries) + **docs-review** (#608/#609 Security, #610/#612 Fixed, #612 rejects Breaking). Duplicate `### Added/Changed/Fixed` subsections consolidated.
- **Restores `## [2.12.0] - 2026-07-15`** (verbatim from the `v2.12.0` tag). Commit `60b30dd5a` (the `-full` variant, landed *after* the v2.12.0 tag) had deleted that header, dissolving 2.12.0's shipped content (Sources #573, ADR-0017, …) back into `[Unreleased]`. This separates them so 2.13.0 contains only genuinely-new work.

## Version bump `2.12.0 → 2.13.0`
Workspace `[workspace.package]` + internal dep pins, `Cargo.lock`, 8 `fuzz/Cargo.toml`, and the SDK manifests (Python `pyproject`/`__init__`, Rust ×2, TypeScript `package.json`/`package-lock`/`index.ts`) — the same file set as the v2.12.0 prep.

## Verification
- `cargo check` builds the v2.13.0 crates; `cargo +nightly fmt --all -- --check` clean.
- CHANGELOG boundary checks: no 2.12.0 content in `[2.13.0]` and vice-versa; `[Unreleased]` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)