### PR TITLE
feat(cli): `fraiseql setup` installs the change-log contract (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type sources, to avoid drowning in synthesized-source noise until they stop being
   synthesized).
 
+### Fixed
+
+- **`fraiseql setup` now installs the `core.tb_entity_change_log` change-log contract, so the
+  first mutation on a freshly authored stack no longer fails at prepare time (#569).** Every
+  default (`changelog = true`) mutation writes this table via its transactional-outbox CTE;
+  previously it shipped only as an observers migration that no documented authoring step
+  applied, so a stack built the documented way (`export_schema` → `compile` → DDL →
+  `fraiseql-server`) failed on its first mutation with `relation "core.tb_entity_change_log"
+  does not exist`. `setup` now applies the contract's idempotent DDL (vendored byte-for-byte
+  from observers migration 08, guarded by a drift test), and `fraiseql doctor --against-db`
+  points at `fraiseql setup` when the table is missing. Row-Level Security (migration 12)
+  remains a separate operator step, and `RETURNS SETOF v_*` mutation functions remain
+  unsupported — both documented in `docs/architecture/change-log-contract.md`.
+
 ## [2.13.1] - 2026-07-18
 
 ### Changed

--- a/crates/fraiseql-cli/sql/helpers/entity_change_log_contract.sql
+++ b/crates/fraiseql-cli/sql/helpers/entity_change_log_contract.sql
@@ -1,0 +1,256 @@
+-- FraiseQL Change-Log Contract — core.tb_entity_change_log
+-- ============================================================================
+-- The framework-owned, superset-column definition of the entity change-log
+-- table: the first step of the "Change Spine" (an app-mediated transactional
+-- outbox the mutation executor writes in-txn; see
+-- docs/architecture/change-log-contract.md).
+--
+-- This migration OWNS the table contract. It supersedes the best-effort
+-- `core.v_entity_change_log` view that 07_create_changelog_views.sql used to
+-- create (07 now ships only the transport-checkpoint view + upsert fn).
+--
+-- It is **purely additive and idempotent**:
+--   - CREATE TABLE IF NOT EXISTS installs the NOT-NULL backbone for a fresh DB.
+--   - ALTER ... ADD COLUMN IF NOT EXISTS brings a pre-existing (app-created /
+--     older-framework) table up to the contract — every added column is
+--     nullable or defaulted, so it is safe on a populated table.
+--   - It never drops or renames an existing column. In particular `tenant_id`
+--     (the per-tenant partition key) is ADDED alongside `fk_customer_org` (the
+--     internal join FK) — the two are complementary under the Trinity pattern,
+--     NOT a rename.
+--
+-- Tenant isolation is enforced by migration 12 (`12_enable_change_log_rls.sql`,
+-- audit #437 F6 / #443): it turns on Row-Level Security so this table reads
+-- fail-closed (deny-by-default) for any role that is not the owner / `BYPASSRLS` /
+-- has not set the `fraiseql.tenant_id` GUC. The trusted cross-tenant consumers
+-- (poller, NATS bridges, server handlers, executor) must run as `BYPASSRLS`/owner.
+--
+-- PostgreSQL DDL. MySQL / SQL Server variants are 09_*/10_* (mirroring
+-- migrations 04_*/05_*). The view is the portable read surface.
+
+CREATE SCHEMA IF NOT EXISTS core;
+
+-- ----------------------------------------------------------------------------
+-- Backbone (NOT NULL, no default) — created only on a fresh table. Every
+-- pre-existing change-log table inherently carries object_type/modification_type,
+-- so CREATE IF NOT EXISTS no-ops and we never add a no-default NOT NULL column
+-- to live rows.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS core.tb_entity_change_log (
+    pk_entity_change_log BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    object_type          TEXT NOT NULL,
+    modification_type    TEXT NOT NULL
+);
+
+-- ----------------------------------------------------------------------------
+-- Contract columns (nullable, or NOT NULL with a safe default) — additive
+-- reconcile path. Native ADD COLUMN IF NOT EXISTS makes each statement
+-- idempotent and safe on a table with live rows: id/created_at backfill from
+-- their defaults, every other column is nullable.
+-- ----------------------------------------------------------------------------
+ALTER TABLE core.tb_entity_change_log
+    -- Defaulted backbone (backfills on a pre-existing table that lacks them).
+    ADD COLUMN IF NOT EXISTS id                 UUID        NOT NULL DEFAULT gen_random_uuid(),
+    ADD COLUMN IF NOT EXISTS created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Spine envelope: the per-tenant partition key + RLS partition key (enforced
+    -- by migration 12), the Trinity public-facing identifier (UUID), complementary
+    -- to the internal join FK fk_customer_org (BIGINT). Stamped explicitly from
+    -- SecurityContext.tenant_id at write time.
+    ADD COLUMN IF NOT EXISTS tenant_id          UUID,
+    -- Internal join FKs (Trinity fk_{entity}) — existing observer schema, kept.
+    ADD COLUMN IF NOT EXISTS fk_customer_org    BIGINT,
+    ADD COLUMN IF NOT EXISTS fk_contact         BIGINT,
+    -- Changed-entity identity + payload.
+    ADD COLUMN IF NOT EXISTS object_id          UUID,
+    ADD COLUMN IF NOT EXISTS object_data        JSONB,
+    -- Opt-in pre-image (changelog_pre_image): the changed entity's BEFORE-state,
+    -- recorded only by mutations/tables that opt in (NULL otherwise). object_data
+    -- stays the AFTER-image from EVERY producer (executor outbox AND #366 capture
+    -- trigger); the pre-image lives in this separate column, never as a
+    -- {before,after} envelope inside object_data. A Debezium event is the
+    -- core.v_entity_change_log_debezium projection below, not a stored shape.
+    ADD COLUMN IF NOT EXISTS object_data_before JSONB,
+    ADD COLUMN IF NOT EXISTS updated_fields     TEXT[],
+    ADD COLUMN IF NOT EXISTS cascade            JSONB,
+    -- Perf observability (#392): populated by the executor's in-txn write.
+    ADD COLUMN IF NOT EXISTS duration_ms        INTEGER,
+    ADD COLUMN IF NOT EXISTS started_at         TIMESTAMPTZ,
+    -- Durable ordering / dedup (#382 broker fan-out).
+    ADD COLUMN IF NOT EXISTS commit_time        TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS seq                BIGINT,
+    -- Actor model (#390): the request's actor classification + the delegated
+    -- human a delegated agent acts for. `acting_for` is the Trinity public-facing
+    -- UUID (like tenant_id), so the executor stamps it without a DB lookup.
+    ADD COLUMN IF NOT EXISTS actor_type         TEXT,
+    ADD COLUMN IF NOT EXISTS acting_for         UUID,
+    -- Replay correctness (#377/#378): column now, value when #377 lands.
+    ADD COLUMN IF NOT EXISTS schema_version     TEXT,
+    -- W3C trace context (#375): columns now, values when #375 lands.
+    ADD COLUMN IF NOT EXISTS trace_id           TEXT,
+    ADD COLUMN IF NOT EXISTS trace_context      JSONB,
+    -- Existing reader columns (poller / NATS bridge).
+    ADD COLUMN IF NOT EXISTS change_status      TEXT,
+    ADD COLUMN IF NOT EXISTS extra_metadata     JSONB,
+    ADD COLUMN IF NOT EXISTS nats_published_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS nats_event_id      UUID;
+
+-- ----------------------------------------------------------------------------
+-- Retype `acting_for` BIGINT -> UUID (#390). v2.6.0 shipped this column as
+-- BIGINT (NULL-by-design, no producer), so on a DB that already ran that form
+-- the ADD COLUMN IF NOT EXISTS above is a no-op and leaves it BIGINT. This
+-- guarded ALTER brings it to the contract UUID type. `USING NULL` is the only
+-- valid conversion (int8 -> uuid has no cast) and is LOSSLESS here precisely
+-- because the column has always been NULL — no #390-era row exists yet. Guarded
+-- on udt_name so it is a no-op on a fresh (already-UUID) table and re-run safe.
+-- ----------------------------------------------------------------------------
+DO $$ BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'core'
+          AND table_name = 'tb_entity_change_log'
+          AND column_name = 'acting_for'
+          AND udt_name <> 'uuid'
+    ) THEN
+        ALTER TABLE core.tb_entity_change_log
+            ALTER COLUMN acting_for TYPE UUID USING NULL;
+    END IF;
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- Monotonic `seq` source (Change Spine durable ordering / dedup on
+-- (object_type, seq)). A plain global SEQUENCE defaulted on the column, so ANY
+-- INSERTer gets a value — the FraiseQL executor AND cooperative external
+-- producers writing contract-conforming rows (the seq is not an executor-only
+-- counter). Re-run safe: CREATE SEQUENCE IF NOT EXISTS + idempotent SET DEFAULT.
+-- ----------------------------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS core.seq_entity_change_log;
+ALTER TABLE core.tb_entity_change_log
+    ALTER COLUMN seq SET DEFAULT nextval('core.seq_entity_change_log');
+ALTER SEQUENCE core.seq_entity_change_log OWNED BY core.tb_entity_change_log.seq;
+
+-- ----------------------------------------------------------------------------
+-- Indexes (re-run safe).
+-- ----------------------------------------------------------------------------
+-- Slowest-mutation ordering (#392 perf forensics).
+CREATE INDEX IF NOT EXISTS idx_entity_log_duration
+    ON core.tb_entity_change_log (duration_ms DESC);
+-- Per-object-type scans (perf + reader).
+CREATE INDEX IF NOT EXISTS idx_entity_log_type
+    ON core.tb_entity_change_log (object_type);
+-- Time-range scans.
+CREATE INDEX IF NOT EXISTS idx_entity_log_created
+    ON core.tb_entity_change_log (created_at);
+-- Per-tenant ordered fan-out. Cross-tenant consumers (poller/bridges) read the
+-- whole stream as a BYPASSRLS/owner role; this index also serves the migration-12
+-- per-tenant RLS read policy (tenant_id = the fraiseql.tenant_id GUC).
+CREATE INDEX IF NOT EXISTS idx_entity_log_tenant_seq
+    ON core.tb_entity_change_log (tenant_id, seq);
+-- Per-object-type dedup on (object_type, seq).
+CREATE INDEX IF NOT EXISTS idx_entity_log_type_seq
+    ON core.tb_entity_change_log (object_type, seq);
+
+-- ----------------------------------------------------------------------------
+-- Read-path view (#392 consumes duration_ms; #149 consumes the `data` JSONB).
+-- Superset of the legacy 07 view: keeps every #149 GraphQL `data` key (so the
+-- entity_change_logs query stays stable) and adds the perf/envelope columns as
+-- top-level columns for indexed WHERE/ORDER BY.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE VIEW core.v_entity_change_log AS
+SELECT
+    pk_entity_change_log,
+    object_type,
+    modification_type,
+    object_id,
+    tenant_id,
+    duration_ms,
+    started_at,
+    trace_id,
+    actor_type,
+    acting_for,
+    seq,
+    created_at,
+    jsonb_build_object(
+        'id',                   id,
+        'pk_entity_change_log', pk_entity_change_log,
+        'tenant_id',            tenant_id,
+        'fk_customer_org',      fk_customer_org,
+        'fk_contact',           fk_contact,
+        'object_type',          object_type,
+        'object_id',            object_id,
+        'modification_type',    modification_type,
+        'change_status',        change_status,
+        'object_data',          object_data,
+        'object_data_before',   object_data_before,
+        'updated_fields',       updated_fields,
+        'cascade',              cascade,
+        'duration_ms',          duration_ms,
+        'started_at',           started_at,
+        'actor_type',           actor_type,
+        'acting_for',           acting_for,
+        'extra_metadata',       extra_metadata,
+        'created_at',           created_at
+    ) AS data
+FROM core.tb_entity_change_log;
+
+COMMENT ON TABLE core.tb_entity_change_log IS
+    'FraiseQL change-log contract (Change Spine Tier 0 outbox). Owned by the framework; superset of perf (#392) + envelope columns. Row-Level Security is enabled by migration 12 (#437 F6 / #443): reads are deny-by-default; cross-tenant consumers must run as BYPASSRLS/owner. See docs/architecture/change-log-contract.md.';
+
+COMMENT ON VIEW core.v_entity_change_log IS
+    'Read projection over tb_entity_change_log. Exposes duration_ms + envelope columns top-level (perf #392) and every GraphQL field in the data JSONB (#149). Cursor key: pk_entity_change_log. security_invoker view (PG15+, set below) so it enforces the base-table RLS (migration 12) for the querying role; a trusted cross-tenant operator surface, restrict SELECT to trusted/BYPASSRLS roles.';
+
+-- ----------------------------------------------------------------------------
+-- Debezium projection — a view, NOT a stored shape (changelog_pre_image).
+-- The base table keeps object_data uniformly the after-image and the pre-image
+-- in object_data_before; `op`/`source` are already columns, so the classic
+-- Debezium `{before, after, op, source}` event is a pure projection. Consumers
+-- that want a Debezium-shaped event read this view; the base table never stores
+-- an envelope. `before` is NULL for rows whose producer did not opt into the
+-- pre-image; `after` is NULL for a DELETE (the row has no after-state).
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE VIEW core.v_entity_change_log_debezium AS
+SELECT
+    pk_entity_change_log,
+    seq,
+    object_data_before AS before,
+    object_data        AS after,
+    modification_type  AS op,            -- INSERT / UPDATE / DELETE / CUSTOM
+    jsonb_build_object(
+        'object_type', object_type,
+        'object_id',   object_id,
+        'tenant_id',   tenant_id,
+        'commit_time', commit_time,
+        'seq',         seq,
+        'trace_id',    trace_id,
+        'actor_type',  actor_type
+    ) AS source
+FROM core.tb_entity_change_log;
+
+COMMENT ON VIEW core.v_entity_change_log_debezium IS
+    'Debezium {before, after, op, source} projection over tb_entity_change_log (changelog_pre_image). before = object_data_before, after = object_data (the uniform after-image), op = modification_type. Pure projection — no envelope is stored in the base table. security_invoker view (PG15+, set below) so it enforces the base-table RLS (migration 12); a trusted cross-tenant operator surface.';
+
+-- ----------------------------------------------------------------------------
+-- View RLS-enforcement mode (#437 F6 / #443). A plain PostgreSQL view runs its
+-- underlying query as the view OWNER, so once migration 12 enables RLS on the base
+-- table these views would BYPASS it (reading as the superuser owner → every
+-- tenant). `security_invoker = true` (PostgreSQL 15+) makes a view run as the
+-- QUERYING role, so it honours the base-table policy + that role's
+-- fraiseql.tenant_id GUC. Set here, at the view definition, rather than as a later
+-- ALTER. Guarded on the server version: on < 15 the option does not exist, so the
+-- views stay owner-run and MUST be protected by restricting SELECT on them to
+-- trusted roles (the migration RAISEs a WARNING). Idempotent (SET is re-run safe);
+-- harmless while RLS is still off — security_invoker only changes the privilege
+-- context, which the trusted reader already satisfies.
+DO $$
+BEGIN
+    IF current_setting('server_version_num')::int >= 150000 THEN
+        EXECUTE 'ALTER VIEW core.v_entity_change_log SET (security_invoker = true)';
+        EXECUTE 'ALTER VIEW core.v_entity_change_log_debezium SET (security_invoker = true)';
+    ELSE
+        RAISE WARNING
+            'PostgreSQL % (< 15): change-log views cannot use security_invoker and will '
+            'bypass the base-table RLS once migration 12 enables it. Restrict SELECT on '
+            'core.v_entity_change_log and core.v_entity_change_log_debezium to trusted / '
+            'BYPASSRLS roles.',
+            current_setting('server_version');
+    END IF;
+END $$;

--- a/crates/fraiseql-cli/src/commands/doctor.rs
+++ b/crates/fraiseql-cli/src/commands/doctor.rs
@@ -1298,7 +1298,9 @@ pub(crate) fn changelog_contract_drift(live: &[LiveColumn]) -> Vec<DoctorCheck> 
         return vec![DoctorCheck::warn(
             CHANGELOG_CONTRACT_NAME,
             "core.tb_entity_change_log not found",
-            "Run `fraiseql migrate up` to install the change-log contract",
+            "Run `fraiseql setup` (installs the change-log contract) or `fraiseql migrate up`. \
+             Every default mutation writes this table via its transactional-outbox CTE, so \
+             without it the first mutation fails at prepare time (#569).",
         )];
     }
 

--- a/crates/fraiseql-cli/src/commands/setup/mod.rs
+++ b/crates/fraiseql-cli/src/commands/setup/mod.rs
@@ -22,6 +22,15 @@ const MUTATION_RESPONSE_SQL: &str = include_str!("../../../sql/helpers/mutation_
 /// spec-conformant, RLS-safe cascade.
 const CASCADE_SQL: &str = include_str!("../../../sql/helpers/cascade.sql");
 
+/// The change-log contract table (`core.tb_entity_change_log`) the mutation executor's
+/// transactional-outbox CTE writes in-txn (#569). Vendored **byte-for-byte** from
+/// `crates/fraiseql-observers/migrations/08_create_entity_change_log_contract.sql`, which
+/// owns the contract; the `changelog_contract_matches_observers_migration` test fails if
+/// the two drift. Idempotent DDL (`CREATE TABLE IF NOT EXISTS` + `ALTER … ADD COLUMN IF
+/// NOT EXISTS`), so re-running `setup` is safe.
+const CHANGELOG_CONTRACT_SQL: &str =
+    include_str!("../../../sql/helpers/entity_change_log_contract.sql");
+
 /// Run the setup command to install helpers to a database.
 ///
 /// # Errors
@@ -65,6 +74,8 @@ pub async fn run(
     formatter.progress("  - fraiseql.library_version()");
     formatter.progress("  - fraiseql.mutation_ok(...)");
     formatter.progress("  - fraiseql.mutation_err(...)");
+    formatter.progress("Installed tables:");
+    formatter.progress("  - core.tb_entity_change_log (mutation change-log outbox — #569)");
 
     Ok(())
 }
@@ -75,7 +86,12 @@ fn print_dry_run(db_url: &str, formatter: &OutputFormatter) {
     formatter.progress("");
     formatter.progress(&format!("Database URL: {}", mask_password(db_url)));
     formatter.progress("");
-    formatter.progress("The following SQL will be executed:");
+    formatter.progress("Would install:");
+    formatter.progress("  - fraiseql.mutation_ok/err/library_version helpers");
+    formatter.progress("  - fraiseql.build_cascade cascade builders");
+    formatter.progress("  - core.tb_entity_change_log change-log contract table (#569)");
+    formatter.progress("");
+    formatter.progress("Mutation-helper SQL that will be executed:");
     formatter.progress("");
     formatter.progress(MUTATION_RESPONSE_SQL);
     formatter.progress("");
@@ -145,7 +161,18 @@ async fn apply_helpers(pool: &deadpool_postgres::Pool, formatter: &OutputFormatt
         .await
         .context("Failed to install FraiseQL cascade builders")?;
 
-    formatter.progress("✓ SQL helpers applied");
+    // Install the change-log contract table (#569). The mutation executor wraps every
+    // mutation in a transactional-outbox CTE that writes `core.tb_entity_change_log`, so
+    // without this table the first mutation fails at prepare with a bare
+    // `relation "core.tb_entity_change_log" does not exist`. Idempotent DDL — safe to
+    // re-run. Row-Level Security on the change-log is a separate operator step (observers
+    // migration 12), intentionally not installed here.
+    client
+        .batch_execute(CHANGELOG_CONTRACT_SQL)
+        .await
+        .context("Failed to install FraiseQL change-log contract table")?;
+
+    formatter.progress("✓ SQL helpers + change-log contract applied");
 
     // Verify installation
     let version: String = client

--- a/crates/fraiseql-cli/src/commands/setup/tests.rs
+++ b/crates/fraiseql-cli/src/commands/setup/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code — panics are acceptable
+
 use super::*;
 
 #[test]
@@ -25,4 +27,27 @@ fn mutation_response_sql_content_exists() {
     assert!(MUTATION_RESPONSE_SQL.contains("fraiseql.library_version"));
     assert!(MUTATION_RESPONSE_SQL.contains("fraiseql.mutation_ok"));
     assert!(MUTATION_RESPONSE_SQL.contains("fraiseql.mutation_err"));
+}
+
+#[test]
+fn changelog_contract_sql_content_exists() {
+    // The vendored contract installs the table the mutation outbox writes (#569).
+    assert!(CHANGELOG_CONTRACT_SQL.contains("core.tb_entity_change_log"));
+    assert!(CHANGELOG_CONTRACT_SQL.contains("CREATE TABLE IF NOT EXISTS"));
+}
+
+/// #569 anti-drift guard (mandatory, gate #3). The CLI's vendored change-log contract DDL
+/// must stay **byte-identical** to the observers migration that OWNS the contract. If this
+/// fails, re-copy `crates/fraiseql-observers/migrations/08_create_entity_change_log_contract.sql`
+/// into `crates/fraiseql-cli/sql/helpers/entity_change_log_contract.sql`.
+#[test]
+fn changelog_contract_matches_observers_migration() {
+    let migration_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fraiseql-observers/migrations/08_create_entity_change_log_contract.sql");
+    let migration = std::fs::read_to_string(&migration_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", migration_path.display()));
+    assert_eq!(
+        CHANGELOG_CONTRACT_SQL, migration,
+        "CLI change-log contract DDL drifted from observers migration 08 — re-copy it"
+    );
 }

--- a/crates/fraiseql-cli/src/commands/tests.rs
+++ b/crates/fraiseql-cli/src/commands/tests.rs
@@ -1490,7 +1490,11 @@ mod doctor_tests {
         assert_eq!(checks.len(), 1, "an absent table yields a single warning");
         assert_eq!(checks[0].status, CheckStatus::Warn);
         assert!(checks[0].detail.contains("not found"));
-        assert!(checks[0].hint.as_deref().unwrap().contains("migrate up"));
+        // #569: the remedy points at both install paths — `fraiseql setup` (now installs the
+        // contract) and `fraiseql migrate up` — and explains why the table is required.
+        let hint = checks[0].hint.as_deref().unwrap();
+        assert!(hint.contains("fraiseql setup"), "names the setup install path: {hint}");
+        assert!(hint.contains("migrate up"), "keeps the migrate path: {hint}");
     }
 
     #[test]

--- a/crates/fraiseql-cli/tests/setup_against_db.rs
+++ b/crates/fraiseql-cli/tests/setup_against_db.rs
@@ -70,3 +70,53 @@ async fn setup_installs_dollar_quoted_helpers() {
         .get("succeeded");
     assert!(!err_succeeded, "mutation_err must return succeeded=false");
 }
+
+/// #569: `fraiseql setup` must also install `core.tb_entity_change_log` — the table every
+/// default mutation's transactional-outbox CTE writes. Without it, the first mutation on a
+/// freshly authored stack fails at prepare with a bare
+/// `relation "core.tb_entity_change_log" does not exist`. The contract DDL is idempotent,
+/// so running setup here (which the sibling test also does) is safe to repeat.
+#[tokio::test]
+async fn setup_installs_change_log_contract() {
+    let Some(url) = fraiseql_test_support::try_database_url() else {
+        eprintln!("skipping #569 setup change-log against-db test: DATABASE_URL not set");
+        return;
+    };
+
+    let out = Command::new(env!("CARGO_BIN_EXE_fraiseql-cli"))
+        .args(["setup", "--database", &url])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "fraiseql setup must install the change-log contract; exit={:?}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+
+    // The contract table exists after setup.
+    let present: bool = client
+        .query_one("SELECT to_regclass('core.tb_entity_change_log') IS NOT NULL AS present", &[])
+        .await
+        .unwrap()
+        .get("present");
+    assert!(present, "setup must install core.tb_entity_change_log (#569)");
+
+    // The NOT-NULL backbone columns the outbox CTE relies on are present.
+    let backbone: i64 = client
+        .query_one(
+            "SELECT count(*) AS n FROM information_schema.columns \
+             WHERE table_schema = 'core' AND table_name = 'tb_entity_change_log' \
+               AND column_name IN ('object_type', 'modification_type')",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get("n");
+    assert_eq!(backbone, 2, "the change-log contract backbone columns must be present");
+}

--- a/docs/architecture/change-log-contract.md
+++ b/docs/architecture/change-log-contract.md
@@ -12,6 +12,37 @@ re-migrated for either consumer.
 
 ---
 
+## Installing the contract
+
+The table is a **hard runtime dependency** of every default (`changelog = true`) mutation:
+the executor wraps the mutation function in a transactional-outbox CTE that writes
+`core.tb_entity_change_log`, so **without the table the first mutation fails at prepare
+time** with `relation "core.tb_entity_change_log" does not exist` (#569). Install it via
+either path — both apply the same idempotent DDL:
+
+- **`fraiseql setup --database <url>`** — installs the mutation helpers **and** the
+  change-log contract table. The paved path for a freshly authored stack.
+- **`fraiseql migrate up`** — applies the full observers migration set (including RLS,
+  migration 12) for a complete change-capture deployment.
+
+`fraiseql doctor --against-db <url>` reports the table as missing (with the remedy above)
+and flags contract drift on an existing one.
+
+**Row-Level Security** (`12_enable_change_log_rls.sql`) is **not** installed by `fraiseql
+setup` — it is a separate hardening step for cross-tenant fail-closed reads. Apply it (via
+`fraiseql migrate up`) in a multi-tenant deployment; the trusted consumers must run as
+`BYPASSRLS`/owner.
+
+**Mutation function shape.** The outbox CTE reads the v2.2 `mutation_response` shape
+(`r.entity_type`, `r.succeeded`, `r.state_changed`, …) from the function's result, so a
+`RETURNS SETOF v_*` mutation function is **not supported** — it fails with `column
+r.entity_type does not exist`. Return the `mutation_response` shape (use
+`fraiseql.mutation_ok` / `fraiseql.mutation_err`; see
+[mutation-response.md](mutation-response.md)). To opt a single mutation out of the
+change-log entirely, set `changelog = false` on it.
+
+---
+
 ## Design principles
 
 1. **One owned contract, shipped once.** The superset of perf + envelope columns


### PR DESCRIPTION
**2.14 train — Phase 04.** Closes the worst new-adopter cliff: a stack built the documented way failed on its **first mutation**.

## The problem

Every default (`changelog = true`) mutation is wrapped in a transactional-outbox CTE that writes `core.tb_entity_change_log`. That table shipped **only** as an observers migration that no documented authoring step (`fraiseql setup`, `compile --emit-ddl`, quickstart) applied — so the first mutation failed at prepare with `relation "core.tb_entity_change_log" does not exist`.

## The fix (decision: A + D, with the mandatory anti-drift test)

- **`fraiseql setup` installs the contract table.** Migration 08 is vendored into `crates/fraiseql-cli/sql/helpers/entity_change_log_contract.sql` and applied (idempotent DDL) after the mutation helpers.
- **Anti-drift guard (gate #3, mandatory):** `changelog_contract_matches_observers_migration` asserts the vendored copy is **byte-identical** to observers migration 08 and fails on drift (RED-proven). Cross-crate `include_str!` was rejected — it breaks `cargo publish` (the migration lives outside `fraiseql-cli`) — so vendored-copy + byte-equality is the path the decision allows.
- **`fraiseql doctor --against-db`** already detected the missing table; its remedy now points at `fraiseql setup` and explains why the table is required.
- **Docs:** `change-log-contract.md` gains an "Installing the contract" section — install paths, RLS-is-separate scoping, and the unsupported `RETURNS SETOF v_*` function shape.

## Scope note (RLS)

`setup` installs the contract **table** (migration 08). **Row-Level Security** (migration 12) stays a separate operator step: a fresh DB has no change-log RLS either way, so this is security-neutral, and auto-installing RLS could break the "just works" flow for an unprivileged connecting role. Documented, and re-checked in the finalize security pass.

## Verification

- ✅ fmt / `clippy --all-targets --all-features -Dwarnings` / rustdoc — clean.
- ✅ `cargo test -p fraiseql-cli --lib` — **668 pass** (incl. the drift test).
- ✅ `cargo test -p fraiseql-cli --features test-postgres --test setup_against_db` — **2 pass against a real PostgreSQL**: `setup` installs `core.tb_entity_change_log` with its NOT-NULL backbone columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)