### PR TITLE
fix(core): recase + project nested LIST-of-object output fields (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Nested list-of-object query output is now recased to camelCase and projected to the
+  selection set (#489).** A nested `[Object]` field projected from a JSONB `data` view
+  was returned as the stored blob verbatim — `snake_case` element keys, plus keys the
+  query never selected — while the camelCase-selected fields came back null. This was the
+  third recasing path after #456 (mutation input) and #486 (query arguments): the SQL
+  projector leaves list fields as the raw sub-blob, so the recasing + selection-set
+  projection is now applied in Rust on both the query path (`project_nested_lists`, wired
+  into the query runner) and the mutation/entity path (`project_entity`), at any depth up
+  to the projection cap. Scalar fields and already-SQL-projected single objects are
+  untouched.
+
 ## [2.13.0] - 2026-07-17
 
 ### Security

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -382,6 +382,16 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         let mut projected =
             projector.project_results(&results, query_match.query_def.returns_list)?;
 
+        // 11a. #489: recase + project nested list-of-object fields the SQL projection
+        //      left as the raw stored sub-blob (snake_case keys, unselected keys). The
+        //      SQL side already projected top-level fields and nested single objects.
+        crate::runtime::project_nested_lists(
+            &mut projected,
+            &query_match.query_def.return_type,
+            query_match.selections.first().map_or(&[][..], |r| r.nested_fields.as_slice()),
+            &self.ctx.schema,
+        );
+
         // 11. Null out masked fields in the projected result
         if !access.masked.is_empty() {
             null_masked_fields(&mut projected, &access.masked);
@@ -709,7 +719,15 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
                 &query_match.selections,
                 &query_match.query_def.return_type,
             );
-        let projected = projector.project_results(&results, query_match.query_def.returns_list)?;
+        let mut projected =
+            projector.project_results(&results, query_match.query_def.returns_list)?;
+        // #489: recase + project nested list-of-object fields left raw by SQL projection.
+        crate::runtime::project_nested_lists(
+            &mut projected,
+            &query_match.query_def.return_type,
+            query_match.selections.first().map_or(&[][..], |r| r.nested_fields.as_slice()),
+            &self.ctx.schema,
+        );
 
         // 5. Wrap in GraphQL data envelope
         let response =
@@ -874,7 +892,15 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
                 &query_match.selections,
                 &query_match.query_def.return_type,
             );
-        let projected = projector.project_results(&results, query_match.query_def.returns_list)?;
+        let mut projected =
+            projector.project_results(&results, query_match.query_def.returns_list)?;
+        // #489: recase + project nested list-of-object fields left raw by SQL projection.
+        crate::runtime::project_nested_lists(
+            &mut projected,
+            &query_match.query_def.return_type,
+            query_match.selections.first().map_or(&[][..], |r| r.nested_fields.as_slice()),
+            &self.ctx.schema,
+        );
 
         // Wrap in GraphQL data envelope.
         let response =

--- a/crates/fraiseql-core/src/runtime/mod.rs
+++ b/crates/fraiseql-core/src/runtime/mod.rs
@@ -84,7 +84,9 @@ pub use field_filter::{FieldAccessResult, can_access_field, classify_field_acces
 pub use jsonb_strategy::{JsonbOptimizationOptions, JsonbStrategy};
 pub use matcher::{QueryMatch, QueryMatcher, suggest_similar};
 pub use planner::{ExecutionPlan, QueryPlanner};
-pub use projection::{FieldMapping, ProjectionMapper, ResultProjector, project_entity};
+pub use projection::{
+    FieldMapping, ProjectionMapper, ResultProjector, project_entity, project_nested_lists,
+};
 pub use query_tracing::{
     QueryExecutionTrace, QueryPhaseSpan, QueryTraceBuilder, create_phase_span, create_query_span,
 };

--- a/crates/fraiseql-core/src/runtime/projection.rs
+++ b/crates/fraiseql-core/src/runtime/projection.rs
@@ -6,7 +6,7 @@ use crate::{
     db::types::JsonbValue,
     error::{FraiseQLError, Result},
     graphql::FieldSelection,
-    schema::{CompiledSchema, FieldDefinition},
+    schema::{CompiledSchema, FieldDefinition, FieldType},
     utils::casing::{to_camel_case, to_snake_case},
 };
 
@@ -619,10 +619,150 @@ fn project_field_value(
                         _ => {},
                     }
                 }
+            } else if fd.field_type.is_list() {
+                // #489: a nested LIST-of-object field. The SQL/stored side returns the
+                // raw aggregated sub-blob (snake_case keys, unselected keys included);
+                // project every element at the element type — the same recasing +
+                // selection-set projection applied to single nested objects — so nested
+                // list output matches top-level and nested-object output.
+                if let Some(child_type) = fd.field_type.inner_type().and_then(FieldType::type_name)
+                {
+                    if let JsonValue::Array(arr) = value {
+                        return JsonValue::Array(
+                            arr.iter()
+                                .map(|el| {
+                                    project_list_element(el, child_type, nested, schema, depth)
+                                })
+                                .collect(),
+                        );
+                    }
+                    // The DB sometimes returns the whole array as a JSON string
+                    // (`->>` text extraction). Re-parse and project each element.
+                    if let JsonValue::String(s) = value {
+                        if let Ok(JsonValue::Array(arr)) = serde_json::from_str::<JsonValue>(s) {
+                            return JsonValue::Array(
+                                arr.iter()
+                                    .map(|el| {
+                                        project_list_element(el, child_type, nested, schema, depth)
+                                    })
+                                    .collect(),
+                            );
+                        }
+                    }
+                }
             }
         }
     }
     value.clone()
