### PR TITLE
feat(server): subscription row-visibility policies hot-reload for new subscriptions (#611)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   points at `fraiseql setup` when the table is missing. Row-Level Security (migration 12)
   remains a separate operator step, and `RETURNS SETOF v_*` mutation functions remain
   unsupported — both documented in `docs/architecture/change-log-contract.md`.
+- **Subscription row-visibility policies now hot-reload for new subscriptions (#611).** A
+  `subscription_policy` added or tightened via a schema hot-reload previously took effect only
+  on server **restart** — a fail-open window where a newly-tightened entity kept delivering
+  all rows to new subscribers until then. The `/ws` handler now reads policies from the live
+  (reload-aware) schema per new subscription, so a reloaded change applies on the next
+  subscribe. Fail-closed is preserved: a policy whose owner identity is unresolvable refuses
+  the subscription, never deliver-all. Already-connected subscriptions keep their
+  subscribe-time boundary until they reconnect (the reload warning now says so); mid-stream
+  re-derivation of live subscriptions is a deferred follow-up.
 
 ## [2.13.1] - 2026-07-18
 

--- a/crates/fraiseql-server/src/routes/graphql/app_state.rs
+++ b/crates/fraiseql-server/src/routes/graphql/app_state.rs
@@ -398,7 +398,8 @@ impl<A: DatabaseAdapter> AppState<A> {
             return Ok(()); // Same schema, no-op
         }
 
-        // #611: subscription policies do not hot-reload — surface any change loudly.
+        // #611: new subscriptions pick up policy changes immediately (layer-1); warn loudly
+        // so operators know already-connected streams must reconnect to apply the change.
         warn_on_subscription_policy_reload(current.schema(), &schema);
 
         // 5. Notify adapter of schema change (clears query result cache if applicable)
@@ -459,7 +460,8 @@ impl<A: DatabaseAdapter> AppState<A> {
             return Ok(()); // Same schema, no-op
         }
 
-        // #611: subscription policies do not hot-reload — surface any change loudly.
+        // #611: new subscriptions pick up policy changes immediately (layer-1); warn loudly
+        // so operators know already-connected streams must reconnect to apply the change.
         warn_on_subscription_policy_reload(current.schema(), &schema);
 
         // 4. Notify adapter of schema change (clears query result cache if applicable)

--- a/crates/fraiseql-server/src/routes/graphql/app_state.rs
+++ b/crates/fraiseql-server/src/routes/graphql/app_state.rs
@@ -698,11 +698,12 @@ impl<A: DatabaseAdapter> AppState<A> {
 /// Warn (loudly) when a schema hot-reload changes the subscription row-visibility
 /// policies (#596/#611).
 ///
-/// The subscription subsystem is resolved once at server start and is **not** re-mounted
-/// on reload, so a policy added or changed here takes effect on **restart**, not now —
-/// a silent fail-open window for a newly-tightened entity. This converts that window
-/// into an operator-visible warning (one map comparison), pending the full reload-aware
-/// remount tracked in #611.
+/// As of #611 layer-1, **new** subscriptions read the live policies (the `/ws` handler
+/// resolves them from the reload-aware executor `ArcSwap`), so a reloaded change reaches
+/// them on the next subscribe. **Already-connected** subscriptions keep their subscribe-time
+/// boundary until they reconnect — this warning makes that window operator-visible so a
+/// reconnect can be forced. Mid-stream re-derivation of live subscriptions is layer-2
+/// (deferred; #611).
 fn warn_on_subscription_policy_reload(
     old_schema: &CompiledSchema,
     new_schema: &CompiledSchema,
@@ -714,9 +715,10 @@ fn warn_on_subscription_policy_reload(
         warn!(
             old = old_policies.len(),
             new = new_policies.len(),
-            "SECURITY: schema reload changes subscription row-visibility policies, but the \
-             subscription subsystem is not re-mounted on reload — the new policies take effect \
-             on RESTART, not now. Restart to apply subscription policy changes (#611)."
+            "SECURITY: schema reload changes subscription row-visibility policies. NEW \
+             subscriptions pick up the change immediately (#611 layer-1); ALREADY-CONNECTED \
+             subscriptions keep their subscribe-time boundary until they reconnect. Force a \
+             reconnect (or restart) to apply the change to existing streams."
         );
     }
     changed

--- a/crates/fraiseql-server/src/routes/subscriptions.rs
+++ b/crates/fraiseql-server/src/routes/subscriptions.rs
@@ -112,6 +112,14 @@ const CONNECTION_INIT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Ping/keepalive interval.
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 
+/// A live source of per-subscription row-visibility policies (#611).
+///
+/// Returns the CURRENT compiled schema's `subscription_policy` map. Installed at mount over
+/// the reload-aware executor `ArcSwap`, so a policy added or changed by a hot-reload reaches
+/// the next subscribe — not only a restart. Type-erased over the database adapter.
+pub type LiveSubscriptionPolicies =
+    Arc<dyn Fn() -> Arc<HashMap<String, SubscriptionPolicy>> + Send + Sync>;
+
 /// State for subscription `WebSocket` handler.
 #[derive(Clone)]
 pub struct SubscriptionState {
@@ -150,6 +158,14 @@ pub struct SubscriptionState {
     /// when the identity is unresolvable. A subscription with no policy keeps today's
     /// behavior (no back-compat break).
     pub subscription_policies: Arc<HashMap<String, SubscriptionPolicy>>,
+    /// #611: live row-visibility policy source. When set (installed at mount from the
+    /// reload-aware executor `ArcSwap`), each **new** subscription is evaluated against the
+    /// **current** schema's policies, so a policy added or tightened by a hot-reload takes
+    /// effect on the next subscribe rather than only on restart. `None` falls back to the
+    /// mount-time `subscription_policies` snapshot — the behavior tests and hosts that do
+    /// not wire a live source keep. Already-connected subscriptions keep their subscribe-time
+    /// boundary until they reconnect (layer-2, deferred; #611).
+    pub live_subscription_policies: Option<LiveSubscriptionPolicies>,
     /// Enriched-identity resolver (#539). When set, the connection's `SecurityContext`
     /// is enriched at subscribe time (only for policy-declaring subscriptions) so the
     /// `fraiseql.enriched.*` owner field is server-resolved, never client-asserted.
@@ -176,6 +192,7 @@ impl SubscriptionState {
             authorizer: None,
             tenant_status_source: None,
             subscription_policies: Arc::new(HashMap::new()),
+            live_subscription_policies: None,
             #[cfg(feature = "auth")]
             identity_resolver: None,
             service_account_authenticator: None,
@@ -183,13 +200,27 @@ impl SubscriptionState {
     }
 
     /// Install the per-subscription row-visibility policies (#596). Typically built by
-    /// [`build_subscription_policies`] from the compiled schema at mount time.
+    /// [`build_subscription_policies`] from the compiled schema at mount time. Used as the
+    /// fallback when no live source (`with_live_subscription_policies`) is installed.
     #[must_use]
     pub fn with_subscription_policies(
         mut self,
         policies: Arc<HashMap<String, SubscriptionPolicy>>,
     ) -> Self {
         self.subscription_policies = policies;
+        self
+    }
+
+    /// Install the live row-visibility policy source (#611). When set, each new subscription
+    /// is evaluated against the current schema's policies, so a hot-reloaded policy applies
+    /// on the next subscribe rather than only on restart. `None` keeps the mount-time
+    /// snapshot behavior.
+    #[must_use]
+    pub fn with_live_subscription_policies(
+        mut self,
+        live: Option<LiveSubscriptionPolicies>,
+    ) -> Self {
+        self.live_subscription_policies = live;
         self
     }
 
@@ -311,7 +342,15 @@ async fn resolve_subscription_rls(
     subscription_name: &str,
     principal: Option<&SecurityContext>,
 ) -> Result<Vec<(String, serde_json::Value)>, String> {
-    let Some(policy) = state.subscription_policies.get(subscription_name) else {
+    // #611: when a live source is installed, evaluate against the CURRENT schema's policies
+    // so a hot-reloaded policy applies to this new subscription; otherwise the mount-time
+    // snapshot. Fail-closed is preserved downstream: a policy that applies but whose owner
+    // identity is unresolvable refuses the subscription (never deliver-all).
+    let policies = state
+        .live_subscription_policies
+        .as_ref()
+        .map_or_else(|| Arc::clone(&state.subscription_policies), |live| live());
+    let Some(policy) = policies.get(subscription_name) else {
         return Ok(Vec::new());
     };
 

--- a/crates/fraiseql-server/src/routes/subscriptions/tests.rs
+++ b/crates/fraiseql-server/src/routes/subscriptions/tests.rs
@@ -114,7 +114,10 @@ mod row_visibility_596 {
     };
 
     use super::{
-        super::{build_subscription_policies, derive_policy_conditions},
+        super::{
+            LiveSubscriptionPolicies, build_subscription_policies, derive_policy_conditions,
+            resolve_subscription_rls,
+        },
         *,
     };
 
@@ -218,6 +221,77 @@ mod row_visibility_596 {
         assert!(map.contains_key("orderUpdated"), "policy-declaring entity is mapped");
         assert!(!map.contains_key("pinged"), "an entity without a policy is not mapped");
         assert_eq!(map.len(), 1);
+    }
+
+    /// #611 layer-1: a policy ADDED by a hot-reload applies to a NEW subscription — the live
+    /// source is read per subscribe, and the newly-scoped entity fails closed for an
+    /// unresolvable identity rather than staying deliver-all until restart.
+    #[tokio::test]
+    async fn policy_added_by_reload_applies_to_new_subscription_fail_closed() {
+        use arc_swap::ArcSwap;
+        // A live source the test swaps to simulate a hot-reload (exactly how the `/ws`
+        // handler reads the reload-aware executor ArcSwap in production).
+        let live_swap: Arc<ArcSwap<HashMap<String, SubscriptionPolicy>>> =
+            Arc::new(ArcSwap::from_pointee(HashMap::new()));
+        let live_swap_reader = live_swap.clone();
+        let live: LiveSubscriptionPolicies = Arc::new(move || live_swap_reader.load_full());
+
+        let manager = Arc::new(SubscriptionManager::new(Arc::new(CompiledSchema::default())));
+        let state = SubscriptionState::new(manager).with_live_subscription_policies(Some(live));
+
+        // Before the reload: no policy → unscoped (deliver-all), even for an anonymous sub.
+        let before = resolve_subscription_rls(&state, "orderUpdated", None).await;
+        assert_eq!(before.expect("no policy → ok"), Vec::new());
+
+        // Reload adds a policy for orderUpdated.
+        let mut reloaded = HashMap::new();
+        reloaded.insert("orderUpdated".to_string(), policy());
+        live_swap.store(Arc::new(reloaded));
+
+        // A NEW anonymous subscription now sees the added policy → refused (fail-closed),
+        // NOT deliver-all. This is the layer-1 guarantee that closes the fail-open window.
+        let after = resolve_subscription_rls(&state, "orderUpdated", None).await;
+        assert!(
+            after.is_err(),
+            "a hot-reloaded policy must apply to new subscriptions (fail-closed): {after:?}"
+        );
+    }
+
+    /// #611 layer-1: the live source overrides the mount-time snapshot. A policy REMOVED by a
+    /// hot-reload leaves new subscriptions unscoped (the operator's explicit choice), rather
+    /// than keeping the stale snapshot's scoping.
+    #[tokio::test]
+    async fn live_source_overrides_mount_time_snapshot() {
+        // Mount-time snapshot HAS a policy; the live source (post-reload) does NOT.
+        let mut snapshot = HashMap::new();
+        snapshot.insert("orderUpdated".to_string(), policy());
+        let live_empty: LiveSubscriptionPolicies = Arc::new(|| Arc::new(HashMap::new()));
+
+        let manager = Arc::new(SubscriptionManager::new(Arc::new(CompiledSchema::default())));
+        let state = SubscriptionState::new(manager)
+            .with_subscription_policies(Arc::new(snapshot))
+            .with_live_subscription_policies(Some(live_empty));
+
+        // The live (empty) source wins over the snapshot → unscoped, not the snapshot's refuse.
+        let r = resolve_subscription_rls(&state, "orderUpdated", None).await;
+        assert_eq!(
+            r.expect("live source removed the policy → unscoped"),
+            Vec::new(),
+            "the live source must override the mount-time snapshot"
+        );
+    }
+
+    /// Without a live source, behavior is unchanged: the mount-time snapshot is used and
+    /// fails closed for a policy-declaring subscription with an anonymous principal.
+    #[tokio::test]
+    async fn no_live_source_falls_back_to_snapshot_fail_closed() {
+        let mut snapshot = HashMap::new();
+        snapshot.insert("orderUpdated".to_string(), policy());
+        let manager = Arc::new(SubscriptionManager::new(Arc::new(CompiledSchema::default())));
+        let state = SubscriptionState::new(manager).with_subscription_policies(Arc::new(snapshot));
+
+        let r = resolve_subscription_rls(&state, "orderUpdated", None).await;
+        assert!(r.is_err(), "snapshot policy still fails closed for an anonymous sub: {r:?}");
     }
 }
 

--- a/crates/fraiseql-server/src/server/routing/admin.rs
+++ b/crates/fraiseql-server/src/server/routing/admin.rs
@@ -305,6 +305,19 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             crate::routes::subscriptions::build_subscription_policies(self.executor.schema()),
         );
 
+        // #611: a live policy source so a hot-reload's subscription_policy change reaches
+        // NEW subscriptions on the next subscribe, not only on restart. It reads the same
+        // reload-aware executor ArcSwap the query plane swaps in `AppState::reload_schema`;
+        // the mount-time `subscription_policies` above stays as the fallback. Already-connected
+        // subscriptions keep their subscribe-time boundary until reconnect (layer-2, deferred).
+        let executor_swap = state.executor.clone();
+        let live_subscription_policies: crate::routes::subscriptions::LiveSubscriptionPolicies =
+            Arc::new(move || {
+                Arc::new(crate::routes::subscriptions::build_subscription_policies(
+                    executor_swap.load().schema(),
+                ))
+            });
+
         #[allow(unused_mut)]
         // Reason: `mut` is needed when the federation/auth features are enabled
         let mut subscription_state = SubscriptionState::new(self.subscription_manager.clone())
@@ -315,6 +328,8 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             .with_authorizer(self.executor.config().authorizer.clone())
             // #596: server-owned row-visibility policies (fail-closed at subscribe time).
             .with_subscription_policies(subscription_policies)
+            // #611: read live policies per new subscription so a hot-reload applies promptly.
+            .with_live_subscription_policies(Some(live_subscription_policies))
             // ADR-0018: let a service account authenticate the /ws upgrade with its secret.
             .with_service_account_authenticator(state.service_account_authenticator.clone())
             // M-tenant-ws-suspended: reject subscribes / pause delivery for a


### PR DESCRIPTION
**2.14 train — Phase 05 (layer 1).** ⚠️ **Auth-adjacent (row-level visibility) — opened for your security review, not auto-merged.**

## What & why

A `subscription_policy` (#596 row-visibility) added or tightened via a schema **hot-reload** previously took effect only on server **restart** (`SubscriptionState` was a mount-time snapshot). That is a **fail-open window**: a newly-tightened entity kept delivering all rows to new subscribers until restart. The interim #614 warning flagged it; this closes it.

## Design (layer 1 only)

- `SubscriptionState` gains an optional, type-erased `LiveSubscriptionPolicies` closure that returns the **current** schema's policy map. It's installed at mount over the reload-aware executor `ArcSwap` — the exact same one `AppState::reload_schema` `.store()`s — so the closure sees the post-reload schema. (Type-erased so `SubscriptionState` needn't be generic over the adapter.)
- `resolve_subscription_rls` reads the live source **per new subscription**, falling back to the mount-time snapshot when no live source is installed (tests / non-standard hosts) — no behavior change for them.
- **Fail-closed preserved.** An unresolvable owner identity still refuses the subscription (never deliver-all). A policy *removed* on reload correctly makes new subs unscoped (the operator's explicit choice).
- `warn_on_subscription_policy_reload` + docs updated: new subscriptions pick up the change immediately; **already-connected** subscriptions keep their subscribe-time boundary until they reconnect.

**Layer 2 deferred** (per plan): mid-stream re-derivation / termination of already-connected subscribers is a larger change; the reload warning + reconnect guidance holds the line meanwhile.

## Review focus (the security-sensitive bits)
- `resolve_subscription_rls` live-vs-snapshot read (`subscriptions.rs`) — fail-closed path unchanged.
- The closure over `state.executor` in `mount_subscriptions` (`admin.rs`) reads the live ArcSwap.

## Verification
- ✅ fmt / `clippy --all-targets --all-features -Dwarnings` / rustdoc — clean.
- ✅ `cargo test -p fraiseql-server --lib` — **1239 pass**, incl. 3 new layer-1 tests: policy-added-on-reload applies **fail-closed**, live source overrides the snapshot, and no-live-source falls back fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)