### PR TITLE
refactor(server)!: untangle the realtime config formats (#605) — Phase 05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **The compiled-schema `"realtime"` section and the `[realtime]` server-config section are no
+  longer honored (#605).** With the dormant `/realtime/v1` subsystem removed, neither is
+  parsed: a compiled schema that still carries a `"realtime"` key loads with a `warn!`
+  ("`realtime` section is no longer supported and is ignored; recompile with the current
+  fraiseql-cli") and the section is dropped — the load never fails on it (fraiseql-cli never
+  emitted this section, so only a hand-authored or stale schema could contain one). A
+  `[realtime]` section in `fraiseql.toml` is now silently ignored by serde, where it
+  previously refused to boot with "config section 'realtime' is not yet implemented". Use
+  `/ws` GraphQL subscriptions for real-time updates.
 - **The `POST /realtime/v1/broadcast` channel-broadcast endpoint and room-presence tracking
   have been removed **without replacement** (#605).** These were the "channels"-style siblings
   of the dormant `/realtime/v1` entity stream: `BroadcastManager` (ephemeral pub/sub) and

--- a/crates/fraiseql-server/src/config/mod.rs
+++ b/crates/fraiseql-server/src/config/mod.rs
@@ -125,10 +125,6 @@ pub struct RuntimeConfig {
     #[serde(default)]
     pub queues: Option<QueueConfig>,
 
-    /// Reserved: placeholder for future real-time update configuration.
-    #[serde(default)]
-    pub realtime: Option<RealtimeConfig>,
-
     /// Reserved: placeholder for future custom-endpoint configuration.
     #[serde(default)]
     pub custom_endpoints: Option<CustomEndpointsConfig>,
@@ -439,10 +435,6 @@ pub struct CacheConfig {}
 /// Reserved: placeholder for future background job-queue configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct QueueConfig {}
-
-/// Reserved: placeholder for future real-time subscription update configuration.
-#[derive(Debug, Clone, Deserialize)]
-pub struct RealtimeConfig {}
 
 /// Reserved: placeholder for future custom HTTP endpoint configuration.
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/fraiseql-server/src/config/tests.rs
+++ b/crates/fraiseql-server/src/config/tests.rs
@@ -106,6 +106,34 @@ fn test_validation_missing_env_var() {
 }
 
 #[test]
+fn test_config_legacy_realtime_section_is_ignored_not_rejected() {
+    // #605: the `[realtime]` server-config section was removed. It previously failed
+    // validation ("config section 'realtime' is not yet implemented"); now, with the
+    // field gone and no `deny_unknown_fields`, serde silently ignores the stray table and
+    // no `realtime` validation error is produced — a stale `fraiseql.toml` still boots.
+    temp_env::with_vars([("DATABASE_URL", Some("postgres://localhost/test"))], || {
+        let toml = r#"
+            [server]
+            port = 4000
+
+            [database]
+            url_env = "DATABASE_URL"
+
+            [realtime]
+        "#;
+
+        let config: RuntimeConfig = toml::from_str(toml).unwrap();
+        let result = ConfigValidator::new(&config).validate();
+
+        assert!(
+            !result.errors.iter().any(|e| format!("{e:?}").contains("realtime")),
+            "a legacy [realtime] section must be silently ignored, not rejected: {:?}",
+            result.errors
+        );
+    });
+}
+
+#[test]
 fn test_validation_cross_field() {
     temp_env::with_vars([("DATABASE_URL", Some("postgres://localhost/test"))], || {
         let toml = r#"

--- a/crates/fraiseql-server/src/config/validation.rs
+++ b/crates/fraiseql-server/src/config/validation.rs
@@ -159,14 +159,13 @@ impl<'a> ConfigValidator<'a> {
                     .to_string(),
             });
         }
-        if self.config.realtime.is_some() {
-            self.result.add_error(ConfigError::ValidationError {
-                field:   "realtime".to_string(),
-                message: "config section 'realtime' is not yet implemented; \
-                          use the 'subscriptions' feature for real-time updates"
-                    .to_string(),
-            });
-        }
+        // NOTE: `[realtime]` is deliberately absent here. Unlike the reserved-future
+        // placeholders above (which refuse to boot so an operator isn't misled into
+        // thinking an unimplemented feature works), `realtime` is a *removed* feature
+        // (#605): its `RuntimeConfig` field was deleted, so a stray `[realtime]` table is
+        // silently ignored by serde (no `deny_unknown_fields`). This is an intentional
+        // back-compat choice for stale `fraiseql.toml` files — do NOT re-add a
+        // refuse-to-boot check here. The behaviour is documented in the CHANGELOG.
         if self.config.custom_endpoints.is_some() {
             self.result.add_error(ConfigError::ValidationError {
                 field:   "custom_endpoints".to_string(),

--- a/crates/fraiseql-server/src/schema/loader.rs
+++ b/crates/fraiseql-server/src/schema/loader.rs
@@ -5,9 +5,7 @@ use std::path::{Path, PathBuf};
 use fraiseql_core::schema::CompiledSchema;
 use fraiseql_functions::FunctionDefinition;
 use serde::Deserialize;
-use tracing::{debug, info};
-
-use crate::realtime::routes::RealtimeSchemaConfig;
+use tracing::{debug, info, warn};
 
 /// Error loading schema.
 #[derive(Debug, thiserror::Error)]
@@ -105,7 +103,7 @@ pub struct FunctionsConfig {
 /// A compiled schema with all optional platform extensions parsed out.
 ///
 /// Use [`CompiledSchemaLoader::load_extended`] to obtain this type. It bundles the
-/// core [`CompiledSchema`] together with optional storage, functions, and realtime
+/// core [`CompiledSchema`] together with optional storage and functions
 /// configurations that are embedded in the compiled schema JSON.
 #[derive(Debug)]
 pub struct ExtendedCompiledSchema {
@@ -117,9 +115,6 @@ pub struct ExtendedCompiledSchema {
 
     /// Serverless functions configuration, if the `"functions"` key is present.
     pub functions: Option<FunctionsConfig>,
-
-    /// Realtime broadcast observer configuration, if the `"realtime"` key is present.
-    pub realtime: Option<RealtimeSchemaConfig>,
 }
 
 /// Loader for compiled GraphQL schemas from JSON files.
@@ -212,9 +207,10 @@ impl CompiledSchemaLoader {
     /// Load schema and all optional platform extension sections from file.
     ///
     /// In addition to the core schema (types, queries, mutations, subscriptions),
-    /// this method parses and validates the `"storage"`, `"functions"`, and
-    /// `"realtime"` top-level keys if they are present. Unknown top-level keys are
-    /// ignored for forward compatibility.
+    /// this method parses and validates the `"storage"` and `"functions"` top-level
+    /// keys if they are present. A legacy `"realtime"` key is ignored with a warning
+    /// (the subsystem was removed in #605). Unknown top-level keys are ignored for
+    /// forward compatibility.
     ///
     /// # Errors
     ///
@@ -224,7 +220,6 @@ impl CompiledSchemaLoader {
     /// Returns [`SchemaLoadError::ValidationError`] if any of the following fail:
     ///   - A storage bucket name contains whitespace or is empty.
     ///   - A function trigger string does not match a recognised pattern.
-    ///   - A realtime entity name does not appear in the schema's type definitions.
     pub async fn load_extended(&self) -> Result<ExtendedCompiledSchema, SchemaLoadError> {
         info!(path = %self.path.display(), "Loading extended compiled schema");
 
@@ -249,10 +244,6 @@ impl CompiledSchemaLoader {
         let schema = CompiledSchema::from_json(&contents, false)
             .map_err(|e| SchemaLoadError::ValidationError(e.to_string()))?;
 
-        // Collect type names for cross-validation.
-        let type_names: std::collections::HashSet<String> =
-            schema.types.iter().map(|t| t.name.as_str().to_owned()).collect();
-
         // Parse and validate the optional sections.
         let storage = raw
             .get("storage")
@@ -274,21 +265,23 @@ impl CompiledSchemaLoader {
             })
             .transpose()?;
 
-        let realtime = raw
-            .get("realtime")
-            .filter(|v| !v.is_null())
-            .map(|v| {
-                let cfg: RealtimeSchemaConfig = serde_json::from_value(v.clone())?;
-                validate_realtime_config(&cfg, &type_names)?;
-                Ok::<_, SchemaLoadError>(cfg)
-            })
-            .transpose()?;
+        // The compiled-schema `"realtime"` section is no longer supported (#605): the
+        // dormant `/realtime/v1` subsystem was removed. fraiseql-cli never emitted this
+        // section (cli and server are version-locked on the format), so only a
+        // hand-authored or stale schema could contain one — warn and ignore rather than
+        // fail, keeping boot resilient while still surfacing the staleness.
+        if raw.get("realtime").is_some_and(|v| !v.is_null()) {
+            warn!(
+                path = %self.path.display(),
+                "compiled-schema `realtime` section is no longer supported and is ignored; \
+                 recompile with the current fraiseql-cli"
+            );
+        }
 
         info!(
             path = %self.path.display(),
             has_storage = storage.is_some(),
             has_functions = functions.is_some(),
-            has_realtime = realtime.is_some(),
             "Extended schema loaded successfully"
         );
 
@@ -296,7 +289,6 @@ impl CompiledSchemaLoader {
             schema,
             storage,
             functions,
-            realtime,
         })
     }
 
@@ -352,26 +344,6 @@ fn validate_functions_config(config: &FunctionsConfig) -> Result<(), SchemaLoadE
                  expected one of: after:mutation:<name>, before:mutation:<name>, \
                  after:storage:<bucket>:<op>, cron:<expr>, http:<method>:<path>",
                 def.name, def.trigger
-            )));
-        }
-    }
-    Ok(())
-}
-
-/// Validate that realtime entities exist in the schema's type definitions.
-///
-/// # Errors
-///
-/// Returns `ValidationError` if any entity name is not present in `type_names`.
-fn validate_realtime_config(
-    config: &RealtimeSchemaConfig,
-    type_names: &std::collections::HashSet<String>,
-) -> Result<(), SchemaLoadError> {
-    for entity in &config.entities {
-        if !type_names.contains(entity) {
-            return Err(SchemaLoadError::ValidationError(format!(
-                "realtime entity {entity:?} is not defined in schema types; \
-                 add a @fraiseql.type decorated class named {entity:?} or remove it from the realtime entities list"
             )));
         }
     }

--- a/crates/fraiseql-server/src/schema/tests.rs
+++ b/crates/fraiseql-server/src/schema/tests.rs
@@ -172,10 +172,13 @@ async fn test_schema_validates_function_triggers() {
     );
 }
 
-// ── Realtime config ───────────────────────────────────────────────────────────
+// ── Realtime config (removed in #605 — warn-and-ignore posture) ─────────────────
 
 #[tokio::test]
-async fn test_schema_loads_realtime_config() {
+async fn test_schema_with_realtime_key_is_ignored() {
+    // The `/realtime/v1` subsystem was removed (#605). A compiled schema that still
+    // carries a `"realtime"` section (hand-authored or stale) must load clean — the
+    // section is ignored (with a warning), not parsed, and never fails the load.
     let json = r#"{
         "types": [
             {"name": "Post", "sql_source": "t_posts"},
@@ -191,26 +194,25 @@ async fn test_schema_loads_realtime_config() {
     let loader = CompiledSchemaLoader::new(file.path());
 
     let extended = loader.load_extended().await.unwrap();
-    let realtime = extended.realtime.unwrap();
-
-    assert!(realtime.enabled);
-    assert_eq!(realtime.entities.len(), 2);
-    assert!(realtime.entities.contains(&"Post".to_string()));
-    assert_eq!(realtime.max_connections_per_context, Some(50));
+    // Core schema still loads; the realtime section is dropped (no field to inspect).
+    assert_eq!(extended.schema.types.len(), 2);
 }
 
 #[tokio::test]
-async fn test_schema_without_realtime_returns_none() {
+async fn test_schema_without_realtime_key_loads_clean() {
+    // Survival pin (#605 Phase 00 pin #4): a realtime-free schema — the overwhelmingly
+    // common case — loads without error before, during, and after the removal.
     let file = write_schema(minimal_schema());
     let loader = CompiledSchemaLoader::new(file.path());
 
-    let extended = loader.load_extended().await.unwrap();
-    assert!(extended.realtime.is_none());
+    loader.load_extended().await.unwrap();
 }
 
 #[tokio::test]
-async fn test_schema_validates_realtime_entities() {
-    // "Ghost" is not in schema types
+async fn test_schema_realtime_key_with_unknown_entity_is_ignored() {
+    // Before #605 this errored (`validate_realtime_config` rejected an entity absent
+    // from the schema types). Under warn-and-ignore, the whole section is dropped, so a
+    // "ghost" entity can no longer fail the load — the section is never validated.
     let json = r#"{
         "types": [{"name": "Post", "sql_source": "t_posts"}],
         "realtime": {
@@ -223,8 +225,8 @@ async fn test_schema_validates_realtime_entities() {
 
     let result = loader.load_extended().await;
     assert!(
-        matches!(result, Err(SchemaLoadError::ValidationError(_))),
-        "expected ValidationError for unknown realtime entity, got {result:?}"
+        result.is_ok(),
+        "realtime section must be ignored, not validated, got {result:?}"
     );
 }
 
@@ -253,9 +255,10 @@ async fn test_schema_full_loads_all_sections() {
 
     let extended = loader.load_extended().await.unwrap();
 
+    // storage + functions load; the legacy `"realtime"` section (still in the fixture) is
+    // ignored with a warning (#605), so the load still succeeds.
     assert!(extended.storage.is_some());
     assert!(extended.functions.is_some());
-    assert!(extended.realtime.is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Phase 05 of the #605 `/realtime/v1` removal train — Cluster F (config formats)

Sixth PR — the **config-format untangle**. Removes the `"realtime"` section from
the compiled-schema loader and `RealtimeConfig` from the server config. This is
**the last non-realtime importer** of `src/realtime/`, so after it the module is
import-free and Phase 06 is a pure deletion.

### The proof this phase exists for
```
$ git grep -n "crate::realtime" -- crates/fraiseql-server/src | grep -v '/realtime/'
(no output — src/realtime/ is now imported by nothing outside itself)
```

### Loader — warn-and-ignore (gate 2)
`schema/loader.rs`: removed the `realtime` field on `ExtendedCompiledSchema`, the
parse block, `validate_realtime_config`, the now-orphaned `type_names` computation,
and the `RealtimeSchemaConfig` import. A compiled schema that still carries a
`"realtime"` key now loads with a `warn!` ("`realtime` section is no longer
supported and is ignored; recompile with the current fraiseql-cli") and the section
is dropped — the load **never fails** on it. (fraiseql-cli never emitted this
section, and cli/server are version-locked on the format, so only a hand-authored
or stale schema could contain one; hard-erroring would punish only those.)

Pinned both ways in `schema/tests.rs`:
- `test_schema_without_realtime_key_loads_clean` — the common case (Phase 00 pin #4).
- `test_schema_with_realtime_key_is_ignored` — a realtime-bearing schema loads clean.
- `test_schema_realtime_key_with_unknown_entity_is_ignored` — **RED→GREEN**: a
  "ghost" entity that used to fail `validate_realtime_config` now loads (the section
  is never validated).

### Server config — now inert
`config/mod.rs`: removed the empty `RealtimeConfig` struct + the `Option<RealtimeConfig>`
field. `config/validation.rs`: removed the check that **rejected** a `[realtime]`
section ("config section 'realtime' is not yet implemented"). With no field and no
`deny_unknown_fields`, serde now silently ignores a stray `[realtime]` TOML table.
New pin `test_config_legacy_realtime_section_is_ignored_not_rejected` (**RED→GREEN**:
errored before, boots clean now).

### `### Breaking` CHANGELOG
Compiled-schema `"realtime"` section no longer honored (warn-and-ignore); `[realtime]`
server-config section inert (was: refuse-to-boot). Both named; `/ws` is the supported
mechanism.

### Verification
- import-free proof (above) ✅
- full `fraiseql-server` lib nextest — 1213 passed ✅
- `make preflight` (fmt, clippy `--all-features -D warnings`, rustdoc, shell gates) ✅

Part of the #605 removal train · Phase 05/07 · no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
