### PR TITLE
feat(cli): accept issuer-less `[auth]` with `jwks_uri` in the compile schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (discovery is impossible without an issuer). Signature (against the pinned JWKS)
   and the mandatory `audience` check still gate every token. See
   [docs/auth/issuer-less-jwt.md](docs/auth/issuer-less-jwt.md). Previously the
-  server refused to start without an `issuer` (`missing field \`issuer\``).
+  server refused to start without an `issuer` (`missing field \`issuer\``). The
+  `fraiseql compile` CLI's `[auth]` schema now also accepts `jwks_uri` and an
+  optional `issuer`, so a single unified config file with an issuer-less `[auth]`
+  block validates under `fraiseql compile`/lint as well as the server.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the mandatory `audience` check still gate every token. See
   [docs/auth/issuer-less-jwt.md](docs/auth/issuer-less-jwt.md). Previously the
   server refused to start without an `issuer` (`missing field \`issuer\``). The
-  `fraiseql compile` CLI's `[auth]` schema now also accepts `jwks_uri` and an
-  optional `issuer`, so a single unified config file with an issuer-less `[auth]`
-  block validates under `fraiseql compile`/lint as well as the server.
+  `fraiseql compile` CLI's `[auth]` schema now mirrors the **full** `OidcConfig`
+  JWT-validation surface (`jwks_uri`, optional `issuer`, `additional_audiences`,
+  `allowed_algorithms`, `jwks_cache_ttl_secs`, `clock_skew_secs`, `required`,
+  `scope_claim`, `require_jti`, `[auth.me]`), so any `[auth]` block the server
+  accepts — including issuer-less — validates under `fraiseql compile`/lint. A
+  drift-guard test keeps the CLI and runtime schemas in lockstep.
 
 ### Changed
 

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use fraiseql_core::security::oidc::MeEndpointConfig;
 use serde::{Deserialize, Serialize};
 
 /// Security configuration