+}
+
+/// Project one element of a nested list-of-object field (#489): recase + project
+/// object elements at `child_type`, passing scalars and non-object strings through.
+fn project_list_element(
+    element: &JsonValue,
+    child_type: &str,
+    nested: &[FieldSelection],
+    schema: &CompiledSchema,
+    depth: usize,
+) -> JsonValue {
+    match element {
+        JsonValue::Object(_) => project_entity_at(element, child_type, nested, schema, depth + 1),
+        // An element itself text-encoded as a JSON object.
+        JsonValue::String(s) => match serde_json::from_str::<JsonValue>(s) {
+            Ok(parsed @ JsonValue::Object(_)) => {
+                project_entity_at(&parsed, child_type, nested, schema, depth + 1)
+            },
+            _ => element.clone(),
+        },
+        _ => element.clone(),
+    }
+}
+
+/// #489 — recase + project nested LIST-of-object fields left raw by the SQL projection.
+///
+/// The query path projects top-level fields and nested single objects at the SQL level
+/// (`jsonb_build_object`), but list fields fall back to the raw stored sub-blob
+/// (`snake_case` keys, unselected keys included). This walks the already-projected
+/// `value` guided by the selection set and, for each list-of-object field (up to the
+/// projection depth cap), replaces its elements with the fully projected form via
+/// [`project_entity`] at the element type. Non-list fields are left untouched — the SQL
+/// side already projected them; single-object fields are only recursed into to reach
+/// any lists nested inside them.
+///
+/// `type_name` is the entity type of `value` (or of each element when `value` is a
+/// list-returning query's top-level array); `selections` is the entity-level selection
+/// set (the query field's `nested_fields`).
+pub fn project_nested_lists(
+    value: &mut JsonValue,
+    type_name: &str,
+    selections: &[FieldSelection],
+    schema: &CompiledSchema,
+) {
+    project_nested_lists_at(value, type_name, selections, schema, 0);
+}
+
+fn project_nested_lists_at(
+    value: &mut JsonValue,
+    type_name: &str,
+    selections: &[FieldSelection],
+    schema: &CompiledSchema,
+    depth: usize,
+) {
+    if depth >= MAX_ENTITY_PROJECTION_DEPTH {
+        return;
+    }
+    match value {
+        // A list-returning query: each element is an entity of `type_name` (the list
+        // itself is not a nesting level).
+        JsonValue::Array(arr) => {
+            for el in arr.iter_mut() {
+                project_nested_lists_at(el, type_name, selections, schema, depth);
+            }
+        },
+        JsonValue::Object(obj) => {
+            let type_def = schema.find_type(type_name);
+            for sel in effective_selections(selections, type_name, schema) {
+                if sel.name == "__typename" {
+                    continue;
+                }
+                let Some(fd) =
+                    type_def.and_then(|td| td.fields.iter().find(|f| f.name.as_str() == sel.name))
+                else {
+                    continue;
+                };
+                if fd.field_type.is_scalar() {
+                    continue;
+                }
+                let key = sel.response_key();
+                if fd.field_type.is_list() {
+                    // The element type of a list-of-object field. `project_entity` fully
+                    // projects each raw element, including any lists nested inside it.
+                    if let Some(child_type) =
+                        fd.field_type.inner_type().and_then(FieldType::type_name)
+                    {
+                        if let Some(JsonValue::Array(arr)) = obj.get_mut(key) {
+                            for el in arr.iter_mut() {
+                                *el = project_entity(el, child_type, &sel.nested_fields, schema);
+                            }
+                        }
+                    }
+                } else if let Some(child_type) = fd.field_type.type_name() {
+                    // Single object already projected by the SQL side — recurse to reach
+                    // any lists nested inside it.
+                    if let Some(child) = obj.get_mut(key) {
+                        project_nested_lists_at(
+                            child,
+                            child_type,
+                            &sel.nested_fields,
+                            schema,
+                            depth + 1,
+                        );
+                    }
+                }
+            }
+        },
+        _ => {},
+    }
 }
 
 /// Look up a field's stored value: canonical `snake_case` key first, then a

