### PR TITLE
fix(release): glibc-ceiling gate must not false-fail fully-static (musl) binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,12 @@ jobs:
           for b in "${{ matrix.binary }}" fraiseql-server; do
             p="target/${{ matrix.target }}/release/$b"
             [ -f "$p" ] || continue
-            max=$(objdump -T "$p" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)
+            # `|| true`: a fully-static binary (musl) has NO glibc symbols, so `grep`
+            # matches nothing and exits 1. Under `shell: bash` (which runs with
+            # `-eo pipefail`), that non-zero pipeline status would abort the step
+            # before the `-z "$max"` skip below — false-failing every static binary.
+            # Keep the guard so `max` is simply empty when there is no glibc dep.
+            max=$(objdump -T "$p" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1 || true)
             if [ -z "$max" ]; then
               echo "✅ $b: no glibc version dependency"
               continue


### PR DESCRIPTION
## Summary

The `Verify glibc ceiling (Linux)` step in `release.yml` **false-failed the musl binary build on v2.14.1**, even though the musl binary is correct.

### Root cause
The step runs under `shell: bash` → GitHub executes it with `-eo pipefail`. For a fully-static binary (musl), `objdump -T | grep -oE 'GLIBC_…'` matches nothing, so `grep` exits `1`; `pipefail` propagates that as the pipeline's status and `errexit` aborts the step **before** the `[ -z "$max" ]` "no glibc dependency" skip. gnu binaries always carry glibc symbols, so `grep` never failed there — which is why this only surfaced when the musl variant (#707) first built on a real tag (v2.14.1).

The v2.14.1 musl asset itself is **fine** — `file` reports `statically linked`, `objdump -T` shows zero glibc symbols. Only the gate was wrong.

### Fix
Add `|| true` to the `max=$(…)` pipeline so a no-glibc binary yields an empty `max` instead of aborting. Real violations are unaffected.

Verified locally under `bash -eo pipefail`:
| input | result |
|---|---|
| static (no GLIBC) | `max` empty → PASS, no abort |
| `GLIBC_2.28` + `GLIBC_2.34` | max `2.34` → PASS (within ceiling) |
| `GLIBC_2.39` | **caught** (still fails, correctly) |

## Impact
- Future releases: the musl artifact stops false-failing the gate.
- v2.14.1: the musl asset is already correct and published; no re-tag needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)