### PR TITLE
feat(cli): cascade id-error names the derivation signal + reference path (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (unchanged, never warns). Development (`FRAISEQL_ENV=development`) downgrades the refusal
   to a warning, matching the `failed_login_*` production/development split.
 
+### Changed
+
+- **The cascade `id: ID!` error now names *why* a type was classified an entity and *how* a
+  mutation reaches it (#653).** When a `cascade = true` mutation drags in a type that lacks
+  `id: ID!`, the error previously stated only the failed assertion — and its two suggested
+  fixes ("add `id`" / "remove `cascade`") were both wrong for an embedded value object the
+  SDK gave a synthesized `sql_source`. It now reports the classification signal (`declares
+  sql_source = "v_money"; an embedded value object … should declare no source`) and the
+  reference path (`createOrder → Order.total → Money`), pointing at the real fix. Purely a
+  diagnostic change — which schemas compile is unchanged.
+
 ## [2.13.1] - 2026-07-18
 
 ### Changed

--- a/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
@@ -32,7 +32,7 @@
 //! alone) and inert unless a mutation opts in — so a schema with no cascade
 //! mutations is byte-identical to one compiled before this pass existed.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use fraiseql_core::schema::{
     CompiledSchema, EnumDefinition, EnumValueDefinition, FieldDefinition, FieldDenyPolicy,
@@ -80,11 +80,17 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) -> anyhow::R
     // CascadeNode`: an entity that cannot back `id: ID!` would otherwise yield a
     // compiled schema that `validate()` rejects with a swallowed "missing field
     // 'id'". Fail fast with one aggregated, actionable error instead.
+    // Reference path a cascade mutation reaches each type through (#653 proposal 4),
+    // computed up front so its immutable borrow ends before the annotate closure below
+    // captures the owned map.
+    let reference_paths = build_reference_paths(schema);
+
     super::interface_conformance::enforce_node_id_conformance(
         schema.types.iter().filter(|t| is_queryable_entity(t)),
         "cascade requires `id: ID!` on every cascade entity (the graphql-cascade CascadeNode \
          interface requires it)",
         "remove `cascade` from the mutations that return them",
+        |ty| annotate_cascade_offender(ty, &reference_paths),
     )?;
 
     let existing_type_names: HashSet<String> =
@@ -169,6 +175,72 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) -> anyhow::R
 /// relay connection/edge wrappers.
 fn is_queryable_entity(ty: &TypeDefinition) -> bool {
     !ty.is_error && !ty.sql_source.as_str().is_empty()
+}
+
+/// Explain (#653) why a type that failed the `id: ID!` contract was classified a cascade
+/// entity, and how a cascade mutation reaches it. Returns `None` when there is nothing to
+/// add. The signal (its declared `sql_source`) is only surfaced for a type with **no**
+/// `id` — a missing-id type is most likely an embedded value object the SDK gave a
+/// synthesized source; a type with a wrong-typed `id` is a genuine entity, where the
+/// source is not the issue.
+fn annotate_cascade_offender(
+    ty: &TypeDefinition,
+    reference_paths: &HashMap<String, String>,
+) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    let has_id = ty.fields.iter().any(|f| f.name == "id");
+    if !has_id && !ty.sql_source.as_str().is_empty() {
+        parts.push(format!(
+            "classified as a cascade entity because it declares sql_source = \"{}\"; an \
+             embedded value object has no independent identity and should declare no source",
+            ty.sql_source.as_str()
+        ));
+    }
+    if let Some(path) = reference_paths.get(ty.name.as_str()) {
+        parts.push(format!("reached via {path}"));
+    }
+    (!parts.is_empty()).then(|| parts.join("\n      "))
+}
+
+/// For each cascade mutation, walk its return type's object graph (breadth-first) and
+/// record the first — shortest — path that reaches each type, e.g.
+/// `createOrder → Order.total → Money` (#653 proposal 4). A type not reachable from any
+/// cascade mutation gets no entry (it is a top-level entity, legitimately identity-bearing).
+fn build_reference_paths(schema: &CompiledSchema) -> HashMap<String, String> {
+    let type_by_name: HashMap<&str, &TypeDefinition> =
+        schema.types.iter().map(|t| (t.name.as_str(), t)).collect();
+    let mut paths: HashMap<String, String> = HashMap::new();
+    for m in schema.mutations.iter().filter(|m| m.cascade) {
+        let root = m.return_type.as_str();
+        let mut seen: HashSet<String> = HashSet::from([root.to_string()]);
+        let mut queue: VecDeque<(String, String)> =
+            VecDeque::from([(root.to_string(), format!("{} → {root}", m.name))]);
+        while let Some((tname, path)) = queue.pop_front() {
+            paths.entry(tname.clone()).or_insert(path.clone());
+            let Some(ty) = type_by_name.get(tname.as_str()) else {
+                continue;
+            };
+            for f in &ty.fields {
+                if let Some(child) = object_type_name(&f.field_type) {
+                    if seen.insert(child.to_string()) {
+                        queue
+                            .push_back((child.to_string(), format!("{path}.{} → {child}", f.name)));
+                    }
+                }
+            }
+        }
+    }
+    paths
+}
+
+/// The named object type a field ultimately refers to, unwrapping `List` wrappers.
+/// Scalars, enums, interfaces, and JSON return `None`.
+fn object_type_name(field_type: &FieldType) -> Option<&str> {
+    match field_type {
+        FieldType::Object(name) => Some(name.as_str()),
+        FieldType::List(inner) => object_type_name(inner),
+        _ => None,
+    }
 }
 
 /// `createUser` → `CreateUserPayload`. Uppercases the first character (mutation