--- a/crates/fraiseql-core/tests/nested_list_query_integration.rs
+++ b/crates/fraiseql-core/tests/nested_list_query_integration.rs
@@ -1,0 +1,163 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(missing_docs)]
+
+//! Issue #489 — a nested LIST-of-object query output must be recased to camelCase
+//! and projected to the selection set, not returned as the raw stored JSONB blob.
+//!
+//! End-to-end on the QUERY path: the view's `data` builds a nested `line_items`
+//! array with `snake_case` element keys (`unit_price`, `sku_code`) and an unselected
+//! `id`. The SQL projector leaves list fields as the raw sub-blob, so the recasing +
+//! projection happens in Rust (`project_nested_lists`, wired into the query runner).
+//! We run a real GraphQL query through parse → SQL → project → serialize and assert
+//! the array comes back camelCased and projected.
+//!
+//! Query-only by design (no mutation), so it needs no `core.*` install and runs
+//! against a bare PostgreSQL.
+
+mod common;
+
+use std::sync::Arc;
+
+use fraiseql_core::{
+    db::{DatabaseAdapter, postgres::PostgresAdapter},
+    runtime::Executor,
+    schema::CompiledSchema,
+};
+use serde_json::json;
+
+const SCHEMA: &str = "issue_489";
+
+async fn provision(adapter: &PostgresAdapter) {
+    adapter
+        .execute_raw_query(&format!("DROP SCHEMA IF EXISTS {SCHEMA} CASCADE"))
+        .await
+        .unwrap();
+    adapter.execute_raw_query(&format!("CREATE SCHEMA {SCHEMA}")).await.unwrap();
+    adapter
+        .execute_raw_query(&format!(
+            "CREATE TABLE {SCHEMA}.tb_order (\
+             id UUID PRIMARY KEY DEFAULT gen_random_uuid(), code TEXT)"
+        ))
+        .await
+        .unwrap();
+    adapter
+        .execute_raw_query(&format!(
+            "CREATE TABLE {SCHEMA}.tb_line (\
+             id UUID PRIMARY KEY DEFAULT gen_random_uuid(), \
+             fk_order UUID REFERENCES {SCHEMA}.tb_order(id), \
+             unit_price NUMERIC, sku_code TEXT, position INT)"
+        ))
+        .await
+        .unwrap();
+
+    // `data.line_items` is a jsonb_agg with snake_case element keys and an `id` the
+    // query below does not select — exactly the #489 shape.
+    adapter
+        .execute_raw_query(&format!(
+            "CREATE VIEW {SCHEMA}.v_order AS SELECT id, jsonb_build_object(\
+               'id', id, 'code', code, \
+               'line_items', COALESCE((SELECT jsonb_agg(jsonb_build_object(\
+                   'id', l.id::text, 'unit_price', l.unit_price, 'sku_code', l.sku_code) \
+                   ORDER BY l.position) FROM {SCHEMA}.tb_line l WHERE l.fk_order = {SCHEMA}.tb_order.id), \
+                 '[]'::jsonb)\
+             ) AS data FROM {SCHEMA}.tb_order"
+        ))
+        .await
+        .unwrap();
+}
+
+async fn seed(adapter: &PostgresAdapter) -> String {
+    let rows = adapter
+        .execute_raw_query(&format!(
+            "INSERT INTO {SCHEMA}.tb_order (code) VALUES ('ORD-1') RETURNING id::text AS id"
+        ))
+        .await
+        .unwrap();
+    let id = rows
+        .into_iter()
+        .next()
+        .and_then(|r| r.get("id").and_then(|v| v.as_str().map(ToString::to_string)))
+        .expect("order id");
+    adapter
+        .execute_raw_query(&format!(
+            "INSERT INTO {SCHEMA}.tb_line (fk_order, unit_price, sku_code, position) VALUES \
+             ('{id}'::uuid, 9.99, 'ABC', 1), ('{id}'::uuid, 4.50, 'XYZ', 2)"
+        ))
+        .await
+        .unwrap();
+    id
+}
+
+fn schema() -> CompiledSchema {
+    serde_json::from_value(json!({
+        "naming_convention": "camelCase",
+        "types": [
+            {
+                "name": "Order",
+                "sql_source": format!("{SCHEMA}.v_order"),
+                "fields": [
+                    { "name": "id", "field_type": "ID" },
+                    { "name": "code", "field_type": "String" },
+                    { "name": "lineItems", "field_type": { "List": { "Object": "LineItem" } } }
+                ]
+            },
+            {
+                "name": "LineItem",
+                "sql_source": format!("{SCHEMA}.v_line"),
+                "fields": [
+                    { "name": "id", "field_type": "ID" },
+                    { "name": "unitPrice", "field_type": "Float" },
+                    { "name": "skuCode", "field_type": "String" }
+                ]
+            }
+        ],
+        "queries": [
+            {
+                "name": "order",
+                "return_type": "Order",
+                "returns_list": false,
+                "nullable": true,
+                "sql_source": format!("{SCHEMA}.v_order"),
+                "arguments": [ { "name": "id", "arg_type": "ID", "nullable": false } ]
+            }
+        ]
+    }))
+    .expect("schema")
+}
+
+#[tokio::test]
+async fn nested_list_query_output_is_recased_and_projected() {
+    let container = common::testcontainer::get_test_container().await;
+    let adapter = Arc::new(PostgresAdapter::new(&container.connection_string()).await.unwrap());
+    provision(&adapter).await;
+    let id = seed(&adapter).await;
+
+    let executor = Executor::new(schema(), Arc::clone(&adapter));
+
+    // Select the nested list with camelCase fields; do NOT select the element `id`.
+    let doc = format!("{{ order(id: \"{id}\") {{ id lineItems {{ unitPrice skuCode }} }} }}");
+    let res = executor.execute(&doc, None).await.unwrap();
+    let order = res.get("data").and_then(|d| d.get("order")).cloned().unwrap();
+
+    assert!(
+        order["lineItems"].is_array(),
+        "lineItems must be an array; got:\n{}",
+        serde_json::to_string_pretty(&order).unwrap()
+    );
+    let items = order["lineItems"].as_array().unwrap();
+    assert_eq!(items.len(), 2, "both line items present");
+
+    // #489 contract: elements are recased to camelCase and projected to the selection.
+    assert_eq!(items[0]["skuCode"], json!("ABC"), "element recased to camelCase (skuCode)");
+    assert_eq!(items[1]["skuCode"], json!("XYZ"));
+    assert!(
+        items[0].get("unitPrice").is_some(),
+        "element field `unitPrice` recased + present"
+    );
+
+    for it in items {
+        assert!(it.get("sku_code").is_none(), "snake_case `sku_code` must not leak");
+        assert!(it.get("unit_price").is_none(), "snake_case `unit_price` must not leak");
+        assert!(it.get("id").is_none(), "unselected element key `id` must not leak");
+    }
+}

