### PR TITLE
fix(cli,core): exclude framework projections from cascade classification (#665 Phase 02)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -229,6 +229,7 @@ func (m *FraiseqlCi) ShellGates(
 		"bash tools/check-test-imports.sh",
 		"bash tools/check-route-syntax.sh",
 		"bash tools/check-deploy-security.sh",
+		"bash tools/check-internal-flag-sites.sh",
 		"bash tools/check-audit-lockstep.sh",
 		"bash tools/check-deadlines.sh",
 	}, "\n")

--- a/Makefile
+++ b/Makefile
@@ -458,6 +458,12 @@ lint-routes:
 lint-deploy-security:
 	@bash tools/check-deploy-security.sh
 
+# Gate: pin the set of production files that READ TypeDefinition.internal (#665), so a
+# property-named flag cannot silently grow new consumers. See tools/check-internal-flag-sites.sh.
+.PHONY: lint-internal-flag
+lint-internal-flag:
+	@bash tools/check-internal-flag-sites.sh
+
 # Run the cheap-but-frequent CI gates locally before `git push`, to catch the
 # failures the Dagger `preflight` leg would reject — rustfmt drift, clippy
 # `-D warnings`, broken rustdoc intra-doc links, and the grep/wc policy gates —
@@ -466,7 +472,7 @@ lint-deploy-security:
 # test suite or service-backed integration tests — those are `make test` and the
 # separate Dagger test/integration legs.
 .PHONY: preflight
-preflight: fmt-check lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-routes test-release-tooling
+preflight: fmt-check lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-routes lint-internal-flag test-release-tooling
 	@echo "=== preflight: lint-unwrap (UNWRAP_ALLOW_LIMIT=3) ==="
 	@$(MAKE) --no-print-directory lint-unwrap UNWRAP_ALLOW_LIMIT=3
 	@echo "=== preflight: check-test-imports ==="

--- a/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
@@ -169,12 +169,22 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) -> anyhow::R
     Ok(())
 }
 
-/// A queryable entity type: view-backed and non-error. The `CascadeNode` interface
-/// is auto-implemented on exactly these. Synthetic types (the cascade envelope,
-/// payloads, `MutationError`) have an empty `sql_source` and are excluded, as are
-/// relay connection/edge wrappers.
+/// A queryable entity type: the `CascadeNode` interface is auto-implemented on exactly
+/// these, and `id: ID!` is enforced on exactly these. Three exclusion legs:
+///
+/// - **error types** (`is_error`) — populated from `mutation_response.metadata`, never a cache
+///   node;
+/// - **framework-internal projections** (`internal`, #665) — the change-log / checkpoint
+///   bookkeeping views `inject_changelog` synthesizes are the change-capture *mechanism*, not
+///   cascade-deliverable entities; `TransportCheckpoint` in particular has no `id` by design and
+///   could never back the CascadeNode contract;
+/// - **empty-source synthetics** — the cascade envelope/payload types and `MutationError` carry an
+///   empty `sql_source`, as do relay connection/edge wrappers.
+///
+/// This one predicate feeds BOTH the `id: ID!` enforcement and the
+/// `implements CascadeNode` auto-loop, so the two can never key off divergent sets.
 fn is_queryable_entity(ty: &TypeDefinition) -> bool {
-    !ty.is_error && !ty.sql_source.as_str().is_empty()
+    !ty.is_error && !ty.internal && !ty.sql_source.as_str().is_empty()
 }
 
 /// Explain (#653) why a type that failed the `id: ID!` contract was classified a cascade

--- a/crates/fraiseql-cli/src/schema/converter/tests.rs
+++ b/crates/fraiseql-cli/src/schema/converter/tests.rs
@@ -2819,44 +2819,50 @@ mod changelog_cascade_conformance_tests {
         }
     }
 
-    /// **#665 REPRO — EXPECTED-FAILURE PIN. This test is FLIPPED by Phase 02 of the
-    /// #665 train into its success shape.**
+    /// **#665 — the fix.** Exposing the change-log and opting a mutation into
+    /// `cascade = true` now COMPILES. `inject_changelog` marks its two projections
+    /// `internal` (Phase 01); `is_queryable_entity` excludes internal types (Phase 02),
+    /// so the framework's own `TransportCheckpoint` — keyed by `transport_name`, no `id`
+    /// by design — is no longer classified a cascade entity and no longer fails the
+    /// `id: ID!` contract on a type the user never wrote.
     ///
