### PR TITLE
test(federation): real-composer regression for #698 cascade envelope @shareable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,12 +681,19 @@ test-federation: federation-up
 		exit $$EXIT
 
 # Golden two-subgraph compose suite — no Docker. Verifies the committed subgraph SDL
-# fixtures still match live FraiseQL rendering (hermetic Rust test), then composes them
-# with real Apollo Federation v2 composition (positive + the #497 negative case). This
-# is the suite that would have caught the #495/#496/#497/#498 federation cluster.
+# fixtures still match live FraiseQL rendering (hermetic Rust tests), then composes them
+# with real Apollo Federation v2 composition (positive + the #497 negative case + the
+# #698 cascade positive case). This is the suite that would have caught the
+# #495/#496/#497/#498 federation cluster and the #698 cascade-envelope sharing bug.
+#
+# Two lock-step tests keep the committed fixtures honest: the core one guards
+# catalog/reviews (built from CompiledSchema builders); the cli one guards the cascade
+# fixtures, which MUST be rendered through the cli converter where cascade synthesis and
+# the #698 @shareable fix live (the core builders bypass it).
 federation-compose-check:
 	@echo "=== Federation golden compose (SDL invariants + real composition) ==="
 	@cargo test -p fraiseql-core --test federation_compose --features federation
+	@cargo test -p fraiseql-cli --test cascade_federation_shareable_e2e --features federation
 	@bash tools/federation/run-compose-check.sh
 
 # ============================================================================

--- a/crates/fraiseql-cli/tests/cascade_federation_shareable_e2e.rs
+++ b/crates/fraiseql-cli/tests/cascade_federation_shareable_e2e.rs
@@ -22,6 +22,8 @@
 //! `INVALID_FIELD_SHARING` — the real-composer assertion lives in the federation-compose CI
 //! leg; this is its hermetic companion (same split as `federation_compose.rs`).
 
+use std::path::PathBuf;
+
 use fraiseql_cli::schema::{IntermediateSchema, converter::SchemaConverter};
 
 /// The five synthesized graphql-cascade envelope value types that are identical across every