--- a/crates/fraiseql-core/tests/nested_list_recasing.rs
+++ b/crates/fraiseql-core/tests/nested_list_recasing.rs
@@ -1,0 +1,172 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(missing_docs)]
+
+//! Issue #489 — nested LIST-of-object output fields must be recased to the
+//! camelCase surface and projected to the selection set, exactly like top-level
+//! fields and nested single objects (the third recasing path after #456 mutation
+//! input and #486 query arguments).
+//!
+//! The stored JSONB `data` builds nested arrays with `snake_case` keys and every
+//! column (not just the selected ones); the SQL projector leaves list fields as the
+//! raw sub-blob, so the recasing/projection must happen in Rust. These pure tests
+//! exercise both Rust projectors that see raw list blobs:
+//!
+//! - [`project_entity`] — the canonical entity projector (mutation success/error payloads, and the
+//!   query-path list pass delegates to it).
+//! - [`project_nested_lists`] — the query-path pass that fixes list fields left raw by the SQL
+//!   projection.
+
+use fraiseql_core::{
+    graphql::FieldSelection,
+    runtime::{project_entity, project_nested_lists},
+    schema::CompiledSchema,
+};
+use serde_json::json;
+
+/// A leaf field selection (no sub-selection, no alias).
+fn field(name: &str) -> FieldSelection {
+    FieldSelection {
+        name:          name.to_string(),
+        alias:         None,
+        arguments:     vec![],
+        nested_fields: vec![],
+        directives:    vec![],
+    }
+}
+
+/// A field selection with a sub-selection.
+fn nested(name: &str, sub: Vec<FieldSelection>) -> FieldSelection {
+    FieldSelection {
+        name:          name.to_string(),
+        alias:         None,
+        arguments:     vec![],
+        nested_fields: sub,
+        directives:    vec![],
+    }
+}
+
+/// Schema: an `Order` with a scalar `id`, a nested single `customer` (Object), and a
+/// nested list `lineItems` (`[LineItem]`) whose elements carry `unitPrice`/`skuCode`
+/// plus an unselected `id`.
+fn schema() -> CompiledSchema {
+    serde_json::from_value(json!({
+        "naming_convention": "camelCase",
+        "types": [
+            {
+                "name": "Order",
+                "sql_source": "v_order",
+                "fields": [
+                    { "name": "id", "field_type": "ID" },
+                    { "name": "customer", "field_type": { "Object": "Customer" } },
+                    { "name": "lineItems", "field_type": { "List": { "Object": "LineItem" } } }
+                ]
+            },
+            {
+                "name": "Customer",
+                "sql_source": "v_customer",
+                "fields": [
+                    { "name": "id", "field_type": "ID" },
+                    { "name": "displayName", "field_type": "String" },
+                    { "name": "orders", "field_type": { "List": { "Object": "Order" } } }
+                ]
+            },
+            {
+                "name": "LineItem",
+                "sql_source": "v_line_item",
+                "fields": [
+                    { "name": "id", "field_type": "ID" },
+                    { "name": "unitPrice", "field_type": "Float" },
+                    { "name": "skuCode", "field_type": "String" }
+                ]
+            }
+        ]
+    }))
+    .expect("schema")
+}
+
+/// The raw stored entity: `snake_case` keys, the nested list built with `snake_case`
+/// element keys plus an unselected `id`.
+fn raw_order() -> serde_json::Value {
+    json!({
+        "id": "o1",
+        "line_items": [
+            { "id": "li1", "unit_price": 9.99, "sku_code": "ABC" },
+            { "id": "li2", "unit_price": 4.50, "sku_code": "XYZ" }
+        ]
+    })
+}
+
+#[test]
+fn project_entity_recases_and_projects_nested_list_objects() {
+    // `{ id lineItems { unitPrice skuCode } }`
+    let selections = vec![
+        field("id"),
+        nested("lineItems", vec![field("unitPrice"), field("skuCode")]),
+    ];
+
+    let out = project_entity(&raw_order(), "Order", &selections, &schema());
+
+    assert_eq!(
+        out,
+        json!({
+            "id": "o1",
+            "lineItems": [
+                { "unitPrice": 9.99, "skuCode": "ABC" },
+                { "unitPrice": 4.50, "skuCode": "XYZ" }
+            ]
+        }),
+        "nested list objects must be recased to camelCase and projected to the selection \
+         set (no snake_case keys, no unselected `id`)"
+    );
+}
+
+#[test]
+fn project_nested_lists_fixes_a_sql_projected_result() {
+    // The query path already projected top-level fields at the SQL level (camelCase
+    // `id`), but left the `lineItems` list as the raw stored sub-blob.
+    let mut sql_projected = json!({
+        "id": "o1",
+        "lineItems": [
+            { "id": "li1", "unit_price": 9.99, "sku_code": "ABC" }
+        ]
+    });
+    let selections = vec![
+        field("id"),
+        nested("lineItems", vec![field("unitPrice"), field("skuCode")]),
+    ];
+
+    project_nested_lists(&mut sql_projected, "Order", &selections, &schema());
+
+    assert_eq!(
+        sql_projected,
+        json!({
+            "id": "o1",
+            "lineItems": [ { "unitPrice": 9.99, "skuCode": "ABC" } ]
+        })
+    );
+}
+
+#[test]
+fn project_nested_lists_reaches_lists_nested_inside_single_objects() {
+    // `customer` is a single object the SQL side already projected (camelCase keys);
+    // the list `orders` inside it is still raw. The pass must recurse into the object.
+    let mut sql_projected = json!({
+        "id": "o1",
+        "customer": {
+            "displayName": "Acme",
+            "orders": [ { "id": "o9", "line_items": [] } ]
+        }
+    });
+    let selections = vec![
+        field("id"),
+        nested("customer", vec![field("displayName"), nested("orders", vec![field("id")])]),
+    ];
+
+    project_nested_lists(&mut sql_projected, "Order", &selections, &schema());
+
+    assert_eq!(
+        sql_projected["customer"]["orders"],
+        json!([ { "id": "o9" } ]),
+        "a list nested inside an already-projected single object must still be projected"
+    );
+}


