### PR TITLE
fix(cli): drop `-d` short from --database (collides with global --debug) (#650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **`fraiseql run`, `fraiseql validate facts`, and `fraiseql introspect facts` no longer
+  collide on `-d` (#650).** The global `--debug` short (`-d`) and each subcommand's
+  `--database` short (also `-d`) claimed the same letter, so debug builds of the CLI
+  panicked at startup (clap `debug_asserts`: "Short option names must be unique … '-d' is
+  in use by both 'database' and 'debug'") and release builds advertised an ambiguous `-d`.
+  `--database` is now long-only on all three subcommands — the global `-d` (debug) is
+  consistent across every subcommand — and a `Cli::command().debug_assert()` test guards
+  against reintroduction. Use `--database <url>` (the long form always worked).
+
 ## [2.14.1] - 2026-07-24
 
 ### Added
@@ -207,6 +218,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   may **newly reject** callers that previously succeeded, so verify role assignments before
   rolling out. Type-level `requires_role` remains unenforced and is tracked separately in
   \#677.
+||||||| parent of 28a1cc50b (fix(cli): drop `-d` short from --database (collides with global --debug) (#650))
 
 ## [2.13.1] - 2026-07-18
 

--- a/crates/fraiseql-cli/src/cli.rs
+++ b/crates/fraiseql-cli/src/cli.rs
@@ -340,7 +340,7 @@ EXAMPLES:
     fraiseql validate schema.json
     fraiseql validate schema.json --check-unused
     fraiseql validate schema.json --strict
-    fraiseql validate facts -s schema.json -d postgres://localhost/db")]
+    fraiseql validate facts -s schema.json --database postgres://localhost/db")]
     Validate {
         #[command(subcommand)]
         command: Option<ValidateCommands>,
@@ -378,8 +378,8 @@ EXAMPLES:
     /// Introspect database for fact tables and output suggestions
     #[command(after_help = "\
 EXAMPLES:
-    fraiseql introspect facts -d postgres://localhost/db
-    fraiseql introspect facts -d postgres://localhost/db -f json")]
+    fraiseql introspect facts --database postgres://localhost/db
+    fraiseql introspect facts --database postgres://localhost/db -f json")]
     Introspect {
         #[command(subcommand)]
         command: IntrospectCommands,
@@ -522,7 +522,10 @@ TOML CONFIG:
         input: Option<String>,
 
         /// Database URL (overrides [database].url in fraiseql.toml and DATABASE_URL env var)
-        #[arg(short, long, value_name = "DATABASE_URL")]
+        // Long-only: the global `--debug` (`Cli.debug`) already owns `-d`. A local
+        // `-d`/`--database` short here collides with it — clap's debug_asserts panic in
+        // debug builds and the short is ambiguous in release builds (#650).
+        #[arg(long, value_name = "DATABASE_URL")]
         database: Option<String>,
 
         /// Port to listen on (overrides [server].port in fraiseql.toml)
@@ -937,7 +940,8 @@ pub(crate) enum ValidateCommands {
         schema: String,
 
         /// Database connection string
-        #[arg(short, long, value_name = "DATABASE_URL")]
+        // Long-only: `-d` is the global `--debug` short (#650).
+        #[arg(long, value_name = "DATABASE_URL")]
         database: String,
     },
 }
@@ -995,7 +999,8 @@ pub(crate) enum IntrospectCommands {
     /// Introspect database for fact tables (tf_* tables)
     Facts {
         /// Database connection string
-        #[arg(short, long, value_name = "DATABASE_URL")]
+        // Long-only: `-d` is the global `--debug` short (#650).
+        #[arg(long, value_name = "DATABASE_URL")]
         database: String,
 
         /// Output format (python, json)

--- a/crates/fraiseql-cli/src/tests.rs
+++ b/crates/fraiseql-cli/src/tests.rs
@@ -261,3 +261,18 @@ mod runner_tests {
         );
     }
 }
+
+mod cli_arg_conflicts {
+    use clap::CommandFactory;
+
+    /// Every subcommand's args — including propagated globals like `--debug` — must have
+    /// unique short flags. clap's `debug_assert` validates the whole command tree and
+    /// panics on a conflict, e.g. the `-d`/`--database` vs global `-d`/`--debug` collision
+    /// of #650. This test (recompiled with `run-server` under `--all-features`) covers the
+    /// `run`, `validate facts`, and `introspect facts` `--database` args; it fails if any
+    /// short-flag conflict is reintroduced on those or any other subcommand.
+    #[test]
+    fn no_conflicting_short_flags() {
+        crate::cli::Cli::command().debug_assert();
+    }
+}


### PR DESCRIPTION
Closes #650.

## Problem

The global `--debug` (`Cli.debug`, `#[arg(short, long, global = true)]`) and every subcommand's `--database` derived the same short, `-d`. Three subcommands were affected: `run` (behind `run-server`), `validate facts`, and `introspect facts`. In debug builds, clap's `debug_asserts` panic at startup:

```
Command run: Short option names must be unique for each argument, but '-d' is in use by both 'database' and 'debug'
```

Release builds compile the assert out but advertise an ambiguous `-d` in `--help`.

## Fix

`--database` is now **long-only** on all three subcommands. Keeping the global `-d` = debug is the least-surprising resolution — it stays consistent across every subcommand, and the `--database` long form (which always worked, and which `DATABASE_URL` / `[database].url` already cover) is unchanged.

Also updated the `validate` / `introspect` `after_help` examples that advertised `-d`, and added a `Cli::command().debug_assert()` pinning test covering the whole command tree.

## Verification

- ✅ `cargo +nightly fmt --check` clean
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` clean
- ✅ `cargo test -p fraiseql-cli --all-features` — 687 lib + all integration tests pass
- ✅ **RED→GREEN proven**: with the fix, `no_conflicting_short_flags` passes; reintroducing the `short` reproduces the exact clap panic above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)