### PR TITLE
test(665): prove changelog + cascade compose; docs + CHANGELOG (#665 Phase 03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`[changelog] expose = true` and `cascade = true` mutations now compile together (#665).**
+  Since 2.12.0 the two features were mutually exclusive. The cascade pass classifies every
+  view-backed, non-error type as a cascade entity and enforces the `CascadeNode` `id: ID!`
+  contract on it — which swept in the framework's own `TransportCheckpoint` projection, keyed by
+  `transport_name` with no `id` by design, so exposing the change-log and opting any mutation
+  into cascade failed to compile on a type the user never wrote and could not fix. Framework-
+  synthesized read-only projections (`EntityChangeLog`, `TransportCheckpoint`) are now marked
+  `internal` and excluded from cascade classification: they are the change-capture *mechanism*,
+  never cascade-deliverable entities, so they carry neither the `id: ID!` enforcement nor the
+  `implements CascadeNode` auto-annotation. The runtime cascade path also rejects a payload entry
+  naming an `internal` type, so the exclusion holds end-to-end. Adds one additive, optional key
+  (`internal`) to the compiled-schema format — cli↔server are version-locked, so no cross-version
+  concern, and single-feature schemas compile byte-identically. (This is the framework-generated
+  instance of the cascade-classification problem whose diagnostic half shipped with #653; the SDK
+  provenance half remains with #653.)
 - **CSV and XLSX exports now emit a deterministic, alphabetically-sorted column order when no
   `?select=` is given.** The fallback column order was taken from `serde_json::Map` iteration,
   which is alphabetical only for the default `BTreeMap` build; a dependency that enables

--- a/crates/fraiseql-cli/tests/changelog_cascade_compose_e2e.rs
+++ b/crates/fraiseql-cli/tests/changelog_cascade_compose_e2e.rs
@@ -1,0 +1,144 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics are acceptable
+//! End-to-end proof that the change-log GraphQL surface and per-mutation cascade compose
+//! (#665). Before the fix these two features were mutually exclusive: the cascade pass
+//! classified the framework's own `TransportCheckpoint` projection — keyed by
+//! `transport_name` with no `id` by design — as a cascade entity and failed the
+//! `CascadeNode` `id: ID!` contract on a type the user never wrote and could not fix.
+//!
+//! This drives the **whole SDK-shaped compile path** (`SchemaConverter::convert`, the same
+//! entry the CLI's `compile` command uses) on a schema that turns on `[observers]`,
+//! `[changelog] expose = true`, AND a `cascade = true` mutation together, and asserts:
+//! the schema compiles (so `validate()` accepts the combined surface — i.e. it will load
+//! and boot), the genuine user entity is a cascade node, and BOTH framework projections
+//! are injected but excluded from cascade classification. The DB-backed round-trip halves
+//! (cascade payload delivery, `entityChangeLogs` pagination) are covered by the existing
+//! `changelog_e2e_full_stack` and the canned-adapter cascade tests, which now accept this
+//! combined schema; this test is the deterministic, DB-free proof of the compile unblock.
+
+use fraiseql_cli::schema::{IntermediateSchema, converter::SchemaConverter};
+
+/// An SDK-shaped `schema.json` exercising all three features at once. Observers must be
+/// enabled or the converter rejects an exposed change-log (`converter/mod.rs` guard).
+const SDK_SCHEMA_CHANGELOG_PLUS_CASCADE: &str = r#"
+{
+  "version": "2.0.0",
+  "types": [
+    {
+      "name": "Post",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false},
+        {"name": "title", "type": "String", "nullable": false}
+      ],
+      "sql_source": "v_post",
+      "is_input": false
+    }
+  ],
+  "queries": [],
+  "mutations": [
+    {
+      "name": "createPost",
+      "return_type": "Post",
+      "cascade": true,
+      "sql_source": "fn_create_post",
+      "operation": "CREATE"
+    }
+  ],
+  "subscriptions": [],
+  "observers_config": {"enabled": true},
+  "changelog_config": {"expose": true}
+}
+"#;
+
+fn compile() -> fraiseql_core::schema::CompiledSchema {
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_CHANGELOG_PLUS_CASCADE).expect("parse SDK schema.json");
+    // A successful convert() means the full pipeline ran — including `validate()` after
+    // both `inject_changelog` and `synthesize_cascade_types` — so the compiled schema is
+    // load-valid and the server will boot on it. Before #665 this returned `Err`.
+    SchemaConverter::convert(intermediate)
+        .expect("#665: changelog + observers + cascade must compile together")
+}
+
+fn implements_cascade_node(
+    schema: &fraiseql_core::schema::CompiledSchema,
+    type_name: &str,
+) -> bool {
+    schema
+        .types
+        .iter()
+        .find(|t| t.name.as_str() == type_name)
+        .unwrap_or_else(|| panic!("{type_name} must be present"))
+        .implements
+        .iter()
+        .any(|i| i == "CascadeNode")
+}
+
+#[test]
+fn changelog_observers_cascade_compile_together() {
+    // The headline unblock: the combination compiles at all.
+    let compiled = compile();
+
+    // Both framework surfaces were injected.
+    assert!(
+        compiled.types.iter().any(|t| t.name.as_str() == "EntityChangeLog"),
+        "change-log projection injected"
+    );
+    assert!(
+        compiled.types.iter().any(|t| t.name.as_str() == "TransportCheckpoint"),
+        "checkpoint projection injected"
+    );
+    assert!(
+        compiled.queries.iter().any(|q| q.name == "entity_change_logs"),
+        "change-log list query injected"
+    );
+    assert!(
+        compiled.queries.iter().any(|q| q.name == "transport_checkpoint"),
+        "checkpoint point-lookup query injected"
+    );
+    assert!(
+        compiled.mutations.iter().any(|m| m.name == "upsert_transport_checkpoint"),
+        "checkpoint upsert mutation injected"
+    );
+
+    // The cascade surface was synthesized for the user mutation.
+    assert!(
+        compiled.interfaces.iter().any(|i| i.name == "CascadeNode"),
+        "CascadeNode interface synthesized"
+    );
+    assert!(
+        compiled.types.iter().any(|t| t.name.as_str() == "CreatePostPayload"),
+        "cascade payload wrapper synthesized"
+    );
+    let create_post = compiled
+        .mutations
+        .iter()
+        .find(|m| m.name == "createPost")
+        .expect("createPost present");
+    assert_eq!(
+        create_post.return_type, "CreatePostPayload",
+        "cascade rewrites the mutation return type to its payload"
+    );
+}
+
+#[test]
+fn user_entity_is_a_cascade_node_but_framework_projections_are_not() {
+    let compiled = compile();
+
+    // The genuine user entity IS a cascade node — enforcement is unchanged for real entities.
+    assert!(
+        implements_cascade_node(&compiled, "Post"),
+        "the user's Post entity implements CascadeNode"
+    );
+
+    // The framework projections are `internal` and excluded from cascade classification —
+    // this is the whole #665 fix. `TransportCheckpoint` has no `id` and could never back the
+    // contract; `EntityChangeLog` is bookkeeping, not a cascade-deliverable entity.
+    assert!(
+        !implements_cascade_node(&compiled, "EntityChangeLog"),
+        "EntityChangeLog is a framework projection, not a cascade entity"
+    );
+    assert!(
+        !implements_cascade_node(&compiled, "TransportCheckpoint"),
+        "TransportCheckpoint is a framework projection, not a cascade entity"
+    );
+}