@@ -132,5 +134,131 @@ fn two_cascade_subgraphs_both_mark_the_envelope_types_shareable() {
         let marker = format!("type {name} @shareable");
         assert!(orders.contains(&marker), "`orders` subgraph missing `{marker}`");
         assert!(users.contains(&marker), "`users` subgraph missing `{marker}`");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Real-composer companion (#698): committed cascade subgraph SDL fixtures.
+//
+// The two-subgraph assertion above only checks that each rendered `_service` SDL
+// *contains* the `@shareable` markers — it never actually composes them. The real
+// `composeServices` proof lives in the federation-compose CI leg
+// (`make federation-compose-check` → `tools/federation/run-compose-check.sh`), which
+// composes committed `.graphql` fixtures with Apollo Federation v2.
+//
+// Those fixtures live beside the core golden pair (`catalog`/`reviews`) in
+// `crates/fraiseql-core/tests/fixtures/federation_compose/`, but the core builders
+// there construct `CompiledSchema` directly and so **bypass the CLI cascade
+// synthesis** where the #698 fix lives. A cascade fixture must therefore be rendered
+// from the real CLI path (`SchemaConverter::convert` → `federation_metadata()` →
+// `generate_service_sdl`) and lock-stepped from *this* crate, so the committed SDL the
+// composer validates is exactly what the fix produces. Revert the `shareable_types`
+// addition in `converter/cascade_types.rs` and this test goes RED (live SDL drops the
+// `@shareable` markers, the committed fixtures still carry them); re-blessing then
+// makes the composer leg go RED with `INVALID_FIELD_SHARING`.
+
+/// A cascade subgraph rich enough to *compose*: unlike [`cascade_subgraph_json`] it
+/// exposes a root query, so the rendered `_service` SDL carries a non-empty
+/// `type Query` (Federation rejects a query-less subgraph with `NO_QUERIES`, which
+/// would mask the sharing check this fixture exists to exercise).
+fn cascade_compose_subgraph_json(service_name: &str, entity: &str, sql_source: &str) -> String {
+    let list_field = format!("{}s", entity.to_lowercase()); // Order → orders
+    format!(
+        r#"
+{{
+  "version": "2.0.0",
+  "types": [
+    {{
+      "name": "{entity}",
+      "fields": [
+        {{"name": "id", "type": "ID", "nullable": false}},
+        {{"name": "total", "type": "Float", "nullable": false}}
+      ],
+      "sql_source": "{sql_source}"
+    }}
+  ],
+  "queries": [
+    {{
+      "name": "{list_field}",
+      "return_type": "{entity}",
+      "returns_list": true,
+      "sql_source": "{sql_source}"
+    }}
+  ],
+  "mutations": [
+    {{
+      "name": "create{entity}",
+      "return_type": "{entity}",
+      "cascade": true,
+      "sql_source": "fn_create_{sql_source}",
+      "operation": "CREATE"
+    }}
+  ],
+  "subscriptions": [],
+  "federation": {{
+    "enabled": true,
+    "service_name": "{service_name}",
+    "apollo_version": 2,
+    "entities": [
+      {{"name": "{entity}", "key_fields": ["id"]}}
+    ]
+  }}
+}}
+"#
+    )
+}
+
+/// Path to a committed subgraph SDL fixture in the core crate's
+/// `federation_compose` fixture dir (shared with the `catalog`/`reviews` golden pair).
+fn compose_fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../fraiseql-core/tests/fixtures/federation_compose")
+        .join(name)
+}
+
+/// The committed cascade subgraph SDL fixtures are what the real-`composeServices`
+/// CI leg composes, so they must match what the CLI renders *today* — otherwise the
+/// leg would validate stale SDL while the live output drifted. This renders both
+/// cascade subgraphs through the real CLI path and diffs them against the committed
+/// `.graphql` files, failing on any drift. Re-bless after an intentional rendering
+/// change with (same env var the core `federation_compose` fixtures use):
+///
+/// ```sh
+/// BLESS_FEDERATION_SDL=1 \
+///   cargo test -p fraiseql-cli --test cascade_federation_shareable_e2e --features federation
+/// ```
+#[test]
+fn committed_cascade_sdl_fixtures_are_current() {
+    let cases = [
+        (
+            "cascade_orders.graphql",
+            cascade_compose_subgraph_json("orders", "Order", "v_order"),
+        ),
+        (
+            "cascade_users.graphql",
+            cascade_compose_subgraph_json("users", "User", "v_user"),
+        ),
+    ];
+    let bless = std::env::var_os("BLESS_FEDERATION_SDL").is_some();
+
+    for (file, json) in cases {
+        let rendered = format!("{}\n", service_sdl(&compile(&json)).trim_end());
+        let path = compose_fixture_path(file);
+
+        if bless {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, &rendered).unwrap();
+            continue;
+        }
+
+        let committed = std::fs::read_to_string(&path).expect(
+            "missing cascade federation_compose SDL fixture; re-bless with BLESS_FEDERATION_SDL=1",
+        );
+        assert_eq!(
+            committed,
+            rendered,
+            "{} is stale; re-bless with BLESS_FEDERATION_SDL=1",
+            path.display()
+        );
     }
 }

--- a/crates/fraiseql-core/tests/federation_compose.rs
+++ b/crates/fraiseql-core/tests/federation_compose.rs
@@ -11,6 +11,14 @@
 //! individually broke. It is hermetic (no Docker, no composer binary); the
 //! companion real-`composeServices` check lives in the federation-compose CI leg.
 //!