@@ -541,9 +542,12 @@ impl Default for TokenRevocationSecurityConfig {
 ///
 /// Two independent groups may be configured, together or separately:
 ///
-/// - **JWT validation** — `issuer` **or** `jwks_uri`, plus `audience`. The server consumes these to
-///   validate incoming bearer tokens. Accepted and functional. `issuer` may be omitted for identity
-///   providers whose access tokens carry no `iss` claim (e.g. self-hosted Hanko); in that
+/// - **JWT validation** — `issuer` **or** `jwks_uri`, plus `audience` and the rest of
+///   `OidcConfig`'s JWT settings (`additional_audiences`, `allowed_algorithms`,
+///   `jwks_cache_ttl_secs`, `clock_skew_secs`, `required`, `scope_claim`, `require_jti`,
+///   `[auth.me]`). The server consumes these to validate incoming bearer tokens; the CLI accepts
+///   them so the same file parses under both. Accepted and functional. `issuer` may be omitted for
+///   identity providers whose access tokens carry no `iss` claim (e.g. self-hosted Hanko); in that
 ///   **issuer-less** mode `jwks_uri` must be pinned, since discovery cannot locate the JWKS
 ///   endpoint without an issuer.
 /// - **PKCE OAuth client** (server-side login) — `discovery_url`, `client_id`, `client_secret_env`,
@@ -574,11 +578,11 @@ impl Default for TokenRevocationSecurityConfig {
 pub struct OidcClientConfig {
     /// OIDC issuer URL for JWT validation (e.g. `"https://accounts.google.com"`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer:              Option<String>,
+    pub issuer:   Option<String>,
     /// Expected `aud` claim for JWT validation. Required at runtime by the
     /// server's `OidcConfig` to prevent token-confusion attacks.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub audience:            Option<String>,
+    pub audience: Option<String>,
     /// Pinned JWKS endpoint for JWT validation (skips OIDC discovery).
     ///
     /// Required for **issuer-less** identity providers — IdPs whose access
@@ -586,7 +590,38 @@ pub struct OidcClientConfig {
     /// unset, discovery cannot locate the JWKS endpoint, so it must be pinned
     /// here. May also be set alongside `issuer` to skip discovery.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jwks_uri:            Option<String>,
+    pub jwks_uri: Option<String>,
+
+    // JWT-validation fields below mirror the server's `OidcConfig` so a single
+    // config file's `[auth]` block parses under both. They are accepted and
+    // structurally validated here but consumed by the server (which re-reads the
+    // same block); the CLI does not act on their values. `cli_auth_schema_...`
+    // in tests pins that this list stays complete as `OidcConfig` evolves.
+    /// Additional accepted `aud` values (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additional_audiences: Vec<String>,
+    /// Allowed JWT signing algorithms (union-compat; the server defaults to RS256).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_algorithms:   Vec<String>,
+    /// JWKS cache TTL in seconds (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jwks_cache_ttl_secs:  Option<u64>,
+    /// Clock-skew tolerance in seconds (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clock_skew_secs:      Option<u64>,
+    /// Require authentication for all requests (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required:             Option<bool>,
+    /// JWT scope-claim name (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope_claim:          Option<String>,
+    /// Require the `jti` claim on every token (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_jti:          Option<bool>,
+    /// `[auth.me]` session-identity endpoint config (union-compat with `OidcConfig`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub me:                   Option<MeEndpointConfig>,
+
     /// PKCE: OIDC provider discovery URL. **Not yet functional (#621).**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discovery_url:       Option<String>,

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -530,10 +530,22 @@ impl Default for TokenRevocationSecurityConfig {
 
 /// OIDC configuration for `[auth]`.
 ///
+/// This is the CLI's **compile-time view** of the `[auth]` block. The server
+/// reads the same `[auth]` block independently into its own
+/// [`OidcConfig`](fraiseql_core::security::OidcConfig) at runtime, so this
+/// schema exists to *accept and structurally validate* the same block the
+/// server consumes — not to lower it into the compiled schema (the compiled
+/// schema carries no auth). Every JWT-validation field here must therefore stay
+/// field-compatible with `OidcConfig`, or `deny_unknown_fields` would reject a
+/// config the server accepts.
+///
 /// Two independent groups may be configured, together or separately:
 ///
-/// - **JWT validation** — `issuer` (required for this group), `audience` (optional). The server
-///   consumes these to validate incoming bearer tokens. Accepted and functional.
+/// - **JWT validation** — `issuer` **or** `jwks_uri`, plus `audience`. The server consumes these to
+///   validate incoming bearer tokens. Accepted and functional. `issuer` may be omitted for identity
+///   providers whose access tokens carry no `iss` claim (e.g. self-hosted Hanko); in that
+///   **issuer-less** mode `jwks_uri` must be pinned, since discovery cannot locate the JWKS
+///   endpoint without an issuer.
 /// - **PKCE OAuth client** (server-side login) — `discovery_url`, `client_id`, `client_secret_env`,
 ///   `server_redirect_uri`, configured all four together. **Not yet functional on the compiled path
 ///   (tracked in #621):** the compiled schema carries no `auth`/`auth_endpoints` for the server to
@@ -549,15 +561,32 @@ impl Default for TokenRevocationSecurityConfig {
 /// issuer   = "https://accounts.google.com"
 /// audience = "my-api"
 /// ```
+///
+/// Issuer-less (e.g. Hanko), pinning the JWKS endpoint:
+///
+/// ```toml
+/// [auth]
+/// jwks_uri = "https://hanko.example.com/.well-known/jwks.json"
+/// audience = "my-relying-party-id"
+/// ```
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct OidcClientConfig {
     /// OIDC issuer URL for JWT validation (e.g. `"https://accounts.google.com"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub issuer:              Option<String>,
-    /// Expected `aud` claim for JWT validation (optional; only meaningful with `issuer`).
+    /// Expected `aud` claim for JWT validation. Required at runtime by the
+    /// server's `OidcConfig` to prevent token-confusion attacks.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audience:            Option<String>,
+    /// Pinned JWKS endpoint for JWT validation (skips OIDC discovery).
+    ///
+    /// Required for **issuer-less** identity providers — IdPs whose access
+    /// tokens omit the `iss` claim (e.g. self-hosted Hanko). With `issuer`
+    /// unset, discovery cannot locate the JWKS endpoint, so it must be pinned
+    /// here. May also be set alongside `issuer` to skip discovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwks_uri:            Option<String>,
     /// PKCE: OIDC provider discovery URL. **Not yet functional (#621).**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discovery_url:       Option<String>,
@@ -578,16 +607,17 @@ pub struct OidcClientConfig {
 impl OidcClientConfig {
     /// Validate the `[auth]` group structure (#612 item 9).
     ///
-    /// The JWT group (`issuer` + optional `audience`) is accepted and functional. The
-    /// PKCE client group is all-four-or-none, and a *complete* client group is rejected
-    /// — it is not yet functional on the compiled path (#621), so it is refused rather
-    /// than silently accepted. At least one group must be present.
+    /// The JWT group (`issuer` or a pinned `jwks_uri`, plus optional `audience`) is
+    /// accepted and functional. The PKCE client group is all-four-or-none, and a
+    /// *complete* client group is rejected — it is not yet functional on the compiled
+    /// path (#621), so it is refused rather than silently accepted. At least one group
+    /// must be present.
     ///
     /// # Errors
     ///
     /// Returns an error naming the specific problem: an incomplete client group (with the
-    /// missing fields), a complete-but-unsupported client group, `audience` without
-    /// `issuer`, or an empty `[auth]` block.
+    /// missing fields), a complete-but-unsupported client group, `audience` without a JWT
+    /// group (neither `issuer` nor `jwks_uri`), or an empty `[auth]` block.
     pub fn validate(&self) -> anyhow::Result<()> {
         let client_fields = [
             ("discovery_url", self.discovery_url.is_some()),
@@ -597,7 +627,10 @@ impl OidcClientConfig {
         ];
         let client_set = client_fields.iter().filter(|(_, set)| *set).count();
         let has_client_group = client_set > 0;
-        let has_jwt_group = self.issuer.is_some();
+        // A JWT-validation group exists if either `issuer` (used for discovery
+        // and `iss` validation) or a pinned `jwks_uri` (issuer-less mode, for
+        // IdPs that omit `iss`) is set. Mirrors the server's `OidcConfig`.
+        let has_jwt_group = self.issuer.is_some() || self.jwks_uri.is_some();
 
         if has_client_group && client_set < client_fields.len() {
             let missing: Vec<&str> =
@@ -622,15 +655,17 @@ impl OidcClientConfig {
 
         if self.audience.is_some() && !has_jwt_group {
             anyhow::bail!(
-                "[auth] audience is set but issuer is not. JWT validation requires issuer — \
-                 add issuer, or remove audience."
+                "[auth] audience is set but neither issuer nor jwks_uri is configured. JWT \
+                 validation needs an issuer (used for discovery and `iss` validation) or a pinned \
+                 jwks_uri (for IdPs whose tokens omit `iss`, e.g. Hanko) — add one, or remove \
+                 audience."
             );
         }
 
         if !has_jwt_group {
             anyhow::bail!(
-                "[auth] is empty. Configure JWT validation with issuer (audience optional). \
-                 An empty [auth] block does nothing."
+                "[auth] is empty. Configure JWT validation with issuer, or with jwks_uri for IdPs \
+                 whose tokens omit `iss` (e.g. Hanko). An empty [auth] block does nothing."
             );
         }
 

--- a/crates/fraiseql-cli/tests/security_config_test.rs
+++ b/crates/fraiseql-cli/tests/security_config_test.rs
@@ -280,6 +280,53 @@ fn test_auth_issuer_without_audience_compiles() {
     schema.validate().expect("issuer alone is a valid JWT [auth] block");
 }
 
+// Issuer-less mode: an IdP whose access tokens omit `iss` (e.g. Hanko) pins the
+// JWKS endpoint and omits `issuer`. The union schema must accept it — the server's
+// OidcConfig reads the same [auth] block and validates the same issuer-less shape,
+// so `deny_unknown_fields` must not reject `jwks_uri`, nor must validate() require
+// an issuer.
+#[test]
+fn test_auth_issuerless_jwks_uri_compiles() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [auth]
+        jwks_uri = "https://hanko.example.com/.well-known/jwks.json"
+        audience = "my-relying-party-id"
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    schema
+        .validate()
+        .expect("an issuer-less [auth] block pinning jwks_uri must compile");
+    let auth = schema.auth.expect("auth section should be present");
+    assert!(auth.issuer.is_none(), "issuer is intentionally unset in issuer-less mode");
+    assert_eq!(
+        auth.jwks_uri.as_deref(),
+        Some("https://hanko.example.com/.well-known/jwks.json")
+    );
+}
+
+// Pinning jwks_uri alongside an issuer (skip discovery, still validate `iss`).
+#[test]
+fn test_auth_issuer_and_jwks_uri_compiles() {
+    let toml = r#"
+        [schema]
+        name = "test"
+        version = "1.0.0"
+        database_target = "postgresql"
+
+        [auth]
+        issuer   = "https://accounts.example.com"
+        jwks_uri = "https://accounts.example.com/.well-known/jwks.json"
+        audience = "my-api"
+    "#;
+    let schema: TomlSchema = toml::from_str(toml).unwrap();
+    schema.validate().expect("issuer + jwks_uri is a valid JWT [auth] block");
+}
+
 // a complete PKCE client group is rejected loud (recognized, not yet functional).
 #[test]
 fn test_auth_complete_client_group_rejected_loud() {
@@ -340,7 +387,9 @@ fn test_auth_empty_block_rejected() {
 }
 
 #[test]
-fn test_auth_audience_without_issuer_rejected() {
+fn test_auth_audience_without_jwt_group_rejected() {
+    // `audience` alone is not a JWT-validation group: it needs either an issuer
+    // (for discovery / `iss` validation) or a pinned jwks_uri (issuer-less mode).
     let toml = r#"
         [schema]
         name = "test"
@@ -351,8 +400,10 @@ fn test_auth_audience_without_issuer_rejected() {
         audience = "my-api"
     "#;
     let schema: TomlSchema = toml::from_str(toml).unwrap();
-    let err = schema.validate().expect_err("audience without issuer must be rejected");
-    assert!(err.to_string().contains("issuer"), "explains issuer is required: {err}");
+    let err = schema.validate().expect_err("audience without a JWT group must be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("issuer"), "names issuer as an option: {msg}");
+    assert!(msg.contains("jwks_uri"), "names jwks_uri as the issuer-less option: {msg}");
 }
 
 #[test]

--- a/crates/fraiseql-cli/tests/security_config_test.rs
+++ b/crates/fraiseql-cli/tests/security_config_test.rs
@@ -309,6 +309,53 @@ fn test_auth_issuerless_jwks_uri_compiles() {
     );
 }
 
+// Drift guard: the CLI `[auth]` union schema must accept EVERY field of the
+// server's `OidcConfig`, so a single config file's `[auth]` block that the server
+// accepts never gets rejected by `fraiseql compile`/lint (`deny_unknown_fields`).
+//
+// A fully-populated `OidcConfig` is serialized and re-parsed as `OidcClientConfig`.
+// If `OidcConfig` gains a field, this literal stops compiling (forcing an update
+// here) and — once the field is set — the round-trip rejects it unless the CLI
+// schema mirrors it. This pins CLI/runtime parity against future drift.
+#[test]
+fn cli_auth_schema_mirrors_every_oidcconfig_field() {
+    use fraiseql_cli::config::toml_schema::OidcClientConfig;
+    use fraiseql_core::security::oidc::{MeEndpointConfig, OidcConfig};
+
+    let runtime = OidcConfig {
+        issuer:               Some("https://issuer.example.com".to_string()),
+        audience:             Some("api".to_string()),
+        additional_audiences: vec!["api-2".to_string()],
+        jwks_cache_ttl_secs:  123,
+        allowed_algorithms:   vec!["RS256".to_string(), "ES256".to_string()],
+        clock_skew_secs:      30,
+        jwks_uri:             Some("https://issuer.example.com/.well-known/jwks.json".to_string()),
+        required:             false,
+        scope_claim:          "scp".to_string(),
+        require_jti:          true,
+        me:                   Some(MeEndpointConfig {
+            enabled:       true,
+            expose_claims: vec!["email".to_string()],
+        }),
+    };
+
+    // Serialize as the server would read it, then parse under the CLI union schema.
+    let auth_value = toml::Value::try_from(&runtime).expect("OidcConfig serializes to TOML");
+    let parsed: OidcClientConfig = auth_value
+        .try_into()
+        .expect("every OidcConfig [auth] field must be accepted by the CLI union schema");
+
+    assert_eq!(parsed.issuer.as_deref(), Some("https://issuer.example.com"));
+    assert_eq!(parsed.audience.as_deref(), Some("api"));
+    assert_eq!(
+        parsed.jwks_uri.as_deref(),
+        Some("https://issuer.example.com/.well-known/jwks.json")
+    );
+    assert_eq!(parsed.jwks_cache_ttl_secs, Some(123));
+    assert!(parsed.me.is_some(), "[auth.me] must round-trip through the CLI schema");
+    parsed.validate().expect("a fully-populated JWT [auth] block validates");
+}
+
 // Pinning jwks_uri alongside an issuer (skip discovery, still validate `iss`).
 #[test]
 fn test_auth_issuer_and_jwks_uri_compiles() {

--- a/docs/auth/issuer-less-jwt.md
+++ b/docs/auth/issuer-less-jwt.md
@@ -58,10 +58,19 @@ issuer there is no way to *discover* the JWKS endpoint, so it must be provided
 explicitly. Starting the server with neither `issuer` nor `jwks_uri` is a
 configuration error.
 
-## Not available on the compiled-schema path (yet)
+## The CLI accepts the same block
 
-This applies to the server reading `[auth]` from `server.toml` directly (the
-`OidcConfig` path). The `fraiseql compile` CLI's `[auth]` schema does not yet
-carry a `jwks_uri` field, so issuer-less mode cannot be expressed through the
-compiled-schema workflow. Use a direct `server.toml` `[auth]` block for
-issuer-less providers.
+Runtime JWT validation is configured entirely by the server reading `[auth]`
+from its own config file into `OidcConfig` — auth is **not** carried in
+`schema.compiled.json`. When you keep one config file for both `fraiseql compile`
+and the server, the CLI's `[auth]` schema (`OidcClientConfig`) validates the
+*same* block structurally, so it accepts issuer-less mode too: `jwks_uri` is a
+recognised field and `issuer` is optional when `jwks_uri` is pinned. A unified
+config like the one above therefore passes `fraiseql compile`/lint **and** runs
+on the server.
+
+> Note: advanced `OidcConfig` fields (e.g. `allowed_algorithms`,
+> `additional_audiences`, `jwks_cache_ttl_secs`) are not yet mirrored in the
+> CLI's `[auth]` schema, so a config that sets them will be rejected by
+> `fraiseql compile` even though the server accepts them. Omit them (the RS256
+> default suits Hanko) or configure `[auth]` only in a server-only config file.

--- a/docs/auth/issuer-less-jwt.md
+++ b/docs/auth/issuer-less-jwt.md
@@ -69,8 +69,10 @@ recognised field and `issuer` is optional when `jwks_uri` is pinned. A unified
 config like the one above therefore passes `fraiseql compile`/lint **and** runs
 on the server.
 
-> Note: advanced `OidcConfig` fields (e.g. `allowed_algorithms`,
-> `additional_audiences`, `jwks_cache_ttl_secs`) are not yet mirrored in the
-> CLI's `[auth]` schema, so a config that sets them will be rejected by
-> `fraiseql compile` even though the server accepts them. Omit them (the RS256
-> default suits Hanko) or configure `[auth]` only in a server-only config file.
+The CLI's `[auth]` schema mirrors the **full** `OidcConfig` JWT-validation
+surface — `issuer`, `audience`, `jwks_uri`, `additional_audiences`,
+`allowed_algorithms`, `jwks_cache_ttl_secs`, `clock_skew_secs`, `required`,
+`scope_claim`, `require_jti`, and `[auth.me]` — so any `[auth]` block the server
+accepts also passes `fraiseql compile`/lint. A drift-guard test
+(`cli_auth_schema_mirrors_every_oidcconfig_field`) fails the build if a future
+`OidcConfig` field is not mirrored, keeping the two in lockstep.


### PR DESCRIPTION
## Summary

Follow-up to #708 (server-side issuer-less OIDC for IdPs like Hanko that omit `iss`). This makes the **`fraiseql compile` CLI** accept the same `[auth]` block the server accepts — including issuer-less mode and the full `OidcConfig` JWT-validation surface.

### Why this is a real fix (not unconsumed config)

The CLI's `[auth]` (`OidcClientConfig`) and the server's `[auth]` (`OidcConfig`) are **two views of the same config file's `[auth]` block** — the server reads it into `OidcConfig` at runtime, the CLI validates it structurally at compile time (`OidcClientConfig` has `#[serde(deny_unknown_fields)]`). Auth is deliberately **not** carried in `schema.compiled.json` (#621), so this is not about the CLI configuring runtime auth — it's about the CLI not **rejecting** a config the server accepts.

After #708 the server's `OidcConfig` accepts issuer-less + `jwks_uri`. Without this PR, the CLI would reject that same block (`deny_unknown_fields` on `jwks_uri`, and `validate()` on "audience without issuer"). This is the established #612 union-schema pattern.

> A full "lower `[auth]` into the compiled schema + build `OidcConfig` from it" path was considered and rejected: it would create a **second source of truth** for auth alongside the server config file, contradicting the #621 design.

## Changes
- `OidcClientConfig` gains `jwks_uri` **and** the remaining `OidcConfig` JWT fields — `additional_audiences`, `allowed_algorithms`, `jwks_cache_ttl_secs`, `clock_skew_secs`, `required`, `scope_claim`, `require_jti`, `[auth.me]` (reusing `MeEndpointConfig`). Full union, so any server-accepted `[auth]` block also passes `fraiseql compile`/lint.
- `validate()`: JWT-validation group now exists when `issuer` **or** `jwks_uri` is set (mirrors `OidcConfig`); refreshed the audience-without-JWT-group and empty-`[auth]` messages to name `jwks_uri`.
- **Drift guard** `cli_auth_schema_mirrors_every_oidcconfig_field`: round-trips a fully-populated `OidcConfig` through the CLI schema. A new `OidcConfig` field breaks the test literal (compile-time) and is rejected by the round-trip unless mirrored — so CLI/runtime parity can't silently drift again (the exact gap #708 opened).
- Struct/`validate` docs clarify the compile-time union role. `docs/auth/issuer-less-jwt.md` + CHANGELOG updated.

## Verification
- ✅ CLI `security_config_test` (29, incl. the drift guard) + `toml_schema` lib security tests (23) pass.
- ✅ `make preflight`: fmt, shell gates, rustdoc `-D warnings`, clippy `--all-targets --all-features -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)