### PR TITLE
chore(release): prepare v2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-07-24
+
 ### Added
 
 - Release: a fully-static `x86_64-unknown-linux-musl` lean binary artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "fraiseql-arrow",
  "fraiseql-cli",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-arrow"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-auth"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cdc-sinks"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "async-nats",
  "chrono",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-cli"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-codegen"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "fraiseql-core",
  "fraiseql-error",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-core"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-db"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "async-trait",
  "bb8",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-error"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "axum",
  "serde",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-federation"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-functions"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-observers"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "arrow",
  "async-nats",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-secrets"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-server"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-storage"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-support"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "testcontainers",
  "testcontainers-modules",
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-test-utils"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "async-trait",
  "fraiseql-core",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-webhooks"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "fraiseql-wire"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,26 +63,26 @@ dashmap = "6.1"
 deadpool = "0.12"
 deadpool-postgres = "0.14"
 # Internal crates
-fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.14.0"}
-fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.14.0"}
+fraiseql-arrow = {path = "crates/fraiseql-arrow", version = "2.14.1"}
+fraiseql-auth = {path = "crates/fraiseql-auth", version = "2.14.1"}
 # Deliberately loose floor (2.3.0, not the current 2.7.0): fraiseql-server takes
 # fraiseql-cli as a dev-dependency while fraiseql-cli depends on fraiseql-server,
 # a publish cycle. A floor equal to the unpublished current version breaks the
 # first `cargo publish` of the cut (the sibling isn't on crates.io yet). Keep this
 # floor loose — see the v2.4.0 release lessons. Do NOT bump it to match the others.
 fraiseql-cli = {path = "crates/fraiseql-cli", version = "2.3.0"}
-fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.14.0"}
-fraiseql-core = {path = "crates/fraiseql-core", version = "2.14.0", default-features = false}
-fraiseql-db = {path = "crates/fraiseql-db", version = "2.14.0", default-features = false}
-fraiseql-error = {path = "crates/fraiseql-error", version = "2.14.0", default-features = false}
-fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.14.0"}
-fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.14.0"}
-fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.14.0"}
-fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.14.0"}
-fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.14.0"}
-fraiseql-server = {path = "crates/fraiseql-server", version = "2.14.0"}
-fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.14.0"}
-fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.14.0"}
+fraiseql-codegen = {path = "crates/fraiseql-codegen", version = "2.14.1"}
+fraiseql-core = {path = "crates/fraiseql-core", version = "2.14.1", default-features = false}
+fraiseql-db = {path = "crates/fraiseql-db", version = "2.14.1", default-features = false}
+fraiseql-error = {path = "crates/fraiseql-error", version = "2.14.1", default-features = false}
+fraiseql-federation = {path = "crates/fraiseql-federation", version = "2.14.1"}
+fraiseql-functions = {path = "crates/fraiseql-functions", version = "2.14.1"}
+fraiseql-storage = {path = "crates/fraiseql-storage", version = "2.14.1"}
+fraiseql-observers = {path = "crates/fraiseql-observers", version = "2.14.1"}
+fraiseql-secrets = {path = "crates/fraiseql-secrets", version = "2.14.1"}
+fraiseql-server = {path = "crates/fraiseql-server", version = "2.14.1"}
+fraiseql-webhooks = {path = "crates/fraiseql-webhooks", version = "2.14.1"}
+fraiseql-wire = {path = "crates/fraiseql-wire", version = "2.14.1"}
 futures = "0.3"
 graphql-parser = "0.4"
 hex = "0.4"
@@ -350,4 +350,4 @@ keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
 rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
-version = "2.14.0"
+version = "2.14.1"

--- a/crates/fraiseql-arrow/fuzz/Cargo.toml
+++ b/crates/fraiseql-arrow/fuzz/Cargo.toml
@@ -21,7 +21,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-arrow-fuzz"
 publish = false
-version = "2.14.0"
+version = "2.14.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-auth/fuzz/Cargo.toml
+++ b/crates/fraiseql-auth/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-auth-fuzz"
-version = "2.14.0"
+version = "2.14.1"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-core/fuzz/Cargo.toml
+++ b/crates/fraiseql-core/fuzz/Cargo.toml
@@ -51,7 +51,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-core-fuzz"
 publish = false
-version = "2.14.0"
+version = "2.14.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-db/fuzz/Cargo.toml
+++ b/crates/fraiseql-db/fuzz/Cargo.toml
@@ -26,7 +26,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-db-fuzz"
 publish = false
