### PR TITLE
refactor(server): tear down realtime subsystem assembly + mount glue (#605) — Phase 04

### DIFF
--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -423,7 +423,6 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             #[cfg(feature = "observers")]
             db_pool,
             storage_state: None,
-            realtime_state: None,
             #[cfg(feature = "functions-runtime")]
             functions_hooks: None,
             tenant_executor_factory: None,
@@ -502,17 +501,6 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         factory: crate::tenancy::TenantExecutorFactory<A>,
     ) -> Self {
         self.tenant_executor_factory = Some(factory);
-        self
-    }
-
-    /// Attach a pre-built realtime `WebSocket` state to the server.
-    ///
-    /// When set, `build_base_router` will merge `realtime_router(state)` at
-    /// `/realtime/v1`.  Call this after constructing the server but before
-    /// calling `serve` or `serve_with_shutdown`.
-    #[must_use]
-    pub fn with_realtime(mut self, state: crate::realtime::server::RealtimeState) -> Self {
-        self.realtime_state = Some(state);
         self
     }
 

--- a/crates/fraiseql-server/src/server/extensions.rs
+++ b/crates/fraiseql-server/src/server/extensions.rs
@@ -372,7 +372,6 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             #[cfg(feature = "observers")]
             db_pool,
             storage_state: None,
-            realtime_state: None,
             #[cfg(feature = "functions-runtime")]
             functions_hooks: None,
             tenant_executor_factory: None,

--- a/crates/fraiseql-server/src/server/mod.rs
+++ b/crates/fraiseql-server/src/server/mod.rs
@@ -142,12 +142,6 @@ pub struct Server<A: DatabaseAdapter> {
     /// a PostgreSQL pool is available for metadata tracking.
     pub(super) storage_state: Option<fraiseql_storage::StorageState>,
 
-    /// Pre-built realtime state for mounting the `WebSocket` endpoint.
-    ///
-    /// When `Some`, `build_base_router` merges `realtime_router(state)` at
-    /// `/realtime/v1`. Set via [`Server::with_realtime`].
-    pub(super) realtime_state: Option<crate::realtime::server::RealtimeState>,
-
     /// Before-mutation function-dispatch hooks, prepared at serve time from the
     /// compiled schema's functions config (modules loaded, runtimes registered,
     /// `send_email` wiring attached). When `Some`, `build_app_state` attaches them

--- a/crates/fraiseql-server/src/server/routing/extensions.rs
+++ b/crates/fraiseql-server/src/server/routing/extensions.rs
@@ -1,5 +1,5 @@
 //! Extension route mounting: MCP, API, RBAC, observers, storage, functions, REST,
-//! realtime, and admission control.
+//! and admission control.
 
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use crate::routes::graphql::AppState;
 
 impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// Mount MCP, API routes, RBAC, observer hooks, storage, functions, REST,
-    /// realtime, and admission control.
+    /// and admission control.
     pub(super) fn mount_extensions(&self, mut app: Router, state: &AppState<A>) -> Router {
         // MCP (Model Context Protocol) route
         #[cfg(feature = "mcp")]
@@ -109,13 +109,6 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             if let Some(rest_app) = rest_query_router(state, self.config.compression_enabled) {
                 app = app.merge(rest_app);
             }
-        }
-
-        // Mount realtime WebSocket routes when a RealtimeState was configured.
-        if let Some(rt_state) = &self.realtime_state {
-            use crate::realtime::routes::realtime_router;
-            app = app.merge(realtime_router(rt_state.clone()));
-            info!("Realtime WebSocket routes mounted: GET /realtime/v1");
         }
 
         // Mount storage routes when StorageState was pre-built during server construction.

--- a/crates/fraiseql-server/src/server/routing/mod.rs
+++ b/crates/fraiseql-server/src/server/routing/mod.rs
@@ -63,7 +63,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             app = self.mount_auth_routes(app);
         }
 
-        // Mount extension routes (MCP, API, RBAC, storage, functions, REST, realtime).
+        // Mount extension routes (MCP, API, RBAC, storage, functions, REST).
         app = self.mount_extensions(app, &state);
 
         // Apply global middleware layers (metrics, tracing, CORS, limits, timeout, rate limiting).

