### PR TITLE
fix(#743): enforce static field RBAC on the unauthenticated query path

### DIFF
--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -596,6 +596,17 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
         // 2. Create execution plan
         let plan = self.ctx.planner.plan(&query_match)?;
 
+        // 2a. #743: static field-level RBAC. An anonymous caller has no roles, so any
+        //     selected field carrying `requires_scope` is denied per its own on_deny
+        //     policy — exactly what an authenticated-but-unscoped principal gets from
+        //     apply_field_rbac_filtering. Classifying here (not after the read) means a
+        //     Reject never reaches the database.
+        let access = super::super::support::security::apply_anonymous_field_rbac_filtering(
+            &self.ctx.schema,
+            &query_match.query_def.return_type,
+            &plan.projection_fields,
+        )?;
+
         // 3. Execute SQL query
         let sql_source = query_match.query_def.sql_source.as_ref().ok_or_else(|| {
             crate::error::FraiseQLError::Validation {
@@ -713,8 +724,11 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             })
             .await?;
 
-        // 4. Project results
-        let projector = ResultProjector::new(plan.projection_fields)
+        // 4. Project results — masked fields stay in the projection so the response still carries
+        //    the key, then get nulled below (same as the authenticated path).
+        let mut all_projection_fields = access.allowed;
+        all_projection_fields.extend(access.masked.iter().cloned());
+        let projector = ResultProjector::new(all_projection_fields)
             .configure_typename_from_selections(
                 &query_match.selections,
                 &query_match.query_def.return_type,
@@ -728,6 +742,11 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             query_match.selections.first().map_or(&[][..], |r| r.nested_fields.as_slice()),
             &self.ctx.schema,
         );
+
+        // 4a. #743: null out fields denied to the anonymous caller under on_deny=Mask.
+        if !access.masked.is_empty() {
+            null_masked_fields(&mut projected, &access.masked);
+        }
 
         // 5. Wrap in GraphQL data envelope
         let response =

--- a/crates/fraiseql-core/src/runtime/executor/support/security.rs
+++ b/crates/fraiseql-core/src/runtime/executor/support/security.rs
@@ -7,7 +7,7 @@
 use crate::{
     error::{FraiseQLError, Result},
     runtime::{classify_field_access, field_filter::FieldAccessResult},
-    schema::{CompiledSchema, SessionVariableSource, SessionVariablesConfig},
+    schema::{CompiledSchema, FieldDenyPolicy, SessionVariableSource, SessionVariablesConfig},
     security::{ENRICHED_NAMESPACE_PREFIX, SecurityContext},
 };
 
@@ -161,4 +161,76 @@ pub(in super::super) fn apply_field_rbac_filtering(
         allowed: projection_fields,
         masked:  Vec::new(),
     })
+}
+
+/// Classify field access for a request that carries **no** principal.
+///
+/// The anonymous path used to skip field RBAC entirely, so a field protected only
+/// by `requires_scope` (and not the dynamic `authorize` flag) was served in full to
+/// unauthenticated callers while authenticated-but-unscoped callers were denied it
+/// — a privilege inversion (#743).
+///
+/// This is [`apply_field_rbac_filtering`] evaluated for a principal with no roles:
+/// [`SecurityContext::can_access_scope`] folds over `roles`, so an empty role set
+/// can never grant a scope, and every `requires_scope` field is denied through its
+/// own `on_deny` policy. Deriving the answer directly avoids fabricating a
+/// stand-in `SecurityContext` that could leak into RLS session variables or
+/// inject-param resolution.
+///
+/// # Errors
+///
+/// Returns [`FraiseQLError::Authorization`] if a requested field requires a scope
+/// and has `on_deny = Reject`.
+pub(in super::super) fn apply_anonymous_field_rbac_filtering(
+    schema: &CompiledSchema,
+    return_type: &str,
+    projection_fields: &[String],
+) -> Result<FieldAccessResult> {
+    let allow_all = || FieldAccessResult {
+        allowed: projection_fields.to_vec(),
+        masked:  Vec::new(),
+    };
+
+    // Mirror the authenticated path: without a SecurityConfig there are no role
+    // definitions, so it does not classify either. Diverging here would just
+    // re-open the gap in the opposite direction.
+    if schema.security.is_none() {
+        return Ok(allow_all());
+    }
+    let Some(type_def) = schema.types.iter().find(|t| t.name == return_type) else {
+        return Ok(allow_all());
+    };
+
+    let mut allowed = Vec::with_capacity(projection_fields.len());
+    let mut masked = Vec::new();
+
+    for name in projection_fields {
+        // Fields absent from the type definition pass through, as in
+        // classify_field_access — they are built-ins such as `__typename`.
+        let Some(field) = type_def.fields.iter().find(|f| &f.name == name) else {
+            allowed.push(name.clone());
+            continue;
+        };
+
+        if field.requires_scope.is_none() {
+            allowed.push(name.clone());
+            continue;
+        }
+
+        match field.on_deny {
+            FieldDenyPolicy::Mask => masked.push(name.clone()),
+            FieldDenyPolicy::Reject => {
+                return Err(FraiseQLError::Authorization {
+                    message:  format!(
+                        "Access denied: field '{name}' on type '{return_type}' \
+                         requires a scope you do not have"
+                    ),
+                    action:   Some("read".to_string()),
+                    resource: Some(format!("{return_type}.{name}")),
+                });
+            },
+        }
+    }
+
+    Ok(FieldAccessResult { allowed, masked })
 }