+//! These `catalog`/`reviews` subgraphs are built from `CompiledSchema` builders, which
+//! **bypass the cli's cascade synthesis** — so the #698 cascade-envelope `@shareable`
+//! fix (which lives in `fraiseql-cli`) cannot be exercised here. Its committed compose
+//! fixtures (`cascade_orders.graphql` / `cascade_users.graphql`, beside these) are
+//! rendered from the cli converter and lock-stepped by
+//! `committed_cascade_sdl_fixtures_are_current` in
+//! `crates/fraiseql-cli/tests/cascade_federation_shareable_e2e.rs`.
+//!
 //! The two subgraphs deliberately share everything a real supergraph shares:
 //! - `Money` — a keyless `@shareable` value type defined in *both* subgraphs.
 //! - `Product` — an entity *owned* by `catalog` and *extended* by `reviews` (`extend type Product

--- a/crates/fraiseql-core/tests/fixtures/federation_compose/cascade_orders.graphql
+++ b/crates/fraiseql-core/tests/fixtures/federation_compose/cascade_orders.graphql
@@ -1,0 +1,601 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@extends"])
+scalar DateTime
+scalar FloatRange
+scalar JSON
+
+enum CascadeOperation {
+  CREATED
+  UPDATED
+  DELETED
+}
+
+enum InvalidationStrategy {
+  INVALIDATE
+  REFETCH
+  REMOVE
+}
+
+enum InvalidationScope {
+  EXACT
+  PREFIX
+  PATTERN
+  ALL
+}
+
+interface CascadeNode {
+  id: ID
+}
+
+input EmailAddressWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  domainEq: String
+  domainIn: [String!]
+  domainEndswith: String
+  localPartStartswith: String
+}
+
+input PhoneNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryCodeEq: String
+  countryCodeIn: [String!]
+  isValid: Boolean
+  typeEq: String
+}
+
+input URLWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  protocolEq: String
+  hostEq: String
+  pathStartswith: String
+}
+
+input DomainNameWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  tldEq: String
+  tldIn: [String!]
+}
+
+input HostnameWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  isFqdn: Boolean
+  depthEq: Float
+}
+
+input PostalCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input LatitudeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+  hemisphereEq: String
+}
+
+input LongitudeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+  hemisphereEq: String
+}
+
+input CoordinatesWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  distanceWithin: FloatRange
+}
+
+input TimezoneWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input LocaleCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input LanguageCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input CountryCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input IBANWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+  checkDigitEq: String
+}
+
+input CUSIPWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  issuerEq: String
+}
+
+input ISINWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input SEDOLWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  checkDigitEq: String
+}
+
+input LEIWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input MICWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input CurrencyCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input MoneyWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  currencyEq: String
+  amountWithinRange: FloatRange
+}
+
+input ExchangeCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input ExchangeRateWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+}
+
+input StockSymbolWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input SlugWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input SemanticVersionWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input HashSHA256WhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input APIKeyWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input LicensePlateWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input VINWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  wmiEq: String
+  manufacturerEq: String
+}
+
+input TrackingNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  carrierEq: String
+}
+
+input ContainerNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  ownerCodeEq: String
+}
+
+input IPAddressWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  inSubnet: String
+}
+
+input IPv4WhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input IPv6WhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input CIDRWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input PortWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input AirportCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input PortCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input FlightNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  airlineCodeEq: String
+}
+
+input MarkdownWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  validFormat: Boolean
+}
+
+input HTMLWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  validXml: Boolean
+}
+
+input MimeTypeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input ColorWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  formatEq: String
+}
+
+input ImageWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  formatEq: String
+}
+
+input FileWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  sizeWithinRange: FloatRange
+}
+
+input DateRangeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  overlaps: String
+}
+
+input DurationWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+}
+
+input PercentageWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+}
+
+type Order @key(fields: "id") {
+  id: ID
+  total: Float
+}
+
+type UpdatedEntity @shareable {
+  id: ID
+  operation: CascadeOperation
+  entity: CascadeNode
+}
+
+type DeletedEntity @shareable {
+  id: ID
+  deletedAt: DateTime
+}
+
+type CascadeMetadata @shareable {
+  timestamp: DateTime
+  transactionId: ID
+  depth: Int
+  affectedCount: Int
+  truncated: Boolean
+  originalCount: Int
+}
+
+type QueryInvalidation @shareable {
+  queryName: String
+  queryHash: String
+  arguments: JSON
+  queryPattern: String
+  strategy: InvalidationStrategy
+  scope: InvalidationScope
+}
+
+type CascadeUpdates @shareable {
+  updated: [UpdatedEntity]
+  deleted: [DeletedEntity]
+  metadata: CascadeMetadata
+  invalidations: [QueryInvalidation]
+}
+
+type CreateOrderPayload {
+  entity: Order
+  cascade: CascadeUpdates
+  updatedFields: [String]
+}
+
+type Query {
+  orders(where: JSON, orderBy: JSON, limit: Int, offset: Int): [Order!]!
+}
+
+type Mutation {
+  createOrder: CreateOrderPayload!
+}
+
+
+
+directive @key(fields: String!, resolvable: Boolean = true) repeatable on OBJECT
+directive @extends on OBJECT
+directive @external on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+scalar link__Import
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+union _Entity = Order
+
+extend type Query {
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}