-version = "2.14.0"
+version = "2.14.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-federation/fuzz/Cargo.toml
+++ b/crates/fraiseql-federation/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ path = "../../fraiseql-error"
 edition = "2021"
 name = "fraiseql-federation-fuzz"
 publish = false
-version = "2.14.0"
+version = "2.14.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-secrets/fuzz/Cargo.toml
+++ b/crates/fraiseql-secrets/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-secrets-fuzz"
-version = "2.14.0"
+version = "2.14.1"
 publish = false
 edition = "2021"
 

--- a/crates/fraiseql-server/fuzz/Cargo.toml
+++ b/crates/fraiseql-server/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-server-fuzz"
 publish = false
-version = "2.14.0"
+version = "2.14.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/fraiseql-wire/fuzz/Cargo.toml
+++ b/crates/fraiseql-wire/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = ".."
 edition = "2021"
 name = "fraiseql-wire-fuzz"
 publish = false
-version = "2.14.0"
+version = "2.14.1"
 
 [package.metadata]
 cargo-fuzz = true

--- a/sdks/official/fraiseql-python/pyproject.toml
+++ b/sdks/official/fraiseql-python/pyproject.toml
@@ -38,7 +38,7 @@ license = {text = "MIT"}
 name = "fraiseql"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.14.0"
+version = "2.14.1"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.2"]

--- a/sdks/official/fraiseql-python/src/fraiseql/__init__.py
+++ b/sdks/official/fraiseql-python/src/fraiseql/__init__.py
@@ -79,7 +79,7 @@ input = input_decorator
 interface = interface_decorator
 union = union_decorator
 
-__version__ = "2.14.0"
+__version__ = "2.14.1"
 
 __all__ = [
     "ID",

--- a/sdks/official/fraiseql-rust/Cargo.toml
+++ b/sdks/official/fraiseql-rust/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["graphql", "authorization", "rbac", "schema"]
 license = "Apache-2.0"
 name = "fraiseql-rust"
 repository = "https://github.com/fraiseql/fraiseql"
-version = "2.14.0"
+version = "2.14.1"
 
 [[test]]
 name = "integration_test"

--- a/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
+++ b/sdks/official/fraiseql-rust/fraiseql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraiseql-client"
-version = "2.14.0"
+version = "2.14.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Async HTTP client for FraiseQL GraphQL servers"

--- a/sdks/official/fraiseql-typescript/package-lock.json
+++ b/sdks/official/fraiseql-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fraiseql",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fraiseql",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/sdks/official/fraiseql-typescript/package.json
+++ b/sdks/official/fraiseql-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fraiseql",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "FraiseQL v2 - Compiled GraphQL execution engine (schema authoring + HTTP client)",
   "repository": {
     "type": "git",

--- a/sdks/official/fraiseql-typescript/src/index.ts
+++ b/sdks/official/fraiseql-typescript/src/index.ts
@@ -32,7 +32,7 @@
  * @packageDocumentation
  */
 
-export const version = "2.14.0";
+export const version = "2.14.1";
 
 // Export type system
 export { typeToGraphQL, extractFieldInfo, extractFunctionSignature } from "./types";


### PR DESCRIPTION
Release prep for **v2.14.1** — a patch that unblocks a real Debian 12 + Hanko deployment.

## Contents (already merged to dev, now versioned)
- **#708** — OIDC `[auth]` `issuer` optional (issuer-less IdPs like Hanko); `iss` required+matched when an issuer *is* set.
- **#709** — CLI `[auth]` union schema mirrors the full `OidcConfig` JWT surface (+ drift guard).
- **#707** — Linux `-gnu` binaries glibc-floored to 2.28 (`cargo-zigbuild`), musl variant, objdump ≤2.34 ceiling gate.

## Why patch (not minor)
`v2.14.0` shipped 2 days ago; `releasing.md` sets a 6-week minimum between minors. These changes unblock a critical production deploy (server boots on issuer-less Hanko) + fix Debian 12 packaging — patch-appropriate.

## Prep commit
`tools/release.sh 2.14.1`: bumped workspace + fuzz + Rust/Python/TS SDK manifests, promoted `[Unreleased]` → `[2.14.1] - 2026-07-24`, README badge, `cargo check` clean.

## Release flow
Merge this to dev, then the **dev merge commit** is tagged `v2.14.1` (per the hygiene rule — never tag a side branch). `release/*` push runs release-smoke (server boot) as an early gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)