### PR TITLE
feat(auth): make OIDC issuer optional for IdPs that omit `iss` (Hanko)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release: a fully-static `x86_64-unknown-linux-musl` lean binary artifact
   (`fraiseql-x86_64-unknown-linux-musl.tar.gz`) for Alpine / distroless / scratch
   containers.
+- Auth: OIDC `[auth]` now supports **issuer-less identity providers** — IdPs whose
+  signed access tokens omit the `iss` claim (e.g. self-hosted Hanko 2.x). The
+  `issuer` field is now optional, symmetric with `audience`: when it is unset,
+  `iss` is not validated and the JWKS endpoint must be pinned via `jwks_uri`
+  (discovery is impossible without an issuer). Signature (against the pinned JWKS)
+  and the mandatory `audience` check still gate every token. See
+  [docs/auth/issuer-less-jwt.md](docs/auth/issuer-less-jwt.md). Previously the
+  server refused to start without an `issuer` (`missing field \`issuer\``).
+
+### Changed
+
+- Auth: when an OIDC `issuer` **is** configured, the `iss` claim is now **required
+  and matched** — a token that omits `iss` is rejected. Previously `iss` was only
+  checked when present (jsonwebtoken validates the issuer only if the claim
+  exists), so an `iss`-less token could slip past a configured issuer. A provider
+  that omits `iss` should now leave `issuer` unset and pin `jwks_uri` (see above).
 
 ### Fixed
 

