### PR TITLE
test(2.14): Phase 00 — baseline pinning tests

### DIFF
--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2192,6 +2192,54 @@ mod tenancy_tests {
         assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
     }
 
+    /// Phase-00 baseline pin for the 2.14 train (#653). An embedded value object
+    /// (`Money`) that the Python SDK gave a synthesized `sql_source` (`v_money`, a view
+    /// that does not exist) is flagged as a cascade entity purely because
+    /// `is_queryable_entity` keys off `!sql_source.is_empty()`. Today the error names
+    /// only the failed assertion ("no `id` field"); it does NOT say (3) *why* the type
+    /// was classified an entity (its `sql_source` signal) nor (4) the reference path that
+    /// pulled it in. Phase 02 adds both — this test flips RED then, making the diagnostic
+    /// improvement a deliberate, visible change rather than a silent one.
+    #[test]
+    fn cascade_embedded_value_object_error_omits_derivation_and_path_today() {
+        use crate::schema::SchemaConverter;
+        // Order is genuinely view-backed and identity-bearing — it must NOT be flagged.
+        let order = IntermediateType {
+            sql_source: Some("v_order".to_string()),
+            ..make_type("Order", vec![make_field("id", "UUID"), make_field("total", "Money")])
+        };
+        // Money is an embedded value object: no independent identity, never queried on its
+        // own. The SDK synthesized `sql_source = "v_money"` for it and no such view exists.
+        let money = IntermediateType {
+            sql_source: Some("v_money".to_string()),
+            ..make_type(
+                "Money",
+                vec![
+                    make_field("amount", "Int"),
+                    make_field("currency", "String"),
+                ],
+            )
+        };
+        let schema =
+            make_schema(vec![order, money], vec![], vec![cascade_mut("createOrder", "Order")]);
+        let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
+
+        // Current behavior, locked: the embedded type is flagged with the bare assertion.
+        assert!(msg.contains("Money"), "names the flagged type: {msg}");
+        assert!(msg.contains("no `id` field"), "states the failed assertion: {msg}");
+
+        // Baseline GAPS that Phase 02 (#653 proposals 3 & 4) will close. Asserted ABSENT so
+        // the pin turns RED-by-design when the richer message lands:
+        assert!(
+            !msg.contains("sql_source") && !msg.contains("v_money"),
+            "#653(3): message does not yet name the classification signal (sql_source): {msg}"
+        );
+        assert!(
+            !msg.contains("createOrder") && !msg.contains('→'),
+            "#653(4): message does not yet name the reference path: {msg}"
+        );
+    }
+
     /// An `id: Int` (a serial pk exposed directly — not the Trinity external id) is
     /// not canonicalized and cannot back `id: ID!`; a cascade over it fails fast with
     /// the actual id type and the remedy (adopt a UUID/ID identity).


### PR DESCRIPTION
**2.14 train — Phase 00.** Lock the current behavior of every surface the train changes, so each later phase's diff reads as an intended change against a green baseline. **Tests only, no production changes.**

## What's new

One characterization test fills the single real gap — the **#653** cascade `id` error. The existing `cascade_missing_id_entity_fails_with_actionable_error` asserts substrings (`"Order"`, `"no id field"`) that would *survive* Phase 02's richer message, so it would not flip. The new test reproduces the issue's embedded-value-object case (`Money` with a synthesized `sql_source="v_money"`, nested in a cascade mutation's return type) and asserts the message **does not yet** name:
- **(3)** the classification signal (`sql_source` / `v_money`), and
- **(4)** the reference path (`createOrder → … → Money`).

Phase 02 adds both → this pin flips **RED-by-design**, making the diagnostic improvement deliberate rather than silent.

## Baseline already pinned (no new tests — avoiding bloat)

This repo is well-characterized; the other three areas are already locked by existing tests, enumerated here so Phase 00 is an auditable baseline statement:

| Area | Pinned by |
|------|-----------|
| #618 proxy-trust warn-not-refuse | 5× `proxy_trust_*` in `server/tests.rs` (+ the `failed_login_lockout_check` prod/dev precedent Phase 01 mirrors) |
| #569 changelog CTE shape | `changelog_cte_*` in `db/postgres/adapter/tests.rs` — `INSERT INTO core.tb_entity_change_log` + `COALESCE(r.entity_type, …)` + effective-change gate (the table + mutation_response shape a fresh stack lacks) |
| #611 subscription reload | `reload_policy_warn_tests` in `routes/graphql/app_state.rs` (the #614 interim warning) |

## Verification
- ✅ `cargo +nightly fmt --check` clean
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` clean
- ✅ `cargo test -p fraiseql-cli --lib` — 664 pass; new pin GREEN (characterizes current behavior)

Plan: `.phases/2026-07-19-2.14-train/` (local). Next: Phase 01 (#618 refuse-to-boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)