### PR TITLE
chore(build): dev profile debug = line-tables-only (tames target/ bloat)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,12 @@ lto = "thin"
 opt-level = 3
 
 [profile.dev]
-debug = true
+# line-tables-only keeps symbol names + file:line in backtraces (what test
+# failures and panics actually surface) while dropping variable/type DWARF.
+# Full debug info across ~90 test binaries and feature-matrix variants grows
+# target/ into the hundreds of GB; for interactive debugger sessions override
+# per-run: CARGO_PROFILE_DEV_DEBUG=full cargo test -p <crate> ...
+debug = "line-tables-only"
 opt-level = 0
 
 [profile.release]


### PR DESCRIPTION
Full debug info in the dev/test profile across ~90 integration-test binaries and feature-matrix variants repeatedly grows `target/` to ~400G, filling the build volume mid-link (`mold: failed to write to an output file. Disk full?`).

**Change:** `[profile.dev] debug = true` → `debug = "line-tables-only"` in the workspace root.

**Observability impact:** none for the common paths — backtraces, panic locations, and test-failure reports keep full symbol names and file:line. What's dropped is variable/type DWARF used by interactive gdb/lldb inspection; for those sessions, opt back in per-run:

```sh
CARGO_PROFILE_DEV_DEBUG=full cargo test -p <crate> ...
```

**Effect:** dev-profile artifacts shrink by roughly two thirds; link times improve. `release` (already `strip = true`) and `bench` profiles untouched. MSRV-safe (named debug levels need Cargo ≥ 1.71; MSRV is 1.92).

Note for reviewers: the first build after this merges recompiles the workspace once (profile fingerprint change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)