--- a/crates/fraiseql-cli/src/schema/converter/interface_conformance.rs
+++ b/crates/fraiseql-cli/src/schema/converter/interface_conformance.rs
@@ -38,19 +38,32 @@ fn id_defect(ty: &TypeDefinition) -> Option<IdDefect> {
 /// Node-style interface (`id: ID!`).
 ///
 /// `lead` is the opening sentence (names the feature + the interface contract);
-/// `remedy` completes the `Fix:` line's "or …" clause. Entities are reported in
-/// iteration order so the message is deterministic. Returns `Ok(())` when every
-/// entity conforms.
+/// `remedy` completes the `Fix:` line's "or …" clause. `annotate` supplies an optional
+/// per-offender note appended under its line — the caller uses it to explain *why* the
+/// type was classified an entity and *how* it was reached (#653). Entities are reported
+/// in iteration order so the message is deterministic. Returns `Ok(())` when every entity
+/// conforms.
 pub(super) fn enforce_node_id_conformance<'a>(
     entities: impl Iterator<Item = &'a TypeDefinition>,
     lead: &str,
     remedy: &str,
+    annotate: impl Fn(&TypeDefinition) -> Option<String>,
 ) -> anyhow::Result<()> {
     let offenders: Vec<String> = entities
-        .filter_map(|ty| id_defect(ty).map(|defect| (ty.name.to_string(), defect)))
-        .map(|(name, defect)| match defect {
-            IdDefect::WrongType(actual) => format!("  - Type '{name}': `id` is {actual}, not ID"),
-            IdDefect::Missing => format!("  - Type '{name}': no `id` field"),
+        .filter_map(|ty| id_defect(ty).map(|defect| (ty, defect)))
+        .map(|(ty, defect)| {
+            let name = ty.name.to_string();
+            let mut line = match defect {
+                IdDefect::WrongType(actual) => {
+                    format!("  - Type '{name}': `id` is {actual}, not ID")
+                },
+                IdDefect::Missing => format!("  - Type '{name}': no `id` field"),
+            };
+            if let Some(note) = annotate(ty) {
+                line.push_str("\n      ");
+                line.push_str(&note);
+            }
+            line
         })
         .collect();
 

--- a/crates/fraiseql-cli/src/schema/converter/relay.rs
+++ b/crates/fraiseql-cli/src/schema/converter/relay.rs
@@ -30,6 +30,9 @@ pub(super) fn inject_relay_types(schema: &mut CompiledSchema) -> anyhow::Result<
         schema.types.iter().filter(|t| t.relay),
         "relay = true requires `id: ID!` on every Relay type (the Relay Node interface requires it)",
         "remove `relay = true` from them",
+        // Relay types are classified by the `relay` flag, not `sql_source`, and are not
+        // pulled in via a mutation cascade — so no derivation/path annotation applies.
+        |_| None,
     )?;
 
     // --- Node interface (inject once if not already present) ---

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2192,16 +2192,15 @@ mod tenancy_tests {
         assert!(msg.contains("Fix:"), "offers a remedy: {msg}");
     }
 
-    /// Phase-00 baseline pin for the 2.14 train (#653). An embedded value object
-    /// (`Money`) that the Python SDK gave a synthesized `sql_source` (`v_money`, a view
-    /// that does not exist) is flagged as a cascade entity purely because
-    /// `is_queryable_entity` keys off `!sql_source.is_empty()`. Today the error names
-    /// only the failed assertion ("no `id` field"); it does NOT say (3) *why* the type
-    /// was classified an entity (its `sql_source` signal) nor (4) the reference path that
-    /// pulled it in. Phase 02 adds both — this test flips RED then, making the diagnostic
-    /// improvement a deliberate, visible change rather than a silent one.
+    /// #653 (2.14 Phase 02). An embedded value object (`Money`) that the Python SDK gave a
+    /// synthesized `sql_source` (`v_money`, a view that does not exist) is flagged as a
+    /// cascade entity purely because `is_queryable_entity` keys off `!sql_source.is_empty()`.
+    /// The error now names (3) *why* the type was classified an entity — its `sql_source`
+    /// signal — and (4) the reference path a cascade mutation reaches it by, so the author
+    /// sees the real fix ("Money should not declare a source") instead of the two wrong ones.
+    /// (This was the Phase 00 baseline pin, flipped from "omits" to "reports".)
     #[test]
-    fn cascade_embedded_value_object_error_omits_derivation_and_path_today() {
+    fn cascade_embedded_value_object_error_reports_derivation_and_path() {
         use crate::schema::SchemaConverter;
         // Order is genuinely view-backed and identity-bearing — it must NOT be flagged.
         let order = IntermediateType {
@@ -2224,20 +2223,42 @@ mod tenancy_tests {
             make_schema(vec![order, money], vec![], vec![cascade_mut("createOrder", "Order")]);
         let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
 
-        // Current behavior, locked: the embedded type is flagged with the bare assertion.
         assert!(msg.contains("Money"), "names the flagged type: {msg}");
         assert!(msg.contains("no `id` field"), "states the failed assertion: {msg}");
+        // #653(3): the message names the classification signal (its declared sql_source).
+        assert!(
+            msg.contains("sql_source") && msg.contains("v_money"),
+            "#653(3): names the classification signal: {msg}"
+        );
+        // #653(4): the message names the reference path a cascade mutation reaches it by.
+        assert!(
+            msg.contains("createOrder → Order.total → Money"),
+            "#653(4): names the reference path: {msg}"
+        );
+    }
 
-        // Baseline GAPS that Phase 02 (#653 proposals 3 & 4) will close. Asserted ABSENT so
-        // the pin turns RED-by-design when the richer message lands:
-        assert!(
-            !msg.contains("sql_source") && !msg.contains("v_money"),
-            "#653(3): message does not yet name the classification signal (sql_source): {msg}"
-        );
-        assert!(
-            !msg.contains("createOrder") && !msg.contains('→'),
-            "#653(4): message does not yet name the reference path: {msg}"
-        );
+    /// #653(4): a flagged queryable entity that no cascade mutation reaches gets the
+    /// `sql_source` signal but NO "reached via" line — it is a top-level entity, not one
+    /// dragged in by a cascade, so there is no path to name.
+    #[test]
+    fn cascade_flagged_entity_unreachable_from_a_mutation_has_no_reference_path() {
+        use crate::schema::SchemaConverter;
+        let order = IntermediateType {
+            sql_source: Some("v_order".to_string()),
+            ..make_type("Order", vec![make_field("id", "UUID")])
+        };
+        // Widget is view-backed but has no `id` and is not reachable from `createOrder`.
+        let widget = IntermediateType {
+            sql_source: Some("v_widget".to_string()),
+            ..make_type("Widget", vec![make_field("label", "String")])
+        };
+        let schema =
+            make_schema(vec![order, widget], vec![], vec![cascade_mut("createOrder", "Order")]);
+        let msg = format!("{:#}", SchemaConverter::convert(schema).unwrap_err());
+
+        assert!(msg.contains("Widget") && msg.contains("no `id` field"), "{msg}");
+        assert!(msg.contains("v_widget"), "#653(3): signal present even off the cascade: {msg}");
+        assert!(!msg.contains("reached via"), "#653(4): no path for an unreachable type: {msg}");
     }
 
     /// An `id: Int` (a serial pk exposed directly — not the Trinity external id) is
@@ -2257,6 +2278,12 @@ mod tenancy_tests {
             "names type + actual id type: {msg}"
         );
         assert!(msg.contains("id: ID!") && msg.contains("Fix:"), "{msg}");
+        // #653(3): a wrong-typed `id` is a genuine entity, not a misclassified value
+        // object — it must NOT get the "declare no source" hint (that guard is `has_id`).
+        assert!(
+            !msg.contains("embedded value object"),
+            "wrong-typed id is a real entity, not a value object: {msg}"
+        );
     }
 
     /// One error lists *every* offender, so a developer fixes them in one pass


### PR DESCRIPTION
**2.14 train — Phase 02.** Implements #653 proposals **(3)** and **(4)** — both non-breaking. The cascade `id: ID!` error stops pointing at two wrong fixes and names the real one.

## The problem

`is_queryable_entity = !is_error && !sql_source.is_empty()` is sound, but its input isn't: the Python SDK synthesizes `sql_source = "v_<snake>"` for *every* `@fraiseql.type`, so an embedded value object (`Money`) claims a backing view (`v_money`) that doesn't exist and gets flagged as a cascade entity. On one real schema, **10 of 11** flagged types were phantom — ~91% noise — and the error's two suggestions ("add `id`" / "remove `cascade`") were both wrong.

## The fix (diagnostics only — which schemas compile is unchanged)

- **(3) derivation signal.** For a missing-`id` type, the error now names *why* it was classified an entity: `declares sql_source = "v_money"; an embedded value object … should declare no source`. Guarded by `has_id`, so a *wrong-typed* `id` (a genuine entity) does **not** get the value-object hint.
- **(4) reference path.** `build_reference_paths` BFS-walks each cascade mutation's return-type object graph and records the shortest path to each type: `createOrder → Order.total → Money`. A type unreachable from any cascade mutation gets no path line.

Mechanically: `enforce_node_id_conformance` (shared with the relay `Node` check) gains an `annotate` closure; relay passes a no-op, cascade supplies the signal + path.

## Tests
- The Phase 00 pin (#657) is **flipped** from asserting the message *omits* the signal/path to asserting it *reports* them (incl. the exact `createOrder → Order.total → Money`).
- New: a flagged entity unreachable from a mutation has the signal but **no** path line; a wrong-typed `id` does **not** get the value-object hint.

## Verification
- ✅ `cargo +nightly fmt --check`, `clippy --all-targets --all-features -Dwarnings`, `RUSTDOCFLAGS=-Dwarnings cargo doc` — clean.
- ✅ `cargo test -p fraiseql-cli --lib` — **665 pass**, no regression in existing cascade/relay tests.

Next: Phase 03 (#653 proposal 2 — warn-grade phantom-source validation under `--database`), which shares this converter area and builds on this message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)