### PR TITLE
fix(release,cli): ship fraiseql-server in the -full tarball; make `fraiseql run` config-drop loud (#643)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,9 +177,11 @@ jobs:
     name: Build Binary (${{ matrix.target }})
     needs: create-github-release
     runs-on: ${{ matrix.os }}
-    # Native targets build BOTH the lean and the `-full` (V8) variant in one job;
-    # V8 release compilation is heavy, so allow more headroom than the lean-only 60m.
-    timeout-minutes: 90
+    # Native targets build the lean umbrella, the `-full` (V8) umbrella, AND the
+    # standalone `fraiseql-server` (#643) in one job. The V8 crate artifact is shared
+    # across the two -full builds, but fraiseql-server is a large crate; V8 release
+    # compilation is heavy, so allow generous headroom over the lean-only 60m.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -291,22 +293,39 @@ jobs:
             || { echo "::error::the -full binary is missing 'functions invoke' — functions-invoke is not compiled in"; exit 1; }
           echo "✅ -full binary ships 'fraiseql functions invoke' (functions-invoke compiled in)."
 
-      - name: Strip full binary (Linux/macOS native)
+      # Second binary in the `-full` tarball: the standalone `fraiseql-server`, the
+      # production `--config server.toml` entrypoint. The umbrella `fraiseql run` is a
+      # dev quick-launcher that reads only [server]/[database] (#643); a real deployment
+      # of auth/federation/observers/enrichment/tenancy/storage needs `fraiseql-server`,
+      # which was previously reachable only by rebuilding from source. Built with the
+      # same stable platform surface `release-full` compiles into the umbrella (auth and
+      # cli are on by default in fraiseql-server). One archive now carries the compiler
+      # CLI and the server at a single revision — the #507 same-revision contract made
+      # physical.
+      - name: Build fraiseql-server binary (cargo, -full)
+        if: '!matrix.use_cross'
+        run: cargo build --release --target ${{ matrix.target }} --package fraiseql-server --features functions-runtime-deno,inbound-email,sources,mcp,metrics,observers,federation
+
+      - name: Strip full binaries (Linux/macOS native)
         if: matrix.os != 'windows-latest' && !matrix.use_cross
-        run: strip target/${{ matrix.target }}/release/${{ matrix.binary }}
+        run: |
+          strip target/${{ matrix.target }}/release/${{ matrix.binary }}
+          strip target/${{ matrix.target }}/release/fraiseql-server
 
       - name: Create full archive (tar.gz)
         if: matrix.archive_ext == 'tar.gz' && !matrix.use_cross
         run: |
           cp target/${{ matrix.target }}/release/${{ matrix.binary }} fraiseql
-          tar czf fraiseql-full-${{ matrix.target }}.tar.gz fraiseql
+          cp target/${{ matrix.target }}/release/fraiseql-server fraiseql-server
+          tar czf fraiseql-full-${{ matrix.target }}.tar.gz fraiseql fraiseql-server
 
       - name: Create full archive (zip)
         if: matrix.archive_ext == 'zip' && !matrix.use_cross
         shell: bash
         run: |
           cp target/${{ matrix.target }}/release/${{ matrix.binary }} fraiseql.exe
-          7z a fraiseql-full-${{ matrix.target }}.zip fraiseql.exe
+          cp target/${{ matrix.target }}/release/fraiseql-server.exe fraiseql-server.exe
+          7z a fraiseql-full-${{ matrix.target }}.zip fraiseql.exe fraiseql-server.exe
 
       - name: Upload full archive to release
         if: '!matrix.use_cross'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The `-full` release tarballs now ship the `fraiseql-server` binary alongside the
+  umbrella `fraiseql` binary (#643).** Previously every tarball — lean and `-full` —
+  contained only the umbrella binary, whose `fraiseql run` subcommand is a development
+  quick-launcher that reads only `[server]` and `[database]`. A `-full` download therefore
+  could not run a real `server.toml` deployment (`[auth]` / `[federation]` / `[observers]`
+  / `[enrichment]` / `[tenancy]` / `[storage]` were silently ignored), and the production
+  entrypoint — `fraiseql-server --config` — was reachable only by rebuilding from source.
+  The `-full` archive now carries **both** binaries, built from one revision (the #507
+  same-revision contract made physical): use `fraiseql-server --config server.toml` for
+  deployments and `fraiseql run` for local iteration. Windows `-full` zips include
+  `fraiseql-server.exe`. The lean default artifact is unchanged; `aarch64-unknown-linux-gnu`
+  remains lean-only (V8 does not cross-compile there — a documented gap in
+  `docs/releases.md`).
+
+### Fixed
+
+- **`fraiseql run` no longer silently ignores unsupported config sections (#643).** Handed
+  a config that declares platform sections it does not consume (`[auth]`, `[federation]`,
+  `[observers]`, `[enrichment]`, `[tenancy]`, `[storage]`, `[security]`), it now logs a
+  warning naming each ignored section and pointing at `fraiseql-server --config`, rather
+  than dropping them without a word. Pointing the dev launcher at a full config stays
+  legitimate (it is a warning, not a boot refusal) — but the drop is no longer silent.
+
 ## [2.13.0] - 2026-07-17
 
 ### Security

--- a/crates/fraiseql-cli/src/commands/run.rs
+++ b/crates/fraiseql-cli/src/commands/run.rs
@@ -417,6 +417,7 @@ fn load_runtime_config_from_toml(
                 format!("Failed to load runtime config from {}", input_path.display())
             })?;
         info!("Loaded [server] and [database] config from {}", input_path.display());
+        warn_ignored_config_sections(input_path);
         return Ok((schema.server, schema.database));
     }
 
@@ -427,6 +428,7 @@ fn load_runtime_config_from_toml(
         match TomlProjectConfig::from_file(toml_path.to_str().unwrap_or("fraiseql.toml")) {
             Ok(cfg) => {
                 info!("Loaded [server] and [database] config from {}", toml_path.display());
+                warn_ignored_config_sections(&toml_path);
                 return Ok((cfg.server, cfg.database));
             },
             Err(e) => {
@@ -443,6 +445,69 @@ fn load_runtime_config_from_toml(
     }
 
     Ok((ServerRuntimeConfig::default(), DatabaseRuntimeConfig::default()))
+}
+
+/// Config-file sections that a full `server.toml` deployment relies on but that
+/// `fraiseql run` does not consume. `run` is a development quick-launcher: it reads
+/// only `[server]` and `[database]` (see [`load_runtime_config_from_toml`]) and builds
+/// the rest of the server from `ServerConfig::default()`, so every table below is
+/// dropped. The production entrypoint that honors them is the `fraiseql-server` binary
+/// (shipped in the `-full` release tarball) run with `--config`.
+const RUN_IGNORED_CONFIG_SECTIONS: &[&str] = &[
+    "auth",
+    "federation",
+    "observers",
+    "enrichment",
+    "tenancy",
+    "storage",
+    "security",
+];
+
+/// Return the ignored platform sections that are present in a raw TOML config, in
+/// [`RUN_IGNORED_CONFIG_SECTIONS`] order (stable for a testable/greppable message).
+///
+/// The typed `[server]`/`[database]` structs cannot see the other tables, so this
+/// re-parses the raw contents into a generic [`toml::Table`] — the same technique the
+/// server binary uses to surface a `[observers]` section built without the feature. A
+/// parse failure yields an empty list: the config was already loaded for
+/// `[server]`/`[database]`, so this stays a best-effort advisory, never a second hard
+/// parse gate.
+pub(crate) fn ignored_config_sections(contents: &str) -> Vec<&'static str> {
+    let Ok(table) = toml::from_str::<toml::Table>(contents) else {
+        return Vec::new();
+    };
+    RUN_IGNORED_CONFIG_SECTIONS
+        .iter()
+        .copied()
+        .filter(|section| table.contains_key(*section))
+        .collect()
+}
+
+/// Warn (never fail) when the loaded config declares sections `fraiseql run` ignores.
+///
+/// Pointing the dev quick-launcher at a full `server.toml` is legitimate
+/// quick-iteration, so this is a warning rather than a boot refusal — but silently
+/// dropping the sections would be the same class of defect as #612 (config accepted
+/// then ignored). Naming each dropped section and the entrypoint that honors it keeps
+/// the behavior honest and loud.
+fn warn_ignored_config_sections(config_path: &Path) {
+    let Ok(contents) = std::fs::read_to_string(config_path) else {
+        return;
+    };
+    let present = ignored_config_sections(&contents);
+    if present.is_empty() {
+        return;
+    }
+    let named = present.iter().map(|s| format!("[{s}]")).collect::<Vec<_>>().join(", ");
+    warn!(
+        ignored_sections = %present.join(", "),
+        "`fraiseql run` is a development quick-launcher that consumes only [server] and \
+         [database]; the config section(s) {named} in {} are ignored. For a deployment \
+         that honors them, run the `fraiseql-server` binary (shipped in the -full release \
+         tarball) with `--config {}`.",
+        config_path.display(),
+        config_path.display(),
+    );
 }
 
 /// Build a `ServerConfig` from resolved runtime parameters.

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -2044,9 +2044,36 @@ mod run_tests {
     use tempfile::TempDir;
 
     use super::super::run::{
-        auto_detect_input, build_config_from, resolve_input, resolve_runtime_config,
+        auto_detect_input, build_config_from, ignored_config_sections, resolve_input,
+        resolve_runtime_config,
     };
     use crate::config::runtime::{DatabaseRuntimeConfig, ServerRuntimeConfig};
+
+    #[test]
+    fn test_ignored_config_sections_detects_platform_tables() {
+        // A config `fraiseql run` cannot fully honor: [server]/[database] are consumed,
+        // the rest are dropped. Detection drives the loud warning (#643).
+        let toml = "\
+[server]\nhost = \"127.0.0.1\"\n\
+[database]\nurl = \"postgres://x\"\n\
+[observers]\n\
+[auth]\n\
+[tenancy]\n";
+        // Stable order follows RUN_IGNORED_CONFIG_SECTIONS, not the file order.
+        assert_eq!(ignored_config_sections(toml), vec!["auth", "observers", "tenancy"]);
+    }
+
+    #[test]
+    fn test_ignored_config_sections_empty_for_server_database_only() {
+        let toml = "[server]\nhost = \"127.0.0.1\"\n[database]\nurl = \"postgres://x\"\n";
+        assert!(ignored_config_sections(toml).is_empty());
+    }
+
+    #[test]
+    fn test_ignored_config_sections_empty_on_unparseable_toml() {
+        // Best-effort advisory: a parse failure must not fail the run path.
+        assert!(ignored_config_sections("this is = = not [[[ toml").is_empty());
+    }
 
     #[test]
     fn test_resolve_input_explicit_existing_file() {

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,19 +8,33 @@ two variants; pick by whether your deployment uses the opt-in platform features.
 | Artifact | Features | Use it when |
 |----------|----------|-------------|
 | `fraiseql-<target>` (**default**) | `cli,server,postgres` | You compile schemas and/or run a plain GraphQL-over-Postgres server. This is the lean binary — no V8, no extra runtime weight. |
-| `fraiseql-full-<target>` | `release-full` — adds Deno/TypeScript functions, scheduled `sources`, `observers`, `mcp`, `inbound` + `inbound-email`, `metrics`, and `run-server` | Your deployment uses any FraiseQL **platform feature**: `after:mutation`/`cron`/`after:capture` functions, scheduled sources, the MCP endpoint, inbound ingestion, or Prometheus metrics. |
+| `fraiseql-full-<target>` | `release-full` — Deno/TypeScript functions, scheduled `sources`, `observers`, `mcp`, `inbound` + `inbound-email`, `metrics`, `federation`, and `run-server` | Your deployment uses any FraiseQL **platform feature**: `after:mutation`/`cron`/`after:capture` functions, scheduled sources, federation, the MCP endpoint, inbound ingestion, or Prometheus metrics. Contains **two** binaries — `fraiseql` and `fraiseql-server` (see below). |
 
-Both are the umbrella `fraiseql` binary (`--package fraiseql`). The `-full` variant
-additionally enables `run-server`, so it is a self-contained server: `fraiseql run`
-serves with every platform feature compiled in.
+The `-full` tarball contains **two** binaries:
+
+- **`fraiseql`** — the umbrella binary (`--package fraiseql`): the compiler CLI plus
+  `fraiseql run`, a development quick-launcher that compiles a schema in memory and serves
+  it. `fraiseql run` reads only the `[server]` and `[database]` config sections (it warns
+  and names any other section it is handed), so it is for local iteration, not production.
+- **`fraiseql-server`** — the standalone production server, driven by `--config server.toml`.
+  This is the entrypoint for a real deployment: it honors the full config surface
+  (`[auth]`, `[federation]`, `[observers]`, `[tenancy]`, `[storage]`, `[security]`, …),
+  wires the observer / tenancy / storage / token-revocation / secrets subsystems, and
+  validates `sql_source`s at boot. Point a full `server.toml` at this binary — not at
+  `fraiseql run`.
+
+The lean `fraiseql-<target>` artifact ships only the umbrella `fraiseql` binary (no
+`fraiseql-server`, and its `fraiseql run` is compiled out).
 
 ## Use the cli and server from the *same* release
 
 The compiled-schema `jsonb_column` contract is a same-revision contract (#507): a schema
 compiled by one revision's cli must be served by the same revision's server. Do **not**
-mix a stock cli from release *N* with a server built from a different revision. The
-simplest safe setup is a single `fraiseql-full-<target>` binary from one release doing
-both `fraiseql compile` and `fraiseql run`.
+mix a stock cli from release *N* with a server built from a different revision. The `-full`
+tarball makes this contract physical: its `fraiseql` (compiler cli) and `fraiseql-server`
+come from a single build of a single revision, so `fraiseql compile` and
+`fraiseql-server --config server.toml` taken from the same archive are revision-matched by
+construction.
 
 ## Platform matrix
 


### PR DESCRIPTION
## Problem (#643)

The published `-full` tarball can't replace `fraiseql-server` — the one thing it exists to do. Verified against the published **v2.13.0** `fraiseql-full-x86_64-unknown-linux-gnu.tar.gz` asset and against `dev` at HEAD:

- Every release tarball (lean **and** `-full`) ships **only** the umbrella `fraiseql` binary.
- The `-full` binary's server entrypoint is `fraiseql run` — which **is** present (so "run-server is absent" was imprecise), but is a **thin dev launcher**: `resolve_runtime_config` loads only `[server]`/`[database]`, `build_config_from` fills the rest from `ServerConfig::default()`, and it constructs `Server::new(…, None)` — skipping observers/storage/tenancy/revocation/secrets/arrow/relay/`init_security`/`sql_source` validation. Every platform section an adopter puts in `server.toml` is silently ignored. `run.rs` already says *"production setups use fraiseql-server directly."*
- The real full-config entrypoint — the standalone `fraiseql-server` binary (`--config`) — was **never shipped**.
- `release-smoke` mirrored the gap: it boots a locally-built `fraiseql-server` (not shipped) and only **link-checks** the umbrella it does ship.

## Fix — artifact shape (option A: ship `fraiseql-server`)

- **`release.yml`**: build `fraiseql-server` with the full stable platform surface (`functions-runtime-deno,inbound-email,sources,mcp,metrics,observers,federation`; `auth`+`cli` on by default) and ship it **inside every `-full` tarball** next to the umbrella binary. Windows `-full` zips include `fraiseql-server.exe`. Job timeout 90m → 120m (a second V8-linked binary; the V8 crate artifact is shared with the umbrella build). One archive now carries the compiler CLI and the server at a single revision — the #507 same-revision contract made physical.
- **`fraiseql run` (cli)**: warns (never fails) when the loaded config declares a platform section it does not consume (`[auth]`/`[federation]`/`[observers]`/`[enrichment]`/`[tenancy]`/`[storage]`/`[security]`), naming each and pointing at `fraiseql-server --config`. Pointing the dev launcher at a full config stays legitimate — but the drop is no longer silent (the #612 philosophy in binary form).
- **Docs / CHANGELOG**: `docs/releases.md` documents the two-binary shape; CHANGELOG gets `### Changed` (artifact shape, stated plainly) + `### Fixed` (run warning).

The lean default artifact is unchanged. `aarch64-unknown-linux-gnu` remains lean-only (V8 does not cross-compile) — a follow-up tracks that gap.

**A2 (separate PR)** makes `release-smoke` download the published `-full` asset and boot the shipped `fraiseql-server` with a real platform config, so this failure mode is structurally impossible to repeat. **Provable on the next tag (2.13.1).**

## Verification

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `cargo test -p fraiseql-cli --features run-server` (686 lib + integration pass, incl. 3 new detection tests)
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- ✅ `make lint-tests-layout` / `lint-routes` / `lint-unwrap` (1 ≤ 3)
- ✅ `release.yml` YAML validated

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)