-    /// Asserts the CURRENT (broken) behavior so it merges green on top of the bug:
-    /// exposing the change-log and opting any single mutation into `cascade = true`
-    /// fails to compile. `inject_changelog` (converter/mod.rs) runs *before*
-    /// `synthesize_cascade_types`, so the framework's own `TransportCheckpoint`
-    /// projection — view-backed, non-error, and keyed by `transport_name` with no `id`
-    /// by design — is classified a cascade entity and fails the `id: ID!` contract.
-    ///
-    /// The result is that the two features are mutually exclusive, on a type the user
-    /// never wrote and cannot fix. This is the discriminating pin for the train: it
-    /// proves Phase 02 changes the one thing it claims to.
+    /// This is the flip of the Phase 00 expected-failure pin
+    /// (`changelog_plus_cascade_fails_on_transport_checkpoint_today`). The whole error —
+    /// including the misleading #659 "embedded value object" hint that misfired on a
+    /// framework projection — is gone, because `validate()` now accepts the schema.
     #[test]
-    fn changelog_plus_cascade_fails_on_transport_checkpoint_today() {
-        let err = SchemaConverter::convert(changelog_schema_with(
+    fn changelog_plus_cascade_compiles_via_internal_exemption() {
+        let compiled = SchemaConverter::convert(changelog_schema_with(
             vec![entity("Post")],
             vec![cascade_mutation("createPost", "Post")],
         ))
-        .expect_err("#665: changelog + cascade is currently mutually exclusive");
-        let msg = err.to_string();
+        .expect("#665: changelog + cascade now compiles (validate() passes)");
 
+        // The two framework projections are `internal` — NOT cascade nodes. Excluding
+        // them is the whole fix: `TransportCheckpoint` has no `id` and could never back
+        // the CascadeNode contract, and `EntityChangeLog` is bookkeeping, not a
+        // cascade-deliverable entity (gate 2).
+        for name in ["TransportCheckpoint", "EntityChangeLog"] {
+            let ty = compiled.types.iter().find(|t| t.name.as_str() == name);
+            assert!(ty.is_some(), "{name} is injected");
+            assert!(
+                !ty.unwrap().implements.iter().any(|i| i == "CascadeNode"),
+                "{name} is a framework projection, not a cascade entity"
+            );
+        }
+
+        // The genuine user entity still IS a cascade node — enforcement is unchanged
+        // for real entities.
+        let post = compiled.types.iter().find(|t| t.name.as_str() == "Post").unwrap();
         assert!(
-            msg.contains("cascade requires `id: ID!`"),
-            "fails via the cascade conformance enforcement, got: {msg}"
+            post.implements.iter().any(|i| i == "CascadeNode"),
+            "the user's Post entity still implements CascadeNode"
         );
-        assert!(
-            msg.contains("TransportCheckpoint") && msg.contains("no `id` field"),
-            "the offender is the framework's own TransportCheckpoint projection, got: {msg}"
-        );
-        // The #659 diagnostic enrichment fires on a framework projection and tells the
-        // user their type is an embedded value object that should drop its source —
-        // advice that is both wrong and unactionable here. Pinned so the flip in
-        // Phase 02 is visibly removing a misleading diagnostic, not just an error.
-        assert!(
-            msg.contains("embedded value object"),
-            "the derivation-signal hint misfires on a framework projection, got: {msg}"
-        );
+
+        // The injected change-log surface survives untouched.
+        assert!(compiled.queries.iter().any(|q| q.name == "entity_change_logs"));
+        assert!(compiled.queries.iter().any(|q| q.name == "transport_checkpoint"));
+        assert!(compiled.mutations.iter().any(|m| m.name == "upsert_transport_checkpoint"));
     }
 
     /// The change-log surface alone (no cascade mutation) compiles — the baseline the

--- a/crates/fraiseql-cli/src/schema/database_validator.rs
+++ b/crates/fraiseql-cli/src/schema/database_validator.rs
@@ -590,8 +590,16 @@ pub async fn validate_schema_against_database(
     // instead of letting it resurface later as an unrelated cascade `id` error. Unlike
     // queries/mutations, type sources are not on the shared `sql_source_probes` work-list,
     // so the hard `FRAISEQL_VALIDATE_SQL_SOURCES` gate does not flag them; this is the only
-    // check that does. Synthetic types (empty source) and error types are skipped — this is
-    // exactly the `is_queryable_entity` set the cascade pass keys off.
+    // check that does. Synthetic types (empty source) and error types are skipped.
+    //
+    // This set INTENTIONALLY DIVERGES from `is_queryable_entity` (the cascade classifier).
+    // After #665 that predicate ALSO excludes framework-`internal` projections, but this
+    // existence check must NOT: a missing `v_entity_change_log` / `v_transport_checkpoint`
+    // is exactly #569's failure mode ("no install path; every mutation fails on a fresh
+    // stack"), so validating the change-log views is precisely the point. Do NOT DRY the
+    // two predicates together — the `internal` exemption belongs to cascade classification
+    // only. The `validator_checks_internal_projection_view_existence` tripwire test pins
+    // this divergence so a future "unification" cannot silently delete the #569 signal.
     for ty in &schema.types {
         let source = ty.sql_source.as_str();
         if ty.is_error || source.is_empty() {

--- a/crates/fraiseql-cli/src/schema/tests.rs
+++ b/crates/fraiseql-cli/src/schema/tests.rs
@@ -297,6 +297,52 @@ mod database_validator_tests {
         );
     }
 
+    /// The type-source existence check INCLUDES framework-`internal` projections — it
+    /// INTENTIONALLY diverges from `is_queryable_entity` (the cascade classifier), which
+    /// excludes them (#665). A change-log projection whose backing view is absent
+    /// (`EntityChangeLog` → `v_entity_change_log`) is exactly #569's failure mode ("no
+    /// install path; every mutation fails on a fresh stack"), so the validator MUST still
+    /// flag it — surfacing that missing view is the whole point of this check.
+    ///
+    /// Pinned as a TRIPWIRE: a future DRY pass that "unifies" this predicate with the
+    /// cascade classifier — adding `!ty.internal` here — deletes the #569 signal, and must
+    /// fail this test instead of passing silently. Do NOT satisfy it by excluding internal
+    /// types; the `internal` exemption belongs to cascade classification only.
+    #[tokio::test]
+    async fn validator_checks_internal_projection_view_existence() {
+        // The database has the user entity's view but NOT the change-log view.
+        let introspector = MockIntrospector::new(DatabaseType::PostgreSQL).with_relation(
+            "public",
+            "v_user",
+            fraiseql_core::db::RelationKind::View,
+        );
+
+        let user = TypeDefinition {
+            sql_source: "v_user".into(),
+            ..make_type("User", vec![("id", FieldType::Id)])
+        };
+        // A framework-`internal` change-log projection whose view is absent from the DB.
+        let change_log = TypeDefinition {
+            sql_source: "v_entity_change_log".into(),
+            internal: true,
+            ..make_type("EntityChangeLog", vec![("id", FieldType::Id)])
+        };
+
+        let schema = make_schema(vec![user, change_log], vec![]);
+        let report = validate_schema_against_database(&schema, &introspector).await.unwrap();
+
+        let flagged = report
+            .warnings
+            .iter()
+            .filter(|w| matches!(w, DatabaseWarning::MissingTypeSource { type_name, .. } if type_name == "EntityChangeLog"))
+            .count();
+        assert_eq!(
+            flagged, 1,
+            "the internal projection's missing view MUST still be flagged (#569): {:?}",
+            report.warnings
+        );
+    }
+
     #[tokio::test]
     async fn test_missing_additional_view() {
         let introspector = MockIntrospector::new(DatabaseType::PostgreSQL)

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -449,12 +449,32 @@ fn build_updated_entities<A: DatabaseAdapter>(
                 path:    Some("cascade.updated.__typename".to_string()),
             });
         };
-        // Fail-closed on an unknown type — we cannot project or authorize it.
-        if ctx.schema.find_type(typename).is_none() {
-            return Err(FraiseQLError::Validation {
-                message: format!("cascade.updated entry has unknown __typename '{typename}'"),
-                path:    Some("cascade.updated.__typename".to_string()),
-            });
+        // Fail-closed on a type we cannot deliver. Two rejections:
+        //  - unknown type — we cannot project or authorize it;
+        //  - framework-`internal` projection (#665, gate 5) — a change-log / checkpoint bookkeeping
+        //    view is the change-capture *mechanism*, never a cascade-deliverable entity. The
+        //    compiler excludes `internal` types from cascade classification, so they do not
+        //    implement `CascadeNode`; an entry naming one (only hand-crafted JSONB can produce this
+        //    — the framework never does) would otherwise yield a payload whose `entity` violates
+        //    its declared interface. This reads `internal` off the re-loaded compiled schema — the
+        //    flag's first runtime consumer, hence Phase 01 serializes it rather than `serde(skip)`.
+        match ctx.schema.find_type(typename) {
+            None => {
+                return Err(FraiseQLError::Validation {
+                    message: format!("cascade.updated entry has unknown __typename '{typename}'"),
+                    path:    Some("cascade.updated.__typename".to_string()),
+                });
+            },
+            Some(ty) if ty.internal => {
+                return Err(FraiseQLError::Validation {
+                    message: format!(
+                        "cascade.updated entry names framework-internal type '{typename}', a \
+                         bookkeeping projection that is not a cascade-deliverable entity"
+                    ),
+                    path:    Some("cascade.updated.__typename".to_string()),
+                });
+            },
+            Some(_) => {},
         }
         // Non-null `id: ID!` and a valid `operation: CascadeOperation!` are required.
         if !entry_obj.contains_key("id") {

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/tests.rs
@@ -3550,4 +3550,39 @@ mod cascade {
         let res = executor.execute(q, None).await;
         assert!(res.is_err(), "unknown cascade __typename must fail closed");
     }
+
+    /// Fail-closed: a cascade entry naming a framework-`internal` projection is rejected
+    /// (#665, gate 5). A change-log/checkpoint view is the change-capture *mechanism*,
+    /// never a cascade-deliverable entity — the compiler excludes internal types from
+    /// cascade classification (`is_queryable_entity`), so they never implement
+    /// `CascadeNode`. This pins that the runtime ALSO rejects a hand-crafted cascade
+    /// JSONB entry that names one, turning "framework projections never appear in a
+    /// payload" from emergent (the type IS in `schema.types`, so the bare existence
+    /// check would pass it) into enforced. It reads `internal` off the compiled schema —
+    /// the flag's first runtime consumer, which is why Phase 01 serializes it.
+    #[tokio::test]
+    async fn cascade_internal_typename_fails_closed() {
+        let mut schema = cascade_schema();
+        let mut ecl = TypeDefinition::new("EntityChangeLog", "core.v_entity_change_log");
+        ecl.fields = vec![FieldDefinition::new("id", FieldType::Id)];
+        ecl.internal = true;
+        schema.types.push(ecl);
+        schema.build_indexes();
+
+        let cascade = json!({
+            "updated": [
+                { "__typename": "EntityChangeLog", "id": "e1", "operation": "UPDATED", "entity": { "id": "e1" } }
+            ],
+            "deleted": []
+        });
+        let executor = Executor::new(schema, Arc::new(CannedMutationAdapter::new(cascade)));
+        let q = "mutation { createPost { cascade { updated { id } } } }";
+        let res = executor.execute(q, None).await;
+        let err = res.expect_err("a cascade entry naming an internal type must fail closed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("EntityChangeLog") && msg.contains("internal"),
+            "the error must legibly name the internal type, got: {msg}"
+        );
+    }
 }

--- a/tools/check-internal-flag-sites.sh
+++ b/tools/check-internal-flag-sites.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# check-internal-flag-sites.sh — pin the set of production files that READ
+# `TypeDefinition.internal` (#665).
+#
+# WHY THIS GATE EXISTS
+# --------------------
+# `internal` marks a framework-synthesized bookkeeping projection (the change-log /
+# checkpoint views `inject_changelog` synthesizes) so cascade entity classification
+# excludes it. The flag is DELIBERATELY scoped to exactly two concerns:
+#
+#   1. cascade entity classification    — cli  `is_queryable_entity`  (cascade_types.rs)
+#   2. the runtime cascade-delivery guard — core mutation runner        (mutation/mod.rs)
+#
+# The hazard of a property-named flag ("internal") is silent scope creep: a later change
+# could reuse it to skip a validation, hide a type from introspection, or drop it from
+# federation. Each of those is a SEPARATE policy decision that deserves its own review —
+# not a free ride on this flag's meaning. A doc-comment alone is not scope control (this
+# repo's own `database_validator.rs` comment is the live proof that comments drift), so
+# this gate makes widening `internal`'s reach a deliberate act: a NEW read site fails CI
+# until someone adds it to ALLOWED below and states why.
+#
+# Notably, `database_validator.rs` intentionally does NOT read `.internal`: it must keep
+# validating that the change-log views exist, because a missing `v_entity_change_log` /
+# `v_transport_checkpoint` is #569's failure mode. If this gate ever reports it, someone
+# DRY'd the cascade classifier and the view-existence check together and deleted the #569
+# signal — revert that, don't add it to ALLOWED.
+#
+# This gate constrains READS only. WRITE sites (`changelog.rs` sets the flag) and
+# struct-literal initializers (`internal: false`) are not scope-widening and are ignored.
+#
+# Mirrors the established shell-gate pattern (lint-routes, lint-unwrap, lint-async-trait).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# Production files permitted to READ `.internal`. Widening this set is a reviewed choice.
+ALLOWED='crates/fraiseql-cli/src/schema/converter/cascade_types.rs
+crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs'
+
+# Field-access READS of `.internal`, in production code only. Exclusions:
+#   - test files (paths ending in tests.rs / _tests.rs, or under a tests/ dir);
+#   - assignment WRITES (`x.internal = y`), but NOT match guards (`if x.internal =>`);
+#   - string-literal false positives (a `host.internal/` URL).
+reads=$(grep -rnP '\.internal\b' crates/*/src/ --include='*.rs' \
+  | grep -vE '/tests?\.rs:|_tests\.rs:|/tests/' \
+  | grep -vP '\.internal\s*=(?![=>])' \
+  | grep -vP '\.internal/' \
+  || true)
+
+violations=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file="${line%%:*}"
+  if ! grep -qxF "$file" <<<"$ALLOWED"; then
+    if [ "$violations" -eq 0 ]; then
+      echo "ERROR: new TypeDefinition.internal READ site(s) outside the allowed set." >&2
+      echo >&2
+      echo "  \`internal\` (#665) is scoped to TWO concerns on purpose:" >&2
+      echo "    1. cascade entity classification (cli is_queryable_entity)" >&2
+      echo "    2. the runtime cascade-delivery guard (core mutation runner)" >&2
+      echo "  Reusing it to skip validation, hide from introspection, or drop from" >&2
+      echo "  federation is a DIFFERENT policy decision that needs its own review — not a" >&2
+      echo "  free ride on this flag. If the new read is intended, add its file to ALLOWED" >&2
+      echo "  in tools/check-internal-flag-sites.sh and say why." >&2
+      echo "  If the file is database_validator.rs, you DRY'd away #569's missing-view" >&2
+      echo "  signal — revert instead." >&2
+      echo >&2
+    fi
+    echo "  $line" >&2
+    violations=1
+  fi
+done <<<"$reads"
+
+if [ "$violations" -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: TypeDefinition.internal is read only by cascade classification + the runtime cascade guard."


### PR DESCRIPTION
Phase 02 of the #665 train — **the actual fix**. Off `origin/dev` at the Phase 01 merge (#679). Makes changelog + cascade compile, and enforces at runtime the invariant the compile-time exemption relies on.

## What changed (5 items, 2 crates + tooling)

| # | Change | Crate |
|---|--------|-------|
| 1 | `converter/cascade_types.rs` — `is_queryable_entity` gains `&& !ty.internal`; one predicate feeds BOTH the `id: ID!` enforcement and the `implements CascadeNode` auto-loop | `fraiseql-cli` |
| 4 | `runtime/executor/runners/mutation/mod.rs` — the cascade `updated` existence check also **rejects** a `__typename` naming an `internal` type (gate 5) | `fraiseql-core` |
| 5 | Phase 00 repro pin flipped RED→GREEN and renamed | tests |
| 2 | `database_validator.rs` — divergence comment rewritten + tripwire test (behavior UNCHANGED) | `fraiseql-cli` |
| 3 | `tools/check-internal-flag-sites.sh` + `make lint-internal-flag`, wired into `preflight` and Dagger `ShellGates` | tooling |

**Items 1 and 4 land atomically.** Before this PR the compile failure was the *only* thing preventing the changelog+cascade combination from existing; the moment the predicate excludes `internal`, the combination compiles and the runtime cascade path becomes reachable for the first time. The guard ships in the same PR — never a compile-fix without it.

## Runtime emission-path trace (why the guard is a belt-and-braces invariant, not a live hole)

The cascade payload is built **solely** from the mutation function's own `cascade` JSONB column — there is no collector that could scoop up change-log rows:

| Step | Location | What it does |
|---|---|---|
| 1 | `mutation/mod.rs` `execute_function_call_with_changelog` | runs the mutation fn, reads its returned `cascade` column |
| 2 | `runtime/mutation_result.rs` `MutationResponse.cascade` | the JSONB the fn itself emitted |
| 3 | `mutation/mod.rs` (reads `cascade.updated` / `.deleted`) | iterates the fn's own entries |
| 4 | `mutation/mod.rs` `build_updated_entities` | reads `__typename` **from each JSONB entry itself** |

There is **no** change-capture feed, watched-view scan, or collector; **zero** references to `v_entity_change_log` / `tb_entity_change_log` under `runtime/`. The only edge between the two is the *inverse* one — `fraiseql-db/.../adapter/database.rs` writes the cascade JSONB *into* `tb_entity_change_log`. Observers can't close the loop either: capture triggers derive only from explicit `subscribable_tables`, which `inject_changelog` never sets.

**But the bound was emergent, not enforced.** The runtime's only check was existence (`find_type(typename).is_none()`), and both projections *are* in `schema.types`. A mutation function hand-crafting `{"__typename":"EntityChangeLog", …}` into its `cascade` column would pass every guard. Nothing generates that (so the premise holds), but nothing rejected it — and after this PR the projections no longer implement `CascadeNode`, so such an entry would yield a payload whose `entity` violates its declared interface. Item 4 turns the invariant from emergent into enforced. This is the flag's **first runtime consumer**: it reads `internal` off a re-loaded compiled schema, which is exactly why Phase 01 serializes it rather than `serde(skip)`.

## `requires_role` — closed, restated (not re-derived)

Does cascade delivery re-check `requires_role` on the delivered entity type? **No — but the reason inverts the framing, so this is NOT a security fix:**

- **type-level `requires_role` is enforced NOWHERE at execution.** The only reads of a `TypeDefinition`'s `requires_role` are introspection visibility (`introspection.rs`) and metadata display (`metadata.rs`); every real access gate reads the **operation**-level role (e.g. `federation.rs` reads the *query* definition's role). Confirmed by grep: no type-level `requires_role` gate exists in the execution path.
- Therefore cascade is **not** a special bypass of a gate that otherwise fires — the gate fires nowhere. The runtime guard (item 4) is a **correctness / tidiness** measure (keep an interface-violating entry out of the payload), not a security control.
- Consequence for Phase 03: the CHANGELOG entry stays a plain `### Fixed`, not a security note.
- The "type-level `requires_role` documented as a gate but enforced nowhere" gap is real but **out of scope** — it is filed as **#677** (needs a product decision: implement vs retract). Do not fold it in here.

## Divergence pinned in code, not just prose

`database_validator.rs`'s type-source existence check **intentionally diverges** from `is_queryable_entity`: it must keep validating the change-log views, because a missing `v_entity_change_log` / `v_transport_checkpoint` is #569's failure mode ("no install path; every mutation fails on a fresh stack"). The stale "exactly the is_queryable_entity set" comment is rewritten to state this, and a tripwire test (`validator_checks_internal_projection_view_existence`) pins that the validator's set **includes** internal types — with the #569 rationale in the test's own doc-comment, where a future DRY-er will be standing. The census gate (`lint-internal-flag`) names *why* the read-site set is fixed so reusing `internal` to skip validation / hide from introspection / drop from federation each fails a check instead of passing silently.

## TDD / RED proofs

- **Predicate + guard:** flipped the repro pin to its success shape → failed (compile still broken) → added `&& !ty.internal` → passed. Added the guard test naming `EntityChangeLog` → failed (no guard) → added the guard → passed.
- **Validator tripwire:** green as-is; temporarily added `|| ty.internal` to the validator → red → reverted.
- **Census gate:** injected a fake `.internal` read in a non-allowlisted file → red → reverted.

## Verification

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ `cargo test -p fraiseql-core --all-features` (only DB-env `changelog_e2e_full_stack` fails — unset `DATABASE_URL`, runs in the Dagger integration leg)
- ✅ `cargo test -p fraiseql-cli --all-features`
- ✅ feature matrix (core `--no-default-features` / default; cli default)
- ✅ `make preflight` (incl. the new `lint-internal-flag`)

## Scope / merge

One PR off `origin/dev`, serial. Milestone **2.14** (#665 carries it) — not set here; **the user assigns milestones and merges**. Phase 03 follows: e2e fixture + docs + CHANGELOG (`### Fixed`) + close #665.
