### PR TITLE
fix(#753): fail loud instead of signing access tokens with a discarded key

### DIFF
--- a/crates/fraiseql-auth/src/session_postgres.rs
+++ b/crates/fraiseql-auth/src/session_postgres.rs
@@ -7,18 +7,35 @@ use crate::{
     session::{SessionData, SessionStore, TokenPair, generate_refresh_token, hash_token, unix_now},
 };
 
+/// How this store signs the access tokens it issues.
+///
+/// Both variants hold key material that outlives the token, so the corresponding
+/// validator can actually verify what was signed.
+enum SigningKey {
+    /// RSA private key in PEM format; tokens are signed RS256.
+    Rs256(Vec<u8>),
+    /// Shared HMAC secret; tokens are signed HS256. The same secret must be given
+    /// to the validating side (e.g. `Hs256AuthState`).
+    Hs256(Vec<u8>),
+}
+
 /// PostgreSQL-backed session store
 pub struct PostgresSessionStore {
     db:          PgPool,
-    /// Optional RSA private key for JWT signing (None falls back to HMAC)
-    signing_key: Option<Vec<u8>>,
+    /// Key used to sign access tokens. `None` means signing is not configured and
+    /// [`SessionStore::create_session`] will fail rather than mint an unverifiable token.
+    signing_key: Option<SigningKey>,
 }
 
 impl PostgresSessionStore {
-    /// Create a new PostgreSQL session store
+    /// Create a new PostgreSQL session store **without** JWT signing configured.
     ///
-    /// # Errors
-    /// Returns error if database connection fails
+    /// Refresh-token bookkeeping ([`SessionStore::get_session`],
+    /// [`SessionStore::revoke_session`], [`SessionStore::revoke_all_sessions`]) works,
+    /// but [`SessionStore::create_session`] will return
+    /// [`AuthError::ConfigError`] because there is no key to sign the access token
+    /// with. Use [`Self::with_rs256_key`] or [`Self::with_hs256_secret`] for a store
+    /// that can issue sessions.
     #[must_use]
     pub const fn new(db: PgPool) -> Self {
         Self {
@@ -36,7 +53,24 @@ impl PostgresSessionStore {
     pub const fn with_rs256_key(db: PgPool, private_key_pem: Vec<u8>) -> Self {
         Self {
             db,
-            signing_key: Some(private_key_pem),
+            signing_key: Some(SigningKey::Rs256(private_key_pem)),
+        }
+    }
+
+    /// Create a new PostgreSQL session store with HS256 (HMAC) JWT signing.
+    ///
+    /// The secret is retained for the life of the store and **must** be the same
+    /// secret configured on the validating side, otherwise the issued tokens will
+    /// not verify.
+    ///
+    /// # Arguments
+    /// * `db` - PostgreSQL connection pool
+    /// * `secret` - Shared HMAC secret (use at least 32 bytes of entropy)
+    #[must_use]
+    pub const fn with_hs256_secret(db: PgPool, secret: Vec<u8>) -> Self {
+        Self {
+            db,
+            signing_key: Some(SigningKey::Hs256(secret)),
         }
     }
 
@@ -73,10 +107,13 @@ impl PostgresSessionStore {
         Ok(())
     }
 
-    /// Generate a JWT access token with RS256 or HMAC signing
+    /// Generate a JWT access token with the configured signing key.
     ///
-    /// Uses RS256 if a signing key is configured, otherwise falls back to HMAC with a
-    /// 256-bit randomly-generated key (via `OsRng`) so the secret has full entropy.
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] when no signing key is configured. Minting
+    /// a token nobody can verify is worse than failing: it produces a login that
+    /// "succeeds" and then 401s on every subsequent request.
     fn generate_access_token(&self, user_id: &str, expires_in: u64) -> Result<String> {
         // SECURITY: Propagate clock errors; unwrap_or_default would produce iat=0.
         let now = unix_now()?;
@@ -98,15 +135,17 @@ impl PostgresSessionStore {
             .extra
             .insert("jti".to_string(), serde_json::json!(uuid::Uuid::new_v4().to_string()));
 
-        if let Some(private_key) = &self.signing_key {
-            crate::jwt::generate_rs256_token(&claims, private_key)
-        } else {
-            // SECURITY: Generate a 256-bit random HMAC key per token so the secret
-            // has full entropy regardless of user_id length or content.
-            // Using OsRng (backed by the OS CSPRNG) ensures cryptographic quality.
-            use rand::Rng;
-            let key_bytes: [u8; 32] = rand::rng().random();
-            crate::jwt::generate_hs256_token(&claims, &key_bytes)
+        match &self.signing_key {
+            Some(SigningKey::Rs256(private_key)) => {
+                crate::jwt::generate_rs256_token(&claims, private_key)
+            },
+            Some(SigningKey::Hs256(secret)) => crate::jwt::generate_hs256_token(&claims, secret),
+            None => Err(AuthError::ConfigError {
+                message: "JWT signing is not configured for this PostgresSessionStore — \
+                          construct it with with_rs256_key or with_hs256_secret. Refusing to \
+                          issue an access token that no validator could verify."
+                    .to_string(),
+            }),
         }
     }
 }
@@ -122,6 +161,12 @@ impl SessionStore for PostgresSessionStore {
 
         // SECURITY: Propagate clock errors; unwrap_or_default would produce issued_at=0.
         let now = unix_now()?;
+        let expires_in = expires_at.saturating_sub(now);
+
+        // Mint the access token before writing the session row: if signing is not
+        // configured this fails, and doing it first keeps an orphan row out of
+        // _system.sessions for a session that was never handed to anyone.
+        let access_token = self.generate_access_token(user_id, expires_in)?;
 
         sqlx::query(
             r"
@@ -147,9 +192,6 @@ impl SessionStore for PostgresSessionStore {
                 }
             }
         })?;
-
-        let expires_in = expires_at.saturating_sub(now);
-        let access_token = self.generate_access_token(user_id, expires_in)?;
 
         Ok(TokenPair {
             access_token,
@@ -229,3 +271,8 @@ impl SessionStore for PostgresSessionStore {
         Ok(())
     }
 }
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-auth/src/session_postgres/tests.rs
+++ b/crates/fraiseql-auth/src/session_postgres/tests.rs
@@ -1,0 +1,64 @@
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use sqlx::postgres::PgPoolOptions;
+
+use super::*;
+use crate::Claims;
+
+/// A pool that is never connected — these tests only exercise token minting,
+/// which never touches the database.
+fn lazy_pool() -> PgPool {
+    PgPoolOptions::new()
+        .connect_lazy("postgres://fraiseql:fraiseql@127.0.0.1:5432/fraiseql")
+        .unwrap()
+}
+
+fn hs256_validation() -> Validation {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_audience(&["fraiseql-api"]);
+    validation.set_issuer(&["fraiseql"]);
+    validation
+}
+
+#[tokio::test]
+async fn unconfigured_store_refuses_to_mint_an_access_token() {
+    let store = PostgresSessionStore::new(lazy_pool());
+
+    let result = store.generate_access_token("u1", 3_600);
+
+    assert!(
+        matches!(result, Err(AuthError::ConfigError { .. })),
+        "a store with no signing key must fail loudly instead of signing with a \
+         throwaway key, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn hs256_store_mints_a_token_verifiable_with_the_configured_secret() {
+    let secret = b"a-shared-secret-of-at-least-32-bytes!".to_vec();
+    let store = PostgresSessionStore::with_hs256_secret(lazy_pool(), secret.clone());
+
+    let token = store.generate_access_token("u1", 3_600).unwrap();
+
+    let decoded = decode::<Claims>(&token, &DecodingKey::from_secret(&secret), &hs256_validation())
+        .expect("token must verify under the secret the store retained");
+    assert_eq!(decoded.claims.sub, "u1");
+}
+
+#[tokio::test]
+async fn hs256_tokens_are_stable_across_calls_not_per_token_random() {
+    // The pre-fix bug signed every token with a fresh random key, so two tokens
+    // from the same store verified under no common key. Both must now verify
+    // under the one configured secret.
+    let secret = b"a-shared-secret-of-at-least-32-bytes!".to_vec();
+    let store = PostgresSessionStore::with_hs256_secret(lazy_pool(), secret.clone());
+
+    let first = store.generate_access_token("u1", 3_600).unwrap();
+    let second = store.generate_access_token("u2", 3_600).unwrap();
+
+    for token in [&first, &second] {
+        decode::<Claims>(token, &DecodingKey::from_secret(&secret), &hs256_validation())
+            .expect("every token from one store must verify under that store's secret");
+    }
+}

--- a/crates/fraiseql-auth/src/tests.rs
+++ b/crates/fraiseql-auth/src/tests.rs
@@ -1095,10 +1095,23 @@ mod session_tests {
     }
 }
 
+/// Shape-level coverage of the raw `jwt::generate_*_token` helpers.
+///
+/// These were previously named `session_postgres_tests` /
+/// `test_generate_access_token_*`, which implied they covered
+/// [`crate::session_postgres::PostgresSessionStore::generate_access_token`]. They
+/// never called it — they call the JWT helpers directly with a caller-supplied
+/// key, and assert only that the output has three dot-separated parts and that
+/// two mints differ. Both assertions held throughout #753, when the store signed
+/// every token with a freshly generated key it then dropped, so the misleading
+/// names were a live source of false assurance.
+///
+/// Store-level behaviour (no key configured → refuse; configured key → verifiable
+/// signature) is covered in `session_postgres/tests.rs`.
 #[cfg(test)]
-mod session_postgres_tests {
+mod jwt_token_shape_tests {
     #[test]
-    fn test_generate_access_token_creates_valid_jwt() {
+    fn hs256_helper_emits_distinct_three_part_tokens() {
         let test_pool = std::sync::Arc::new(std::sync::Mutex::new(()));
         let _ = test_pool;
 
@@ -1138,7 +1151,7 @@ mod session_postgres_tests {
     }
 
     #[test]
-    fn test_generate_access_token_with_rs256_key() {
+    fn rs256_helper_emits_a_three_part_token() {
         let test_key = include_bytes!("../test_data/test_rsa_key.pem");
 
         let now = std::time::SystemTime::now()


### PR DESCRIPTION
Fixes #753.

## Problem

`PostgresSessionStore::generate_access_token` had this fallback when
`signing_key` was `None` (the default `PostgresSessionStore::new(pool)`
constructor):

```rust
let key_bytes: [u8; 32] = rand::rng().random();
crate::jwt::generate_hs256_token(&claims, &key_bytes)
```

`key_bytes` is a stack local. It is dropped on return, never stored, and never
shared with any `JwtValidator` / `Hs256AuthState` / `OidcValidator`. The comment
called this a SECURITY improvement ("full entropy"), but full entropy in a
signing key nobody retains makes the signature cryptographically meaningless.

This is the `access_token` returned by `SessionStore::create_session`, which is
handed to end users by `auth_callback`, the multi-provider callback (including
the #427 fragment redirect), and `saml_acs`. The adopter-visible symptom: OAuth
completes, tokens come back, and every subsequent request 401s — with the very
real risk that the "fix" is to disable signature verification, converting the
bug into an auth bypass.

## Fix

Follows the suggestion on the issue, and the fail-honest-loud precedent already
set for `auth_refresh` (L-auth-refresh-500):

- `signing_key: Option<Vec<u8>>` becomes `Option<SigningKey>` with `Rs256(pem)`
  and `Hs256(secret)` variants — both hold key material that outlives the token.
- No key configured → `AuthError::ConfigError` (sanitized to a 500 by the
  existing `IntoResponse` mapping) rather than a fake-signed token.
- New `with_hs256_secret(db, secret)` constructor for adopters who want HMAC mode
  with a persistent secret shared with the validator.
- `new()` is now documented for what it is: session bookkeeping works,
  `create_session` fails.

One adjacent change: `create_session` now mints the access token *before* the
`INSERT`. Otherwise the new fail-loud path would write a session row and then
error, leaving an orphan in `_system.sessions` for a session nobody received.

## Verification

Three new tests in `session_postgres.rs`. They use `connect_lazy`, so no live
Postgres is needed — token minting never touches the pool.

Confirmed the tests bind by restoring the throwaway-key branch:

```
a store with no signing key must fail loudly instead of signing with a throwaway key,
got: Ok("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1MSIsImlhdCI6MTc4NDk3NzQ2OCw…")
```

- `cargo test -p fraiseql-auth` — all green.
- `cargo clippy -p fraiseql-auth --all-targets` — clean.

Note: `--all-features` cannot build in this environment (the SAML feature needs
libxml2, which is not installed); default features were used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)