### PR TITLE
feat(server)!: refuse to boot on unrestricted proxy trust in production (#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **In production, `[security.rate_limiting] trust_proxy_headers = true` with an empty or
+  omitted `trusted_proxy_cidrs` now refuses to boot (#618).** The 2.13 deprecation warning
+  (#609) promised exactly this. Trusting `X-Forwarded-For` from every direct peer lets any
+  client spoof its IP and bypass per-IP rate limiting (and poison IP-derived logging).
+  Restrict trust with `trusted_proxy_cidrs = ["10.0.0.0/8"]` (your load-balancer/proxy
+  ranges), or opt into trust-all **explicitly** with `trusted_proxy_cidrs = ["0.0.0.0/0"]`
+  (unchanged, never warns). Development (`FRAISEQL_ENV=development`) downgrades the refusal
+  to a warning, matching the `failed_login_*` production/development split.
+
 ## [2.13.1] - 2026-07-18
 
 ### Changed

--- a/crates/fraiseql-server/src/server/initialization.rs
+++ b/crates/fraiseql-server/src/server/initialization.rs
@@ -238,14 +238,15 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             crate::ServerConfig::is_production_mode(),
         )?;
 
-        // Warn when trust_proxy_headers is enabled without restricting which IPs are
-        // trusted proxies — any client can then spoof X-Forwarded-For (#609). Explicit
-        // ["0.0.0.0/0"] opts into trust-all deliberately and does not warn.
-        if let Some(msg) =
-            proxy_trust_startup_warning(sec.trust_proxy_headers, sec.trusted_proxy_cidrs.as_deref())
-        {
-            warn!("{msg}");
-        }
+        // Refuse to boot in production when trust_proxy_headers is enabled without
+        // restricting which IPs are trusted proxies — any client could then spoof
+        // X-Forwarded-For and bypass per-IP rate limits (#609/#618). Explicit
+        // ["0.0.0.0/0"] opts into trust-all deliberately; development downgrades to a warning.
+        proxy_trust_check(
+            sec.trust_proxy_headers,
+            sec.trusted_proxy_cidrs.as_deref(),
+            crate::ServerConfig::is_production_mode(),
+        )?;
 
         let config = crate::middleware::RateLimitConfig::from_security_config(&sec);
 
@@ -672,34 +673,61 @@ pub(super) fn failed_login_lockout_check(
     Ok(())
 }
 
-/// Startup warning for an unrestricted `X-Forwarded-For` trust posture (#609).
+/// Startup check for an unrestricted `X-Forwarded-For` trust posture (#609/#618).
 ///
-/// Returns the warning to emit when `trust_proxy_headers` is enabled but no CIDR
-/// range restricts which direct peers may set `X-Forwarded-For` — the trust-every-proxy
-/// posture, where any client can spoof its IP and bypass per-IP rate limiting. Returns
-/// `None` when the configuration is safe: proxy trust off, or a **non-empty** CIDR list —
-/// including `["0.0.0.0/0"]`, the sanctioned way to say "trust every proxy" on purpose,
-/// which is a valid CIDR that `extract_real_ip` already treats as trust-all.
+/// When `trust_proxy_headers` is enabled but no CIDR range restricts which direct peers
+/// may set `X-Forwarded-For` — the trust-every-proxy-by-omission posture — any client can
+/// spoof its IP and bypass per-IP rate limiting (or poison IP-derived logging). In
+/// **production** this refuses to boot (`ServerError::ConfigError`); in **development** it
+/// downgrades to a warning, matching [`failed_login_lockout_check`].
 ///
-/// Empty-by-omission warns and carries a deprecation notice: trusting all proxies
-/// implicitly is scheduled to refuse boot in 2.14 (#618). An operator who writes
-/// `["0.0.0.0/0"]` opted in deliberately, so the list is non-empty and this does not fire.
-pub(super) fn proxy_trust_startup_warning(
+/// Safe configurations return `Ok(())` with no warning: proxy trust off, or a **non-empty**
+/// CIDR list — including `["0.0.0.0/0"]`, the sanctioned explicit "trust every proxy" opt-in,
+/// a valid CIDR that `extract_real_ip` already treats as trust-all.
+///
+/// 2.13 shipped this as a deprecation warning promising a 2.14 refuse-to-boot (#618); this
+/// is that promotion. Operators who genuinely want trust-all keep it working by writing
+/// `trusted_proxy_cidrs = ["0.0.0.0/0"]` explicitly.
+///
+/// # Errors
+///
+/// Returns `ServerError::ConfigError` when `trust_proxy_headers = true`, the resolved CIDR
+/// list is empty, and `is_production` is true.
+pub(super) fn proxy_trust_check(
     trust_proxy_headers: bool,
     trusted_proxy_cidrs: Option<&[String]>,
-) -> Option<&'static str> {
-    if trust_proxy_headers && trusted_proxy_cidrs.is_none_or(<[String]>::is_empty) {
-        Some(
-            "Rate limiter: trust_proxy_headers = true but trusted_proxy_cidrs is not set. \
-             Any client can spoof X-Forwarded-For and bypass per-IP rate limits. Set \
-             trusted_proxy_cidrs in [security.rate_limiting] to your proxy ranges (e.g. \
-             [\"10.0.0.0/8\"] for internal load balancers), or [\"0.0.0.0/0\"] to keep \
-             trusting every proxy explicitly. DEPRECATED: trusting all proxies by omission \
-             will refuse to boot in 2.14 (#618).",
-        )
-    } else {
-        None
+    is_production: bool,
+) -> crate::Result<()> {
+    let trust_all_by_omission =
+        trust_proxy_headers && trusted_proxy_cidrs.is_none_or(<[String]>::is_empty);
+    if !trust_all_by_omission {
+        return Ok(());
     }
+    if is_production {
+        return Err(crate::ServerError::ConfigError(
+            concat!(
+                "FraiseQL failed to start\n\n",
+                "  [security.rate_limiting] trust_proxy_headers = true, but trusted_proxy_cidrs\n",
+                "  is empty or unset. Every direct peer would be trusted to set X-Forwarded-For,\n",
+                "  so any client could spoof its IP and bypass per-IP rate limiting (and poison\n",
+                "  IP-derived logging).\n\n",
+                "  Restrict which peers are trusted proxies:\n",
+                "    trusted_proxy_cidrs = [\"10.0.0.0/8\"]   # your load balancer / proxy ranges\n\n",
+                "  Or, to keep trusting every proxy on purpose, opt in explicitly:\n",
+                "    trusted_proxy_cidrs = [\"0.0.0.0/0\"]\n\n",
+                "  For local development only:\n",
+                "    Set FRAISEQL_ENV=development to downgrade this to a warning.",
+            )
+            .into(),
+        ));
+    }
+    warn!(
+        "[security.rate_limiting] trust_proxy_headers = true but trusted_proxy_cidrs is empty. \
+         Any client can spoof X-Forwarded-For and bypass per-IP rate limits. Allowed only \
+         because FRAISEQL_ENV=development; set trusted_proxy_cidrs to your proxy ranges (e.g. \
+         [\"10.0.0.0/8\"]), or [\"0.0.0.0/0\"] to keep trusting every proxy explicitly."
+    );
+    Ok(())
 }
 
 // ── Observer transport selection (#350) ──────────────────────────────────────

--- a/crates/fraiseql-server/src/server/tests.rs
+++ b/crates/fraiseql-server/src/server/tests.rs
@@ -263,42 +263,53 @@ mod initialization_tests {
         assert!(failed_login_lockout_check(5, 60, false).is_ok());
     }
 
-    // #609: trusting X-Forwarded-For from all proxies (empty CIDR list) warns with a
-    // 2.14 refuse-to-boot deprecation notice (#618); an explicit ["0.0.0.0/0"] opt-in
-    // does not warn.
-    use super::super::initialization::proxy_trust_startup_warning;
+    // #618: trusting X-Forwarded-For from all proxies (empty CIDR list) now REFUSES to
+    // boot in production and downgrades to a warning in development — the 2.13 deprecation
+    // (#609) promised this. An explicit ["0.0.0.0/0"] opt-in is safe (non-empty list).
+    use super::super::initialization::proxy_trust_check;
 
     #[test]
-    fn proxy_trust_all_by_omission_warns_with_deprecation() {
-        let msg = proxy_trust_startup_warning(true, None)
-            .expect("trust_proxy_headers = true with no CIDRs must warn");
-        assert!(msg.contains("DEPRECATED"), "carries the deprecation notice: {msg}");
-        assert!(msg.contains("2.14"), "names the refuse-to-boot version: {msg}");
-        assert!(msg.contains("#618"), "links the follow-up issue: {msg}");
+    fn proxy_trust_all_by_omission_refuses_boot_in_production() {
+        // trust + no CIDRs (None) → refuse in production, with an actionable message.
+        let err = proxy_trust_check(true, None, true).expect_err("must refuse to boot");
+        let msg = format!("{err}");
+        assert!(msg.contains("trusted_proxy_cidrs"), "names the fix: {msg}");
+        assert!(msg.contains("0.0.0.0/0"), "names the explicit trust-all opt-in: {msg}");
     }
 
     #[test]
-    fn proxy_trust_empty_list_warns() {
-        assert!(proxy_trust_startup_warning(true, Some(&[])).is_some());
+    fn proxy_trust_empty_list_refuses_boot_in_production() {
+        // An explicitly empty list is the same permissive posture as omission.
+        assert!(proxy_trust_check(true, Some(&[]), true).is_err());
     }
 
     #[test]
-    fn proxy_trust_explicit_trust_all_does_not_warn() {
-        // ["0.0.0.0/0"] is the sanctioned explicit opt-in — a deliberate, non-empty
-        // list, so the deprecation warning must not fire.
+    fn proxy_trust_all_by_omission_is_a_warning_in_development() {
+        // Development downgrades to a warning (boot proceeds), matching failed_login.
+        assert!(proxy_trust_check(true, None, false).is_ok());
+        assert!(proxy_trust_check(true, Some(&[]), false).is_ok());
+    }
+
+    #[test]
+    fn proxy_trust_explicit_trust_all_is_ok_even_in_production() {
+        // ["0.0.0.0/0"] is the sanctioned explicit opt-in — a deliberate, non-empty list,
+        // so it neither errors nor warns, in production or development.
         let cidrs = vec!["0.0.0.0/0".to_string()];
-        assert!(proxy_trust_startup_warning(true, Some(&cidrs)).is_none());
+        assert!(proxy_trust_check(true, Some(&cidrs), true).is_ok());
+        assert!(proxy_trust_check(true, Some(&cidrs), false).is_ok());
     }
 
     #[test]
-    fn proxy_trust_restricted_cidrs_do_not_warn() {
+    fn proxy_trust_restricted_cidrs_are_ok_in_production() {
         let cidrs = vec!["10.0.0.0/8".to_string()];
-        assert!(proxy_trust_startup_warning(true, Some(&cidrs)).is_none());
+        assert!(proxy_trust_check(true, Some(&cidrs), true).is_ok());
     }
 
     #[test]
-    fn proxy_trust_disabled_does_not_warn() {
-        assert!(proxy_trust_startup_warning(false, None).is_none());
+    fn proxy_trust_disabled_is_ok() {
+        // trust_proxy_headers = false → the CIDR list is irrelevant; never errors/warns.
+        assert!(proxy_trust_check(false, None, true).is_ok());
+        assert!(proxy_trust_check(false, None, false).is_ok());
     }
 
     // #350: a configured non-Postgres observer transport that cannot run must fail


### PR DESCRIPTION
Closes #618. **2.14 train — Phase 01.**

## What & why

The 2.13 deprecation warning (#609) promised that, in 2.14, `[security.rate_limiting] trust_proxy_headers = true` with an empty/omitted `trusted_proxy_cidrs` would **refuse to boot**. This delivers that. Trusting `X-Forwarded-For` from every direct peer lets any client spoof its IP and bypass per-IP rate limiting (and poison IP-derived logging).

## Change

`proxy_trust_startup_warning(...) -> Option<&str>` becomes `proxy_trust_check(trust, cidrs, is_production) -> crate::Result<()>`, mirroring the `failed_login_lockout_check` precedent exactly:

- **production** + `trust=true` + empty/omitted cidrs → `ServerError::ConfigError` (refuse to boot), with an actionable message.
- **development** (`FRAISEQL_ENV=development`) → downgrade to a warning; boot proceeds.
- **safe** (trust off, or a non-empty list including the explicit `["0.0.0.0/0"]` trust-all opt-in) → `Ok(())`, no warning.

Wired into `rate_limiter_from_schema` with `?` (the call site already `?`-propagates the sibling `failed_login_lockout_check`). Single call site; `pub(super)` fn with no other callers.

### Breaking

Operators who genuinely want trust-all keep it working by writing `trusted_proxy_cidrs = ["0.0.0.0/0"]` explicitly — only the omission/empty case changes (warn → refuse in production). Documented in CHANGELOG `### Breaking`.

## Verification
- ✅ `cargo +nightly fmt --check`, `clippy --all-targets --all-features -Dwarnings`, `RUSTDOCFLAGS=-Dwarnings cargo doc` — all clean.
- ✅ `cargo test -p fraiseql-server --lib` — **1236 pass**, incl. 6 rewritten `proxy_trust_*` tests (prod refuses for `None` + empty list; dev warns; explicit `0.0.0.0/0` ok in prod+dev; restricted cidrs ok; disabled ok).
- ✅ No boot test regressed — default `trust_proxy_headers` is `false`, so only the explicit unsafe config refuses.

Baseline was pinned in Phase 00 (#657) via the existing `proxy_trust_*` tests, which this PR rewrites to the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)