--- a/crates/fraiseql-server/src/server/routing/realtime_removal_survival_tests.rs
+++ b/crates/fraiseql-server/src/server/routing/realtime_removal_survival_tests.rs
@@ -35,8 +35,8 @@ use tower::ServiceExt;
 use crate::{server::Server, server_config::ServerConfig};
 
 /// Assemble a full production router (base + admin + extensions) from `config` with an empty
-/// schema and a healthy mock adapter — no OIDC validator, nothing that would mount the dormant
-/// realtime subsystem (which requires an explicit `.with_realtime(..)`).
+/// schema and a healthy mock adapter — no OIDC validator. This is the same base + admin +
+/// extension mount path the binary assembles.
 async fn prod_router(config: ServerConfig) -> Router {
     let server: Server<CachedDatabaseAdapter<FailingAdapter>> =
         Server::new(config, CompiledSchema::new(), Arc::new(FailingAdapter::new()), None)

--- a/crates/fraiseql-server/src/server/routing_tests.rs
+++ b/crates/fraiseql-server/src/server/routing_tests.rs
@@ -6,8 +6,6 @@
 //! 404 (route not mounted) or something else (handler ran).
 //!
 //! Concretely:
-//! - `GET /realtime/v1` without a `WebSocket` `Upgrade` header → **400** when the realtime router
-//!   is merged (handler exists but rejects non-WS requests), or **404** when it is not.
 //! - `GET /storage/v1/list/{bucket}` → **non-404** when the storage router is merged (handler runs,
 //!   may return 401/500 due to auth/DB), or **404** when it is not.
 
@@ -21,15 +19,9 @@ use fraiseql_storage::{
     backend::{LocalBackend, StorageBackend},
     config::{BucketAccess, BucketConfig},
 };
-use futures::future::BoxFuture;
 use sqlx::PgPool;
 use tempfile::tempdir;
 use tokio::net::TcpListener;
-
-use crate::realtime::{
-    routes::realtime_router,
-    server::{RealtimeConfig, RealtimeServer, RealtimeState, TokenInfo, TokenValidator},
-};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -41,28 +33,6 @@ async fn spawn(router: Router) -> SocketAddr {
         axum::serve(listener, router.into_make_service()).await.unwrap();
     });
     addr
-}
-
-/// A [`TokenValidator`] that accepts every token.
-#[derive(Clone)]
-struct AlwaysOkValidator;
-
-impl TokenValidator for AlwaysOkValidator {
-    fn validate<'a>(&'a self, _token: &'a str) -> BoxFuture<'a, Result<TokenInfo, String>> {
-        Box::pin(async move { Ok(TokenInfo::new("test-user".to_string(), 0, i64::MAX)) })
-    }
-}
-
-/// Build a minimal `RealtimeState` with a single known entity.
-fn realtime_state() -> RealtimeState {
-    let server = Arc::new(RealtimeServer::with_entities(
-        RealtimeConfig::default(),
-        ["TestEntity".to_string()].into(),
-    ));
-    RealtimeState {
-        server,
-        validator: Arc::new(AlwaysOkValidator),
-    }
 }
 
 /// Build a `StorageState` backed by a temp directory with one public-read bucket.
