### PR TITLE
feat(cli): warn on phantom @fraiseql.type sql_source under --database (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sql_source = "v_money"; an embedded value object … should declare no source`) and the
   reference path (`createOrder → Order.total → Money`), pointing at the real fix. Purely a
   diagnostic change — which schemas compile is unchanged.
+- **`compile --database` now warns when a `@fraiseql.type` declares a `sql_source` view that
+  is absent from the connected database (#653).** These phantom sources — usually an
+  embedded value object the SDK synthesized a `v_<name>` source for — were invisible to
+  every existing check (type sources are not on the shared existence-probe work-list that
+  the hard `FRAISEQL_VALIDATE_SQL_SOURCES` gate uses). The warning surfaces them at their
+  origin instead of later as an unrelated cascade `id` error. Warn-grade and non-breaking:
+  it never fails the compile, and the opt-in hard gate is unchanged (it still does not probe
+  type sources, to avoid drowning in synthesized-source noise until they stop being
+  synthesized).
 
 ## [2.13.1] - 2026-07-18
 

--- a/crates/fraiseql-cli/src/schema/database_validator.rs
+++ b/crates/fraiseql-cli/src/schema/database_validator.rs
@@ -56,6 +56,19 @@ pub enum DatabaseWarning {
         /// The `sql_source` function that was not found.
         sql_source:    String,
     },
+    /// L1: a `@fraiseql.type`'s declared `sql_source` view does not exist (#653).
+    ///
+    /// Most often an embedded value object the SDK gave a synthesized `v_<name>` source by
+    /// naming convention (a view that was never authored). Advisory only — it never fails
+    /// the compile; the hard `FRAISEQL_VALIDATE_SQL_SOURCES` gate deliberately does **not**
+    /// probe type sources (it would drown in synthesized-source noise), so this warn-grade
+    /// path under `--database` is the only place phantom type sources surface.
+    MissingTypeSource {
+        /// Name of the type.
+        type_name:  String,
+        /// The `sql_source` view that was not found.
+        sql_source: String,
+    },
     /// L1: `additional_view` does not exist.
     MissingAdditionalView {
         /// Name of the query.
@@ -157,6 +170,18 @@ impl fmt::Display for DatabaseWarning {
                 write!(
                     f,
                     "mutation `{mutation_name}`: sql_source function `{sql_source}` does not exist in database"
+                )
+            },
+            Self::MissingTypeSource {
+                type_name,
+                sql_source,
+            } => {
+                write!(
+                    f,
+                    "type `{type_name}`: sql_source `{sql_source}` does not exist in the \
+                     database — if `{type_name}` is an embedded value object it should declare \
+                     no source (a value object has no independent identity; it is fetched via \
+                     its parent)"
                 )
             },
             Self::MissingAdditionalView {
@@ -556,6 +581,27 @@ pub async fn validate_schema_against_database(
                     sql_source:    source.clone(),
                 });
             }
+        }
+    }
+
+    // Validate type sources (L1 only, warn-grade). A `@fraiseql.type`'s `sql_source` is a
+    // view/table; a declared source that does not exist is usually an embedded value object
+    // the SDK synthesized a source for (#653). Surface it at its origin — never failing —
+    // instead of letting it resurface later as an unrelated cascade `id` error. Unlike
+    // queries/mutations, type sources are not on the shared `sql_source_probes` work-list,
+    // so the hard `FRAISEQL_VALIDATE_SQL_SOURCES` gate does not flag them; this is the only
+    // check that does. Synthetic types (empty source) and error types are skipped — this is
+    // exactly the `is_queryable_entity` set the cascade pass keys off.
+    for ty in &schema.types {
+        let source = ty.sql_source.as_str();
+        if ty.is_error || source.is_empty() {
+            continue;
+        }
+        if !relation_source_exists(introspector, &schema_qualified, &unqualified, source).await? {
+            warnings.push(DatabaseWarning::MissingTypeSource {
+                type_name:  ty.name.to_string(),
+                sql_source: source.to_string(),
+            });
         }
     }
 

--- a/crates/fraiseql-cli/src/schema/tests.rs
+++ b/crates/fraiseql-cli/src/schema/tests.rs
@@ -245,6 +245,57 @@ mod database_validator_tests {
         );
     }
 
+    // #653 (2.14 Phase 03): a `@fraiseql.type`'s declared `sql_source` view that is absent
+    // from the DB warns (warn-grade, never fails) under `compile --database`. Synthesized
+    // types (empty source) are skipped. The hard `FRAISEQL_VALIDATE_SQL_SOURCES` gate does
+    // not probe type sources; this is the only check that surfaces phantom type sources.
+    #[tokio::test]
+    async fn missing_type_source_warns_and_skips_synthetic_types() {
+        let introspector = MockIntrospector::new(DatabaseType::PostgreSQL).with_relation(
+            "public",
+            "v_order",
+            fraiseql_core::db::RelationKind::View,
+        );
+
+        // Order is view-backed and its view exists → no warning.
+        let order = TypeDefinition {
+            sql_source: "v_order".into(),
+            ..make_type("Order", vec![("id", FieldType::Id)])
+        };
+        // Money is an embedded value object the SDK synthesized `v_money` for → one warning.
+        let money = TypeDefinition {
+            sql_source: "v_money".into(),
+            ..make_type("Money", vec![("amount", FieldType::Int)])
+        };
+        // A synthesized cascade payload (empty sql_source) must be skipped, not warned about.
+        let synthetic =
+            make_type("CreateOrderPayload", vec![("entity", FieldType::Object("Order".into()))]);
+
+        let schema = make_schema(vec![order, money, synthetic], vec![]);
+        let report = validate_schema_against_database(&schema, &introspector).await.unwrap();
+
+        let type_warnings: Vec<_> = report
+            .warnings
+            .iter()
+            .filter(|w| matches!(w, DatabaseWarning::MissingTypeSource { .. }))
+            .collect();
+        assert_eq!(
+            type_warnings.len(),
+            1,
+            "only the phantom type source warns: {:?}",
+            report.warnings
+        );
+        assert!(
+            matches!(&type_warnings[0], DatabaseWarning::MissingTypeSource { type_name, sql_source }
+                if type_name == "Money" && sql_source == "v_money")
+        );
+        assert!(
+            type_warnings[0].to_string().contains("embedded value object"),
+            "message points at the real fix: {}",
+            type_warnings[0]
+        );
+    }
+
     #[tokio::test]
     async fn test_missing_additional_view() {
         let introspector = MockIntrospector::new(DatabaseType::PostgreSQL)


### PR DESCRIPTION
**2.14 train — Phase 03.** Implements #653 proposal **(2)** — warn-grade, per the reviewed decision.

## What & why

The Python SDK synthesizes `sql_source = "v_<snake>"` for *every* `@fraiseql.type`, so embedded value objects claim backing views that don't exist. These phantom **type** sources were invisible to *every* existing check — `sql_source_probes` (the shared work-list the hard `FRAISEQL_VALIDATE_SQL_SOURCES` gate uses) enumerates only queries and mutations, not types.

`compile --database` now checks each type's declared `sql_source` view exists and emits a `MissingTypeSource` warning for absent ones, surfacing the phantom at its origin instead of later as an unrelated cascade `id` error.

## Design (matches gate #2 decision)

- **Warn-grade / non-breaking** — never fails the compile; flows through the existing `validate_schema_against_database` → `warn!` loop (no `compile.rs` change). Reuses the same `relation_source_exists` resolution as the query check.
- **Hard gate untouched** — type sources are *not* added to `sql_source_probes`, so `FRAISEQL_VALIDATE_SQL_SOURCES` / `validate --against-db` stay clean of synthesized-source noise (until proposal 1 stops the synthesis).
- Error types and synthetic (empty-source) types are skipped — exactly the `is_queryable_entity` set.

**Cycle 2 (DB-enriching the cascade error) intentionally dropped:** the cascade `id` check runs during DB-agnostic `convert` and bails *before* `--database` validation, so threading a DB connection into `convert` would be disproportionate. Phase 02's signal (names the `sql_source`) and this warning (confirms it's phantom) are complementary.

## Verification
- ✅ fmt / `clippy --all-targets --all-features -Dwarnings` / rustdoc — clean.
- ✅ `cargo test -p fraiseql-cli --lib` — **666 pass**, incl. a `MockIntrospector` unit test (phantom warns; existing source doesn't; synthetic skipped; message names "embedded value object").

🤖 Generated with [Claude Code](https://claude.com/claude-code)