--- a/crates/fraiseql-core/src/runtime/executor/tests.rs
+++ b/crates/fraiseql-core/src/runtime/executor/tests.rs
@@ -1445,6 +1445,82 @@ mod field_rbac {
         }
     }
 
+    /// #743: an anonymous caller must not out-rank an authenticated-but-unscoped one.
+    /// `salary` carries `requires_scope` + `on_deny = Reject`; the viewer is rejected
+    /// (C16), so a request with no security context at all must be too.
+    ///
+    /// The backing rows deliberately *contain* `salary`: before the fix this query
+    /// returned `200 OK` with the salary projected into the response, so the fixture
+    /// has to carry the secret for the test to witness the leak rather than merely
+    /// the absence of an error.
+    #[tokio::test]
+    async fn test_reject_field_denied_for_anonymous_request() {
+        let schema = schema_with_rbac_fields();
+        let results = vec![
+            JsonbValue::new(serde_json::json!({"id": "1", "name": "Alice", "salary": 120_000})),
+            JsonbValue::new(serde_json::json!({"id": "2", "name": "Bob", "salary": 95_000})),
+        ];
+        let adapter = Arc::new(MockAdapter::new(results));
+        let config = RuntimeConfig::default();
+        let executor = Executor::with_config(schema, adapter, config);
+
+        let result = executor.execute("{ users { id salary } }", None).await;
+
+        assert!(
+            result.is_err(),
+            "a scope-protected field must not be served to an unauthenticated caller, got: {:?}",
+            result.ok()
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("salary") || err_msg.to_lowercase().contains("authoriz"),
+            "error should name the field or the authorization failure, got: {err_msg}"
+        );
+    }
+
+    /// #743: the `on_deny = Mask` half — an anonymous caller gets null, not the value.
+    #[tokio::test]
+    async fn test_mask_field_returns_null_for_anonymous_request() {
+        let schema = schema_with_rbac_fields();
+        let results = vec![JsonbValue::new(
+            serde_json::json!({"id": 1, "name": "Alice", "email": "alice@example.com"}),
+        )];
+        let adapter = Arc::new(MockAdapter::new(results));
+        let config = RuntimeConfig::default();
+        let executor = Executor::with_config(schema, adapter, config);
+
+        let result = executor.execute("{ users { id email } }", None).await.unwrap();
+
+        let users = &result["data"]["users"];
+        assert!(users.is_array(), "expected users array in response: {result}");
+        for user in users.as_array().unwrap() {
+            assert!(
+                user["email"].is_null(),
+                "masked field 'email' must be null for an anonymous caller, got: {}",
+                user["email"]
+            );
+            assert!(!user["id"].is_null(), "unmasked field 'id' should still have a real value");
+        }
+    }
+
+    /// #743 must not over-reach: fields with no `requires_scope` stay readable
+    /// anonymously.
+    #[tokio::test]
+    async fn test_public_fields_still_served_to_anonymous_request() {
+        let schema = schema_with_rbac_fields();
+        let adapter = Arc::new(MockAdapter::new(mock_user_results()));
+        let config = RuntimeConfig::default();
+        let executor = Executor::with_config(schema, adapter, config);
+
+        let result = executor.execute("{ users { id name } }", None).await;
+
+        assert!(
+            result.is_ok(),
+            "unprotected fields must remain publicly readable: {:?}",
+            result.err()
+        );
+    }
+
     /// C16+C17: Public fields always accessible
     #[tokio::test]
     async fn test_public_fields_always_accessible() {


### PR DESCRIPTION
Fixes #743.

## Problem

`execute_regular_query_maybe_security` routes `security_context = None` to
`execute_regular_query`, which guarded only:

- query-level `requires_role`
- `inject_params`
- relay routing
- `authorize`-gated fields, via `deny_if_gated_field_selected`

That last guard tests `FieldDefinition.authorize` and nothing else.
`requires_scope: Option<String>` and `authorize: bool` are independent fields, so
a field protected **only** by `requires_scope` was projected and returned in full
to unauthenticated callers.

The authenticated sibling `execute_regular_query_with_security` calls
`apply_field_rbac_filtering`, which rejects or masks. So:

| Caller | `salary` (`requires_scope`, `on_deny = Reject`) |
|---|---|
| Authenticated, lacks scope | 403 |
| Authenticated, has scope | value |
| **Anonymous** | **value** ← privilege inversion |

`execute_dispatch`'s doc explicitly claims the two paths "cannot diverge".

## Fix

Added `apply_anonymous_field_rbac_filtering` beside `apply_field_rbac_filtering`
in `executor/support/security.rs`. It is the same classification evaluated for a
principal with no roles — `SecurityContext::can_access_scope` folds over `roles`,
so an empty role set can never grant a scope, and every `requires_scope` field is
denied through its own `on_deny` policy.

Two deliberate choices:

- **No stand-in `SecurityContext`.** The issue offered "construct an anonymous
  SecurityContext" as one option. Deriving the answer directly is equivalent but
  keeps a fake principal from leaking into RLS session-variable resolution or
  inject-param handling, which key off `Some(ctx)`.
- **`on_deny` is honoured, not blanket-rejected.** The issue's other option
  (a `deny_if_scope_field_selected` guard) would always 403. That would turn
  today's silent leak into a hard error for deployments that deliberately
  configured `Mask`, whose anonymous callers should get `null`.

Classification runs right after planning, so a `Reject` never reaches the
database.

## Verification

Three new tests in the existing `field_rbac` module. Confirmed they bind by
neutralizing the new classification:

```
a scope-protected field must not be served to an unauthenticated caller,
got: Some(Object {"data": Object {"users": Array [...]}})

masked field 'email' must be null for an anonymous caller, got: "alice@example.com"
```

- `cargo test -p fraiseql-core --lib` — 2660 passed.
- `cargo test -p fraiseql-core --tests` — passes except `changelog_e2e`, which
  fails identically on unmodified `dev` (it needs Docker testcontainers,
  unavailable in this environment).
- `cargo clippy -p fraiseql-core --lib --tests` — clean.

## Adjacent observation (not fixed here)

Both paths short-circuit to "allow everything" when `schema.security` is `None`,
even for fields that declare `requires_scope`. The new function mirrors that
rather than diverging in the opposite direction, but it is a fail-open worth its
own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)