@@ -91,36 +61,6 @@ async fn storage_state(bucket: &str) -> StorageState {
 
 fn lazy_pool() -> PgPool {
     PgPool::connect_lazy("postgres://test:test@localhost/test").unwrap()
-}
-
-// ── Realtime ──────────────────────────────────────────────────────────────────
-
-/// `GET /realtime/v1` without a `WebSocket` upgrade header returns **400**
-/// (handler is mounted and runs), not **404** (no route).
-#[tokio::test]
-async fn test_realtime_route_mounted_when_enabled() {
-    let router = Router::new()
-        .route("/health", get(|| async { "ok" }))
-        .merge(realtime_router(realtime_state()));
-
-    let addr = spawn(router).await;
-    let status = reqwest::get(format!("http://{addr}/realtime/v1?token=test"))
-        .await
-        .unwrap()
-        .status();
-
-    assert_ne!(status.as_u16(), 404, "/realtime/v1 should be mounted (got {status})");
-}
-
-/// `GET /realtime/v1` returns **404** when the realtime router is not merged.
-#[tokio::test]
-async fn test_realtime_route_not_mounted_when_disabled() {
-    let router = Router::new().route("/health", get(|| async { "ok" }));
-
-    let addr = spawn(router).await;
-    let status = reqwest::get(format!("http://{addr}/realtime/v1")).await.unwrap().status();
-
-    assert_eq!(status.as_u16(), 404, "/realtime/v1 should not be mounted");
 }
 
 // ── Storage ───────────────────────────────────────────────────────────────────
@@ -161,16 +101,14 @@ async fn test_storage_routes_not_mounted_when_disabled() {
 
 // ── Coexistence ───────────────────────────────────────────────────────────────
 
-/// When both routers are merged, both route trees are reachable and the base
+/// When an extension router is merged, its route tree is reachable and the base
 /// `/health` route remains unaffected.
 #[tokio::test]
 async fn test_existing_routes_unaffected_when_subsystems_added() {
-    let rt_state = realtime_state();
     let st_state = storage_state("coexist-test").await;
 
     let router = Router::new()
         .route("/health", get(|| async { "ok" }))
-        .merge(realtime_router(rt_state))
         .merge(fraiseql_storage::storage_router(st_state));
 
     let addr = spawn(router).await;
@@ -179,13 +117,7 @@ async fn test_existing_routes_unaffected_when_subsystems_added() {
     let health_status = reqwest::get(format!("http://{addr}/health")).await.unwrap().status();
     assert_eq!(health_status.as_u16(), 200);
 
-    // Both subsystem routes exist (non-404)
-    let rt_status = reqwest::get(format!("http://{addr}/realtime/v1?token=test"))
-        .await
-        .unwrap()
-        .status();
-    assert_ne!(rt_status.as_u16(), 404);
-
+    // The storage subsystem route exists (non-404)
     let st_status = reqwest::get(format!("http://{addr}/storage/v1/list/coexist-test"))
         .await
         .unwrap()

--- a/crates/fraiseql-server/src/subsystems/builder.rs
+++ b/crates/fraiseql-server/src/subsystems/builder.rs
@@ -1,6 +1,6 @@
 //! Builder for assembling server subsystems with cross-subsystem validation.
 
-use super::{FunctionsSubsystem, RealtimeSubsystem, ServerSubsystems, StorageSubsystem};
+use super::{FunctionsSubsystem, ServerSubsystems, StorageSubsystem};
 
 /// Error returned when `ServerSubsystemsBuilder::build` detects a configuration problem.
 #[derive(Debug, thiserror::Error)]
@@ -33,14 +33,12 @@ pub enum SubsystemBuildError {
 /// let subsystems = ServerSubsystemsBuilder::new()
 ///     .with_storage(storage_subsystem)
 ///     .with_functions(functions_subsystem)
-///     .with_realtime(realtime_subsystem)
 ///     .build()?;
 /// ```
 #[derive(Default)]
 pub struct ServerSubsystemsBuilder {
     storage:   Option<StorageSubsystem>,
     functions: Option<FunctionsSubsystem>,
-    realtime:  Option<RealtimeSubsystem>,
 }
 
 impl ServerSubsystemsBuilder {
@@ -64,13 +62,6 @@ impl ServerSubsystemsBuilder {
         self
     }
 
-    /// Register the realtime subsystem.
-    #[must_use = "builder method returns modified builder"]
-    pub fn with_realtime(mut self, subsystem: RealtimeSubsystem) -> Self {
-        self.realtime = Some(subsystem);
-        self
-    }
-
     /// Validate cross-subsystem dependencies and build [`ServerSubsystems`].
     ///
     /// # Errors
@@ -82,7 +73,6 @@ impl ServerSubsystemsBuilder {
         Ok(ServerSubsystems {
             storage:   self.storage,
             functions: self.functions,
-            realtime:  self.realtime,
         })
     }
 

--- a/crates/fraiseql-server/src/subsystems/mod.rs
+++ b/crates/fraiseql-server/src/subsystems/mod.rs
@@ -1,7 +1,7 @@
 //! Server subsystem assembly and lifecycle management.
 //!
-//! [`ServerSubsystems`] bundles the three optional platform extensions —
-//! object storage, serverless functions, and realtime entity streams — into a
+//! [`ServerSubsystems`] bundles the optional platform extensions —
+//! object storage and serverless functions — into a
 //! single coherent struct that the server can query, route-mount, and shut down
 //! in a controlled order.
 //!
@@ -15,7 +15,6 @@
 //! let subsystems = ServerSubsystemsBuilder::new()
 //!     .with_storage(storage_subsystem)
 //!     .with_functions(functions_subsystem)
-//!     .with_realtime(realtime_subsystem)
 //!     .build()?;
 //! ```
 //!
@@ -23,10 +22,8 @@
 //!
 //! Shutdown proceeds in reverse initialization order:
 //! 1. Stop the cron scheduler (functions)
-//! 2. Drain the realtime event channel
-//! 3. Drop the realtime server (closes all `WebSocket` connections)
-//! 4. Drop the functions observer (stops dispatching events)
-//! 5. Drop the storage backend (flushes any pending writes)
+//! 2. Drop the functions observer (stops dispatching events)
+//! 3. Drop the storage backend (flushes any pending writes)
 
 pub mod builder;
 pub mod validator;
@@ -44,12 +41,7 @@ pub use builder::{ServerSubsystemsBuilder, SubsystemBuildError};
 use fraiseql_functions::{FunctionObserver, triggers::TriggerRegistry};
 pub use validator::{SubsystemConfigWarning, validate_subsystems_config};
 
-use crate::{
-    realtime::{
-        observer::RealtimeBroadcastObserver, routes::RealtimeSchemaConfig, server::RealtimeServer,
-    },
-    schema::loader::{FunctionsConfig, SchemaStorageConfig},
-};
+use crate::schema::loader::{FunctionsConfig, SchemaStorageConfig};
 
 // ── Subsystem structs ─────────────────────────────────────────────────────────
 
@@ -90,24 +82,6 @@ pub struct FunctionsSubsystem {
     pub config: FunctionsConfig,
 }
 
-/// Realtime subsystem: `WebSocket` broadcast server and event observer.
-///
-/// Assembled at server startup from the `[realtime]` section of the compiled schema.
-/// The server handles `WebSocket` connections; the observer receives mutation events
-/// from the observer pipeline and forwards them to connected clients.
-pub struct RealtimeSubsystem {
-    /// The `WebSocket` broadcast server.
-    ///
-    /// Pass this to [`crate::realtime::routes::realtime_router`] to mount `/realtime/v1`.
-    pub server: Arc<RealtimeServer>,
-
-    /// Observer that forwards mutation events into the realtime delivery pipeline.
-    pub observer: RealtimeBroadcastObserver,
-
-    /// Schema-level realtime configuration (enabled flag, entity list, capacity overrides).
-    pub schema_config: RealtimeSchemaConfig,
-}
-
 // ── Aggregated container ──────────────────────────────────────────────────────
 
 /// All optional platform subsystems assembled from the compiled schema.
@@ -115,17 +89,13 @@ pub struct RealtimeSubsystem {
 /// Each field is `None` when the corresponding section is absent from or disabled
 /// in the compiled schema. Callers can use [`is_storage_enabled`][Self::is_storage_enabled]
 /// etc. to check at a glance, or match directly on the `Option` fields.
-#[allow(missing_debug_implementations)] // Reason: inner types (RealtimeBroadcastObserver) don't implement Debug
+#[allow(missing_debug_implementations)] // Reason: inner subsystem types (e.g. FunctionObserver) don't implement Debug
 pub struct ServerSubsystems {
     /// Object storage subsystem, present when the schema's `"storage"` key is set.
     pub storage: Option<StorageSubsystem>,
 
     /// Serverless functions subsystem, present when the schema's `"functions"` key is set.
     pub functions: Option<FunctionsSubsystem>,
-
-    /// Realtime broadcast subsystem, present when the schema's `"realtime"` key is set
-    /// and `enabled` is `true`.
-    pub realtime: Option<RealtimeSubsystem>,
 }
 
 impl ServerSubsystems {
@@ -137,7 +107,6 @@ impl ServerSubsystems {
         Self {
             storage:   None,
             functions: None,
-            realtime:  None,
         }
     }
 
@@ -151,12 +120,6 @@ impl ServerSubsystems {
     #[must_use]
     pub const fn is_functions_enabled(&self) -> bool {
         self.functions.is_some()
-    }
-
-    /// Returns `true` if the realtime subsystem is present.
-    #[must_use]
-    pub const fn is_realtime_enabled(&self) -> bool {
-        self.realtime.is_some()
     }
 }
 

--- a/crates/fraiseql-server/src/subsystems/tests.rs
+++ b/crates/fraiseql-server/src/subsystems/tests.rs
@@ -3,10 +3,7 @@
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 #![allow(missing_docs)] // Reason: test code
 
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use fraiseql_functions::{
     FunctionDefinition, FunctionObserver, RuntimeType, triggers::TriggerRegistry,
@@ -22,18 +19,11 @@ use tempfile::tempdir;
 #[cfg(feature = "functions-runtime")]
 use super::BeforeMutationHooks;
 use super::{
-    FunctionsSubsystem, RealtimeSubsystem, ServerSubsystems, StorageSubsystem,
+    FunctionsSubsystem, ServerSubsystems, StorageSubsystem,
     builder::{ServerSubsystemsBuilder, SubsystemBuildError},
     validator::{SubsystemConfigWarning, validate_subsystems_config},
 };
-use crate::{
-    realtime::{
-        observer::RealtimeBroadcastObserver,
-        routes::RealtimeSchemaConfig,
-        server::{RealtimeConfig, RealtimeServer},
-    },
-    schema::loader::{FunctionsConfig, SchemaBucketDef, SchemaStorageConfig},
-};
+use crate::schema::loader::{FunctionsConfig, SchemaBucketDef, SchemaStorageConfig};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -87,14 +77,6 @@ fn minimal_functions_config() -> FunctionsConfig {
     }
 }
 
-fn minimal_realtime_config() -> RealtimeSchemaConfig {
-    serde_json::from_value(serde_json::json!({
-        "enabled": true,
-        "entities": ["User"]
-    }))
-    .unwrap()
-}
-
 // ── Storage ───────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -109,7 +91,6 @@ async fn test_server_state_with_storage() {
 
     assert!(subsystems.storage.is_some());
     assert!(subsystems.functions.is_none());
-    assert!(subsystems.realtime.is_none());
 }
 
 #[test]
@@ -137,7 +118,6 @@ fn test_server_state_with_functions() {
 
     assert!(subsystems.functions.is_some());
     assert!(subsystems.storage.is_none());
-    assert!(subsystems.realtime.is_none());
     assert_eq!(subsystems.functions.as_ref().unwrap().trigger_registry.function_count, 1);
 }
 
@@ -224,33 +204,6 @@ fn with_email_attaches_sender_resolver_and_transport() {
     assert!(hooks.email_transport.is_some(), "transport attached");
 }
 
-// ── Realtime ──────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_server_state_with_realtime() {
-    let entities: HashSet<String> = ["User".to_string()].into();
-    let server = Arc::new(RealtimeServer::with_entities(RealtimeConfig::default(), entities));
-    let (observer, _rx) = RealtimeBroadcastObserver::new(256);
-
-    let subsystem = RealtimeSubsystem {
-        server,
-        observer,
-        schema_config: minimal_realtime_config(),
-    };
-
-    let subsystems = ServerSubsystemsBuilder::new().with_realtime(subsystem).build().unwrap();
-
-    assert!(subsystems.realtime.is_some());
-    assert!(subsystems.storage.is_none());
-    assert!(subsystems.functions.is_none());
-}
-
-#[test]
-fn test_server_state_without_realtime() {
-    let subsystems = ServerSubsystemsBuilder::new().build().unwrap();
-    assert!(subsystems.realtime.is_none());
-}
-
 // ── All features ──────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -271,25 +224,14 @@ async fn test_server_state_all_features() {
         module_registry: std::collections::HashMap::new(),
     };
 
-    let entities: HashSet<String> = ["User".to_string()].into();
-    let rt_server = Arc::new(RealtimeServer::with_entities(RealtimeConfig::default(), entities));
-    let (rt_observer, _rx) = RealtimeBroadcastObserver::new(256);
-    let realtime = RealtimeSubsystem {
-        server:        rt_server,
-        observer:      rt_observer,
-        schema_config: minimal_realtime_config(),
-    };
-
     let subsystems = ServerSubsystemsBuilder::new()
         .with_storage(storage)
         .with_functions(functions)
-        .with_realtime(realtime)
         .build()
         .unwrap();
 
     assert!(subsystems.storage.is_some());
     assert!(subsystems.functions.is_some());
-    assert!(subsystems.realtime.is_some());
 }
 
 // ── Cross-subsystem validation ────────────────────────────────────────────────
@@ -393,25 +335,10 @@ fn test_subsystems_is_functions_enabled() {
 }
 
 #[test]
-fn test_subsystems_is_realtime_enabled() {
-    let entities: HashSet<String> = ["Post".to_string()].into();
-    let server = Arc::new(RealtimeServer::with_entities(RealtimeConfig::default(), entities));
-    let (observer, _rx) = RealtimeBroadcastObserver::new(64);
-    let subsystem = RealtimeSubsystem {
-        server,
-        observer,
-        schema_config: minimal_realtime_config(),
-    };
-    let subsystems = ServerSubsystemsBuilder::new().with_realtime(subsystem).build().unwrap();
-    assert!(subsystems.is_realtime_enabled());
-}
-
-#[test]
 fn test_empty_subsystems_all_disabled() {
     let subsystems = ServerSubsystems::none();
     assert!(!subsystems.is_storage_enabled());
     assert!(!subsystems.is_functions_enabled());
-    assert!(!subsystems.is_realtime_enabled());
 }
 
 // ── Config validation ─────────────────────────────────────────────────────────
@@ -497,32 +424,6 @@ fn test_validate_empty_functions_registry_warns() {
     assert!(
         warnings.contains(&SubsystemConfigWarning::EmptyFunctionsRegistry),
         "expected EmptyFunctionsRegistry warning"
-    );
-}
-
-/// Realtime with no entities → `RealtimeWithNoEntities` warning.
-#[test]
-fn test_validate_realtime_no_entities_warns() {
-    let server = Arc::new(RealtimeServer::with_entities(
-        RealtimeConfig::default(),
-        HashSet::new(), // empty entity set
-    ));
-    let (observer, _rx) = RealtimeBroadcastObserver::new(64);
-    let schema_config: RealtimeSchemaConfig = serde_json::from_value(serde_json::json!({
-        "enabled": true,
-        "entities": []
-    }))
-    .unwrap();
-    let subsystem = RealtimeSubsystem {
-        server,
-        observer,
-        schema_config,
-    };
-    let subsystems = ServerSubsystemsBuilder::new().with_realtime(subsystem).build().unwrap();
-    let warnings = validate_subsystems_config(&subsystems);
-    assert!(
-        warnings.contains(&SubsystemConfigWarning::RealtimeWithNoEntities),
-        "expected RealtimeWithNoEntities warning"
     );
 }
 

--- a/crates/fraiseql-server/src/subsystems/validator.rs
+++ b/crates/fraiseql-server/src/subsystems/validator.rs
@@ -47,10 +47,6 @@ pub enum SubsystemConfigWarning {
     /// The functions module directory is configured but no function
     /// definitions exist in the schema. The directory will be ignored.
     EmptyFunctionsRegistry,
-
-    /// The realtime subsystem is enabled but no entities are declared.
-    /// Clients will not be able to subscribe to any entity streams.
-    RealtimeWithNoEntities,
 }
 
 impl fmt::Display for SubsystemConfigWarning {
@@ -69,11 +65,6 @@ impl fmt::Display for SubsystemConfigWarning {
             Self::EmptyFunctionsRegistry => f.write_str(
                 "the functions module directory is configured but no function \
                  definitions exist in the schema; the directory will be ignored",
-            ),
-            Self::RealtimeWithNoEntities => f.write_str(
-                "the realtime subsystem is enabled but no entities are declared; \
-                 clients will receive errors for all subscribe requests — \
-                 add entities under the 'realtime.entities' key in the compiled schema",
             ),
         }
     }
@@ -97,12 +88,6 @@ pub fn validate_subsystems_config(subsystems: &ServerSubsystems) -> Vec<Subsyste
     if let Some(functions) = &subsystems.functions {
         if functions.config.definitions.is_empty() {
             warnings.push(SubsystemConfigWarning::EmptyFunctionsRegistry);
-        }
-    }
-
-    if let Some(realtime) = &subsystems.realtime {
-        if realtime.schema_config.entities.is_empty() {
-            warnings.push(SubsystemConfigWarning::RealtimeWithNoEntities);
         }
     }
 

--- a/crates/fraiseql-server/tests/platform_e2e_test.rs
+++ b/crates/fraiseql-server/tests/platform_e2e_test.rs
@@ -58,7 +58,6 @@ fn test_platform_e2e_server_subsystems_none_is_all_absent() {
     let subsystems = ServerSubsystems::none();
     assert!(!subsystems.is_storage_enabled());
     assert!(!subsystems.is_functions_enabled());
-    assert!(!subsystems.is_realtime_enabled());
 }
 
 /// Verify that `BeforeMutationHooks` can be constructed from a trigger registry.


### PR DESCRIPTION
## Phase 04 of the #605 `/realtime/v1` removal train — Cluster E (server assembly + subsystems)

Fifth PR — the structural teardown. Removes every assembly seam that could ever
construct or mount the realtime subsystem, so that after this phase the
`src/realtime/` module is imported by **exactly one** non-realtime file
(`schema/loader.rs`, Cluster F / Phase 05) and otherwise only itself (Phase 06).

### Removed
- **`subsystems/`**: the `RealtimeSubsystem` struct, `ServerSubsystems.realtime`
  field, `is_realtime_enabled()`, `ServerSubsystemsBuilder::with_realtime`, the
  `RealtimeWithNoEntities` validator warning + its check, the `realtime::` imports,
  and the shutdown-ordering doc steps for the realtime channel/server.
- **`server/`**: the `Server.realtime_state` field, `ServerBuilder::with_realtime`,
  and the two struct-literal `realtime_state: None` defaults (`builder.rs` +
  the arrow-gated construction in `extensions.rs`).
- **`server/routing/extensions.rs`**: the mount-if-`Some` glue that merged
  `realtime_router` at `/realtime/v1`; doc lists updated.
- **Tests**: realtime cases removed from `subsystems/tests.rs` (storage/functions
  tests kept; mixed tests trimmed to their non-realtime assertions),
  `server/routing_tests.rs` (the two `/realtime/v1` mount tests + the realtime half
  of the coexistence test, rewritten storage-only; `AlwaysOkValidator` +
  `realtime_state()` helper removed), and the `is_realtime_enabled()` assertion in
  `tests/platform_e2e_test.rs`.

### The proof this phase exists for
After it, the reduced-import grep is exactly one line:
```
$ git grep -n "crate::realtime" -- crates/fraiseql-server/src | grep -v '/realtime/'
crates/fraiseql-server/src/schema/loader.rs:10:use crate::realtime::routes::RealtimeSchemaConfig;
```
`/realtime/v1` → 404 is now **structural**: nothing can mount it, even in tests.
The Phase 00 survival pins (incl. `default_prod_assembly_does_not_mount_realtime_v1`)
stay green.

### No runtime behaviour change
Every removed seam defaulted to `None`/off in production — no assembly ever
constructed a `RealtimeSubsystem` or set `realtime_state`. The crate-API removals
(`with_realtime`, `RealtimeSubsystem`, `is_realtime_enabled`) have no callers. The
full feature-matrix run is the proof; per the train's convention this phase carries
no `### Breaking` CHANGELOG entry (reserved for 01/02/05/06; finalize consolidates
the crate-API removals).

### Verification
- reduced-import grep = `schema/loader.rs` only ✅
- full `fraiseql-server` lib nextest ✅
- `make preflight` (fmt, clippy `--all-targets --all-features -D warnings`, rustdoc,
  shell gates) ✅ — the `--all-features` clippy is load-bearing here (catches any
  feature-gated `realtime_state` construction site)

Part of the #605 removal train · Phase 04/07 · no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