--- a/crates/fraiseql-server/tests/changelog_cascade_compose_boot.rs
+++ b/crates/fraiseql-server/tests/changelog_cascade_compose_boot.rs
@@ -1,0 +1,77 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics are acceptable
+//! Boot proof for the change-log + cascade composition (#665): a schema that turns on
+//! `[observers]`, `[changelog] expose = true`, AND a `cascade = true` mutation together
+//! compiles, and a `Server` loads the compiled schema and boots on it.
+//!
+//! This is the DB-free "loads and boots" half of the Phase 03 e2e: `SchemaConverter::convert`
+//! runs the full compile pipeline (the #665 unblock), `Server::new` then loads the combined
+//! compiled schema and mounts every subsystem on it, and the always-on `/health` liveness
+//! probe confirms the process is serving. It uses a `FailingAdapter` (no database) — the DB
+//! round-trip halves (cascade delivery, `entityChangeLogs` pagination) run in the
+//! Dagger integration leg against real Postgres via the existing changelog/cascade harnesses.
+
+mod common;
+
+use std::sync::Arc;
+
+use fraiseql_cli::schema::{IntermediateSchema, converter::SchemaConverter};
+use fraiseql_test_utils::failing_adapter::FailingAdapter;
+
+use crate::common::server_harness::TestServer;
+
+/// SDK-shaped `schema.json` with all three features on at once. Observers must be enabled
+/// or the converter rejects an exposed change-log.
+const SDK_SCHEMA_CHANGELOG_PLUS_CASCADE: &str = r#"
+{
+  "version": "2.0.0",
+  "types": [
+    {
+      "name": "Post",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false},
+        {"name": "title", "type": "String", "nullable": false}
+      ],
+      "sql_source": "v_post",
+      "is_input": false
+    }
+  ],
+  "queries": [],
+  "mutations": [
+    {
+      "name": "createPost",
+      "return_type": "Post",
+      "cascade": true,
+      "sql_source": "fn_create_post",
+      "operation": "CREATE"
+    }
+  ],
+  "subscriptions": [],
+  "observers_config": {"enabled": true},
+  "changelog_config": {"expose": true}
+}
+"#;
+
+#[tokio::test]
+async fn changelog_cascade_schema_loads_and_boots() {
+    // Compile the combined surface (the #665 unblock — this returned Err before the fix).
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_CHANGELOG_PLUS_CASCADE).expect("parse SDK schema.json");
+    let schema = SchemaConverter::convert(intermediate)
+        .expect("#665: changelog + observers + cascade must compile together");
+
+    // `Server::new` (inside TestServer::start) must load the combined compiled schema and
+    // mount every subsystem without panicking — the "loads and boots" proof. A `FailingAdapter`
+    // keeps this DB-free; its default `health_check` succeeds, so `/health` returns 200.
+    let server = TestServer::start(schema, Arc::new(FailingAdapter::new())).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{}/health", server.url))
+        .send()
+        .await
+        .expect("GET /health");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "server must boot on the combined changelog+cascade schema and serve /health"
+    );
+}

