### PR TITLE
refactor(server): remove the dead AppState realtime-observer seam (#605) — Phase 03

### DIFF
--- a/crates/fraiseql-server/src/routes/graphql/app_state.rs
+++ b/crates/fraiseql-server/src/routes/graphql/app_state.rs
@@ -133,14 +133,6 @@ pub struct AppState<A: DatabaseAdapter> {
     /// when no hooks are registered — zero overhead for mutations without hooks.
     pub before_mutation_hooks: Option<Arc<crate::subsystems::BeforeMutationHooks>>,
 
-    /// Realtime broadcast observer (optional, requires realtime subsystem).
-    ///
-    /// When `Some`, mutation completions are forwarded to the realtime delivery
-    /// pipeline. The observer uses a bounded mpsc channel — events are dropped
-    /// (not buffered) when the delivery pipeline is under backpressure, so
-    /// mutation response latency is never affected.
-    pub realtime_observer: Option<Arc<crate::realtime::observer::RealtimeBroadcastObserver>>,
-
     /// Enrichment-profile identity resolver (#539). `Some` when
     /// `[identity.enrichment].enabled` and an auth DB pool is present; every
     /// authenticated request then resolves its DB identity and fail-closes
@@ -202,7 +194,6 @@ impl<A: DatabaseAdapter> AppState<A> {
             tenant_audit_log: None,
             usage: Arc::clone(crate::usage::aggregator::global_aggregator()),
             before_mutation_hooks: None,
-            realtime_observer: None,
             #[cfg(feature = "auth")]
             identity_resolver: None,
         }
@@ -328,19 +319,6 @@ impl<A: DatabaseAdapter> AppState<A> {
     #[must_use]
     pub fn with_functions(mut self, hooks: Arc<crate::subsystems::BeforeMutationHooks>) -> Self {
         self.before_mutation_hooks = Some(hooks);
-        self
-    }
-
-    /// Attach a realtime broadcast observer for mutation event forwarding.
-    ///
-    /// When set, mutation completions are forwarded to the realtime delivery
-    /// pipeline via a bounded mpsc channel.
-    #[must_use]
-    pub fn with_realtime_observer(
-        mut self,
-        observer: Arc<crate::realtime::observer::RealtimeBroadcastObserver>,
-    ) -> Self {
-        self.realtime_observer = Some(observer);
         self
     }
 


### PR DESCRIPTION
## Phase 03 of the #605 `/realtime/v1` removal train — Cluster D (AppState observer seam)

Fourth PR. Removes the `AppState` mutation-observer seam — the hook that *would*
have fed mutation events into the realtime delivery pipeline. Isolated as its own
small diff because it sits on the live mutation path (the first removal attempt
flagged "the `with_realtime_observer` ambiguity"); this resolves it.

### The seam was write-only-dead
The trace (from Phase 00, re-confirmed on fresh dev) is decisive:
- `AppState::with_realtime_observer` has **zero callers** — not in production, not
  in any test.
- `realtime_observer` is **never read** anywhere — there is **no** mutation-completion
  forwarding call site that consumes it. The field was declared, defaulted to
  `None`, and set only by a builder nobody calls.

So removing it **cannot change any runtime behaviour** — response shape, cascade
behaviour, and change-log write are all untouched (the observer was never in the
mutation path). No new pin is added because there is no behaviour to pin that the
existing mutation-path test suite doesn't already cover; **the full suite passing
is the regression proof.** (Its only type was `realtime::observer::RealtimeBroadcastObserver`,
Cluster A — so the field had to go before that module is deleted in Phase 06.)

### Removed
`crates/fraiseql-server/src/routes/graphql/app_state.rs` only:
- the `realtime_observer` field (+ its doc),
- its `None` default in the constructor,
- the `with_realtime_observer` builder method (+ its doc).

### Not in this phase (correctly untouched)
The two `tests/platform_e2e_test.rs` `realtime_observer` tests construct
`RealtimeBroadcastObserver` **directly** (not via this AppState seam), so they do
not break here — they break when the `realtime` module is deleted in **Phase 06**,
where they'll be removed. Everything in Clusters A/E/F/G is untouched.

### Crate API note
`AppState::with_realtime_observer` (a `pub` builder with no callers) is removed.
No HTTP or config surface changes, so per the train's convention this phase carries
no `### Breaking` CHANGELOG entry (those are 01/02/05/06); the finalize pass folds
the crate-API removals into the coherent narrative.

### Verification
- full `fraiseql-server` lib nextest ✅
- `make preflight` (fmt, clippy `--all-targets --all-features -D warnings`, rustdoc,
  shell gates) ✅

Part of the #605 removal train · Phase 03/07 · no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
