### PR TITLE
ci(sbom): dispatch SBOM generation explicitly from release.yml (fixes suppressed trigger)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,36 @@ jobs:
               --prerelease=$PRERELEASE
           fi
 
+  # Kick off SBOM generation for this release.
+  #
+  # The release above is created with the default GITHUB_TOKEN, and GitHub suppresses
+  # workflow runs from events triggered by that token (recursion prevention). So the
+  # `release: published` event NEVER reaches sbom-generation.yml — which is exactly why
+  # the v2.13.1 release produced no SBOM. `workflow_dispatch` and `repository_dispatch`
+  # are the ONLY events exempt from that suppression, so dispatch the SBOM workflow
+  # explicitly here instead of relying on the (suppressed) release event.
+  trigger-sbom:
+    name: Trigger SBOM generation
+    needs: create-github-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Least-privilege: a job-level permissions block REPLACES the workflow default, so
+    # this grants ONLY the actions:write needed to dispatch another workflow.
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch SBOM Generation for this release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          TAG="v${VERSION}"
+          gh workflow run sbom-generation.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$TAG" \
+            -f version="$VERSION"
+          echo "Dispatched sbom-generation.yml for $VERSION (ref $TAG)."
+
   # Build binaries for multiple platforms
   build-binaries:
     name: Build Binary (${{ matrix.target }})

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -57,6 +57,25 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Generating SBOM for version: $VERSION"
 
+    - name: Check the target release exists (attach only if so)
+      id: release_check
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # On a `release` event the release exists by definition; on workflow_dispatch it
+        # exists when release.yml's trigger-sbom job dispatched us AFTER create-github-release.
+        # Gating attach on this (rather than event name) keeps a manual dispatch with a
+        # version that has no release from CREATING a spurious release — it becomes a safe
+        # generate-only run instead.
+        TAG="v${{ steps.version.outputs.version }}"
+        if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "Release $TAG exists — the SBOM will be attached to it."
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No release $TAG — generating and signing the SBOM only, not attaching."
+        fi
+
     - name: Generate SBOM (CycloneDX JSON)
       run: |
         cargo cyclonedx --format json --all \
@@ -179,9 +198,14 @@ jobs:
         retention-days: 90
 
     - name: Attach SBOM to Release
-      if: github.event_name == 'release'
+      # Runs for BOTH the `release` event and the workflow_dispatch path (release.yml's
+      # trigger-sbom job), gated on the release actually existing so a manual generate-only
+      # dispatch never creates one. `tag_name` is set explicitly because on workflow_dispatch
+      # there is no `github.event.release` to infer it from.
+      if: steps.release_check.outputs.exists == 'true'
       uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
       with:
+        tag_name: v${{ steps.version.outputs.version }}
         files: |
           fraiseql-${{ steps.version.outputs.version }}-sbom.json
           fraiseql-${{ steps.version.outputs.version }}-sbom.json.bundle


### PR DESCRIPTION
## Problem

**SBOM Generation never ran for the v2.13.1 release.** `create-github-release` creates the release with `gh release create` authenticated by the default `GITHUB_TOKEN`. GitHub suppresses workflow runs from events triggered by that token (recursion prevention), so the `release: published` event never reaches `sbom-generation.yml`.

Run history corroborates the diagnosis:
- The only `release`-triggered SBOM run is the old **v2.2.1** (created differently, before releases moved to a `GITHUB_TOKEN`-authored `gh release create`).
- Every recent SBOM run is a manual `workflow_dispatch`, and the most recent one **succeeded** (1m13s) — the generate → sign → validate → upload pipeline is healthy. The gap is purely the trigger.

`workflow_dispatch` and `repository_dispatch` are the **only** events exempt from `GITHUB_TOKEN` suppression.

## Fix

**`release.yml`** — new `trigger-sbom` job (`needs: create-github-release`, least-privilege `actions: write`) that dispatches `sbom-generation.yml` via `gh workflow run` once the release exists. Dispatching is allowed from `GITHUB_TOKEN`, unlike the release event.

**`sbom-generation.yml`**:
- New `release_check` step — attach only when the target release actually exists, so a manual generate-only dispatch (a version with no release) can never *create* a spurious release; it degrades to a safe generate + sign-only run.
- `Attach SBOM to Release` now runs for both the `release` event and the dispatch path (gated on `release_check`) and sets `tag_name` explicitly (there is no `github.event.release` to infer it from under `workflow_dispatch`).
- The `release: published` trigger is **kept** — harmless, and still fires for human-published releases (not `GITHUB_TOKEN`-suppressed).

## Verification

- ✅ Both workflows parse (`yaml.safe_load`).
- ✅ `sbom-generation.yml` is dispatchable; a recent `workflow_dispatch` run succeeded in 1m13s.
- ✅ Diagnosis matches run history (release-triggered runs stopped; only dispatch runs since).

### On proving it end-to-end

The new `trigger-sbom` job only runs on a real release (the maintainer's gate). **`v*` tags on this repo are armed to publish** (`release.yml` runs `publish-crates`/`publish-python`/etc. on `push: tags: 'v*'`), so I did **not** cut any scratch/draft release to prove it — creating a `v*` tag risks a real publish, and softprops attaching to a draft could publish it.

Safe ways to prove, if you want pre-merge confidence:
- **Generate-only (no release, no publish):** `gh workflow run sbom-generation.yml --ref ci/sbom-release-trigger -f version=0.0.0-proof` — exercises this branch's `release_check` (→ `exists=false` → skips attach) plus generate/sign/validate. (Note: cosign keyless writes one entry to the public Rekor log; the SBOM content is already-public dependency data.)
- **End-to-end:** the next real release will run `trigger-sbom` → dispatch → attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)