### PR TITLE
chore(release): prepare v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-07-22
+
 ### Breaking
 
 - **The dormant `/realtime/v1` WebSocket subsystem has been removed in full (#605).** It was a
@@ -89,6 +91,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   synthesized).
 
 ### Fixed
+
+- **Federation subgraphs with `cascade = true` mutations now compose into a supergraph (#698).**
+  A cascade mutation makes the compiler synthesize five envelope value types — `UpdatedEntity`,
+  `DeletedEntity`, `CascadeMetadata`, `QueryInvalidation`, `CascadeUpdates` — that are
+  structurally identical in every cascade-enabled subgraph and carry no independent identity.
+  They were emitted non-`@shareable`, so composing two such subgraphs into a supergraph failed
+  Federation-v2 validation with one `INVALID_FIELD_SHARING` per field (21 in total). The
+  synthesizer now marks exactly the envelope types it generates `@shareable` — via
+  `federation.shareable_types`, the same mechanism the authored `MutationError` uses — when a
+  federation block is present; a user type that already owns one of those names and the
+  per-mutation `<Name>Payload` types are left alone. Per-subgraph compile and runtime are
+  unchanged (the failure only ever surfaced at supergraph composition); the fix is schema-only.
 
 - **`[changelog] expose = true` and `cascade = true` mutations now compile together (#665).**
   Since 2.12.0 the two features were mutually exclusive. The cascade pass classifies every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "fraiseql-arrow",
  "fraiseql-cli",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-arrow"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-auth"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cdc-sinks"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "async-nats",
  "chrono",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cli"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-codegen"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "fraiseql-core",
  "fraiseql-error",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-core"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-db"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-error"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "axum",
  "serde",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-federation"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-functions"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-observers"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "arrow",
  "async-nats",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-secrets"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-server"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-storage"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-support"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "testcontainers",
  "testcontainers-modules",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-utils"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "async-trait",
  "fraiseql-core",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-webhooks"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4218,7 +4218,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-wire"
-version = "2.13.1"
+version = "2.14.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,26 +63,26 @@ dashmap = "6.1"
 deadpool = "0.12"
 deadpool-postgres = "0.14"
 # Internal crates
-fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.13.1"}
-fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.13.1"}
+fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.14.0"}
+fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.14.0"}
 # Deliberately loose floor (2.3.0, not the current 2.7.0): fraiseql-server takes
 # fraiseql-cli as a dev-dependency while fraiseql-cli depends on fraiseql-server,
 # a publish cycle. A floor equal to the unpublished current version breaks the
 # first `cargo publish` of the cut (the sibling isn't on crates.io yet). Keep this
 # floor loose — see the v2.4.0 release lessons. Do NOT bump it to match the others.
 fraiseql-cli = {path = "crates/fraiseql-cli", version = "2.3.0"}
-fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.13.1"}
-fraiseql-core = {path = "crates/fraiseql-core", version = "2.13.1", default-features = false}
-fraiseql-db = {path = "crates/fraiseql-db", version = "2.13.1", default-features = false}
-fraiseql-error = {path = "crates/fraiseql-error", version = "2.13.1", default-features = false}
-fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.13.1"}
-fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.13.1"}
-fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.13.1"}
-fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.13.1"}
-fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.13.1"}
-fraiseql-server = {path = "crates/fraiseql-server", version = "2.13.1"}
-fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.13.1"}
-fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.13.1"}
+fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.14.0"}
+fraiseql-core = {path = "crates/fraiseql-core", version = "2.14.0", default-features = false}
+fraiseql-db = {path = "crates/fraiseql-db", version = "2.14.0", default-features = false}
+fraiseql-error = {path = "crates/fraiseql-error", version = "2.14.0", default-features = false}
+fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.14.0"}
+fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.14.0"}
+fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.14.0"}
+fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.14.0"}
+fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.14.0"}
+fraiseql-server = {path = "crates/fraiseql-server", version = "2.14.0"}
+fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.14.0"}
+fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.14.0"}
 futures = "0.3"
 graphql-parser = "0.4"
 hex = "0.4"
@@ -350,4 +350,4 @@ keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
 rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
-version = "2.13.1"
+version = "2.14.0"

--- a/crates/fraiseql-arrow/fuzz/Cargo.toml
+++ b/crates/fraiseql-arrow/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-arrow-fuzz"
 publish = false
-version = "2.13.1"
+version = "2.14.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-auth-fuzz"
-version = "2.13.1"
+version = "2.14.0"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-core/fuzz/Cargo.toml
+++ b/crates/fraiseql-core/fuzz/Cargo.toml
@@ -51,7 +51,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-core-fuzz"
 publish = false
-version = "2.13.1"
+version = "2.14.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-db/fuzz/Cargo.toml
+++ b/crates/fraiseql-db/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-db-fuzz"
 publish = false
-version = "2.13.1"
+version = "2.14.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-federation/fuzz/Cargo.toml
+++ b/crates/fraiseql-federation/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ path = "../../fraiseql-error"
 edition = "2021"
 name = "fraiseql-federation-fuzz"
 publish = false
-version = "2.13.1"
+version = "2.14.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-secrets/fuzz/Cargo.toml
+++ b/crates/fraiseql-secrets/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-secrets-fuzz"
-version = "2.13.1"
+version = "2.14.0"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-server/fuzz/Cargo.toml
+++ b/crates/fraiseql-server/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-server-fuzz"
 publish = false
-version = "2.13.1"
+version = "2.14.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-wire/fuzz/Cargo.toml
+++ b/crates/fraiseql-wire/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-wire-fuzz"
 publish = false
-version = "2.13.1"
+version = "2.14.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdks/official/fraiseql-python/pyproject.toml
+++ b/sdks/official/fraiseql-python/pyproject.toml
@@ -38,7 +38,7 @@ license = {text = "MIT"}
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.13.1"
+version = "2.14.0"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]

--- a/sdks/official/fraiseql-python/src/fraiseql/__init__.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/__init__.py
@@ -79,7 +79,7 @@ input = input_decorator
 interface = interface_decorator
 union = union_decorator
 
-__version__ = "2.13.1"
+__version__ = "2.14.0"
 
 __all__ = [
     "ID",

--- a/sdks/official/fraiseql-rust/Cargo.toml
+++ b/sdks/official/fraiseql-rust/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["graphql", "authorization", "rbac", "schema"]
 license = "Apache-2.0"
 name = "fraiseql-rust"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "2.13.1"
+version = "2.14.0"
 
 [[test]]
 name = "integration_test"

--- a/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
+++ b/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-client"
-version = "2.13.1"
+version = "2.14.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Async HTTP client for FraiseQL GraphQL servers"

--- a/sdks/official/fraiseql-typescript/package-lock.json
+++ b/sdks/official/fraiseql-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fraiseql",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fraiseql",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/sdks/official/fraiseql-typescript/package.json
+++ b/sdks/official/fraiseql-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fraiseql",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "FraiseQL v2 - Compiled GraphQL execution engine (schema authoring + HTTP client)",
   "repository": {
     "type": "git",

--- a/sdks/official/fraiseql-typescript/src/index.ts
+++ b/sdks/official/fraiseql-typescript/src/index.ts
@@ -32,7 +32,7 @@
  * @packageDocumentation
  */
 
-export const version = "2.13.1";
+export const version = "2.14.0";
 
 // Export type system
 export { typeToGraphQL, extractFieldInfo, extractFunctionSignature } from "./types";


### PR DESCRIPTION
Release-prep for **v2.14.0** (per `docs/contributing/branching-model.md`: bump + CHANGELOG via a
`chore/release-prep` PR to `dev`, then tag the `dev` merge commit).

## What this does
- **Version bump `2.13.1` → `2.14.0`** across the workspace (`tools/release.sh`): root `Cargo.toml`
  + internal dep floors, the 8 fuzz crates, the Rust SDK, and the **Python** (`pyproject.toml` +
  `__init__.py`) and **TypeScript** (`package.json` + lockfile + `index.ts`) SDKs, plus `Cargo.lock`.
- **CHANGELOG finalized** — `[Unreleased]` → `## [2.14.0] - 2026-07-22` (empty `[Unreleased]` kept
  for future work).
- **Adds the missing #698 `### Fixed` entry** (cascade-envelope `@shareable` federation fix — merged
  in #699 with no CHANGELOG line).

## v2.14.0 payload (already merged + validated on `dev`)
- **Breaking:** #605 (`/realtime/v1` removed), #618 (`trust_proxy_headers` boot-refusal)
- **Added:** #687 `@fraiseql.type(embedded=True)`
- **Changed:** #653 cascade diagnostic re-point, #653 phantom-source warn
- **Fixed:** **#698** (cascade envelope `@shareable`), #665, CSV/XLSX column order, `fraiseql setup`
  change-log contract, #611 subscription hot-reload
- **Security:** #676 `mutation(requires_role=…)` enforcement

## Verification
- `cargo check --workspace` (in `release.sh`) + `cargo +nightly fmt --check` clean.
- Prep diff is manifests + `Cargo.lock` + CHANGELOG only — no code changes.

## After merge (the release-cut — NOT in this PR; needs a maintainer)
1. `make release-validate VERSION=2.14.0` (tokenless Dagger dry-run: publish-order + dry-run).
2. Tag the **`dev` merge commit**: `git tag -a v2.14.0` + `git push origin v2.14.0` (the tag on the
   dev merge commit, never a side branch — the v2.11.0-botch guard).
3. The tag push triggers the release workflow → builds the lean + `-full` artifacts and publishes
   crates.io / PyPI / npm / Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)