### PR TITLE
fix(rest): sort CSV/XLSX fallback columns deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CSV and XLSX exports now emit a deterministic, alphabetically-sorted column order when no
+  `?select=` is given.** The fallback column order was taken from `serde_json::Map` iteration,
+  which is alphabetical only for the default `BTreeMap` build; a dependency that enables
+  serde_json's `preserve_order` feature (e.g. the `functions-runtime-deno` runtime, or any
+  `--all-features` build) flips the map to insertion order, silently changing export column
+  order for the same data. `determine_columns` now sorts the fallback keys explicitly, so the
+  header is alphabetical regardless of feature resolution. Default-build output is byte-for-byte
+  unchanged; `?select=` still drives explicit column order.
 - **`fraiseql setup` now installs the `core.tb_entity_change_log` change-log contract, so the
   first mutation on a freshly authored stack no longer fails at prepare time (#569).** Every
   default (`changelog = true`) mutation writes this table via its transactional-outbox CTE;

--- a/crates/fraiseql-server/src/routes/rest/streaming/csv/mod.rs
+++ b/crates/fraiseql-server/src/routes/rest/streaming/csv/mod.rs
@@ -9,8 +9,8 @@
 //!   (default `true` — Excel needs it).
 //! - One header row whose columns are the top-level fields of the query result. If `?select=a,b,c`
 //!   is provided the column order matches that list (paren-aware: `posts(id,title)` becomes a
-//!   single `posts` column); otherwise columns come from `serde_json::Map` iteration, which is
-//!   stable (alphabetical) under the default `serde_json` build used in this workspace.
+//!   single `posts` column); otherwise columns are the first row's keys, sorted alphabetically
+//!   (deterministic regardless of `serde_json`'s `preserve_order` feature).
 //! - One row per result, RFC 4180 quoting, configurable delimiter via
 //!   [`ExportConfig::csv_delimiter`].
 //!
@@ -461,15 +461,25 @@ pub(crate) fn guard_formula_injection(value: &str) -> String {
 ///
 /// Preference:
 /// 1. `?select=` order, when supplied.
-/// 2. First row's `serde_json::Map` iteration order (alphabetical under the workspace's default
-///    `serde_json` build).
+/// 2. First row's keys, sorted alphabetically.
+///
+/// The fallback sorts explicitly rather than leaning on `serde_json::Map`
+/// iteration order: that order is alphabetical only for the default (`BTreeMap`)
+/// build and becomes insertion order when any dependency enables the
+/// `preserve_order` feature (e.g. under `--all-features`), which would silently
+/// change export column order. Sorting here keeps the header deterministic
+/// regardless of `serde_json`'s feature resolution.
 fn determine_columns(select_columns: Option<&[String]>, rows: &[serde_json::Value]) -> Vec<String> {
     if let Some(cols) = select_columns {
         return cols.to_vec();
     }
     rows.first()
         .and_then(|v| v.as_object())
-        .map(|m| m.keys().cloned().collect())
+        .map(|m| {
+            let mut cols: Vec<String> = m.keys().cloned().collect();
+            cols.sort();
+            cols
+        })
         .unwrap_or_default()
 }
 

--- a/crates/fraiseql-server/src/routes/rest/streaming/csv/tests.rs
+++ b/crates/fraiseql-server/src/routes/rest/streaming/csv/tests.rs
@@ -233,8 +233,8 @@ fn determine_columns_prefers_select_list() {
 fn determine_columns_falls_back_to_first_row_keys() {
     let rows = vec![json!({"id": 1, "name": "Alice"})];
     let cols = determine_columns(None, &rows);
-    // serde_json::Map is alphabetically ordered without preserve_order;
-    // see module docs.
+    // `determine_columns` sorts the fallback keys explicitly, so the order is
+    // alphabetical regardless of `serde_json`'s `preserve_order` feature.
     assert_eq!(cols, vec!["id", "name"]);
 }
 
@@ -471,14 +471,18 @@ fn select_columns_drive_order_when_present() {
 
 #[test]
 fn no_select_falls_back_to_sorted_first_row_keys() {
-    // Without ?select=, the column order comes from serde_json::Map
-    // iteration which the workspace's default serde_json build sorts
-    // alphabetically — deterministic and assertable.
+    // Without ?select=, `determine_columns` sorts the first row's keys
+    // explicitly, so the header is alphabetical (email, id, name) regardless of
+    // `serde_json`'s `preserve_order` feature — deterministic under any feature
+    // resolution, including `--all-features`.
     let rows = vec![json!({"name": "Alice", "email": "a@b", "id": 1})];
     let cols = determine_columns(None, &rows);
     let payload = write_csv_payload(&cols, &rows, b',', false, true).unwrap();
     let s = String::from_utf8(payload.to_vec()).unwrap();
     assert!(s.starts_with("email,id,name\n"));
+    // The data row follows the same sorted order — reordering the header keeps
+    // each value under its own column (values are keyed by name, not position).
+    assert!(s.contains("a@b,1,Alice"), "data row must align with the sorted header: {s}");
 }
 
 #[test]

--- a/crates/fraiseql-server/src/routes/rest/streaming/xlsx/mod.rs
+++ b/crates/fraiseql-server/src/routes/rest/streaming/xlsx/mod.rs
@@ -454,15 +454,25 @@ fn too_many_rows_error(max_rows: u64) -> RestError {
 ///
 /// Preference:
 /// 1. `?select=` order, when supplied.
-/// 2. First row's `serde_json::Map` iteration order (alphabetical under the workspace's default
-///    `serde_json` build).
+/// 2. First row's keys, sorted alphabetically.
+///
+/// The fallback sorts explicitly rather than leaning on `serde_json::Map`
+/// iteration order: that order is alphabetical only for the default (`BTreeMap`)
+/// build and becomes insertion order when any dependency enables the
+/// `preserve_order` feature (e.g. under `--all-features`), which would silently
+/// change export column order. Sorting here keeps the header deterministic
+/// regardless of `serde_json`'s feature resolution.
 fn determine_columns(select_columns: Option<&[String]>, rows: &[serde_json::Value]) -> Vec<String> {
     if let Some(cols) = select_columns {
         return cols.to_vec();
     }
     rows.first()
         .and_then(|v| v.as_object())
-        .map(|m| m.keys().cloned().collect())
+        .map(|m| {
+            let mut cols: Vec<String> = m.keys().cloned().collect();
+            cols.sort();
+            cols
+        })
         .unwrap_or_default()
 }
 

--- a/crates/fraiseql-server/src/routes/rest/streaming/xlsx/tests.rs
+++ b/crates/fraiseql-server/src/routes/rest/streaming/xlsx/tests.rs
@@ -226,6 +226,16 @@ fn determine_columns_falls_back_to_first_row_keys() {
 }
 
 #[test]
+fn determine_columns_fallback_is_sorted_regardless_of_key_insertion_order() {
+    // Keys given out of alphabetical order: `determine_columns` sorts them
+    // explicitly, so the header is deterministic (email, id, name) regardless of
+    // `serde_json`'s `preserve_order` feature — including under `--all-features`.
+    let rows = vec![json!({"name": "Alice", "email": "a@b", "id": 1})];
+    let cols = determine_columns(None, &rows);
+    assert_eq!(cols, vec!["email", "id", "name"]);
+}
+
+#[test]
 fn determine_columns_empty_when_no_rows_and_no_select() {
     let rows: Vec<serde_json::Value> = Vec::new();
     assert!(determine_columns(None, &rows).is_empty());


### PR DESCRIPTION
## Deterministic CSV/XLSX export column order under `--all-features`

Pre-requisite fix ahead of the #605 realtime-removal train: the `Dagger — test`
leg (`cargo test --workspace --all-features`) is red on dev, and this is one
deterministic cause.

### The bug
Without `?select=`, CSV and XLSX export column order came from
`serde_json::Map` iteration order. That is alphabetical **only** for the default
`BTreeMap` build; when any dependency enables serde_json's `preserve_order`
feature (which `--all-features` does), `Map` becomes an `IndexMap` and iterates
in **insertion order** instead. So a result whose first row is
`{"name", "email", "id"}` exports columns as `name,email,id` under
`--all-features` but `email,id,name` on a default build — a silent,
feature-dependent behavior change in a user-facing export.

This made `csv::tests::no_select_falls_back_to_sorted_first_row_keys` fail
deterministically under `--all-features`.

### The fix
`determine_columns` (in both `csv/mod.rs` and `xlsx/mod.rs`) now **sorts** the
fallback first-row keys explicitly, so the header is deterministic regardless of
serde_json's feature resolution. The default build's behaviour (already
alphabetical) is unchanged; `--all-features` now matches it instead of silently
switching to insertion order.

- Docs (module + `determine_columns`) and the affected test comments updated to
  state the explicit sort rather than lean on a serde_json-build assumption.
- Added `xlsx::tests::determine_columns_fallback_is_sorted_regardless_of_key_insertion_order`
  mirroring the CSV pin, guarding the XLSX path against the same latent bug.

### Verification
- `cargo nextest run -p fraiseql-server --all-features -E 'test(rest::streaming::)'` ✅
- `cargo nextest run -p fraiseql-server --all-features --no-fail-fast` ✅ (no other
  server-crate `--all-features` failures)
- default features ✅ · `cargo +nightly fmt --check` ✅ ·
  `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅ ·
  `make preflight` ✅

Not part of the #605 realtime map — a standalone hygiene fix that restores a
green trunk for the removal train to gate against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
