### PR TITLE
fix(cli): enforce mutation requires_role — the authored role was dropped at compile (#676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscribe-time boundary until they reconnect (the reload warning now says so); mid-stream
   re-derivation of live subscriptions is a deferred follow-up.
 
+### Security
+
+- **`mutation(requires_role=…)` is now enforced — the authored role was previously discarded
+  at compile time, shipping the mutation ungated (#676).** A mutation declared with
+  `@fraiseql.mutation(requires_role="admin")` (a capability documented in
+  `docs/guides/operation-authorization.md`) was accepted by the SDK, silently dropped during
+  compilation, and served callable by **any** principal — with no error at author time, no
+  warning at compile time, and nothing in the compiled artifact recording that a gate had been
+  requested. The runtime gate itself was always correct and tested; it simply never received
+  its input. Two links were broken: `IntermediateMutation` declared no `requires_role` field
+  (so serde discarded the key from `schema.json`), and the converter hardcoded `None`. Both are
+  fixed, mirroring the query path, which was unaffected throughout.
+
+  **Audit your mutations.** Any deployment relying on `requires_role` for mutation
+  authorization was unprotected by that control on every release since it was documented;
+  compensating controls (field authorizers, operation authorizers, RLS, gateway rules) were
+  not affected. Recompiling with this release makes the declared roles take effect — which
+  may **newly reject** callers that previously succeeded, so verify role assignments before
+  rolling out. Type-level `requires_role` remains unenforced and is tracked separately in
+  \#677.
+
 ## [2.13.1] - 2026-07-18
 
 ### Changed

--- a/crates/fraiseql-cli/src/schema/converter/mutations.rs
+++ b/crates/fraiseql-cli/src/schema/converter/mutations.rs
@@ -75,7 +75,7 @@ impl SchemaConverter {
             rest_path: None,
             rest_method: None,
             upsert_function: None,
-            requires_role: None,
+            requires_role: intermediate.requires_role,
             changelog: intermediate.changelog,
             input_style: intermediate.input_style,
             changelog_pre_image: intermediate.changelog_pre_image,

--- a/crates/fraiseql-cli/src/schema/intermediate/operations.rs
+++ b/crates/fraiseql-cli/src/schema/intermediate/operations.rs
@@ -148,6 +148,14 @@ pub struct IntermediateMutation {
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub inject: IndexMap<String, String>,
 
+    /// Role required to execute this mutation and see it in introspection.
+    ///
+    /// Mirrors [`IntermediateQuery::requires_role`]. Enforced at runtime with the same
+    /// enumeration-hiding "not found" response as the query gate — a principal lacking
+    /// the role cannot distinguish a forbidden mutation from a nonexistent one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_role: Option<String>,
+
     /// Fact tables whose version counter should be bumped after this mutation succeeds.
     ///
     /// Used for correct invalidation of analytic/aggregate cache entries.
@@ -222,6 +230,7 @@ impl Default for IntermediateMutation {
             operation:               None,
             deprecated:              None,
             inject:                  IndexMap::new(),
+            requires_role:           None,
             invalidates_fact_tables: Vec::new(),
             invalidates_views:       Vec::new(),
             changelog:               default_changelog(),

--- a/crates/fraiseql-cli/tests/auto_mutation_error_union_test.rs
+++ b/crates/fraiseql-cli/tests/auto_mutation_error_union_test.rs
@@ -37,6 +37,7 @@ fn object_mutation(name: &str, return_type: &str) -> IntermediateMutation {
         operation:               Some("CUSTOM".to_string()),
         deprecated:              None,
         inject:                  IndexMap::new(),
+        requires_role:           None,
         invalidates_fact_tables: Vec::new(),
         invalidates_views:       Vec::new(),
         changelog:               true,

--- a/crates/fraiseql-cli/tests/converter_field_survival_test.rs
+++ b/crates/fraiseql-cli/tests/converter_field_survival_test.rs
@@ -236,6 +236,68 @@ fn converter_threads_invalidates_fact_tables_on_mutation() {
     );
 }
 
+/// #676: an authored `mutation(requires_role=…)` must reach the compiled schema.
+///
+/// The runtime gate at `runtime/executor/runners/mutation/mod.rs` is correct and
+/// enumeration-hiding, but it can only fire if the role survives compilation. It did
+/// not: `IntermediateMutation` declared no `requires_role` field (so serde dropped the
+/// key silently) and the converter hardcoded `None`. The result was an authored
+/// admin-only mutation shipping callable by anyone, with no error at author time and
+/// none at compile time.
+///
+/// The query twin of this test (`converter_threads_requires_role_on_query`) existed
+/// throughout; only the mutation side was missing, which is why the gap survived.
+#[test]
+fn converter_threads_requires_role_on_mutation() {
+    let schema = IntermediateSchema {
+        types: vec![order_type()],
+        mutations: vec![IntermediateMutation {
+            name: "deleteOrganization".to_string(),
+            return_type: "Order".to_string(),
+            sql_source: Some("fn_delete_organization".to_string()),
+            requires_role: Some("admin".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let compiled = SchemaConverter::convert(schema).expect("convert must succeed");
+    let m = compiled
+        .find_mutation("deleteOrganization")
+        .expect("'deleteOrganization' must be present");
+
+    assert_eq!(
+        m.requires_role.as_deref(),
+        Some("admin"),
+        "requires_role must survive SchemaConverter::convert()"
+    );
+}
+
+/// #676: the role must also survive **deserialization** of the authored `schema.json`.
+///
+/// This is the link the converter test cannot cover. `IntermediateMutation` carries no
+/// `deny_unknown_fields`, so before the fix a `requires_role` key emitted by the SDK was
+/// discarded without comment — the field was gone before the converter ever ran. Pinning
+/// the JSON boundary keeps the whole authoring → compile chain honest.
+#[test]
+fn mutation_requires_role_survives_schema_json_deserialization() {
+    let json = serde_json::json!({
+        "name": "deleteOrganization",
+        "return_type": "Order",
+        "sql_source": "fn_delete_organization",
+        "requires_role": "admin",
+    });
+
+    let m: IntermediateMutation =
+        serde_json::from_value(json).expect("intermediate mutation must deserialize");
+
+    assert_eq!(
+        m.requires_role.as_deref(),
+        Some("admin"),
+        "requires_role must survive schema.json deserialization"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Type field survival
 // ---------------------------------------------------------------------------

--- a/crates/fraiseql-cli/tests/e2e_schema_generation.rs
+++ b/crates/fraiseql-cli/tests/e2e_schema_generation.rs
@@ -487,6 +487,7 @@ fn test_e2e_full_field_assertion() {
             deprecated:              None,
             sql_source:              Some("fn_create_user".to_string()),
             inject:                  IndexMap::default(),
+            requires_role:           None,
             invalidates_fact_tables: vec![],
             invalidates_views:       vec![],
             changelog:               true,


### PR DESCRIPTION
Closes #676.

A mutation declared `@fraiseql.mutation(requires_role="admin")` was accepted by the SDK, silently discarded during compilation, and served callable by **any** principal — no error at author time, no warning at compile time, and nothing in the compiled artifact recording that a gate had been requested and dropped.

The runtime gate was never at fault. `runtime/executor/runners/mutation/mod.rs:820` is correct, enumeration-hiding, and already covered by `mod mutation_rbac` (#149). It simply never received its input.

## The two broken links

Both are mirrored correctly on the query path, which was unaffected throughout:

| Link | Mutation (broken) | Query (correct) |
|---|---|---|
| Intermediate struct | `IntermediateMutation` declared no `requires_role`; no `deny_unknown_fields`, so serde discarded the key from `schema.json` | `IntermediateQuery:99-101` declares it |
| Converter | `converter/mutations.rs:78` hardcoded `requires_role: None` | `converter/queries.rs:158` threads it |

Because the field was gone before the converter ran, fixing either link alone would have been insufficient.

## Both SDKs emit the key — the loss was entirely compiler-side

- **Python:** `@fraiseql.mutation` forwards `**cfg` verbatim (`decorators.py:899`). It fails fast on bad `invalidates_views` / `changelog` / `input_style` values, but has no allowlist, so `requires_role` passed through unremarked.
- **TypeScript:** `registerMutation` runs the shared `normaliseConfig`, which maps `requiresRole` → `requires_role` (`registry.ts:307`, applied at `:587`).

Neither SDK needed a change.

## This is one bug class, third instance

An authoring-layer key that no intermediate struct declares is discarded without comment. The previous instance is recorded in its own doc-comment at `intermediate/operations.rs:212` — `cascade`, "Before this field, the compiler silently dropped the SDK flag."

**A suspected fourth, not fixed here:** per-operation REST config. The TS SDK emits a `rest: {path, method}` block per operation (`registry.ts:404`), but neither `IntermediateQuery` nor `IntermediateMutation` declares a `rest` field, and `rest_path` is written as an unconditional `None` in both converters (`mutations.rs:75`, `queries.rs:159`) with no other writer anywhere in the crate. That would mean per-operation REST annotations never reach the compiled schema. Reported on #676 for triage rather than folded in — it is a functionality question, not a security one, and deserves its own verification.

Worth considering separately: the silent-drop shape itself. Any future authoring/compiler skew fails the same quiet way.

## Verification

**RED proven.** Both new tests failed to compile against the pre-fix struct — `E0560 struct IntermediateMutation has no field named requires_role` (:258) and `E0609 no field requires_role` (:295). The field's absence *is* the bug, so compile-failure is the honest red.

Two pins added to `converter_field_survival_test.rs`:
- `converter_threads_requires_role_on_mutation` — the twin of the long-standing `converter_threads_requires_role_on_query`, whose absence is precisely why this survived.
- `mutation_requires_role_survives_schema_json_deserialization` — the JSON boundary the converter test cannot reach.

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo test -p fraiseql-cli` (full, not `--lib`) — 668 lib + all integration green
- ✅ `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- ✅ `make preflight`

## Rollout note

The CHANGELOG entry is under `### Security` and carries an audit warning: recompiling makes declared roles take effect, which may **newly reject** callers that previously succeeded. Role assignments should be verified before rolling out.

The commit is deliberately *not* marked `!` — this restores documented behavior rather than breaking an API — but the runtime effect on a deployment relying on the broken state is real, hence the explicit note.

Type-level `requires_role` remains unenforced and is tracked separately in #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)