### PR TITLE
docs(687): document embedded=True + re-point cascade diagnostic (#687 Phase 03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,15 +51,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (unchanged, never warns). Development (`FRAISEQL_ENV=development`) downgrades the refusal
   to a warning, matching the `failed_login_*` production/development split.
 
+### Added
+
+- **`@fraiseql.type(embedded=True)` declares a type an embedded value object (#687,
+  follow-up to #653).** An embedded value object has no independent identity and is always
+  nested under a parent entity (e.g. a `Money` amount on an `Order`). Such a type declares
+  **no** `sql_source` — the SDK suppresses the synthesized `v_{name}` — and is exempt from
+  cascade classification: the compiler never enforces the `CascadeNode` `id: ID!` contract on
+  it nor auto-implements the interface. This fixes the case where a value object embedded under
+  a `cascade` mutation could not compile at all: its synthesized source made it a cascade
+  entity that could never satisfy `id: ID!`. Purely additive — `embedded` defaults false, a
+  type must opt in, and nothing currently-compiling changes. The SDK rejects the two
+  contradictions the combination implies: `embedded=True` with an explicit `sql_source` (a
+  value object has no backing view), and `embedded=True` with `cascade=True` (a value object
+  cannot originate a cascade).
+
 ### Changed
 
-- **The cascade `id: ID!` error now names *why* a type was classified an entity and *how* a
-  mutation reaches it (#653).** When a `cascade = true` mutation drags in a type that lacks
-  `id: ID!`, the error previously stated only the failed assertion — and its two suggested
-  fixes ("add `id`" / "remove `cascade`") were both wrong for an embedded value object the
-  SDK gave a synthesized `sql_source`. It now reports the classification signal (`declares
-  sql_source = "v_money"; an embedded value object … should declare no source`) and the
-  reference path (`createOrder → Order.total → Money`), pointing at the real fix. Purely a
+- **The cascade `id: ID!` error now names *why* a type was classified an entity, *how* a
+  mutation reaches it, and the actionable fix for each case (#653, #659, #687).** When a
+  `cascade = true` mutation drags in a type that lacks `id: ID!`, the error previously stated
+  only the failed assertion — and its two suggested fixes ("add `id`" / "remove `cascade`")
+  were both wrong for an embedded value object the SDK gave a synthesized `sql_source`. It now
+  reports the classification signal and names both exits — `classified as a cascade entity
+  because it declares sql_source = "v_money"; if it is an embedded value object, mark it
+  embedded=True (it will declare no source and be exempt); if it is an entity, add id: ID!` —
+  alongside the reference path (`createOrder → Order.total → Money`). Purely a
   diagnostic change — which schemas compile is unchanged.
 - **`compile --database` now warns when a `@fraiseql.type` declares a `sql_source` view that
   is absent from the connected database (#653).** These phantom sources — usually an

--- a/docs/adr/0017-entity-identity-contract.md
+++ b/docs/adr/0017-entity-identity-contract.md
@@ -113,6 +113,15 @@ and `--json` output, so any residual rejection is self-diagnosing.
   `uuid`-typed — so it emits `id: UUID`, which the compiler's `UUID → ID`
   canonicalization handles. No SpecQL change is required for conformance; emitting
   `id: ID` directly for the identity column would be an optional honesty improvement.
+- **A type can declare itself a non-entity (#687).** `@fraiseql.type(embedded=True)` marks an
+  embedded value object — no independent identity, always nested under a parent (e.g. a `Money`
+  amount on an `Order`) — which emits no `sql_source` and is exempt from this contract: no
+  `id: ID!`, no `CascadeNode`/`Node`. Entity-ness is therefore **author-declared** — a value
+  object opts out with `embedded`, and every other view-backed type must present `id: ID!` — not
+  inferred from the `sql_source` shape. Before this, the SDK synthesized a `v_{name}` source for
+  every `@fraiseql.type`, so an embedded value object under a cascade was classified an entity
+  and failed the backstop (point 3) on a type with no identity by design; the declaration is the
+  fix. The backstop still fires for a genuine, non-`embedded` entity that lacks `id: ID!`.
 - **Future (graphql-cascade#5):** if a genuine need for heterogeneous-identity
   cascades emerges, the union model can relax this contract without breaking anyone
   (error → working is non-breaking).

--- a/docs/architecture/mutation-response.md
+++ b/docs/architecture/mutation-response.md
@@ -272,6 +272,32 @@ cascade is truncated with `metadata.truncated`, max response size → rejected).
 > `internal` type, so a change-log row can never ride in a cascade. The two features
 > compose freely — see [the change-log-over-GraphQL guide](../guides/changelog-graphql.md).
 
+> **Embedded value objects are not cascade entities (#687).** A type with no independent
+> identity — a `Money` amount, a `Dimensions` triple — is *embedded* under a parent entity,
+> not a cache node of its own. Declare it `@fraiseql.type(embedded=True)`: it emits no
+> `sql_source` and is exempt from the eligibility check above — it does **not** implement
+> `CascadeNode` and is never enforced against `id: ID!`.
+>
+> ```python
+> @fraiseql.type(embedded=True)
+> class Money:
+>     amount: int
+>     currency: str
+>
+> @fraiseql.type(sql_source="v_order")
+> class Order:
+>     id: str
+>     total: Money  # rides inside the Order payload; no id of its own
+> ```
+>
+> This is **author-declared**, not inferred from the source. Without the marker, the SDK
+> synthesizes a `v_money` source for every `@fraiseql.type`, which classifies `Money` as a
+> cascade entity and fails the compile on a type that has no identity by design — the reason a
+> value object under a `cascade` mutation could not compile before #687. The declaration is
+> the fix, so `embedded=True` rejects an explicit `sql_source` (no backing view) and `cascade`
+> (a value object cannot originate a cascade). Contrast the `internal` exemption above: that is
+> set by the framework on projections it synthesizes; `embedded` is the *author's* declaration.
+
 ### Row-visibility boundary (RLS)
 
 FraiseQL enforces **field-level** authorization on every cascade entity, but it

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -107,6 +107,7 @@ class Post:
 | `implements` | `list[str] \| None` | Interface names this type implements |
 | `relay` | `bool` | Enable Relay cursor pagination for this type |
 | `requires_role` | `str \| None` | JWT role required to access any field on this type |
+| `embedded` | `bool` | Mark an embedded value object (no independent identity, nested under a parent). Declares no `sql_source`; exempt from the cascade `CascadeNode` `id: ID!` contract |
 
 ```python
 @fraiseql.type(relay=True, requires_role="admin")
@@ -115,6 +116,30 @@ class AuditLog:
     action: str
     created_at: str
 ```
+
+**Embedded value objects.** A type with no independent identity — a `Money` amount, a
+`Dimensions` triple, an address-as-value — is *embedded* under a parent entity rather than
+being a cache node of its own. Mark it `embedded=True`: it declares no `sql_source` and is
+exempt from the cascade identity contract, so a schema that nests it under a `cascade=True`
+mutation compiles (without the marker its synthesized `v_{name}` source makes it a cascade
+entity that fails the `id: ID!` requirement).
+
+```python
+@fraiseql.type(embedded=True)
+class Money:
+    amount: int
+    currency: str
+
+@fraiseql.type(sql_source="v_order")
+class Order:
+    id: str
+    total: Money  # embedded value object — no id of its own
+```
+
+`embedded=True` cannot be combined with `sql_source` (a value object has no backing view) or
+with `cascade=True` (a value object cannot originate a cascade); both raise a `ValueError` at
+authoring time. See [entity identity](adr/0017-entity-identity-contract.md) and the
+[cascade surface](architecture/mutation-response.md#cascade-the-typed-cascade-surface).
 
 ---
 


### PR DESCRIPTION
## #687 Phase 03 — Docs + CHANGELOG

Stacked on **#696** (Phase 02) → **#689** (Phase 01). Base is `feat/687-phase-02-sdk-embedded`
so the diff shows only Phase 03. **After #689 + #696 merge to `dev`, rebase this onto `dev` and
retarget** (repo squash-merges).

Additive documentation for the `@fraiseql.type(embedded=True)` marker (Phase 02), plus the
CHANGELOG cleanup Phase 01 deferred.

### Changes
- **CHANGELOG `[Unreleased]`:** `### Added` (`embedded=True`); updated the `### Changed` #653
  diagnostic entry to quote the **shipped** "mark it `embedded=True`" wording (was the stale
  "should declare no source"). No `### Breaking` — additive.
- **`docs/authoring.md`:** `@fraiseql.type` reference gains the `embedded` param + an "Embedded
  value objects" subsection (Money/Order example, the two rejected combinations).
- **`docs/architecture/mutation-response.md`:** cascade section gains an "Embedded value objects
  are not cascade entities (#687)" note, parallel to the #665 framework-projections note.
- **`docs/adr/0017-entity-identity-contract.md`:** consequence bullet — entity-ness is now
  **author-declared** (value objects opt out via `embedded`), not inferred from `sql_source`.

### Verification
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` clean.
- Doc Python snippets `ast.parse`-valid; no markdown-link/lint gate exists in-repo.
- Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)