### PR TITLE
feat(python-sdk): @fraiseql.type(embedded=True) value-object marker + golden e2e (#687 Phase 02)

### DIFF
--- a/crates/fraiseql-cli/tests/embedded_value_object_cascade_e2e.rs
+++ b/crates/fraiseql-cli/tests/embedded_value_object_cascade_e2e.rs
@@ -1,0 +1,156 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics are acceptable
+//! End-to-end proof that an author-declared embedded value object (#687) compiles under a
+//! cascade — the SDK-realistic half of Phase 02, closing the #653 bug.
+//!
+//! The scenario is exactly what `@fraiseql.type(embedded=True)` emits (Phase 02 SDK side):
+//! a `Money` value object with **`embedded: true` and no `sql_source`** (the SDK suppresses
+//! the synthesized `v_money`), embedded as `Order.total`, under a `cascade = true`
+//! `createOrder` mutation. On v2.13.1 this schema **does not compile at all**: `Money`
+//! carries a synthesized source, is classified a cascade entity, and hard-fails the
+//! `CascadeNode` `id: ID!` contract on a type that has no identity by design.
+//!
+//! This drives the whole SDK-shaped compile path (`SchemaConverter::convert`, the same entry
+//! the CLI's `compile` command uses) and asserts three things:
+//!   (i)   it **compiles clean** (so `validate()` accepts it — it will load and boot);
+//!   (ii)  `Money` does **not** implement `CascadeNode` (a value object is never a cache node),
+//!         while the genuine `Order` entity does;
+//!   (iii) the compiled `Money.embedded == true` — the author's declaration round-trips into
+//!         the compiled schema the server re-loads.
+//!
+//! (iii) is the assertion genuinely RED before Phase 01: serde drops the unknown `embedded`
+//! field on a pre-01 compiler, so the flag never reaches the compiled schema. (i)/(ii) are
+//! green either way here, because a source-suppressed `Money` is already excluded by the
+//! empty-source leg of `is_queryable_entity` — which is the whole point of source-suppression.
+//! This is distinct from Phase 01 Cycle 2, which tests the `&& !ty.embedded` guard against a
+//! *non-empty-source* contradiction the SDK never emits; here the source is genuinely absent.
+
+use fraiseql_cli::schema::{IntermediateSchema, converter::SchemaConverter};
+
+/// An SDK-shaped `schema.json`: an embedded `Money` value object (no source) under a cascade
+/// mutation. This is the exact shape `@fraiseql.type(embedded=True)` produces — mirrored by
+/// the `python-sdk-02-embedded.json` golden fixture.
+const SDK_SCHEMA_EMBEDDED_UNDER_CASCADE: &str = r#"
+{
+  "version": "2.0.0",
+  "types": [
+    {
+      "name": "Order",
+      "fields": [
+        {"name": "id", "type": "ID", "nullable": false},
+        {"name": "total", "type": "Money", "nullable": false}
+      ],
+      "sql_source": "v_order"
+    },
+    {
+      "name": "Money",
+      "embedded": true,
+      "fields": [
+        {"name": "amount", "type": "Int", "nullable": false},
+        {"name": "currency", "type": "String", "nullable": false}
+      ]
+    }
+  ],
+  "queries": [],
+  "mutations": [
+    {
+      "name": "createOrder",
+      "return_type": "Order",
+      "cascade": true,
+      "sql_source": "fn_create_order",
+      "operation": "CREATE"
+    }
+  ],
+  "subscriptions": []
+}
+"#;
+
+fn compile() -> fraiseql_core::schema::CompiledSchema {
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(SDK_SCHEMA_EMBEDDED_UNDER_CASCADE).expect("parse SDK schema.json");
+    // A successful convert() means the full pipeline ran — including `validate()` after
+    // `synthesize_cascade_types` — so the compiled schema is load-valid and the server will
+    // boot on it. Before #687 (source-suppression) this returned `Err`: the synthesized
+    // `v_money` made `Money` a cascade entity that could not satisfy `id: ID!`.
+    SchemaConverter::convert(intermediate)
+        .expect("#687: an embedded value object under a cascade must compile")
+}
+
+fn implements_cascade_node(
+    schema: &fraiseql_core::schema::CompiledSchema,
+    type_name: &str,
+) -> bool {
+    schema
+        .types
+        .iter()
+        .find(|t| t.name.as_str() == type_name)
+        .unwrap_or_else(|| panic!("{type_name} must be present"))
+        .implements
+        .iter()
+        .any(|i| i == "CascadeNode")
+}
+
+#[test]
+fn embedded_value_object_under_cascade_compiles() {
+    // (i) The headline unblock: the schema compiles at all (the #653 bug this closes).
+    let compiled = compile();
+
+    // The cascade surface was still synthesized for the genuine entity mutation.
+    assert!(
+        compiled.interfaces.iter().any(|i| i.name == "CascadeNode"),
+        "CascadeNode interface synthesized"
+    );
+    let create_order = compiled
+        .mutations
+        .iter()
+        .find(|m| m.name == "createOrder")
+        .expect("createOrder present");
+    assert_eq!(
+        create_order.return_type, "CreateOrderPayload",
+        "cascade rewrites the mutation return type to its payload"
+    );
+}
+
+#[test]
+fn embedded_money_is_not_a_cascade_node_but_order_is() {
+    let compiled = compile();
+
+    // (ii) The genuine `Order` entity IS a cascade node — enforcement is unchanged for it.
+    assert!(
+        implements_cascade_node(&compiled, "Order"),
+        "the user's Order entity implements CascadeNode"
+    );
+
+    // (ii) The declared value object is exempt: it is delivered inside its parent's payload,
+    // never as a cache node of its own, so it must not auto-implement CascadeNode.
+    let money = compiled
+        .types
+        .iter()
+        .find(|t| t.name.as_str() == "Money")
+        .expect("Money must be present");
+    assert!(
+        !money.implements.iter().any(|i| i == "CascadeNode"),
+        "a value object is never a cascade node: {:?}",
+        money.implements
+    );
+    assert!(
+        money.find_field("id").is_none(),
+        "no synthetic `id` was forced onto the value object"
+    );
+}
+
+#[test]
+fn compiled_money_carries_the_embedded_flag() {
+    let compiled = compile();
+
+    // (iii) The RED assertion: the author's `embedded=True` declaration round-trips into the
+    // compiled schema the server re-loads. On a pre-Phase-01 compiler this is false — serde
+    // silently drops the unknown `embedded` field. Proven RED by mutation: reverting
+    // `embedded: intermediate.embedded` to `embedded: false` in `converter/types.rs` turns
+    // this assertion RED while leaving the compile/exemption assertions green.
+    let money = compiled
+        .types
+        .iter()
+        .find(|t| t.name.as_str() == "Money")
+        .expect("Money must be present");
+    assert!(money.embedded, "the compiled schema must carry Money.embedded == true");
+}

--- a/sdks/official/fraiseql-python/src/fraiseql/decorators.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/decorators.py
@@ -412,6 +412,7 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
     shareable: bool = False,
     subscribable_tables: list[str] | None = None,
     subscribable_pre_image: bool = False,
+    embedded: bool = False,
 ) -> type[T] | Callable[[type[T]], type[T]]:
     """Decorator to mark a Python class as a GraphQL type.
 
@@ -454,6 +455,15 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
             (OLD) into ``object_data_before`` — the out-of-band parity for a
             mutation's ``changelog_pre_image``. Default ``False`` (after-image
             only). Only meaningful together with ``subscribable_tables``.
+        embedded: Mark this type an embedded value object (#687) — a type with no
+            independent identity that is always nested under a parent entity (e.g. a
+            ``Money`` amount on an ``Order``). An embedded type declares **no**
+            ``sql_source`` (the synthesized ``v_{name}`` is suppressed) and is exempt
+            from cascade classification: the compiler never enforces ``id: ID!`` on it
+            nor auto-implements ``CascadeNode``, so a cascade schema that embeds it
+            compiles. Mutually exclusive with ``sql_source`` (a value object has no
+            backing view) and with ``cascade`` (a value object cannot originate a
+            cascade). Default ``False``.
 
     Returns:
         The original class (unmodified)
@@ -507,6 +517,25 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
             )
             raise ValueError(msg)
 
+        # Reject embedded value-object contradictions (#687) *before* the sql_source and
+        # cascade-without-crud checks, so the value-object message wins. The compiler only
+        # warn!s on the hand-authored `embedded` + source form — the SDK must make it
+        # unreachable, and a value object can never originate a cascade.
+        if embedded and sql_source is not None:
+            msg = (
+                f"@fraiseql.type on {c.__name__!r}: embedded=True declares a value object with "
+                f"no backing view, so it cannot be combined with sql_source={sql_source!r}. "
+                "An embedded type declares no source; remove sql_source or drop embedded=True."
+            )
+            raise ValueError(msg)
+        if embedded and cascade:
+            msg = (
+                f"@fraiseql.type on {c.__name__!r}: embedded=True declares a value object, which "
+                "cannot originate a cascade, so it cannot be combined with cascade=True. "
+                "A cascade originates from a keyed entity's mutation, never a value object."
+            )
+            raise ValueError(msg)
+
         # Validate the @subscribable opt-in + its pre-image flag (#366).
         _validate_subscribable(
             subscribable_tables, subscribable_pre_image, f"@fraiseql.type on {c.__name__!r}"
@@ -552,6 +581,7 @@ def type(  # noqa: PLR0913 — public API; all parameters are meaningful
             shareable=shareable,
             subscribable_tables=subscribable_tables,
             subscribable_pre_image=subscribable_pre_image,
+            embedded=embedded,
         )
 
         # Generate CRUD operations if requested

--- a/sdks/official/fraiseql-python/src/fraiseql/registry.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/registry.py
@@ -99,6 +99,7 @@ class SchemaRegistry:
         shareable: bool = False,
         subscribable_tables: list[str] | None = None,
         subscribable_pre_image: bool = False,
+        embedded: bool = False,
     ) -> None:
         """Register a GraphQL type.
 
