### PR TITLE
fix(cli): mark synthesized cascade envelope types @shareable for federation (#698)

### DIFF
--- a/crates/fraiseql-cli/Cargo.toml
+++ b/crates/fraiseql-cli/Cargo.toml
@@ -120,6 +120,10 @@ name = "functions_invoke"
 required-features = ["functions-invoke"]
 
 [[test]]
+name = "cascade_federation_shareable_e2e"
+required-features = ["federation"]
+
+[[test]]
 name = "cli_federation_validation"
 required-features = ["federation"]
 

--- a/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
+++ b/crates/fraiseql-cli/src/schema/converter/cascade_types.rs
@@ -134,20 +134,35 @@ pub(super) fn synthesize_cascade_types(schema: &mut CompiledSchema) -> anyhow::R
     if !existing_enum_names.contains(INVALIDATION_SCOPE) {
         schema.enums.push(invalidation_scope_enum());
     }
-    if !existing_type_names.contains(UPDATED_ENTITY) {
-        schema.types.push(updated_entity_type());
+    // Track exactly which envelope value types this pass synthesized (a name already owned by
+    // a real user type is left alone), so federation can mark precisely those `@shareable`.
+    let mut synthesized_envelopes: Vec<&'static str> = Vec::new();
+    for (name, build) in [
+        (UPDATED_ENTITY, updated_entity_type as fn() -> TypeDefinition),
+        (DELETED_ENTITY, deleted_entity_type),
+        (CASCADE_METADATA, cascade_metadata_type),
+        (QUERY_INVALIDATION, query_invalidation_type),
+        (CASCADE_UPDATES, cascade_updates_type),
+    ] {
+        if !existing_type_names.contains(name) {
+            schema.types.push(build());
+            synthesized_envelopes.push(name);
+        }
     }
-    if !existing_type_names.contains(DELETED_ENTITY) {
-        schema.types.push(deleted_entity_type());
-    }
-    if !existing_type_names.contains(CASCADE_METADATA) {
-        schema.types.push(cascade_metadata_type());
-    }
-    if !existing_type_names.contains(QUERY_INVALIDATION) {
-        schema.types.push(query_invalidation_type());
-    }
-    if !existing_type_names.contains(CASCADE_UPDATES) {
-        schema.types.push(cascade_updates_type());
+
+    // Federation (#698): the synthesized envelope value types are structurally identical in
+    // every cascade-enabled subgraph and carry no independent identity, so a supergraph that
+    // composes two such subgraphs rejects them with `INVALID_FIELD_SHARING` unless they are
+    // `@shareable` in each. Mark exactly the ones this pass synthesized — the same treatment the
+    // authored `MutationError` value type already gets via `shareable_types`. No-op without a
+    // federation block; the per-mutation `<Name>Payload` types are uniquely named per entity and
+    // never collide, so they are deliberately not marked.
+    if let Some(fed) = schema.federation.as_mut() {
+        for name in synthesized_envelopes {
+            if !fed.shareable_types.iter().any(|t| t == name) {
+                fed.shareable_types.push(name.to_string());
+            }
+        }
     }
 
     // 3. Per-mutation payload wrapper + return-type rewrite. Plan up front so the mutation list

--- a/crates/fraiseql-cli/tests/cascade_federation_shareable_e2e.rs
+++ b/crates/fraiseql-cli/tests/cascade_federation_shareable_e2e.rs
@@ -1,0 +1,136 @@
+#![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics are acceptable
+//! Regression: the synthesized graphql-cascade envelope value types must be `@shareable`
+//! so a multi-subgraph federation with `cascade = true` mutations composes (#698).
+//!
+//! A `cascade = true` mutation makes the cli synthesize a fixed set of envelope value types
+//! (`UpdatedEntity`, `DeletedEntity`, `CascadeMetadata`, `QueryInvalidation`, `CascadeUpdates`)
+//! — structurally identical in **every** cascade-enabled subgraph and carrying no identity.
+//! Before this fix they were emitted as plain, non-`@shareable` types, so composing two such
+//! subgraphs into a supergraph fails Federation-v2 validation with one `INVALID_FIELD_SHARING`
+//! per field (21 in total): the same value type is resolved from multiple subgraphs and is
+//! non-shareable in all of them. This is the exact class already handled for the authored
+//! `MutationError` via `federation.shareable_types`; the synthesizer is the still-unhandled
+//! instance of it.
+//!
+//! The fix marks the five envelope types `@shareable` at the single synthesis site. This test
+//! drives the real compile path (`SchemaConverter::convert`) on a federation-enabled subgraph
+//! with a cascade mutation and asserts, hermetically, both halves:
+//!   1. the compiled `federation.shareable_types` carries the five envelope types, and
+//!   2. the rendered `_service { sdl }` marks each of them `type <X> @shareable`.
+//!
+//! Two subgraphs that both render the identical envelope types `@shareable` compose without
+//! `INVALID_FIELD_SHARING` — the real-composer assertion lives in the federation-compose CI
+//! leg; this is its hermetic companion (same split as `federation_compose.rs`).
+
+use fraiseql_cli::schema::{IntermediateSchema, converter::SchemaConverter};
+
+/// The five synthesized graphql-cascade envelope value types that are identical across every
+/// cascade subgraph and therefore must be `@shareable`. (The per-mutation `<Name>Payload`
+/// types are uniquely named per entity and never collide; the shared enums and the
+/// `CascadeNode` interface compose by identity, so neither needs `@shareable`.)
+const ENVELOPE_TYPES: &[&str] = &[
+    "UpdatedEntity",
+    "DeletedEntity",
+    "CascadeMetadata",
+    "QueryInvalidation",
+    "CascadeUpdates",
+];
+
+/// An SDK-shaped federation subgraph with exactly one `cascade = true` mutation — the shape
+/// `@fraiseql.type(crud=True, cascade=True)` + a federation block produces.
+fn cascade_subgraph_json(service_name: &str, entity: &str, sql_source: &str) -> String {
+    format!(
+        r#"
+{{
+  "version": "2.0.0",
+  "types": [
+    {{
+      "name": "{entity}",
+      "fields": [
+        {{"name": "id", "type": "ID", "nullable": false}},
+        {{"name": "total", "type": "Float", "nullable": false}}
+      ],
+      "sql_source": "{sql_source}"
+    }}
+  ],
+  "queries": [],
+  "mutations": [
+    {{
+      "name": "create{entity}",
+      "return_type": "{entity}",
+      "cascade": true,
+      "sql_source": "fn_create_{sql_source}",
+      "operation": "CREATE"
+    }}
+  ],
+  "subscriptions": [],
+  "federation": {{
+    "enabled": true,
+    "service_name": "{service_name}",
+    "apollo_version": 2,
+    "entities": [
+      {{"name": "{entity}", "key_fields": ["id"]}}
+    ]
+  }}
+}}
+"#
+    )
+}
+
+fn compile(json: &str) -> fraiseql_core::schema::CompiledSchema {
+    let intermediate: IntermediateSchema =
+        serde_json::from_str(json).expect("parse SDK schema.json");
+    SchemaConverter::convert(intermediate).expect("cascade + federation subgraph must compile")
+}
+
+fn service_sdl(schema: &fraiseql_core::schema::CompiledSchema) -> String {
+    let raw = schema.raw_schema();
+    let meta = schema
+        .federation_metadata()
+        .expect("federation_metadata must be Some when enabled");
+    fraiseql_core::federation::generate_service_sdl(&raw, &meta)
+}
+
+#[test]
+fn cascade_envelope_types_are_added_to_shareable_types() {
+    let compiled = compile(&cascade_subgraph_json("orders", "Order", "v_order"));
+    let fed = compiled.federation.as_ref().expect("federation block present");
+
+    for name in ENVELOPE_TYPES {
+        assert!(
+            fed.shareable_types.iter().any(|t| t == name),
+            "synthesized cascade envelope type {name:?} must be in federation.shareable_types \
+             (else composition fails INVALID_FIELD_SHARING); got {:?}",
+            fed.shareable_types
+        );
+    }
+}
+
+#[test]
+fn cascade_envelope_types_render_shareable_in_service_sdl() {
+    let compiled = compile(&cascade_subgraph_json("orders", "Order", "v_order"));
+    let sdl = service_sdl(&compiled);
+
+    for name in ENVELOPE_TYPES {
+        let marker = format!("type {name} @shareable");
+        assert!(
+            sdl.contains(&marker),
+            "cascade envelope type {name:?} must render `{marker}` in the _service SDL, got:\n{sdl}"
+        );
+    }
+}
+
+#[test]
+fn two_cascade_subgraphs_both_mark_the_envelope_types_shareable() {
+    // The composition scenario: two independent cascade-enabled subgraphs each synthesize the
+    // identical envelope types. Federation v2 composes them only if *both* mark those shared
+    // value types `@shareable`; before #698 neither did → INVALID_FIELD_SHARING.
+    let orders = service_sdl(&compile(&cascade_subgraph_json("orders", "Order", "v_order")));
+    let users = service_sdl(&compile(&cascade_subgraph_json("users", "User", "v_user")));
+
+    for name in ENVELOPE_TYPES {
+        let marker = format!("type {name} @shareable");
+        assert!(orders.contains(&marker), "`orders` subgraph missing `{marker}`");
+        assert!(users.contains(&marker), "`users` subgraph missing `{marker}`");
+    }
+}


### PR DESCRIPTION
Closes #698.

## Problem
A `cascade = true` mutation makes the compiler synthesize five envelope value types
(`UpdatedEntity`, `DeletedEntity`, `CascadeMetadata`, `QueryInvalidation`, `CascadeUpdates`),
structurally identical in **every** cascade-enabled subgraph and carrying no identity. They were
emitted as plain, **non-`@shareable`** types, so composing two such subgraphs into a supergraph
fails Federation-v2 validation with **one `INVALID_FIELD_SHARING` per field (21 total)**. Each
subgraph compiles/runs fine — the failure only surfaces at supergraph composition (regression
window: 2.12.0+, where cascade synthesis landed).

## Fix
At the single synthesis site (`synthesize_cascade_types`), when a federation block is present,
add exactly the envelope types this pass synthesized to `federation.shareable_types` — the same
mechanism the authored `MutationError` value type already uses. Only freshly-synthesized names
are marked (a user type owning one of these names is left alone); the per-mutation `<Name>Payload`
types are uniquely named per entity and never collide, so they're not marked. **No-op without a
federation block** — non-federation cascade output is byte-identical.

## Tests
New `cascade_federation_shareable_e2e.rs` (`required-features = federation`) drives the real
`SchemaConverter::convert` path on cascade + federation subgraphs and asserts, for **two**
subgraphs: (a) compiled `federation.shareable_types` carries the five types, and (b) the rendered
`_service { sdl }` marks each `type <X> @shareable`. **RED before the fix.** The
real-`composeServices` mechanism these route through is already validated by
`make federation-compose-check` (a shared `@shareable` `Money` composes cleanly in real Apollo Fed v2).

**Optional follow-up (not in this PR):** a dedicated real-composer fixture pair of two *cascade*
subgraphs. The current real-composer leg builds fixtures from core-level builders that bypass CLI
cascade synthesis, so it already proves `@shareable` composes but not specifically the cascade
envelopes; the hermetic CLI test above locks the cascade→`@shareable` step. Happy to add it if wanted.

## Verification
- fmt / clippy `--workspace --all-targets --all-features -D warnings` / rustdoc clean
- `cargo test -p fraiseql-cli --features federation` (678 lib + all integration) + `-p fraiseql-core federation_compose`
- `make preflight`; `make federation-compose-check` (real Apollo Fed v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)