### PR TITLE
test(665): Phase 00 baseline pins for changelog + cascade conformance

### DIFF
--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2674,6 +2674,210 @@ mod changelog_validation_tests {
     }
 }
 
+// ── #665 changelog projections vs. cascade entity classification ─────────────
+
+mod changelog_cascade_conformance_tests {
+    //! Pins for the interaction between the framework-synthesized changelog
+    //! projections and cascade entity classification (#665), plus the two exclusion
+    //! legs `is_queryable_entity`'s doc-comment claims but which nothing pinned.
+
+    use fraiseql_core::schema::ChangelogConfig;
+    use serde_json::json;
+
+    use crate::schema::{
+        converter::SchemaConverter,
+        intermediate::{
+            IntermediateField, IntermediateMutation, IntermediateSchema, IntermediateType,
+        },
+    };
+
+    fn field(name: &str, field_type: &str) -> IntermediateField {
+        IntermediateField {
+            name:           name.to_string(),
+            field_type:     field_type.to_string(),
+            nullable:       false,
+            description:    None,
+            directives:     None,
+            requires_scope: None,
+            on_deny:        None,
+            authorize:      None,
+            hierarchy:      None,
+        }
+    }
+
+    /// A view-backed entity with a conformant `id: ID`.
+    fn entity(name: &str) -> IntermediateType {
+        IntermediateType {
+            name: name.to_string(),
+            sql_source: Some(format!("v_{}", name.to_lowercase())),
+            fields: vec![field("id", "ID"), field("title", "String")],
+            ..IntermediateType::default()
+        }
+    }
+
+    fn cascade_mutation(name: &str, entity_type: &str) -> IntermediateMutation {
+        IntermediateMutation {
+            name: name.to_string(),
+            return_type: entity_type.to_string(),
+            cascade: true,
+            sql_source: Some(format!("fn_{}", name.to_lowercase())),
+            ..IntermediateMutation::default()
+        }
+    }
+
+    fn schema_with(
+        types: Vec<IntermediateType>,
+        mutations: Vec<IntermediateMutation>,
+    ) -> IntermediateSchema {
+        IntermediateSchema {
+            version: "2.0.0".to_string(),
+            types,
+            mutations,
+            ..IntermediateSchema::default()
+        }
+    }
+
+    /// The same, with the change-log surface exposed (and its observers prerequisite).
+    fn changelog_schema_with(
+        types: Vec<IntermediateType>,
+        mutations: Vec<IntermediateMutation>,
+    ) -> IntermediateSchema {
+        IntermediateSchema {
+            changelog_config: Some(ChangelogConfig {
+                expose: true,
+                ..Default::default()
+            }),
+            observers_config: Some(json!({ "enabled": true, "backend": "redis" })),
+            ..schema_with(types, mutations)
+        }
+    }
+
+    /// The cascade envelope and payload types are never cascade nodes: each is
+    /// synthesized with an empty `sql_source`, which is the sole mechanism excluding
+    /// them from `is_queryable_entity`.
+    ///
+    /// Pinned because the exclusion is load-bearing but was previously only implied by
+    /// `synth_type`'s construction — no test asserted it.
+    #[test]
+    fn cascade_envelope_types_are_never_cascade_nodes() {
+        let compiled = SchemaConverter::convert(schema_with(
+            vec![entity("Post")],
+            vec![cascade_mutation("createPost", "Post")],
+        ))
+        .expect("cascade-only schema compiles");
+
+        // The user entity is a cascade node …
+        let post = compiled.types.iter().find(|t| t.name.as_str() == "Post").unwrap();
+        assert!(
+            post.implements.iter().any(|i| i == "CascadeNode"),
+            "Post implements CascadeNode"
+        );
+
+        // … and none of the synthesized machinery is.
+        for name in [
+            "UpdatedEntity",
+            "DeletedEntity",
+            "CascadeUpdates",
+            "CascadeMetadata",
+            "QueryInvalidation",
+            "CreatePostPayload",
+        ] {
+            let ty = compiled.types.iter().find(|t| t.name.as_str() == name);
+            assert!(ty.is_some(), "{name} is synthesized");
+            let ty = ty.unwrap();
+            assert!(ty.sql_source.as_str().is_empty(), "{name} declares no sql_source");
+            assert!(
+                !ty.implements.iter().any(|i| i == "CascadeNode"),
+                "{name} does not implement CascadeNode"
+            );
+        }
+    }
+
+    /// Relay connection/edge wrappers are excluded from the cascade entity set for the
+    /// same reason. `is_queryable_entity`'s doc-comment asserts this ("as are relay
+    /// connection/edge wrappers"); until now nothing combined `relay = true` with
+    /// `cascade = true` to prove it.
+    #[test]
+    fn relay_wrapper_types_are_never_cascade_nodes() {
+        let post = IntermediateType {
+            relay: true,
+            ..entity("Post")
+        };
+        let compiled = SchemaConverter::convert(schema_with(
+            vec![post],
+            vec![cascade_mutation("createPost", "Post")],
+        ))
+        .expect("relay + cascade compiles");
+
+        for name in ["PostConnection", "PostEdge", "PageInfo"] {
+            let ty = compiled.types.iter().find(|t| t.name.as_str() == name);
+            assert!(ty.is_some(), "{name} is synthesized by the relay pass");
+            assert!(
+                !ty.unwrap().implements.iter().any(|i| i == "CascadeNode"),
+                "{name} is a pagination wrapper, not a cascade entity"
+            );
+        }
+    }
+
+    /// **#665 REPRO — EXPECTED-FAILURE PIN. This test is FLIPPED by Phase 02 of the
+    /// #665 train into its success shape.**
+    ///
+    /// Asserts the CURRENT (broken) behavior so it merges green on top of the bug:
+    /// exposing the change-log and opting any single mutation into `cascade = true`
+    /// fails to compile. `inject_changelog` (converter/mod.rs) runs *before*
+    /// `synthesize_cascade_types`, so the framework's own `TransportCheckpoint`
+    /// projection — view-backed, non-error, and keyed by `transport_name` with no `id`
+    /// by design — is classified a cascade entity and fails the `id: ID!` contract.
+    ///
+    /// The result is that the two features are mutually exclusive, on a type the user
+    /// never wrote and cannot fix. This is the discriminating pin for the train: it
+    /// proves Phase 02 changes the one thing it claims to.
+    #[test]
+    fn changelog_plus_cascade_fails_on_transport_checkpoint_today() {
+        let err = SchemaConverter::convert(changelog_schema_with(
+            vec![entity("Post")],
+            vec![cascade_mutation("createPost", "Post")],
+        ))
+        .expect_err("#665: changelog + cascade is currently mutually exclusive");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("cascade requires `id: ID!`"),
+            "fails via the cascade conformance enforcement, got: {msg}"
+        );
+        assert!(
+            msg.contains("TransportCheckpoint") && msg.contains("no `id` field"),
+            "the offender is the framework's own TransportCheckpoint projection, got: {msg}"
+        );
+        // The #659 diagnostic enrichment fires on a framework projection and tells the
+        // user their type is an embedded value object that should drop its source —
+        // advice that is both wrong and unactionable here. Pinned so the flip in
+        // Phase 02 is visibly removing a misleading diagnostic, not just an error.
+        assert!(
+            msg.contains("embedded value object"),
+            "the derivation-signal hint misfires on a framework projection, got: {msg}"
+        );
+    }
+
+    /// The change-log surface alone (no cascade mutation) compiles — the baseline the
+    /// fix must not disturb.
+    #[test]
+    fn changelog_without_cascade_compiles() {
+        let compiled = SchemaConverter::convert(changelog_schema_with(
+            vec![entity("Post")],
+            vec![IntermediateMutation {
+                cascade: false,
+                ..cascade_mutation("createPost", "Post")
+            }],
+        ))
+        .expect("changelog-only schema compiles");
+
+        assert!(compiled.types.iter().any(|t| t.name == "EntityChangeLog"));
+        assert!(compiled.types.iter().any(|t| t.name == "TransportCheckpoint"));
+        assert!(!compiled.interfaces.iter().any(|i| i.name == "CascadeNode"));
+    }
+}
+
 // ── #573 scheduled ingress sources ───────────────────────────────────────────
 
 #[test]