### PR DESCRIPTION
## Problem (#489)

A nested `[Object]` field projected from a JSONB `data` view came back as the stored blob **verbatim** — `snake_case` element keys **and** keys the query never selected — while the camelCase-selected fields returned `null`:

```graphql
{ order(id: "…") { id lineItems { unitPrice skuCode } } }
```
```jsonc
// got:      { "lineItems": [ { "id": "…", "unit_price": 9.99, "sku_code": "ABC" } ] }
// expected: { "lineItems": [ { "unitPrice": 9.99, "skuCode": "ABC" } ] }
```

Top-level fields and nested **single** objects were already correct — the SQL projector builds them with `jsonb_build_object`. **List** fields fall back to the raw sub-blob, so the recasing + selection-set projection has to happen in Rust. This is the **third recasing path** after #456 (mutation input) and #486 (query arguments).

## Fix

- **`project_field_value`** (canonical entity projector): recase + project each element of a nested list-of-object field at the element type — the same treatment single nested objects already get. Fixes the mutation/entity path and makes `project_entity` complete (nested lists at any depth).
- **`project_nested_lists`** (new): the query path projects top-level fields and nested single objects at the SQL level but leaves list fields raw. This pass walks the projected result and projects list elements via `project_entity`, recursing into single objects to reach deeper lists. Wired into all three query runners. Scalars and already-projected single objects are untouched.

## Verification

- ✅ **RED pinned**: with the fix disabled, the query-path integration test and the `project_nested_lists` unit tests fail (raw `snake_case` leaks); with it, they pass.
- ✅ **Unit tests** (no DB): `project_entity` + `project_nested_lists` recasing/projection, incl. lists nested inside single objects.
- ✅ **Query-path integration test** against real PostgreSQL — query-only, so it needs no `core.*` install.
- ✅ Covers **all three recasing paths**: #489 (new tests), #456/#486 (existing suites green).
- ✅ `cargo +nightly fmt --check`; `clippy --workspace --all-targets --all-features -- -D warnings`; `RUSTDOCFLAGS=-D warnings cargo doc … --all-features --no-deps`
- ✅ `fraiseql-core` lib: **2643 pass** (no regression); `make lint-tests-layout` / `lint-unwrap`

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)