--- a/crates/fraiseql-core/tests/fixtures/federation_compose/cascade_users.graphql
+++ b/crates/fraiseql-core/tests/fixtures/federation_compose/cascade_users.graphql
@@ -1,0 +1,601 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@external", "@requires", "@provides", "@shareable", "@inaccessible", "@override", "@extends"])
+scalar DateTime
+scalar FloatRange
+scalar JSON
+
+enum CascadeOperation {
+  CREATED
+  UPDATED
+  DELETED
+}
+
+enum InvalidationStrategy {
+  INVALIDATE
+  REFETCH
+  REMOVE
+}
+
+enum InvalidationScope {
+  EXACT
+  PREFIX
+  PATTERN
+  ALL
+}
+
+interface CascadeNode {
+  id: ID
+}
+
+input EmailAddressWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  domainEq: String
+  domainIn: [String!]
+  domainEndswith: String
+  localPartStartswith: String
+}
+
+input PhoneNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryCodeEq: String
+  countryCodeIn: [String!]
+  isValid: Boolean
+  typeEq: String
+}
+
+input URLWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  protocolEq: String
+  hostEq: String
+  pathStartswith: String
+}
+
+input DomainNameWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  tldEq: String
+  tldIn: [String!]
+}
+
+input HostnameWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  isFqdn: Boolean
+  depthEq: Float
+}
+
+input PostalCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input LatitudeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+  hemisphereEq: String
+}
+
+input LongitudeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+  hemisphereEq: String
+}
+
+input CoordinatesWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  distanceWithin: FloatRange
+}
+
+input TimezoneWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input LocaleCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input LanguageCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input CountryCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input IBANWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+  checkDigitEq: String
+}
+
+input CUSIPWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  issuerEq: String
+}
+
+input ISINWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input SEDOLWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  checkDigitEq: String
+}
+
+input LEIWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input MICWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input CurrencyCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input MoneyWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  currencyEq: String
+  amountWithinRange: FloatRange
+}
+
+input ExchangeCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input ExchangeRateWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+}
+
+input StockSymbolWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input SlugWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input SemanticVersionWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input HashSHA256WhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input APIKeyWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input LicensePlateWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  countryEq: String
+}
+
+input VINWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  wmiEq: String
+  manufacturerEq: String
+}
+
+input TrackingNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  carrierEq: String
+}
+
+input ContainerNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  ownerCodeEq: String
+}
+
+input IPAddressWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  inSubnet: String
+}
+
+input IPv4WhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input IPv6WhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input CIDRWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input PortWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input AirportCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input PortCodeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input FlightNumberWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  airlineCodeEq: String
+}
+
+input MarkdownWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  validFormat: Boolean
+}
+
+input HTMLWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  validXml: Boolean
+}
+
+input MimeTypeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+}
+
+input ColorWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  formatEq: String
+}
+
+input ImageWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  formatEq: String
+}
+
+input FileWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  sizeWithinRange: FloatRange
+}
+
+input DateRangeWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  overlaps: String
+}
+
+input DurationWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+}
+
+input PercentageWhereInput {
+  eq: String
+  neq: String
+  in: [String!]
+  nin: [String!]
+  contains: String
+  isnull: Boolean
+  withinRange: FloatRange
+}
+
+type User @key(fields: "id") {
+  id: ID
+  total: Float
+}
+
+type UpdatedEntity @shareable {
+  id: ID
+  operation: CascadeOperation
+  entity: CascadeNode
+}
+
+type DeletedEntity @shareable {
+  id: ID
+  deletedAt: DateTime
+}
+
+type CascadeMetadata @shareable {
+  timestamp: DateTime
+  transactionId: ID
+  depth: Int
+  affectedCount: Int
+  truncated: Boolean
+  originalCount: Int
+}
+
+type QueryInvalidation @shareable {
+  queryName: String
+  queryHash: String
+  arguments: JSON
+  queryPattern: String
+  strategy: InvalidationStrategy
+  scope: InvalidationScope
+}
+
+type CascadeUpdates @shareable {
+  updated: [UpdatedEntity]
+  deleted: [DeletedEntity]
+  metadata: CascadeMetadata
+  invalidations: [QueryInvalidation]
+}
+
+type CreateUserPayload {
+  entity: User
+  cascade: CascadeUpdates
+  updatedFields: [String]
+}
+
+type Query {
+  users(where: JSON, orderBy: JSON, limit: Int, offset: Int): [User!]!
+}
+
+type Mutation {
+  createUser: CreateUserPayload!
+}
+
+
+
+directive @key(fields: String!, resolvable: Boolean = true) repeatable on OBJECT
+directive @extends on OBJECT
+directive @external on FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+directive @shareable on FIELD_DEFINITION | OBJECT
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+scalar link__Import
+
+type _Service {
+  sdl: String!
+}
+
+scalar _Any
+
+union _Entity = User
+
+extend type Query {
+  _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+}