--- a/crates/fraiseql-core/src/schema/changelog/tests.rs
+++ b/crates/fraiseql-core/src/schema/changelog/tests.rs
@@ -54,6 +54,61 @@ fn exposed_config_injects_full_surface() {
     assert!(schema.mutation_index.contains_key("upsert_transport_checkpoint"));
 }
 
+/// `EntityChangeLog.id` is `FieldType::Id` — the reason this projection satisfies the
+/// Node-style `id: ID!` contract that the cascade and Relay passes force onto entities,
+/// while its sibling `TransportCheckpoint` does not (#665).
+///
+/// Pinned because the only pre-existing assertion on this field
+/// (`camel_case_convention_renders_camelcase_identifiers`) checks that it *exists* — it
+/// is there to prove single-word names aren't recased, and would still pass if the field
+/// type changed.
+#[test]
+fn entity_change_log_id_field_is_id_typed() {
+    let schema = exposed_schema(ChangelogConfig {
+        expose: true,
+        ..Default::default()
+    });
+
+    let ecl = schema
+        .types
+        .iter()
+        .find(|t| t.name == ENTITY_CHANGE_LOG)
+        .expect("EntityChangeLog");
+    let id = ecl.find_field("id").expect("EntityChangeLog.id");
+    assert_eq!(id.field_type, FieldType::Id, "EntityChangeLog.id backs the `id: ID!` contract");
+    assert!(!id.nullable, "EntityChangeLog.id is non-null");
+}
+
+/// `TransportCheckpoint` is keyed by `transport_name` and deliberately carries **no**
+/// `id`: it is a consumer's cursor bookkeeping row, not an identity-bearing entity.
+///
+/// This absence is the precondition of #665 — it is what makes the framework's own
+/// projection fail the cascade `id: ID!` enforcement. Pinned explicitly so that adding a
+/// synthetic `id` here can never become a silent, incidental "fix": that would dissolve
+/// the bug out from under this train's regression test while leaving the real defect
+/// (framework projections being classified as cascade entities at all) in place.
+#[test]
+fn transport_checkpoint_has_no_id_field() {
+    let schema = exposed_schema(ChangelogConfig {
+        expose: true,
+        ..Default::default()
+    });
+
+    let tc = schema
+        .types
+        .iter()
+        .find(|t| t.name == TRANSPORT_CHECKPOINT)
+        .expect("TransportCheckpoint");
+    assert!(
+        tc.find_field("id").is_none(),
+        "TransportCheckpoint is keyed by transport_name and has no `id` by design"
+    );
+    assert!(
+        tc.find_field("transport_name").is_some(),
+        "TransportCheckpoint.transport_name is key"
+    );
+}
+
 #[test]
 fn list_query_uses_filter_machinery_and_bypasses_cache() {
     let schema = exposed_schema(ChangelogConfig {


### PR DESCRIPTION
Phase 00 of the #665 train (4 phases, serial, each merged before the next). **Tests only — no production code changes.**

Pins every behavior the fix must not change, plus the #665 repro as an expected-failure pin, so the Phase 01/02 diffs can only show the intended change.

## Baseline re-verification (the plan had moved)

The plan was written against `origin/dev @ post-#662`; the #605 realtime-removal train has since merged 8 PRs. Re-verified every code reference against `origin/dev @ ba68529fb`. **The four load-bearing references survive exactly:**

| Claim | Status |
|---|---|
| Pass order `:285` `inject_changelog` → `:293` `synthesize_cascade_types` → `:313` `validate` | ✅ exact |
| `is_queryable_entity` at `cascade_types.rs:176`; consumers `:89` (enforcement) + `:108` (auto-implement) — exactly two | ✅ exact |
| `changelog.rs` is the only production `TypeDefinition::new` site (`:92`, `:116`) | ✅ exact |
| `EntityChangeLog` carries `FieldType::Id`; `TransportCheckpoint` keyed by `transport_name`, no `id` | ✅ exact |

Four drift corrections:

1. **`database_validator.rs` path was wrong in the plan.** Actual: `crates/fraiseql-cli/src/schema/database_validator.rs` — *not* under `converter/`. Comment `:594`, inline predicate `:597`. The substance is confirmed: the stale "exactly the `is_queryable_entity` set the cascade pass keys off" comment is present verbatim, so the Phase 02 divergence work is unaffected.
2. **New trap the plan did not cover — a doctest.** `TypeDefinition` has no `Default` impl, so adding a field breaks ~11 exhaustive struct literals (the plan anticipates those; the compiler enumerates them). But `graphql_type_defs.rs:25-42` is an exhaustive struct literal **inside a doctest**, which `cargo check` does not compile. Direct precedent six commits back: `1440af622 fix(core): repair TypeDefinition doctest broken by subscription_policy field`. Phase 01 takes the doctest into scope and adds `RUSTDOCFLAGS="-D warnings" cargo doc` to its gate.
3. `app_state.rs` `TypeDefinition` hit moved `:738` → `:716`; still inside `#[cfg(test)]`, so "changelog.rs is the only production synthesizer" holds.
4. The plan's "#605 touches neither `fraiseql-cli` nor `fraiseql-core` schema code" is slightly false — #672 touched `fraiseql-core/src/schema/subscription_policy.rs`. Nowhere near changelog/cascade; the no-ordering-constraint conclusion survives.

## Existing coverage (enumerated first; only gaps added)

**Already covered — not duplicated.** Survival-set item 3 (user-entity enforcement stays rich) is well covered and left alone: `cascade_missing_id_entity_fails_with_actionable_error` (`:2182`), `cascade_embedded_value_object_error_reports_derivation_and_path` (`:2203`, the #659-hardened message), `cascade_flagged_entity_unreachable_from_a_mutation_has_no_reference_path` (`:2244`), `cascade_int_id_entity_fails_with_actionable_error` (`:2268`), `cascade_conformance_error_aggregates_all_offenders` (`:2292`), `synthesis_never_leaks_a_raw_validator_bail` (`:2352`). Changelog injection is covered by 11 tests in `changelog/tests.rs` and the 5-test `changelog_validation_tests` module.

**Confirmed gap: no test anywhere combines changelog + cascade** — verified three ways (every `expose = true` site builds a schema with no mutations; every `cascade: true` site sets `changelog_config: None`; no fixture sets both). That gap is exactly what let #665 ship.

## What this PR adds

| Test | Pins |
|---|---|
| `entity_change_log_id_field_is_id_typed` | `EntityChangeLog.id` is `FieldType::Id`, non-null. The only pre-existing assertion checked existence, not type. |
| `transport_checkpoint_has_no_id_field` | The deliberate absence of `id` — the precondition of #665. Stops a synthetic `id` becoming a silent incidental "fix". |
| `cascade_envelope_types_are_never_cascade_nodes` | Envelope/payload types declare empty `sql_source`, never implement `CascadeNode`. |
| `relay_wrapper_types_are_never_cascade_nodes` | Same for `PostConnection`/`PostEdge`/`PageInfo` — an exclusion the doc-comment claimed but nothing tested. |
| **`changelog_plus_cascade_fails_on_transport_checkpoint_today`** | **The #665 repro, asserting current broken behavior so it merges green. Phase 02 flips it.** |
| `changelog_without_cascade_compiles` | Single-feature baseline. |

The repro pin also asserts that the #659 derivation hint *misfires* here: it tells the user their `TransportCheckpoint` is an "embedded value object" that "should declare no source" — advice that is both wrong and unactionable on a type they never wrote and cannot edit. Pinned so Phase 02's flip visibly removes a misleading diagnostic, not merely an error.

## RED proof

Every new pin was proven able to fail by mutating the source, watching it fail, and reverting:

- **Core pins** — `EntityChangeLog.id` → `String` and an `id` added to `TransportCheckpoint`: both fail on their own assertions (`left: String, right: Id` / "keyed by transport_name and has no `id` by design").
- **Repro pin** — `is_queryable_entity` given a stand-in for Phase 02's `!ty.internal`: `convert()` succeeds and `expect_err` panics. This is precisely the flip Phase 02 must produce, and it confirms the design early: with `TransportCheckpoint` excluded, changelog + cascade compiles, so `EntityChangeLog` does pass on its own `id`.
- **Envelope + relay pins** — synthetic types given a non-empty `sql_source`: the envelope pin fails its own assertion, the relay pin fails compile-conformance (the wrappers become id-less cascade entities).

## Verification

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo test -p fraiseql-core -p fraiseql-cli` — all green except `changelog_e2e_full_stack`, which is **pre-existing and environmental**: it panics in `testcontainer.rs:41` on an unset `DATABASE_URL` before reaching any schema logic, and runs in the Dagger integration leg. `changelog_e2e.rs` is untouched by this branch.
- ✅ `make preflight`

Refs #665