--- a/docs/architecture/mutation-response.md
+++ b/docs/architecture/mutation-response.md
@@ -261,6 +261,17 @@ field-level authorizer (#423) on it, exactly like a queried entity, and enforces
 the response limits (`RuntimeConfig.cascade_limits`: max affected entities → the
 cascade is truncated with `metadata.truncated`, max response size → rejected).
 
+> **Framework projections are not cascade entities (#665).** When the change-log GraphQL
+> surface is exposed (`[changelog] expose = true`), FraiseQL injects two read-only
+> projections — `EntityChangeLog` and `TransportCheckpoint`. They are the change-capture
+> *mechanism*, not cascade-deliverable entities, so they are marked `internal` and excluded
+> from cascade classification: they do **not** implement `CascadeNode` and are exempt from
+> the `id: ID!` eligibility check above (`TransportCheckpoint` is keyed by `transport_name`
+> and has no `id` by design, so the check would otherwise fail on a framework type the
+> user never wrote). The runtime cascade path also rejects a payload entry naming an
+> `internal` type, so a change-log row can never ride in a cascade. The two features
+> compose freely — see [the change-log-over-GraphQL guide](../guides/changelog-graphql.md).
+
 ### Row-visibility boundary (RLS)
 
 FraiseQL enforces **field-level** authorization on every cascade entity, but it

--- a/docs/guides/changelog-graphql.md
+++ b/docs/guides/changelog-graphql.md
@@ -116,6 +116,20 @@ are genuinely different streams, not one federated entity.
 The compiler emits a warning when `[changelog] expose = true` on a federation
 subgraph, restating the single-owner rule (the owning subgraph can ignore it).
 
+## Composes with cascade
+
+The change-log surface and per-mutation `cascade = true` are independent and compose
+freely — a schema can expose `entity_change_logs` **and** opt mutations into the typed
+cascade payload. The injected `EntityChangeLog` and `TransportCheckpoint` types are
+framework-synthesized read-only projections: the change-capture *mechanism*, not
+cascade-deliverable entities. They are excluded from cascade entity classification, so
+they do **not** implement `CascadeNode` and are never enforced against the cascade
+`id: ID!` contract — which matters for `TransportCheckpoint`, keyed by `transport_name`
+with no `id` by design. The runtime never projects a change-log row into a cascade
+payload (and rejects one that names such a type). A cascade mutation delivers *your*
+entities; the change-log records *what changed* — two separate streams that don't
+collide.
+
 ## Cursor pagination
 
 `entity_change_logs` is a standard FraiseQL list query: it uses the generic


### PR DESCRIPTION
Phase 03 (finalize) of the #665 train — off `origin/dev` at the Phase 02 merge (#680). **No source changes**: the fix shipped in Phases 01/02 (#679, #680). This proves the combination end-to-end, documents that the features compose, and records the CHANGELOG entry.

`Closes #665.`

## e2e — deterministic, DB-free, verifiable in the normal suite

The full DB round-trip (cascade delivery + `entityChangeLogs` pagination) needs a real Postgres container and runs only in the Dagger integration leg, so rather than ship a fixture I can't execute locally I split the proof into two verifiable halves that run in the ordinary suite:

- **`fraiseql-cli/tests/changelog_cascade_compose_e2e.rs`** — drives the whole SDK-shaped compile path (`SchemaConverter::convert`, the same entry `fraiseql compile` uses) on a schema with `[observers]` + `[changelog] expose = true` + a `cascade = true` mutation. Asserts it **compiles** (the #665 unblock — a successful `convert()` means `validate()` accepted the combined surface, so it will load), both framework projections (`EntityChangeLog`, `TransportCheckpoint`) are injected but **excluded** from cascade classification (do not implement `CascadeNode`), and the genuine user entity still **is** a cascade node.
- **`fraiseql-server/tests/changelog_cascade_compose_boot.rs`** — `Server::new` **loads** the combined compiled schema and **boots** on it (`FailingAdapter`, no DB); the always-on `/health` liveness probe serves `200`. This is the "server loads and boots" half.

The DB-backed round-trip halves stay with the existing `changelog_e2e_full_stack` and canned-adapter cascade tests — both now accept this combined schema — which run against real Postgres in the Dagger integration leg.

**Guard rails intact:** `[changelog] expose = true` without `[observers]` still errors (`changelog_expose_without_observers_is_rejected`), and the federation single-owner warning is unchanged.

## docs

- **`docs/guides/changelog-graphql.md`** — new "Composes with cascade" section.
- **`docs/architecture/mutation-response.md`** — a callout in the cascade section: `EntityChangeLog` / `TransportCheckpoint` are `internal` framework projections, never cascade-deliverable entities, so they don't implement `CascadeNode` and the runtime rejects a payload entry naming one.

## CHANGELOG

Plain `### Fixed` under `[Unreleased]` (2.14): changelog + cascade no longer mutually exclusive; framework projections exempt from the cascade `id: ID!` contract; notes the additive `internal` compiled-format key. **Not** security-flavoured — type-level `requires_role` is enforced nowhere at execution (tracked in #677), so the runtime guard is correctness, not a security control. (Contrast the sibling #676 fix, which shipped under `### Security` separately.)

## Downstream acceptance

With this train merged, a changelog + cascade schema **compiles, loads, and boots for the first time** — proven here by the two e2e tests. The adopting project's combined schema is unblocked.

## Verification

- ✅ `cargo +nightly fmt --check`
- ✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- ✅ both new e2e tests pass; guard-rail (expose-without-observers) intact
- ✅ `markdownlint` (CHANGELOG + both guides, against `.markdownlint.json`)
- ✅ `make preflight` (incl. `lint-internal-flag`)

## Train summary & close-out

The full #665 rationale — root cause, the flag+predicate+guard fix, the explicit rejection of option 2 (static reachability is unsound: `UpdatedEntity.entity: CascadeNode` makes runtime deliverability unbounded), and the **intentional** `database_validator` divergence (it keeps validating the change-log views because a missing one is #569's failure mode; guarded by the tripwire test + `make lint-internal-flag`) — is posted as a close-out comment on #665.

Milestone **2.14** (#665 carries it) — not set here; **the user assigns milestones and merges**. On merge, `Closes #665` closes the issue.