--- a/tools/federation/run-compose-check.sh
+++ b/tools/federation/run-compose-check.sh
@@ -3,13 +3,20 @@
 #
 # Composes the committed FraiseQL-rendered subgraph SDLs with Apollo Federation v2
 # composition (@apollo/composition — the engine `rover supergraph compose` wraps)
-# and asserts both golden cases:
-#   - catalog + reviews          → composes cleanly
-#   - catalog + reviews_conflict → rejected with INVALID_FIELD_SHARING (#497)
+# and asserts the golden cases:
+#   - catalog + reviews              → composes cleanly
+#   - catalog + reviews_conflict     → rejected with INVALID_FIELD_SHARING (#497)
+#   - cascade_orders + cascade_users → composes cleanly (#698): two cascade-enabled
+#     subgraphs synthesize the identical envelope value types, which compose only
+#     because the cli marks them @shareable. Without the fix this fails with 21
+#     INVALID_FIELD_SHARING errors (one per envelope field).
 #
-# The fixtures are kept in lock-step with live FraiseQL output by the Rust test
-# `committed_sdl_fixtures_are_current`; run that (or `make federation-compose-check`,
-# which runs both) after any change to federation SDL rendering.
+# The catalog/reviews fixtures are kept in lock-step with live FraiseQL output by the
+# Rust test `committed_sdl_fixtures_are_current` (fraiseql-core); the cascade_* fixtures
+# by `committed_cascade_sdl_fixtures_are_current` (fraiseql-cli — they must be rendered
+# from the cli converter, where cascade synthesis and the #698 fix live). Run those (or
+# `make federation-compose-check`, which runs all three) after any change to federation
+# SDL rendering.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,5 +37,10 @@ echo "→ negative: catalog + reviews_conflict must be rejected (#497)"
 node compose-check.mjs --expect-fail=INVALID_FIELD_SHARING \
   "catalog=$fixtures/catalog.graphql" \
   "reviews_conflict=$fixtures/reviews_conflict.graphql"