@@ -124,15 +125,26 @@ class SchemaRegistry:
                 also record the pre-image (OLD) into ``object_data_before`` (the
                 ``changelog_pre_image`` out-of-band parity). Emitted only when
                 ``True`` and there are tables to subscribe.
+            embedded: Whether the author declared this an embedded value object
+                (``@fraiseql.type(embedded=True)``, #687). When ``True`` the type
+                declares **no** ``sql_source`` — the synthesized ``v_{name}`` is
+                suppressed, since that source is exactly what would misclassify a value
+                object as a cascade entity — and ``embedded: true`` is emitted so the
+                compiler exempts it from the ``CascadeNode`` ``id: ID!`` contract.
         """
         field_list = [cls._build_field_def(k, v) for k, v in fields.items()]
 
-        type_def: dict[str, Any] = {
-            "name": name,
-            "sql_source": sql_source or f"v_{_pascal_to_snake(name)}",
-            "fields": field_list,
-            "description": description,
-        }
+        # An embedded value object (#687) declares no backing view: suppress the
+        # synthesized ``v_{name}`` source and mark it embedded. Every other type keeps
+        # its synthesized source and carries no ``embedded`` key (byte-identical to
+        # pre-#687 output).
+        type_def: dict[str, Any] = {"name": name}
+        if embedded:
+            type_def["embedded"] = True
+        else:
+            type_def["sql_source"] = sql_source or f"v_{_pascal_to_snake(name)}"
+        type_def["fields"] = field_list
+        type_def["description"] = description
 
         if name in cls._types:
             raise ValueError(

--- a/sdks/official/fraiseql-python/tests/test_embedded_value_object.py
+++ b/sdks/official/fraiseql-python/tests/test_embedded_value_object.py
@@ -1,0 +1,56 @@
+"""Rejection tests for the ``@fraiseql.type(embedded=True)`` value-object marker (#687).
+
+An embedded value object has no independent identity and no backing view, so two
+combinations are contradictions the SDK refuses at authoring time — the compiler only
+``warn!``s on the hand-authored form because the SDK is supposed to make it unreachable.
+"""
+
+import pytest
+
+import fraiseql
+from fraiseql.registry import SchemaRegistry
+
+
+@pytest.fixture(autouse=True)
+def clear_registry() -> None:
+    """Clear registry before each test."""
+    SchemaRegistry.clear()
+
+
+def test_embedded_with_sql_source_raises() -> None:
+    """A value object has no backing view — ``embedded=True`` + an explicit ``sql_source``
+    is a contradiction (the SDK suppresses the source for an embedded type)."""
+    with pytest.raises(ValueError, match="backing view"):
+
+        @fraiseql.type(embedded=True, sql_source="v_money")
+        class Money:
+            amount: int
+            currency: str
+
+
+def test_embedded_with_cascade_raises() -> None:
+    """A value object cannot originate a cascade — ``embedded=True`` + ``cascade=True``
+    is a contradiction (only a keyed entity mutation may cascade)."""
+    with pytest.raises(ValueError, match="cannot originate a cascade"):
+
+        @fraiseql.type(embedded=True, cascade=True)
+        class Money:
+            amount: int
+            currency: str
+
+
+def test_embedded_value_object_alone_is_accepted() -> None:
+    """The non-contradictory form registers cleanly (guards against over-rejection)."""
+
+    @fraiseql.type(embedded=True)
+    class Money:
+        amount: int
+        currency: str
+
+    money = next(t for t in SchemaRegistry.get_schema()["types"] if t["name"] == "Money")
+    assert money["embedded"] is True
+    assert "sql_source" not in money
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/sdks/official/fraiseql-python/tests/test_golden_schema.py
+++ b/sdks/official/fraiseql-python/tests/test_golden_schema.py
@@ -55,3 +55,44 @@ def test_golden_python_sdk_01_basic_query_mutation() -> None:
     assert _normalize(generated["types"]) == _normalize(golden["types"])
     assert _normalize(generated["queries"]) == _normalize(golden["queries"])
     assert _normalize(generated["mutations"]) == _normalize(golden["mutations"])
+
+
+def test_golden_python_sdk_02_embedded() -> None:
+    """Python SDK must emit an embedded value object (#687) matching the golden fixture.
+
+    ``Money`` is embedded under an ``Order`` returned by a ``cascade=True`` mutation. The
+    fixture pins the authoring half of (a): ``Money`` carries ``"embedded": true`` and — the
+    load-bearing part — declares **no** ``sql_source`` (the synthesized ``v_money`` is exactly
+    what would misclassify it as a cascade entity). The compile half (this same shape compiles
+    clean, ``Money`` is not a ``CascadeNode``) is proven separately by the Rust convert e2e.
+    """
+
+    @fraiseql.type(embedded=True)
+    class Money:
+        """A monetary amount embedded on an order — no independent identity."""
+
+        amount: int
+        currency: str
+
+    @fraiseql.type(sql_source="v_order")
+    class Order:
+        """An order whose total is an embedded Money value object."""
+
+        id: str
+        total: Money
+
+    @fraiseql.mutation(sql_source="fn_create_order", operation="insert", cascade=True)
+    def create_order(reference: str) -> Order:
+        """Create an order (returns a cascade payload)."""
+
+    generated = SchemaRegistry.get_schema()
+    golden_path = GOLDEN_DIR / "python-sdk-02-embedded.json"
+    golden = json.loads(golden_path.read_text())
+
+    assert _normalize(generated["types"]) == _normalize(golden["types"])
+    assert _normalize(generated["mutations"]) == _normalize(golden["mutations"])
+
+    # The point of the fixture: Money is emitted embedded, with no synthesized source.
+    money = next(t for t in generated["types"] if t["name"] == "Money")
+    assert money["embedded"] is True
+    assert "sql_source" not in money

--- a/sdks/official/fraiseql-python/tests/test_types_export_minimal.py
+++ b/sdks/official/fraiseql-python/tests/test_types_export_minimal.py
@@ -200,5 +200,45 @@ def test_export_types_no_queries_or_mutations() -> None:
         assert "mutations" not in schema or len(schema.get("mutations", [])) == 0
 
 
+def test_embedded_type_emits_flag_and_suppresses_source() -> None:
+    """An @fraiseql.type(embedded=True) value object emits ``embedded: true`` and NO
+    ``sql_source`` — the synthesized ``v_money`` is exactly what misclassifies a value
+    object as a cascade entity (#687), so the SDK must suppress it."""
+
+    @fraiseql.type(embedded=True)
+    class Money:
+        """A monetary amount — an embedded value object, no independent identity."""
+
+        amount: int
+        currency: str
+
+    schema = SchemaRegistry.get_schema()
+    money = next(t for t in schema["types"] if t["name"] == "Money")
+
+    assert money["embedded"] is True
+    assert "sql_source" not in money, (
+        "an embedded value object must declare no source — a synthesized v_money is what "
+        "misclassifies it as a cascade entity"
+    )
+
+
+def test_non_embedded_type_is_unchanged() -> None:
+    """A default (non-embedded) type keeps its synthesized ``sql_source`` and carries NO
+    ``embedded`` key (skip-when-false ⇒ byte-identical to pre-#687)."""
+
+    @fraiseql.type
+    class User:
+        """A user."""
+
+        id: str
+        name: str
+
+    schema = SchemaRegistry.get_schema()
+    user = next(t for t in schema["types"] if t["name"] == "User")
+
+    assert user["sql_source"] == "v_user"
+    assert "embedded" not in user
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/sdks/official/tests/fixtures/golden/python-sdk-02-embedded.json
+++ b/sdks/official/tests/fixtures/golden/python-sdk-02-embedded.json
@@ -1,0 +1,57 @@
+{
+  "types": [
+    {
+      "name": "Money",
+      "embedded": true,
+      "fields": [
+        {
+          "name": "amount",
+          "type": "Int",
+          "nullable": false
+        },
+        {
+          "name": "currency",
+          "type": "String",
+          "nullable": false
+        }
+      ],
+      "description": "A monetary amount embedded on an order — no independent identity."
+    },
+    {
+      "name": "Order",
+      "sql_source": "v_order",
+      "fields": [
+        {
+          "name": "id",
+          "type": "ID",
+          "nullable": false
+        },
+        {
+          "name": "total",
+          "type": "Money",
+          "nullable": false
+        }
+      ],
+      "description": "An order whose total is an embedded Money value object."
+    }
+  ],
+  "mutations": [
+    {
+      "name": "createOrder",
+      "return_type": "Order",
+      "returns_list": false,
+      "nullable": false,
+      "arguments": [
+        {
+          "name": "reference",
+          "type": "String",
+          "nullable": false
+        }
+      ],
+      "description": "Create an order (returns a cascade payload).",
+      "sql_source": "fn_create_order",
+      "operation": "insert",
+      "cascade": true
+    }
+  ]
+}


### PR DESCRIPTION
## #687 Phase 02 — SDK `@fraiseql.type(embedded=True)` + golden e2e

Stacked on **#689** (Phase 01, the compiler side). **This PR is based on
`feat/687-phase-01-embedded-classifier`** so the diff shows only Phase 02. After #689 merges to
`dev`, this branch will be **rebased onto `dev` and retargeted** (the repo squash-merges, so the
Phase-01 commit is dropped in favor of dev's squash).

### What this adds (the authoring side — unblocks the common `Money` case)
- `@fraiseql.type(embedded=True)` marks a value object with no independent identity. It emits
  `"embedded": true` and **suppresses the synthesized `sql_source`**. That synthesized `v_{name}`
  is exactly what misclassified a value object as a cascade entity and hard-failed the `CascadeNode`
  `id: ID!` contract (the **#653 bug**). Source-suppression is the mechanism that unblocks it; the
  Phase 01 classifier leg is the declared, source-independent guard.
- The SDK **rejects** the two contradictions the compiler can only `warn!` on:
  - `embedded=True` + explicit `sql_source` → `ValueError` (no backing view);
  - `embedded=True` + `cascade=True` → `ValueError` (a value object cannot originate a cascade).

### Additive, not breaking
`embedded` defaults false; a non-embedded type is byte-identical to before (`python-sdk-01-basic.json`
untouched). Value-object schemas that hard-fail today start compiling once they opt in.

### Tests
- **Emission:** `test_types_export_minimal.py` — flag emitted + source suppressed; normal type unchanged.
- **Rejections:** `test_embedded_value_object.py` — the two `ValueError`s + an accept-the-valid-form guard.
- **Proof A (golden):** `python-sdk-02-embedded.json` + `test_golden_schema.py` case — `Money` embedded
  under an `Order` returned by a `cascade=True` mutation. Fixture **generated from SDK output**.
- **Proof B (compile e2e):** `crates/fraiseql-cli/tests/embedded_value_object_cascade_e2e.rs` — the
  SDK-realistic **no-source** `Money` drives `SchemaConverter::convert`; asserts it compiles, `Money`
  is not a `CascadeNode` while `Order` is, and the compiled **`Money.embedded == true`**. That last
  assertion is the genuinely-RED-pre-Phase-01 one (RED proven by mutation). Distinct from Phase 01
  Cycle 2 (which tests the guard against a *non-empty-source* contradiction).

### Verification
- **SDK:** `ruff check` / `ruff format --check` clean; 6 new pytest pass (only pre-existing
  optional-dep failures in `test_langchain`/`test_llamaindex`); `ty` at pre-existing baseline +1
  (idiomatic decorator-stub `empty-body` class).
- **Rust:** `fmt --check`; `clippy --workspace --all-targets --all-features -D warnings`; rustdoc
  `-D warnings`; full `cargo test -p fraiseql-cli`; `make preflight` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)