### PR TITLE
ci(sbom): migrate Cosign SBOM signing to the 3.x bundle format (#599)

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -74,22 +74,23 @@ jobs:
         echo "✅ SBOM is valid CycloneDX JSON"
 
     - name: Install Cosign
+      # Take the installer default (cosign 3.x). The previous `cosign-release: v2.6.3`
+      # pin existed only to keep the removed `--output-signature`/`--output-certificate`
+      # sign-blob flags working; this workflow now emits the cosign 3.x `--bundle`
+      # format, so the pin is dropped (#599). The bundle format is forward-stable.
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
-      with:
-        # cosign 3.x changes sign-blob output to the bundle format; stay on v2
-        # until the sign + documented verify flow is migrated together.
-        cosign-release: 'v2.6.3'
 
     - name: Sign SBOM with Cosign (keyless)
       run: |
+        # cosign 3.x sign-blob: a single self-contained `--bundle` (signature +
+        # certificate + Rekor entry) replaces the v2 `--output-signature` /
+        # `--output-certificate` pair. Verified with `cosign verify-blob --bundle` (#599).
         cosign sign-blob --yes \
           "fraiseql-${{ steps.version.outputs.version }}-sbom.json" \
-          --output-signature "fraiseql-${{ steps.version.outputs.version }}-sbom.json.sig" \
-          --output-certificate "fraiseql-${{ steps.version.outputs.version }}-sbom.json.pem"
+          --bundle "fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle"
 
-        echo "✅ SBOM signed with Cosign (keyless)"
-        echo "   Signature: fraiseql-${{ steps.version.outputs.version }}-sbom.json.sig"
-        echo "   Certificate: fraiseql-${{ steps.version.outputs.version }}-sbom.json.pem"
+        echo "✅ SBOM signed with Cosign (keyless, bundle format)"
+        echo "   Bundle: fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle"
 
     - name: Generate SHA256 checksums
       run: |
@@ -102,8 +103,7 @@ jobs:
       run: |
         mkdir -p sbom-artifacts
         cp fraiseql-${{ steps.version.outputs.version }}-sbom.json sbom-artifacts/
-        cp fraiseql-${{ steps.version.outputs.version }}-sbom.json.sig sbom-artifacts/
-        cp fraiseql-${{ steps.version.outputs.version }}-sbom.json.pem sbom-artifacts/
+        cp fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle sbom-artifacts/
         cp fraiseql-${{ steps.version.outputs.version }}-sbom.json.sha256 sbom-artifacts/
 
         # Create README for verification
@@ -113,8 +113,7 @@ jobs:
         ## Files Included
 
         - `fraiseql-${{ steps.version.outputs.version }}-sbom.json` - CycloneDX SBOM (JSON format)
-        - `fraiseql-${{ steps.version.outputs.version }}-sbom.json.sig` - Cosign signature (keyless)
-        - `fraiseql-${{ steps.version.outputs.version }}-sbom.json.pem` - Cosign certificate
+        - `fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle` - Cosign signing bundle (keyless: signature + certificate + Rekor entry)
         - `fraiseql-${{ steps.version.outputs.version }}-sbom.json.sha256` - SHA256 checksum
 
         ## Verify SBOM Integrity
@@ -126,9 +125,10 @@ jobs:
 
         ### 2. Verify Cosign Signature
         ```bash
+        # Requires cosign 3.x (the bundle format). The bundle carries the signature,
+        # the signing certificate, and the Rekor transparency-log entry.
         cosign verify-blob \
-          --signature fraiseql-${{ steps.version.outputs.version }}-sbom.json.sig \
-          --certificate fraiseql-${{ steps.version.outputs.version }}-sbom.json.pem \
+          --bundle fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle \
           --certificate-identity-regexp "https://github.com/fraiseql/fraiseql" \
           --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
           fraiseql-${{ steps.version.outputs.version }}-sbom.json
@@ -184,8 +184,7 @@ jobs:
       with:
         files: |
           fraiseql-${{ steps.version.outputs.version }}-sbom.json
-          fraiseql-${{ steps.version.outputs.version }}-sbom.json.sig
-          fraiseql-${{ steps.version.outputs.version }}-sbom.json.pem
+          fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle
           fraiseql-${{ steps.version.outputs.version }}-sbom.json.sha256
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem (#599)

cosign 3.0 replaced `sign-blob --output-signature/--output-certificate` with a single self-contained `--bundle`. The SBOM workflow pinned `cosign-release: v2.6.3` **only** to keep the old flags working. Taking the installer default (cosign 3.x) would have silently broken SBOM signing at the next release, and the documented `verify-blob --signature/--certificate` flow would no longer match the published artifacts.

## Changes

- **Sign** with `cosign sign-blob --bundle …-sbom.json.bundle` (was the `--output-signature` / `--output-certificate` pair).
- **Drop** the `cosign-release: v2.6.3` pin — use the installer default (cosign 3.x). The bundle format is forward-stable, so no re-pin.
- **Attach/upload** the single `.bundle` in place of `.sig` + `.pem`.
- **README** verify instructions use `cosign verify-blob --bundle …` (identity + OIDC-issuer assertions unchanged) and note cosign 3.x is required.

Clean cutover: cosign 3.x cannot emit the old pair, so there is no dual-publish transition period — the break is documented in the artifact README (fix-forward). Takes effect on the next release's SBOM run; **safe now** (no release in flight, per #599's timing note).

## Verification

- ✅ YAML parses
- ✅ no functional `.sig`/`.pem`/`--output-*` references remain (only migration comments)

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)