+
+echo "→ positive: cascade_orders + cascade_users must compose (#698)"
+node compose-check.mjs \
+  "cascade_orders=$fixtures/cascade_orders.graphql" \
+  "cascade_users=$fixtures/cascade_users.graphql"
 
 echo "✓ federation compose check passed"


### PR DESCRIPTION
## Summary

The #698 fix (shipped in v2.14.0) marks the five synthesized graphql-cascade envelope value types — `UpdatedEntity`, `DeletedEntity`, `CascadeMetadata`, `QueryInvalidation`, `CascadeUpdates` — `@shareable`, so a supergraph that composes two cascade-enabled subgraphs stops failing Federation-v2 `INVALID_FIELD_SHARING`. That fix was locked only by a **hermetic SDL-string** test (`cascade_federation_shareable_e2e.rs`) — nothing ever ran two cascade subgraphs through the **real Apollo Federation v2 composer**.

This is an additive follow-up (v2.14.0 already shipped) that closes the gap: two cascade-enabled subgraphs (`cascade_orders` + `cascade_users`) that **actually compose** via `@apollo/composition`, wired into the existing `make federation-compose-check` golden suite.

## Architectural gotcha (load-bearing)

The existing `catalog`/`reviews` compose fixtures are built from core-level `CompiledSchema` builders that **bypass the cli's cascade synthesis** — so the #698 fix (which lives in `fraiseql-cli/.../converter/cascade_types.rs`) can't be exercised there. The cascade fixtures must be rendered from the **real cli path** (`SchemaConverter::convert` → `federation_metadata()` → `generate_service_sdl`), committed, and kept honest by a lock-step test.

Because the core crate can't depend on `fraiseql-cli`, that lock-step guard (`committed_cascade_sdl_fixtures_are_current`) lives in the **cli** crate, and `make federation-compose-check` now runs both lock-step tests before composing.

## RED / GREEN proof

**RED** — temporarily reverting the `shareable_types` addition at the synthesis site:
- the lock-step test fails (live SDL drops the `@shareable` markers vs the committed fixtures), and
- re-blessing then makes real composition fail with exactly **21 `INVALID_FIELD_SHARING`** errors (3+2+6+6+4 — the count #698 predicted).

**GREEN** — with the fix in place:
- `committed_cascade_sdl_fixtures_are_current` passes, and
- `cascade_orders + cascade_users` **composes cleanly (0 hints)**.

This also empirically validates the #698 analysis that the shared enums and the `CascadeNode` interface compose by identity (they need no `@shareable`) — only the five value types do.

## Changes

- **`cascade_federation_shareable_e2e.rs`** — `cascade_compose_subgraph_json` (a cascade subgraph rich enough to compose: it exposes a root query so the SDL carries a non-empty `type Query`, else Federation rejects with `NO_QUERIES` and masks the sharing check) + `committed_cascade_sdl_fixtures_are_current` with `BLESS_FEDERATION_SDL` bless support.
- **New committed fixtures** `cascade_orders.graphql` / `cascade_users.graphql` — full, honest cli-rendered `_service` SDL (includes the auto-injected rich-filter input library; `compile_rich_filters` emits it unconditionally).
- **`tools/federation/run-compose-check.sh`** — adds the `cascade_orders + cascade_users` positive compose case.
- **`Makefile`** (`federation-compose-check`) — also runs the cli lock-step test.
- **`federation_compose.rs`** — header cross-reference to the cascade companion.

## Verification

✅ RED proven both ways (lock-step drift + 21 `INVALID_FIELD_SHARING` on real compose); GREEN restored byte-identical (no diff to `cascade_types.rs`)
✅ `cargo +nightly fmt --check`
✅ `cargo clippy --workspace --all-targets --all-features -- -D warnings`
✅ `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
✅ `make preflight`
✅ `make federation-compose-check` (both lock-step tests + all 3 real compositions)
✅ `cargo test -p fraiseql-cli --features federation`
✅ `cargo test -p fraiseql-core` (only DB-gated integration tests fail without `DATABASE_URL`; `federation_compose` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)