--- a/crates/fraiseql-core/src/security/oidc/mod.rs
+++ b/crates/fraiseql-core/src/security/oidc/mod.rs
@@ -35,7 +35,7 @@
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let config = OidcConfig {
-//!     issuer: "https://your-tenant.auth0.com/".to_string(),
+//!     issuer: Some("https://your-tenant.auth0.com/".to_string()),
 //!     audience: Some("your-api-identifier".to_string()),
 //!     ..Default::default()
 //! };

--- a/crates/fraiseql-core/src/security/oidc/providers.rs
+++ b/crates/fraiseql-core/src/security/oidc/providers.rs
@@ -49,11 +49,21 @@ pub struct MeEndpointConfig {
 /// token confusion attacks. See the `audience` field documentation for details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OidcConfig {
-    /// Issuer URL (e.g., `https://your-tenant.auth0.com/`)
+    /// Issuer URL (e.g., `https://your-tenant.auth0.com/`), optional.
     ///
-    /// Must match the `iss` claim in tokens exactly.
-    /// Should include trailing slash if provider expects it.
-    pub issuer: String,
+    /// When set, it serves two purposes: OIDC discovery (building the
+    /// `.well-known/openid-configuration` URL when `jwks_uri` is not pinned) and
+    /// `iss`-claim validation — tokens must then carry a matching `iss`. Include
+    /// a trailing slash if the provider expects one.
+    ///
+    /// When unset (`None`), `iss` is **not** validated and no discovery is
+    /// performed, so `jwks_uri` must be pinned explicitly. This supports `IdPs`
+    /// whose access tokens omit the `iss` claim (e.g. self-hosted Hanko).
+    /// Signature verification (against the pinned JWKS) and `audience`
+    /// validation still apply, which is sufficient for a single-`IdP`,
+    /// direct-`jwks_uri` deployment.
+    #[serde(default)]
+    pub issuer: Option<String>,
 
     /// Expected audience claim (REQUIRED for security).
     ///
@@ -178,7 +188,7 @@ pub(super) fn default_scope_claim() -> String {
 impl Default for OidcConfig {
     fn default() -> Self {
         Self {
-            issuer:               String::new(),
+            issuer:               None,
             audience:             None,
             additional_audiences: Vec::new(),
             jwks_cache_ttl_secs:  default_jwks_cache_ttl(),
@@ -203,7 +213,7 @@ impl OidcConfig {
     #[must_use]
     pub fn auth0(domain: &str, audience: &str) -> Self {
         Self {
-            issuer: format!("https://{domain}/"),
+            issuer: Some(format!("https://{domain}/")),
             audience: Some(audience.to_string()),
             ..Default::default()
         }
@@ -219,7 +229,7 @@ impl OidcConfig {
     #[must_use]
     pub fn keycloak(base_url: &str, realm: &str, client_id: &str) -> Self {
         Self {
-            issuer: format!("{base_url}/realms/{realm}"),
+            issuer: Some(format!("{base_url}/realms/{realm}")),
             audience: Some(client_id.to_string()),
             ..Default::default()
         }
@@ -234,7 +244,7 @@ impl OidcConfig {
     #[must_use]
     pub fn okta(domain: &str, audience: &str) -> Self {
         Self {
-            issuer: format!("https://{domain}"),
+            issuer: Some(format!("https://{domain}")),
             audience: Some(audience.to_string()),
             ..Default::default()
         }
@@ -250,7 +260,7 @@ impl OidcConfig {
     #[must_use]
     pub fn cognito(region: &str, user_pool_id: &str, client_id: &str) -> Self {
         Self {
-            issuer: format!("https://cognito-idp.{region}.amazonaws.com/{user_pool_id}"),
+            issuer: Some(format!("https://cognito-idp.{region}.amazonaws.com/{user_pool_id}")),
             audience: Some(client_id.to_string()),
             ..Default::default()
         }
@@ -265,7 +275,7 @@ impl OidcConfig {
     #[must_use]
     pub fn azure_ad(tenant_id: &str, client_id: &str) -> Self {
         Self {
-            issuer: format!("https://login.microsoftonline.com/{tenant_id}/v2.0"),
+            issuer: Some(format!("https://login.microsoftonline.com/{tenant_id}/v2.0")),
             audience: Some(client_id.to_string()),
             ..Default::default()
         }
@@ -279,7 +289,7 @@ impl OidcConfig {
     #[must_use]
     pub fn google(client_id: &str) -> Self {
         Self {
-            issuer: "https://accounts.google.com".to_string(),
+            issuer: Some("https://accounts.google.com".to_string()),
             audience: Some(client_id.to_string()),
             ..Default::default()
         }
@@ -290,25 +300,38 @@ impl OidcConfig {
     /// # Errors
     ///
     /// Returns `SecurityError::SecurityConfigError` if:
-    /// - Issuer is empty
-    /// - Issuer does not use HTTPS (except localhost/127.0.0.1)
+    /// - `issuer` is set but does not use HTTPS (except localhost/127.0.0.1)
+    /// - `issuer` is unset and `jwks_uri` is not pinned (discovery is impossible without an issuer)
     /// - Neither `audience` nor `additional_audiences` are configured
     /// - No algorithms are allowed
     pub fn validate(&self) -> Result<()> {
-        if self.issuer.is_empty() {
-            return Err(SecurityError::SecurityConfigError(
-                "OIDC issuer URL is required".to_string(),
-            ));
-        }
-
-        if !self.issuer.starts_with("https://")
-            && !self.issuer.starts_with("http://localhost")
-            && !self.issuer.starts_with("http://127.0.0.1")
-        {
-            return Err(SecurityError::SecurityConfigError(
-                "OIDC issuer must use HTTPS (except localhost/127.0.0.1 for development)"
-                    .to_string(),
-            ));
+        match &self.issuer {
+            Some(issuer) => {
+                if !issuer.starts_with("https://")
+                    && !issuer.starts_with("http://localhost")
+                    && !issuer.starts_with("http://127.0.0.1")
+                {
+                    return Err(SecurityError::SecurityConfigError(
+                        "OIDC issuer must use HTTPS (except localhost/127.0.0.1 for development)"
+                            .to_string(),
+                    ));
+                }
+            },
+            None => {
+                // Issuer-less mode: `iss` is not validated and OIDC discovery is
+                // impossible (the discovery URL is built from the issuer), so the
+                // JWKS endpoint must be pinned. Signature + audience validation
+                // still apply — sufficient for a single-IdP deployment whose
+                // tokens omit `iss` (e.g. Hanko).
+                if self.jwks_uri.is_none() {
+                    return Err(SecurityError::SecurityConfigError(
+                        "OIDC issuer is unset, so `jwks_uri` must be pinned: without an issuer, \
+                         discovery cannot locate the JWKS endpoint. Set `issuer` to your IdP's \
+                         issuer URL, or set `jwks_uri` to its JWKS endpoint directly."
+                            .to_string(),
+                    ));
+                }
+            },
         }
 
         // CRITICAL SECURITY FIX: Audience validation is now mandatory

--- a/crates/fraiseql-core/src/security/oidc/tests.rs
+++ b/crates/fraiseql-core/src/security/oidc/tests.rs
@@ -24,7 +24,7 @@ use crate::security::{
 #[test]
 fn test_oidc_config_default() {
     let config = OidcConfig::default();
-    assert!(config.issuer.is_empty());
+    assert!(config.issuer.is_none());
     assert!(config.audience.is_none());
     // SECURITY: Cache TTL reduced to 5 minutes to prevent token cache poisoning
     assert_eq!(config.jwks_cache_ttl_secs, 300);
@@ -36,59 +36,67 @@ fn test_oidc_config_default() {
 #[test]
 fn test_oidc_config_auth0() {
     let config = OidcConfig::auth0("my-tenant.auth0.com", "my-api");
-    assert_eq!(config.issuer, "https://my-tenant.auth0.com/");
+    assert_eq!(config.issuer.as_deref(), Some("https://my-tenant.auth0.com/"));
     assert_eq!(config.audience, Some("my-api".to_string()));
 }
 
 #[test]
 fn test_oidc_config_keycloak() {
     let config = OidcConfig::keycloak("https://keycloak.example.com", "myrealm", "myclient");
-    assert_eq!(config.issuer, "https://keycloak.example.com/realms/myrealm");
+    assert_eq!(config.issuer.as_deref(), Some("https://keycloak.example.com/realms/myrealm"));
     assert_eq!(config.audience, Some("myclient".to_string()));
 }
 
 #[test]
 fn test_oidc_config_okta() {
     let config = OidcConfig::okta("myorg.okta.com", "api://default");
-    assert_eq!(config.issuer, "https://myorg.okta.com");
+    assert_eq!(config.issuer.as_deref(), Some("https://myorg.okta.com"));
     assert_eq!(config.audience, Some("api://default".to_string()));
 }
 
 #[test]
 fn test_oidc_config_cognito() {
     let config = OidcConfig::cognito("us-east-1", "us-east-1_abc123", "client123");
-    assert_eq!(config.issuer, "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123");
+    assert_eq!(
+        config.issuer.as_deref(),
+        Some("https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123")
+    );
     assert_eq!(config.audience, Some("client123".to_string()));
 }
 
 #[test]
 fn test_oidc_config_azure_ad() {
     let config = OidcConfig::azure_ad("tenant-id-123", "client-id-456");
-    assert_eq!(config.issuer, "https://login.microsoftonline.com/tenant-id-123/v2.0");
+    assert_eq!(
+        config.issuer.as_deref(),
+        Some("https://login.microsoftonline.com/tenant-id-123/v2.0")
+    );
     assert_eq!(config.audience, Some("client-id-456".to_string()));
 }
 
 #[test]
 fn test_oidc_config_google() {
     let config = OidcConfig::google("123456.apps.googleusercontent.com");
-    assert_eq!(config.issuer, "https://accounts.google.com");
+    assert_eq!(config.issuer.as_deref(), Some("https://accounts.google.com"));
     assert_eq!(config.audience, Some("123456.apps.googleusercontent.com".to_string()));
 }
 
 #[test]
-fn test_oidc_config_validate_empty_issuer() {
+fn test_oidc_config_validate_default_is_rejected() {
+    // Default config has no issuer, no jwks_uri, and no audience — every guard
+    // must reject it. The first guard reached is the issuer-less/no-jwks check.
     let config = OidcConfig::default();
     let result = config.validate();
     assert!(
         matches!(result, Err(SecurityError::SecurityConfigError(_))),
-        "expected SecurityConfigError for empty issuer, got: {result:?}"
+        "expected SecurityConfigError for an unconfigured OidcConfig, got: {result:?}"
     );
 }
 
 #[test]
 fn test_oidc_config_validate_http_issuer() {
     let config = OidcConfig {
-        issuer: "http://insecure.example.com".to_string(),
+        issuer: Some("http://insecure.example.com".to_string()),
         ..Default::default()
     };
     let result = config.validate();
@@ -98,7 +106,7 @@ fn test_oidc_config_validate_http_issuer() {
 #[test]
 fn test_oidc_config_validate_localhost_allowed() {
     let config = OidcConfig {
-        issuer: "http://localhost:8080".to_string(),
+        issuer: Some("http://localhost:8080".to_string()),
         audience: Some("my-api".to_string()),
         ..Default::default()
     };
@@ -110,7 +118,7 @@ fn test_oidc_config_validate_localhost_allowed() {
 #[test]
 fn test_oidc_config_validate_https_required() {
     let config = OidcConfig {
-        issuer: "https://secure.example.com".to_string(),
+        issuer: Some("https://secure.example.com".to_string()),
         audience: Some("https://api.example.com".to_string()),
         ..Default::default()
     };
@@ -119,10 +127,46 @@ fn test_oidc_config_validate_https_required() {
         .unwrap_or_else(|e| panic!("expected https:// issuer to be valid: {e}"));
 }
 
+// ============================================================================
+// Issuer-less mode: IdPs whose access tokens omit the `iss` claim (e.g. Hanko).
+// `issuer` is optional, symmetric with `audience`; when unset the JWKS URI must
+// be pinned (discovery is impossible without an issuer) and `iss` is not checked.
+// ============================================================================
+
+#[test]
+fn issuerless_config_with_pinned_jwks_and_audience_is_valid() {
+    let config = OidcConfig {
+        issuer: None,
+        audience: Some("relying-party-id".to_string()),
+        jwks_uri: Some("https://hanko.example.com/.well-known/jwks.json".to_string()),
+        ..Default::default()
+    };
+    config
+        .validate()
+        .unwrap_or_else(|e| panic!("issuer-less config with pinned jwks_uri must be valid: {e}"));
+}
+
+#[test]
+fn issuerless_config_without_jwks_uri_is_rejected() {
+    // Without an issuer, discovery cannot find the JWKS endpoint, so `jwks_uri`
+    // must be pinned. Audience is set so this isolates the issuer/jwks_uri guard.
+    let config = OidcConfig {
+        issuer: None,
+        audience: Some("relying-party-id".to_string()),
+        jwks_uri: None,
+        ..Default::default()
+    };
+    let result = config.validate();
+    assert!(
+        matches!(result, Err(SecurityError::SecurityConfigError(_))),
+        "issuer-less config without a pinned jwks_uri must be rejected, got: {result:?}"
+    );
+}
+
 #[test]
 fn test_oidc_config_with_custom_cache_ttl() {
     let config = OidcConfig {
-        issuer: "http://localhost:8080".to_string(),
+        issuer: Some("http://localhost:8080".to_string()),
         jwks_cache_ttl_secs: 600, // Custom 10-minute TTL
         ..Default::default()
     };
@@ -145,7 +189,7 @@ fn test_oidc_config_default_cache_ttl_is_short() {
 fn make_validator(issuer: &str) -> OidcValidator {
     OidcValidator {
         config:       OidcConfig {
-            issuer: issuer.to_string(),
+            issuer: Some(issuer.to_string()),
             ..Default::default()
         },
         http_client:  reqwest::Client::new(),
@@ -279,7 +323,7 @@ async fn refresh_jwks_replaces_the_cache_with_freshly_fetched_keys() {
         .await;
 
     let config = OidcConfig {
-        issuer: issuer.clone(),
+        issuer: Some(issuer.clone()),
         ..Default::default()
     };
     let validator = OidcValidator::with_jwks_uri(config, format!("{issuer}{jwks_path}"));
@@ -330,7 +374,7 @@ async fn get_decoding_key_refetch_evicts_rotated_out_keys() {
         .await;
 
     let config = OidcConfig {
-        issuer: issuer.clone(),
+        issuer: Some(issuer.clone()),
         ..Default::default()
     };
     let validator = OidcValidator::with_jwks_uri(config, format!("{issuer}{jwks_path}"));
@@ -418,7 +462,7 @@ async fn oidc_discovery_oversized_response_is_rejected() {
         .await;
 
     let config = OidcConfig {
-        issuer: mock.uri(),
+        issuer: Some(mock.uri()),
         audience: Some("test-audience".to_string()),
         ..Default::default()
     };
@@ -445,7 +489,7 @@ async fn oidc_discovery_within_size_limit_proceeds_to_parse() {
         .await;
 
     let config = OidcConfig {
-        issuer: mock.uri(),
+        issuer: Some(mock.uri()),
         audience: Some("test-audience".to_string()),
         ..Default::default()
     };
@@ -468,12 +512,12 @@ fn with_jwks_uri_creates_validator_without_panicking() {
     // with_jwks_uri must not panic even when the client builder is invoked;
     // verifies the fallback unwrap_or_default() path compiles and runs.
     let config = OidcConfig {
-        issuer: "https://example.com".to_string(),
+        issuer: Some("https://example.com".to_string()),
         jwks_uri: Some("https://example.com/.well-known/jwks.json".to_string()),
         ..Default::default()
     };
     let validator = OidcValidator::with_jwks_uri(config, "https://example.com/jwks".to_string());
-    assert_eq!(validator.issuer(), "https://example.com");
+    assert_eq!(validator.issuer(), Some("https://example.com"));
 }
 
 // ============================================================================
@@ -574,7 +618,7 @@ async fn validate_token_with_real_rsa_keypair_and_wiremock_jwks() {
 
     // ── 4. Create OidcValidator pointing at wiremock ─────────────────
     let config = OidcConfig {
-        issuer: issuer.clone(),
+        issuer: Some(issuer.clone()),
         audience: Some("fraiseql-test-api".to_string()),
         allowed_algorithms: vec!["RS256".to_string()],
         ..Default::default()
@@ -645,7 +689,7 @@ async fn validate_token_rejects_wrong_signing_key() {
     let token: String = chars.into_iter().collect();
 
     let config = OidcConfig {
-        issuer: issuer.clone(),
+        issuer: Some(issuer.clone()),
         audience: Some("fraiseql-test-api".to_string()),
         allowed_algorithms: vec!["RS256".to_string()],
         ..Default::default()
@@ -705,7 +749,7 @@ async fn validate_token_rejects_expired_jwt() {
     let token = jsonwebtoken::encode(&header, &claims, &encoding_key).unwrap();
 
     let config = OidcConfig {
-        issuer: issuer.clone(),
+        issuer: Some(issuer.clone()),
         audience: Some("fraiseql-test-api".to_string()),
         allowed_algorithms: vec!["RS256".to_string()],
         ..Default::default()
@@ -769,7 +813,7 @@ async fn validate_token_rejects_wrong_audience() {
     let token = jsonwebtoken::encode(&header, &claims, &encoding_key).unwrap();
 
     let config = OidcConfig {
-        issuer: issuer.clone(),
+        issuer: Some(issuer.clone()),
         audience: Some("fraiseql-test-api".to_string()),
         allowed_algorithms: vec!["RS256".to_string()],
         ..Default::default()
@@ -778,6 +822,133 @@ async fn validate_token_rejects_wrong_audience() {
 
     let result = validator.validate_token(&token).await;
     assert!(result.is_err(), "wrong audience must be rejected");
+}
+
+/// Issuer-less end-to-end: a Hanko-shaped access token that carries **no `iss`
+/// claim** must validate when `issuer` is unset and the JWKS URI is pinned.
+/// Signature (against the pinned JWKS) and `audience` still gate the token.
+#[tokio::test]
+async fn validate_token_without_iss_claim_accepted_when_issuer_unset() {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header};
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    let mock = MockServer::start().await;
+    let jwks_path = "/.well-known/jwks.json";
+    let jwks_body = json!({
+        "keys": [{
+            "kty": "RSA",
+            "kid": "hanko-key",
+            "alg": "RS256",
+            "use": "sig",
+            "n":   TEST_RSA_N,
+            "e":   TEST_RSA_E,
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path(jwks_path))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&jwks_body))
+        .expect(1..)
+        .mount(&mock)
+        .await;
+
+    // Hanko 2.x access-token shape: sub/aud/exp/iat (+ session_id, email); no `iss`.
+    let now = chrono::Utc::now().timestamp();
+    let claims = json!({
+        "sub":        "hanko-user-1",
+        "aud":        ["relying-party-id"],
+        "exp":        now + 3600,
+        "iat":        now,
+        "email":      "user@example.com",
+        "session_id": "sess-123",
+    });
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some("hanko-key".to_string());
+    let encoding_key = EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_KEY_PEM.as_bytes()).unwrap();
+    let token = jsonwebtoken::encode(&header, &claims, &encoding_key).unwrap();
+
+    // Issuer-less config: no `issuer`, pinned `jwks_uri`, mandatory `audience`.
+    let config = OidcConfig {
+        issuer: None,
+        audience: Some("relying-party-id".to_string()),
+        jwks_uri: Some(format!("{}{jwks_path}", mock.uri())),
+        allowed_algorithms: vec!["RS256".to_string()],
+        ..Default::default()
+    };
+    let validator = OidcValidator::with_jwks_uri(config, format!("{}{jwks_path}", mock.uri()));
+
+    let user = validator
+        .validate_token(&token)
+        .await
+        .expect("issuer-less token (no `iss`) must validate against a pinned JWKS");
+    assert_eq!(user.user_id.as_str(), "hanko-user-1");
+    assert_eq!(user.email.as_deref(), Some("user@example.com"));
+}
+
+/// Security boundary: when an `issuer` **is** configured, a token that omits
+/// `iss` must still be rejected — setting an issuer keeps `iss` mandatory
+/// (jsonwebtoken's `set_issuer` requires the claim). This pins that the
+/// issuer-less relaxation only applies when the operator opts out of `iss`.
+#[tokio::test]
+async fn validate_token_missing_iss_rejected_when_issuer_set() {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header};
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    let mock = MockServer::start().await;
+    let jwks_path = "/.well-known/jwks.json";
+    let jwks_body = json!({
+        "keys": [{
+            "kty": "RSA",
+            "kid": "with-issuer-key",
+            "alg": "RS256",
+            "use": "sig",
+            "n":   TEST_RSA_N,
+            "e":   TEST_RSA_E,
+        }]
+    });
+    Mock::given(method("GET"))
+        .and(path(jwks_path))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&jwks_body))
+        .expect(1..)
+        .mount(&mock)
+        .await;
+
+    // Token omits `iss`.
+    let now = chrono::Utc::now().timestamp();
+    let claims = json!({
+        "sub": "user-42",
+        "aud": "fraiseql-test-api",
+        "exp": now + 3600,
+        "iat": now,
+    });
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some("with-issuer-key".to_string());
+    let encoding_key = EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_KEY_PEM.as_bytes()).unwrap();
+    let token = jsonwebtoken::encode(&header, &claims, &encoding_key).unwrap();
+
+    // Issuer IS configured → `iss` is mandatory, so the token is rejected.
+    let config = OidcConfig {
+        issuer: Some("https://issuer.example.com".to_string()),
+        audience: Some("fraiseql-test-api".to_string()),
+        jwks_uri: Some(format!("{}{jwks_path}", mock.uri())),
+        allowed_algorithms: vec!["RS256".to_string()],
+        ..Default::default()
+    };
+    let validator = OidcValidator::with_jwks_uri(config, format!("{}{jwks_path}", mock.uri()));
+
+    let result = validator.validate_token(&token).await;
+    assert!(
+        result.is_err(),
+        "a token missing `iss` must be rejected when an issuer is configured"
+    );
 }
 
 mod audience_tests {

--- a/crates/fraiseql-core/src/security/oidc/token.rs
+++ b/crates/fraiseql-core/src/security/oidc/token.rs
@@ -82,9 +82,18 @@ impl OidcValidator {
         let jwks_uri = if let Some(ref uri) = config.jwks_uri {
             uri.clone()
         } else {
+            // No pinned JWKS URI: locate it via OIDC discovery from the issuer.
+            // `config.validate()` above guarantees `issuer` is set whenever
+            // `jwks_uri` is not, so this error is unreachable in practice —
+            // it keeps the discovery path total without an unwrap.
+            let issuer = config.issuer.as_deref().ok_or_else(|| {
+                SecurityError::SecurityConfigError(
+                    "OIDC discovery requires an issuer when `jwks_uri` is not pinned".to_string(),
+                )
+            })?;
             // Perform OIDC discovery
             let discovery_url =
-                format!("{}/.well-known/openid-configuration", config.issuer.trim_end_matches('/'));
+                format!("{}/.well-known/openid-configuration", issuer.trim_end_matches('/'));
 
             tracing::debug!(url = %discovery_url, "Performing OIDC discovery");
 
@@ -222,7 +231,21 @@ impl OidcValidator {
 
         // Build validation
         let mut validation = Validation::new(self.get_algorithm(&header)?);
-        validation.set_issuer(&[&self.config.issuer]);
+
+        // Validate the `iss` claim only when an issuer is configured.
+        //
+        // `set_issuer` alone checks `iss` *only if the claim is present*
+        // (jsonwebtoken's default `required_spec_claims` is just `{exp}`), so we
+        // also require `iss` — a configured issuer then means "iss must be
+        // present AND match", matching operator intent.
+        //
+        // In issuer-less mode both are skipped: tokens that omit `iss` (e.g.
+        // Hanko access tokens) are accepted, gated only by signature (against
+        // the pinned JWKS) and `audience`.
+        if let Some(ref issuer) = self.config.issuer {
+            validation.set_issuer(&[issuer]);
+            validation.set_required_spec_claims(&["exp", "iss"]);
+        }
 
         // Set audience validation — always enabled when any audience is configured.
         // The validate() call earlier guarantees at least one audience is set,
@@ -405,10 +428,13 @@ impl OidcValidator {
         self.config.required
     }
 
-    /// Get the configured issuer.
+    /// Get the configured issuer, if any.
+    ///
+    /// Returns `None` in issuer-less mode (`IdPs` whose tokens omit the `iss`
+    /// claim, validated via a pinned `jwks_uri`).
     #[must_use]
-    pub fn issuer(&self) -> &str {
-        &self.config.issuer
+    pub fn issuer(&self) -> Option<&str> {
+        self.config.issuer.as_deref()
     }
 
     /// Clear the JWKS cache.

--- a/crates/fraiseql-core/tests/oidc_audience_validation_test.rs
+++ b/crates/fraiseql-core/tests/oidc_audience_validation_test.rs
@@ -12,7 +12,7 @@ use fraiseql_core::security::oidc::OidcConfig;
 #[test]
 fn test_oidc_config_without_audience_fails_validation() {
     let config = OidcConfig {
-        issuer: "https://example.auth0.com/".to_string(),
+        issuer: Some("https://example.auth0.com/".to_string()),
         audience: None,
         additional_audiences: vec![],
         ..Default::default()
@@ -32,7 +32,7 @@ fn test_oidc_config_without_audience_fails_validation() {
 #[test]
 fn test_oidc_config_with_audience_passes_validation() {
     let config = OidcConfig {
-        issuer: "https://example.auth0.com/".to_string(),
+        issuer: Some("https://example.auth0.com/".to_string()),
         audience: Some("https://api.example.com".to_string()),
         additional_audiences: vec![],
         ..Default::default()
@@ -47,7 +47,7 @@ fn test_oidc_config_with_audience_passes_validation() {
 #[test]
 fn test_oidc_config_with_additional_audiences_passes_validation() {
     let config = OidcConfig {
-        issuer: "https://example.auth0.com/".to_string(),
+        issuer: Some("https://example.auth0.com/".to_string()),
         audience: None,
         additional_audiences: vec!["https://api.example.com".to_string()],
         ..Default::default()
@@ -62,7 +62,7 @@ fn test_oidc_config_with_additional_audiences_passes_validation() {
 #[test]
 fn test_oidc_config_with_both_audience_and_additional_passes_validation() {
     let config = OidcConfig {
-        issuer: "https://example.auth0.com/".to_string(),
+        issuer: Some("https://example.auth0.com/".to_string()),
         audience: Some("https://api.example.com".to_string()),
         additional_audiences: vec!["https://api2.example.com".to_string()],
         ..Default::default()
@@ -78,7 +78,7 @@ fn test_oidc_config_with_both_audience_and_additional_passes_validation() {
 fn test_oidc_config_auth0_pattern() {
     // Typical Auth0 configuration pattern
     let config = OidcConfig {
-        issuer: "https://my-tenant.auth0.com/".to_string(),
+        issuer: Some("https://my-tenant.auth0.com/".to_string()),
         audience: Some("https://api.myapp.com".to_string()),
         ..Default::default()
     };
@@ -92,7 +92,7 @@ fn test_oidc_config_auth0_pattern() {
 fn test_oidc_config_keycloak_pattern() {
     // Typical Keycloak configuration pattern
     let config = OidcConfig {
-        issuer: "https://keycloak.example.com/auth/realms/my-realm".to_string(),
+        issuer: Some("https://keycloak.example.com/auth/realms/my-realm".to_string()),
         audience: Some("my-client-id".to_string()),
         ..Default::default()
     };
@@ -106,7 +106,7 @@ fn test_oidc_config_keycloak_pattern() {
 fn test_oidc_config_okta_pattern() {
     // Typical Okta configuration pattern
     let config = OidcConfig {
-        issuer: "https://dev-12345.okta.com".to_string(),
+        issuer: Some("https://dev-12345.okta.com".to_string()),
         audience: Some("api://myapp".to_string()),
         ..Default::default()
     };
@@ -120,7 +120,7 @@ fn test_oidc_config_okta_pattern() {
 fn test_oidc_config_multiple_audiences() {
     // Configuration allowing tokens for multiple services
     let config = OidcConfig {
-        issuer: "https://example.auth0.com/".to_string(),
+        issuer: Some("https://example.auth0.com/".to_string()),
         audience: Some("https://api.example.com".to_string()),
         additional_audiences: vec![
             "https://api-v2.example.com".to_string(),
@@ -135,24 +135,46 @@ fn test_oidc_config_multiple_audiences() {
 }
 
 #[test]
-fn test_oidc_config_issuer_validation_still_required() {
-    // Audience being required doesn't override issuer requirement
+fn test_oidc_config_issuerless_requires_pinned_jwks_uri() {
+    // `issuer` is optional (symmetric with `audience`), but without it OIDC
+    // discovery can't locate the JWKS endpoint — so an unset issuer with no
+    // pinned `jwks_uri` must be rejected. Audience is set to isolate this guard.
     let config = OidcConfig {
-        issuer: String::new(), // Missing issuer
+        issuer: None,   // issuer-less mode …
+        jwks_uri: None, // … but no pinned JWKS endpoint to fall back on
         audience: Some("https://api.example.com".to_string()),
         ..Default::default()
     };
 
     let result = config.validate();
-    assert!(result.is_err(), "expected Err for missing issuer, got: {result:?}");
-    assert!(format!("{:?}", result.unwrap_err()).contains("issuer"));
+    assert!(
+        result.is_err(),
+        "expected Err for issuer-less config without jwks_uri, got: {result:?}"
+    );
+    assert!(format!("{:?}", result.unwrap_err()).contains("jwks_uri"));
+}
+
+#[test]
+fn test_oidc_config_issuerless_with_pinned_jwks_uri_is_valid() {
+    // The complementary positive case: an IdP whose tokens omit `iss` (e.g.
+    // Hanko) is usable when the JWKS endpoint is pinned and audience is set.
+    let config = OidcConfig {
+        issuer: None,
+        jwks_uri: Some("https://hanko.example.com/.well-known/jwks.json".to_string()),
+        audience: Some("relying-party-id".to_string()),
+        ..Default::default()
+    };
+
+    config
+        .validate()
+        .unwrap_or_else(|e| panic!("issuer-less config with pinned jwks_uri should validate: {e}"));
 }
 
 #[test]
 fn test_oidc_config_https_requirement_still_enforced() {
     // Audience being required doesn't override HTTPS requirement
     let config = OidcConfig {
-        issuer: "http://example.com/".to_string(), // Not HTTPS (and not localhost)
+        issuer: Some("http://example.com/".to_string()), // Not HTTPS (and not localhost)
         audience: Some("https://api.example.com".to_string()),
         ..Default::default()
     };
@@ -166,7 +188,7 @@ fn test_oidc_config_https_requirement_still_enforced() {
 fn test_oidc_config_localhost_exception_still_works() {
     // Audience requirement doesn't affect localhost exception
     let config = OidcConfig {
-        issuer: "http://localhost:8080/".to_string(),
+        issuer: Some("http://localhost:8080/".to_string()),
         audience: Some("localhost".to_string()),
         ..Default::default()
     };

--- a/crates/fraiseql-server/src/middleware/oidc_auth.rs
+++ b/crates/fraiseql-server/src/middleware/oidc_auth.rs
@@ -19,6 +19,16 @@ use crate::{
     token_revocation::{TokenRejection, TokenRevocationManager},
 };
 
+/// Build the `WWW-Authenticate: Bearer` challenge value.
+///
+/// The `realm` parameter is included only when an issuer is configured. In
+/// issuer-less mode (`IdPs` whose access tokens omit `iss`, validated via a
+/// pinned `jwks_uri`) the bare `Bearer` challenge is returned, since there is
+/// no issuer to advertise as the realm.
+fn bearer_challenge(issuer: Option<&str>) -> String {
+    issuer.map_or_else(|| "Bearer".to_string(), |issuer| format!("Bearer realm=\"{issuer}\""))
+}
+
 /// State for OIDC authentication middleware.
 #[derive(Clone)]
 pub struct OidcAuthState {
@@ -228,10 +238,7 @@ pub async fn oidc_auth_middleware(
                 tracing::debug!("Authentication required but no token found (header or cookie)");
                 return (
                     StatusCode::UNAUTHORIZED,
-                    [(
-                        header::WWW_AUTHENTICATE,
-                        format!("Bearer realm=\"{}\"", auth_state.validator.issuer()),
-                    )],
+                    [(header::WWW_AUTHENTICATE, bearer_challenge(auth_state.validator.issuer()))],
                     "Authentication required",
                 )
                     .into_response();
@@ -343,10 +350,7 @@ async fn authenticate_required(
             tracing::debug!("Admin/required auth: no token (header or cookie)");
             return Err((
                 StatusCode::UNAUTHORIZED,
-                [(
-                    header::WWW_AUTHENTICATE,
-                    format!("Bearer realm=\"{}\"", auth_state.validator.issuer()),
-                )],
+                [(header::WWW_AUTHENTICATE, bearer_challenge(auth_state.validator.issuer()))],
                 "Authentication required",
             )
                 .into_response());
@@ -458,7 +462,7 @@ mod revocation_tests {
 
     fn validator() -> Arc<OidcValidator> {
         let config = OidcConfig {
-            issuer:               "https://test.fraiseql.dev".to_string(),
+            issuer:               Some("https://test.fraiseql.dev".to_string()),
             audience:             Some("https://api.test.fraiseql.dev".to_string()),
             required:             true,
             additional_audiences: vec![],

--- a/crates/fraiseql-server/src/routes/jwks_admin/tests.rs
+++ b/crates/fraiseql-server/src/routes/jwks_admin/tests.rs
@@ -12,7 +12,7 @@ use super::refresh_jwks_handler;
 async fn refresh_jwks_fails_closed_when_provider_unreachable() {
     // Validator pointing at an unreachable JWKS endpoint (connection refused).
     let config = OidcConfig {
-        issuer: "http://localhost:8080".to_string(),
+        issuer: Some("http://localhost:8080".to_string()),
         ..Default::default()
     };
     let validator =

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -311,7 +311,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         // Initialize OIDC validator if auth is configured
         let oidc_validator = if let Some(ref auth_config) = config.auth {
             info!(
-                issuer = %auth_config.issuer,
+                issuer = ?auth_config.issuer,
                 "Initializing OIDC authentication"
             );
             let validator = OidcValidator::new(auth_config.clone())

--- a/crates/fraiseql-server/src/server/extensions.rs
+++ b/crates/fraiseql-server/src/server/extensions.rs
@@ -268,7 +268,7 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         #[cfg(feature = "auth")]
         let oidc_validator = if let Some(ref auth_config) = config.auth {
             info!(
-                issuer = %auth_config.issuer,
+                issuer = ?auth_config.issuer,
                 "Initializing OIDC authentication"
             );
             let validator = OidcValidator::new(auth_config.clone())

--- a/crates/fraiseql-server/tests/admin_authz_test.rs
+++ b/crates/fraiseql-server/tests/admin_authz_test.rs
@@ -32,7 +32,7 @@ use tower::ServiceExt;
 /// plane) — the configuration under which H5 manifested.
 fn optional_oidc_state() -> OidcAuthState {
     let config = OidcConfig {
-        issuer:               "https://test.fraiseql.dev".to_string(),
+        issuer:               Some("https://test.fraiseql.dev".to_string()),
         audience:             Some("https://api.test.fraiseql.dev".to_string()),
         required:             false,
         additional_audiences: vec![],

--- a/crates/fraiseql-server/tests/auth_me_integration_test.rs
+++ b/crates/fraiseql-server/tests/auth_me_integration_test.rs
@@ -203,7 +203,7 @@ async fn test_auth_me_reads_host_cookie() {
 
     // Required auth — will reject invalid tokens with 401
     let config = OidcConfig {
-        issuer:               "https://test.fraiseql.dev".to_string(),
+        issuer:               Some("https://test.fraiseql.dev".to_string()),
         audience:             Some("https://api.test.fraiseql.dev".to_string()),
         required:             true,
         additional_audiences: vec![],

--- a/crates/fraiseql-server/tests/auth_regression_test.rs
+++ b/crates/fraiseql-server/tests/auth_regression_test.rs
@@ -47,7 +47,7 @@ use tower::ServiceExt;
 /// safe for tests because the 401 is returned before the JWKS endpoint is hit.
 fn required_oidc_state() -> OidcAuthState {
     let config = OidcConfig {
-        issuer:               "https://test.fraiseql.dev".to_string(),
+        issuer:               Some("https://test.fraiseql.dev".to_string()),
         audience:             Some("https://api.test.fraiseql.dev".to_string()),
         required:             true, // THE CRITICAL FLAG — the E1 fix enforces this
         additional_audiences: vec![],
@@ -68,7 +68,7 @@ fn required_oidc_state() -> OidcAuthState {
 /// Build an `OidcAuthState` where authentication is *optional* (`required=false`).
 fn optional_oidc_state() -> OidcAuthState {
     let config = OidcConfig {
-        issuer:               "https://test.fraiseql.dev".to_string(),
+        issuer:               Some("https://test.fraiseql.dev".to_string()),
         audience:             Some("https://api.test.fraiseql.dev".to_string()),
         required:             false, // optional auth
         additional_audiences: vec![],

--- a/crates/fraiseql-server/tests/grpc_transport_e2e_test.rs
+++ b/crates/fraiseql-server/tests/grpc_transport_e2e_test.rs
@@ -915,7 +915,7 @@ fn build_service_with_auth(
     use fraiseql_core::security::{OidcConfig, OidcValidator};
 
     let config = OidcConfig {
-        issuer: "https://test-issuer.example.com".to_string(),
+        issuer: Some("https://test-issuer.example.com".to_string()),
         audience: Some("test-audience".to_string()),
         required: true,
         ..OidcConfig::default()

--- a/docs/auth/issuer-less-jwt.md
+++ b/docs/auth/issuer-less-jwt.md
@@ -1,0 +1,67 @@
+# JWT validation for IdPs that omit `iss` (issuer-less mode)
+
+Some identity providers issue signed access tokens **without an `iss` (issuer)
+claim** — for example self-hosted [Hanko](https://www.hanko.io/) 2.x, whose
+access tokens carry `sub`, `aud`, `exp`, `iat` (plus `email`, `session_id`) but
+no `iss`. FraiseQL's OIDC `[auth]` supports these providers: the `issuer` field
+is **optional**, symmetric with `audience`.
+
+## How it works
+
+`[auth]` (the server's `OidcConfig`) treats `issuer` as optional:
+
+| `issuer` | Behaviour |
+|----------|-----------|
+| **set** | `iss` **must be present and equal** the configured issuer. When `jwks_uri` is not pinned, `issuer` is also used for OIDC discovery. |
+| **unset** | `iss` is **not validated**. Discovery is impossible without an issuer, so `jwks_uri` **must be pinned**. |
+
+In both modes the token is still gated by:
+
+- **signature** — verified against the keys fetched from the configured
+  `jwks_uri` (or the discovered JWKS endpoint), and
+- **audience** — `audience` is mandatory and checked against the token's `aud`.
+
+## Configuration (`server.toml`)
+
+Pin the IdP's JWKS endpoint and set the audience to your relying-party
+identifier; omit `issuer`:
+
+```toml
+[auth]
+# issuer intentionally omitted — Hanko access tokens carry no `iss` claim.
+jwks_uri = "https://hanko.example.com/.well-known/jwks.json"
+audience = "<your-relying-party-id>"   # matched against the token's `aud`
+allowed_algorithms = ["RS256"]          # or your IdP's signing algorithm
+```
+
+If you instead set `issuer`, `iss` becomes required and validated (and
+`jwks_uri` may be omitted to use OIDC discovery):
+
+```toml
+[auth]
+issuer   = "https://accounts.google.com"
+audience = "<your-client-id>"
+```
+
+## Why dropping `iss` is safe here
+
+With a **pinned `jwks_uri`**, the signing keys come from the endpoint you
+configured — not from a URL discovered inside the token's own `iss`. Forgery is
+prevented by the signature (only your IdP holds the private key), and
+cross-service token confusion is prevented by the mandatory `audience` check.
+`iss` validation is defence-in-depth against *key confusion* when multiple
+issuers share one JWKS — which does not apply to a single-IdP, direct-`jwks_uri`
+deployment.
+
+Because `issuer` is unset, FraiseQL requires `jwks_uri` to be pinned: without an
+issuer there is no way to *discover* the JWKS endpoint, so it must be provided
+explicitly. Starting the server with neither `issuer` nor `jwks_uri` is a
+configuration error.
+
+## Not available on the compiled-schema path (yet)
+
+This applies to the server reading `[auth]` from `server.toml` directly (the
+`OidcConfig` path). The `fraiseql compile` CLI's `[auth]` schema does not yet
+carry a `jwks_uri` field, so issuer-less mode cannot be expressed through the
+compiled-schema workflow. Use a direct `server.toml` `[auth]` block for
+issuer-less providers.


### PR DESCRIPTION
## Summary

Makes OIDC `issuer` **optional** so identity providers whose signed access tokens omit the `iss` claim — e.g. self-hosted **Hanko 2.x** (passkey-first) — can be used with `fraiseql-server`. Reported from a real deployment: `fraiseql-server 2.14.0` fronted by Hanko, whose tokens carry `sub`/`aud`/`exp`/`iat` (+ `email`/`session_id`) but no `iss`, could not be configured at all (server refused to start with `missing field \`issuer\``).

Implements option 1 from the request (issuer optional, symmetric with `audience`), with a safety refinement: **issuer-less mode is gated on a pinned `jwks_uri`**.

## The contract

| `issuer` | Behaviour |
|----------|-----------|
| **set**  | `iss` **must be present and match** (added to `required_spec_claims`); used for discovery when `jwks_uri` is not pinned |
| **unset**| `iss` **not validated**; discovery impossible, so `jwks_uri` **must** be pinned |

In both modes the token is still gated by **signature** (against the configured/pinned JWKS) and the **mandatory `audience`** check.

### Hanko `server.toml`
```toml
[auth]
jwks_uri = "https://hanko.example.com/.well-known/jwks.json"
audience = "<your-relying-party-id>"
allowed_algorithms = ["RS256"]
```

## Behavioural finding (see CHANGELOG → Changed)

The report assumed a configured issuer already rejects an `iss`-less token. It does **not** on `jsonwebtoken` 10.4 — `set_issuer` validates `iss` *only if present* (confirmed in `validation.rs`). So an `iss`-less token could previously slip past a configured issuer. This PR makes an configured issuer require `iss` (present + matched), giving a crisp, defensible contract. This only ever rejects a genuine misconfiguration (issuer set + `iss`-less tokens → should use issuer-less mode instead); **zero test blast radius**.

## Why dropping `iss` is safe here

With a pinned `jwks_uri`, signing keys come from the configured endpoint (not discovered from the token's own `iss`). Forgery is prevented by the signature; cross-service token confusion by the mandatory `audience` check. `iss` is defence-in-depth against *key confusion* across issuers sharing a JWKS — N/A for a single-IdP, direct-`jwks_uri` deployment.

## Changes
- `OidcConfig.issuer: Option<String>` (serde-default); `validate()` gates issuer-less on a pinned `jwks_uri`; provider constructors / `Default` / discovery path updated.
- `validate_token`: skip `iss` when unset; require `iss` when set.
- `OidcValidator::issuer() -> Option<&str>`; `WWW-Authenticate` omits `realm` in issuer-less mode.
- All `OidcConfig` struct-literal call sites across core + server tests updated.
- Docs: `docs/auth/issuer-less-jwt.md`; CHANGELOG Added + Changed.

## Scope note
Fixes the **`server.toml` → `OidcConfig`** path (the reported error). The `fraiseql compile` CLI's separate `[auth]` schema (`OidcClientConfig`) has no `jwks_uri` field, so issuer-less mode is not expressible via the compiled-schema workflow — documented as a known limitation; a follow-up could add `jwks_uri` to the CLI schema.

## Verification
- ✅ 54 `fraiseql-core` OIDC tests pass, incl. a new **Hanko-shaped no-`iss` accept** test and a **security-boundary reject-when-issuer-set** test.
- ✅ Server auth tests pass (`auth_regression` / `admin_authz` / `auth_me` / `oidc_auth` / `jwks_admin`).
- ✅ `make preflight`: fmt, shell gates, rustdoc `-D warnings`, clippy `--all-targets --all-features -D warnings`.
- ✅ `cargo check --workspace --all-targets --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)