### PR TITLE
fix(#751): key webhook replay protection on signed material, not request headers

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -831,6 +831,10 @@ func (m *FraiseqlCi) integrationServer(ctx context.Context, source *dagger.Direc
 		// Tier-C migrated (each helper creates + TRUNCATE/DROP its tables for shared-DB isolation).
 		"cargo test -p fraiseql-server --test usage_postgres_backend_test -- --test-threads=1",
 		"cargo test -p fraiseql-server --features observers --test observer_repository_test -- --test-threads=1",
+		// #751: the inbound webhook replay defence is only provable against a real
+		// idempotency claim — the defect it guards lived precisely where no
+		// real-system test reached.
+		"cargo test -p fraiseql-server --features inbound --test webhook_replay_header_dedup_pg -- --test-threads=1",
 		// pipeline_e2e is env-gated (FRAISEQL_PIPELINE_E2E); it compiles a schema and drives a server.
 		"cargo test -p fraiseql-server --test pipeline_e2e_test -- --test-threads=1",
 		"echo 'test-integration OK: server suite passed'",

--- a/crates/fraiseql-server/src/inbound/webhook.rs
+++ b/crates/fraiseql-server/src/inbound/webhook.rs
@@ -246,29 +246,55 @@ fn collect_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
         .collect()
 }
 
-/// The dedup / idempotency key of a delivery: a provider delivery-id header, else
-/// the payload's top-level `id`, else a stable hash of the raw body (so an
-/// identical redelivery still deduplicates).
-fn extract_event_id(payload: &Value, headers: &BTreeMap<String, String>, body: &[u8]) -> String {
-    headers
-        .get("webhook-id")
-        .or_else(|| headers.get("x-github-delivery"))
-        .cloned()
-        .or_else(|| payload.get("id").and_then(Value::as_str).map(str::to_string))
-        .unwrap_or_else(|| {
-            use std::hash::{Hash as _, Hasher as _};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            body.hash(&mut hasher);
-            format!("body:{:016x}", hasher.finish())
-        })
+/// The dedup / idempotency key of a delivery: the payload's top-level `id`, else a
+/// stable `SHA-256` of the raw body (so an identical redelivery still deduplicates).
+///
+/// # Why request headers are not consulted (#751)
+///
+/// This key is what [`PostgresIdempotencyStore::claim`] and the spine dedup on, and
+/// what decides whether `after:ingest` fires. Every supported provider signs the
+/// **body** only — GitHub/GitLab/Shopify/Postmark/`LemonSqueezy`/generic
+/// `HMAC(body)`, Stripe `HMAC(t.body)`, Paddle `HMAC(ts:body)`. No verifier covers
+/// request headers.
+///
+/// So keying on `webhook-id` / `x-github-delivery`, as this used to, put the entire
+/// replay defence under the control of whoever sends the HTTP request: one captured
+/// signed delivery replayed with a fresh header value passed signature verification,
+/// claimed a fresh key, and re-fired `after:ingest` — indefinitely for providers
+/// without timestamp freshness. Only signed material can key the replay defence.
+///
+/// If Svix-style `webhook-id` support is wanted, it needs a verifier that actually
+/// signs `{id}.{timestamp}.{body}`; the header may be trusted only then.
+fn extract_event_id(payload: &Value, body: &[u8]) -> String {
+    payload.get("id").and_then(Value::as_str).map_or_else(
+        || {
+            use sha2::{Digest as _, Sha256};
+            // SHA-256 rather than DefaultHasher: this key is persisted, and
+            // DefaultHasher's output is explicitly not stable across Rust releases, so a
+            // toolchain bump would silently reset every stored idempotency key.
+            format!("body:{}", hex::encode(Sha256::digest(body)))
+        },
+        str::to_string,
+    )
 }
 
-/// The provider's event type, from a known header or the payload's `type` field.
+/// The provider's event type, from the payload's `type` field, else a known header.
+///
+/// The signed payload wins (#751): for Stripe and friends an injected
+/// `x-github-event` header can no longer relabel a delivery whose body says
+/// otherwise.
+///
+/// The header remains a *fallback* because `GitHub` carries the event type nowhere
+/// else — its body has no `type` field and its `HMAC` does not cover headers, so
+/// there is no signed alternative to prefer. For such providers the type stays
+/// advisory; the replay amplification it used to enable is closed by
+/// [`extract_event_id`] no longer trusting headers.
 fn extract_event_type(payload: &Value, headers: &BTreeMap<String, String>) -> String {
-    headers
-        .get("x-github-event")
-        .cloned()
-        .or_else(|| payload.get("type").and_then(Value::as_str).map(str::to_string))
+    payload
+        .get("type")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| headers.get("x-github-event").cloned())
         .unwrap_or_default()
 }
 
@@ -321,7 +347,7 @@ pub async fn webhook_handler(
     };
 
     let header_map = collect_headers(&headers);
-    let event_id = extract_event_id(&payload, &header_map, &body);
+    let event_id = extract_event_id(&payload, &body);
     let event_type = extract_event_type(&payload, &header_map);
 
     // Normalize before the pipeline so the durable payload is the normalized

--- a/crates/fraiseql-server/src/inbound/webhook/tests.rs
+++ b/crates/fraiseql-server/src/inbound/webhook/tests.rs
@@ -133,3 +133,96 @@ fn webhook_source_rejects_delivery_without_event_id() {
     };
     assert!(source.normalize(&raw).is_err());
 }
+
+// ── #751: dedup keys must derive from signed material only ──────────────
+
+mod signed_dedup_key {
+    //! Every supported provider signs the body only — no verifier covers request
+    //! headers. Keying the replay defence on `webhook-id` / `x-github-delivery`
+    //! therefore let anyone replaying one captured signed delivery mint a fresh
+    //! idempotency key per attempt, re-firing `after:ingest` each time.
+
+    use std::collections::BTreeMap;
+
+    use super::super::{extract_event_id, extract_event_type};
+
+    fn headers(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect()
+    }
+
+    // Header-independence is a *type-level* property here: `extract_event_id` no
+    // longer takes headers at all, so no assertion in this module can vary them.
+    // The behavioural proof that a replay under a fresh `x-github-delivery` now
+    // deduplicates end-to-end lives in the live-PG regression test
+    // `tests/webhook_replay_header_dedup_pg.rs`, which drives the real handler.
+
+    #[test]
+    fn an_identical_body_always_yields_an_identical_key() {
+        // Without a payload `id`, the key must still be a pure function of the signed
+        // body — that is what collapses a replay onto one idempotency claim.
+        let body = br#"{"action":"opened","number":1}"#;
+        let payload = serde_json::from_slice(body).unwrap();
+
+        assert_eq!(extract_event_id(&payload, body), extract_event_id(&payload, body));
+    }
+
+    #[test]
+    fn signed_payload_id_keys_the_delivery_when_present() {
+        let body = br#"{"id":"evt_1","type":"charge.succeeded"}"#;
+        let payload = serde_json::from_slice(body).unwrap();
+
+        assert_eq!(
+            extract_event_id(&payload, body),
+            "evt_1",
+            "a signed top-level id is the natural key and must be used verbatim"
+        );
+    }
+
+    #[test]
+    fn distinct_bodies_get_distinct_keys() {
+        let a = br#"{"action":"opened","number":1}"#;
+        let b = br#"{"action":"opened","number":2}"#;
+        let pa = serde_json::from_slice(a).unwrap();
+        let pb = serde_json::from_slice(b).unwrap();
+
+        assert_ne!(
+            extract_event_id(&pa, a),
+            extract_event_id(&pb, b),
+            "genuinely different deliveries must not collapse into one key"
+        );
+    }
+
+    #[test]
+    fn body_hash_key_is_sha256_not_the_unstable_default_hasher() {
+        // The key is persisted, so it has to survive a toolchain bump.
+        // SHA-256("{}") = 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+        let body = b"{}";
+        let payload = serde_json::from_slice(body).unwrap();
+
+        assert_eq!(
+            extract_event_id(&payload, body),
+            "body:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        );
+    }
+
+    #[test]
+    fn signed_payload_type_beats_an_injected_header() {
+        let payload = serde_json::json!({ "type": "charge.succeeded" });
+        let h = headers(&[("x-github-event", "push")]);
+
+        assert_eq!(
+            extract_event_type(&payload, &h),
+            "charge.succeeded",
+            "an unsigned header must not relabel a delivery whose signed body states its type"
+        );
+    }
+
+    #[test]
+    fn github_event_header_still_used_when_the_body_carries_no_type() {
+        // GitHub bodies have no `type`; the header is the only source there is.
+        let payload = serde_json::json!({ "action": "opened" });
+        let h = headers(&[("x-github-event", "pull_request")]);
+
+        assert_eq!(extract_event_type(&payload, &h), "pull_request");
+    }
+}

--- a/crates/fraiseql-server/tests/webhook_replay_header_dedup_pg.rs
+++ b/crates/fraiseql-server/tests/webhook_replay_header_dedup_pg.rs
@@ -1,0 +1,227 @@
+//! #751 regression: an inbound webhook replay cannot mint a fresh idempotency key
+//! by varying an unsigned request header.
+//!
+//! Every supported provider signs the **body** only — `GitHub`'s `X-Hub-Signature-256`
+//! is `HMAC-SHA256(secret, body)` and covers no header. While the dedup key was read
+//! from `webhook-id` / `x-github-delivery`, anyone holding one captured signed
+//! delivery could POST it repeatedly under a fresh delivery header: signature
+//! verification passed each time, each replay claimed a new
+//! `webhooks.tb_inbound_delivery` row, and `after:ingest` re-fired per replay.
+//!
+//! The unit tests in `src/inbound/webhook/tests.rs` pin the key-derivation function;
+//! only this test proves the property that actually matters — that the *handler*,
+//! against a real database and the real idempotency claim, collapses the replay onto
+//! one delivery. That is the seam the audit found unguarded.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: server` suite.
+//!
+//! **Execution engine:** `PostgreSQL` · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** truncates the shared `webhooks` ledger on setup → run
+//! `--test-threads=1`.
+#![cfg(feature = "inbound")]
+#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use std::collections::HashMap;
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+};
+use fraiseql_server::{
+    config::WebhookRouteConfig,
+    inbound::{WebhookInboundState, webhook_router},
+};
+use fraiseql_test_support::try_database_url;
+use fraiseql_webhooks::PostgresIdempotencyStore;
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use tower::ServiceExt as _;
+
+const SECRET_ENV: &str = "FRAISEQL_TEST_GITHUB_WEBHOOK_SECRET";
+const SECRET: &str = "whsec_751";
+
+/// The body of one captured, genuinely signed `GitHub` delivery. It deliberately has
+/// no top-level `id`: `GitHub` bodies carry none, so this exercises the body-hash
+/// branch — the branch the delivery header used to shadow.
+const CAPTURED_BODY: &[u8] =
+    br#"{"action":"opened","number":1,"repository":{"full_name":"acme/widgets"}}"#;
+
+/// `HMAC-SHA256(secret, body)` in `GitHub`'s `sha256=<hex>` form — the one signature
+/// the attacker captured along with the body.
+fn github_signature(body: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(SECRET.as_bytes()).unwrap();
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Build the real inbound router over a live pool, with one configured `GitHub` route.
+fn router(pool: PgPool) -> Router {
+    let mut routes = HashMap::new();
+    routes.insert(
+        "github".to_string(),
+        WebhookRouteConfig {
+            secret_env: SECRET_ENV.to_string(),
+            provider:   "github".to_string(),
+            path:       None,
+        },
+    );
+    let state = WebhookInboundState::new(pool, &routes, |name| {
+        (name == SECRET_ENV).then(|| SECRET.to_string())
+    });
+    webhook_router(state)
+}
+
+/// Connect, create the ledger + spine, and truncate so each test starts clean.
+/// Returns `None` (skip) when `DATABASE_URL` is unset.
+async fn setup() -> Option<PgPool> {
+    let url = try_database_url()?;
+    let pool = PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap();
+    PostgresIdempotencyStore::new(pool.clone()).init().await.unwrap();
+    WebhookInboundState::init_spine(&pool).await.unwrap();
+    sqlx::query("TRUNCATE webhooks.tb_inbound_delivery RESTART IDENTITY")
+        .execute(&pool)
+        .await
+        .unwrap();
+    Some(pool)
+}
+
+/// POST the captured body under an attacker-chosen `X-GitHub-Delivery`, returning
+/// the HTTP status and the JSON status string.
+async fn post_replay(router: &Router, delivery_id: &str) -> (StatusCode, String) {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/webhooks/github")
+        .header("X-Hub-Signature-256", github_signature(CAPTURED_BODY))
+        .header("X-GitHub-Delivery", delivery_id)
+        .header("X-GitHub-Event", "pull_request")
+        .header("content-type", "application/json")
+        .body(Body::from(CAPTURED_BODY))
+        .unwrap();
+
+    let response = router.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let disposition = json
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("expected a status field, got: {json}"))
+        .to_string();
+    (status, disposition)
+}
+
+async fn delivery_count(pool: &PgPool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT count(*) FROM webhooks.tb_inbound_delivery")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+macro_rules! skip_if_no_db {
+    () => {
+        match setup().await {
+            Some(pool) => pool,
+            None => {
+                eprintln!("skipping #751 webhook replay test: DATABASE_URL not set");
+                return;
+            },
+        }
+    };
+}
+
+/// The exact attack from #751: one captured signed body, replayed under a second,
+/// attacker-chosen `X-GitHub-Delivery`. Before the fix both replays were
+/// `processed`; now the second deduplicates against the first.
+#[tokio::test]
+async fn replay_under_a_fresh_delivery_header_is_a_duplicate() {
+    let pool = skip_if_no_db!();
+    let router = router(pool.clone());
+
+    let (first_status, first) = post_replay(&router, "11111111-1111-1111-1111-111111111111").await;
+    let (second_status, second) =
+        post_replay(&router, "22222222-2222-2222-2222-222222222222").await;
+
+    assert_eq!(first_status, StatusCode::OK, "the genuine delivery is accepted");
+    assert_eq!(first, "processed", "the genuine delivery is processed once");
+    assert_eq!(second_status, StatusCode::OK);
+    assert_eq!(
+        second, "duplicate",
+        "#751: a replay of the same signed body must deduplicate even though the sender \
+         chose a fresh X-GitHub-Delivery — the signature covers the body only, so the header \
+         must not key the replay defence",
+    );
+    assert_eq!(
+        delivery_count(&pool).await,
+        1,
+        "#751: the replay must claim no second idempotency row (a second row is what let \
+         after:ingest re-fire per replay)",
+    );
+}
+
+/// The same body with no delivery header at all must land on the same key as the
+/// header-bearing replays — proving the header is not an input on any path, rather
+/// than merely being overridden by something else.
+#[tokio::test]
+async fn a_replay_with_no_delivery_header_hits_the_same_key() {
+    let pool = skip_if_no_db!();
+    let router = router(pool.clone());
+
+    let (_, first) = post_replay(&router, "33333333-3333-3333-3333-333333333333").await;
+
+    let bare = Request::builder()
+        .method("POST")
+        .uri("/webhooks/github")
+        .header("X-Hub-Signature-256", github_signature(CAPTURED_BODY))
+        .header("X-GitHub-Event", "pull_request")
+        .header("content-type", "application/json")
+        .body(Body::from(CAPTURED_BODY))
+        .unwrap();
+    let response = router.clone().oneshot(bare).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(first, "processed");
+    assert_eq!(
+        json.get("status").and_then(serde_json::Value::as_str),
+        Some("duplicate"),
+        "the key is a pure function of the signed body, so presence or absence of the \
+         delivery header cannot change it",
+    );
+    assert_eq!(delivery_count(&pool).await, 1, "still exactly one claimed delivery");
+}
+
+/// A genuinely different delivery still gets through — the fix must not collapse
+/// distinct events onto one key (which would silently drop real webhooks).
+#[tokio::test]
+async fn distinct_bodies_are_still_processed_independently() {
+    let pool = skip_if_no_db!();
+    let router = router(pool.clone());
+
+    let (_, first) = post_replay(&router, "44444444-4444-4444-4444-444444444444").await;
+
+    let other_body = br#"{"action":"closed","number":2,"repository":{"full_name":"acme/widgets"}}"#;
+    let request = Request::builder()
+        .method("POST")
+        .uri("/webhooks/github")
+        .header("X-Hub-Signature-256", github_signature(other_body))
+        .header("X-GitHub-Delivery", "44444444-4444-4444-4444-444444444444")
+        .header("X-GitHub-Event", "pull_request")
+        .header("content-type", "application/json")
+        .body(Body::from(other_body.to_vec()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(first, "processed");
+    assert_eq!(
+        json.get("status").and_then(serde_json::Value::as_str),
+        Some("processed"),
+        "a different signed body is a different event and must still be processed — even \
+         when it reuses the previous delivery header",
+    );
+    assert_eq!(delivery_count(&pool).await, 2, "two genuinely distinct deliveries were claimed");
+}


### PR DESCRIPTION
## Problem

`extract_event_id` derived the dedup / idempotency key from the `webhook-id` or `x-github-delivery` **request header** before falling back to the payload's `id`.

Every supported provider signs the **body** only — GitHub/GitLab/Shopify/Postmark/LemonSqueezy/generic `HMAC(body)`, Stripe `HMAC(t.body)`, Paddle `HMAC(ts:body)`. No verifier covers request headers.

That put the entire replay defence under the control of whoever sends the HTTP request: one captured, genuinely signed delivery replayed with a fresh header value passed signature verification, claimed a fresh key in `webhooks.tb_inbound_delivery`, and re-fired `after:ingest` — once per replay, indefinitely for providers without timestamp freshness.

## Changes

- **`extract_event_id` no longer takes headers at all.** Header-independence is now a *type-level* property rather than a behaviour a future edit could regress. The key is the payload's top-level `id`, else a hash of the raw body.
- **The body-hash fallback moves from `DefaultHasher` to SHA-256.** This key is persisted; `DefaultHasher`'s output is explicitly not stable across Rust releases, so a toolchain bump would have silently reset every stored idempotency key and let every historical delivery replay once.
- **`extract_event_type` now prefers the signed payload's `type`** over the `x-github-event` header, so an injected header can no longer relabel a delivery whose body says otherwise.

  The header stays a *fallback* because GitHub carries the event type nowhere else — its body has no `type` field and its HMAC does not cover headers, so there is no signed alternative to prefer. For such providers the type remains advisory; the replay amplification it used to enable is closed by the key no longer trusting headers.

## Scope note

Svix-style `webhook-id` support is deliberately **not** restored here: it needs a verifier that actually signs `{id}.{timestamp}.{body}`, and only then may the header be trusted. The doc comment records that condition so the next person doesn't re-add the header as a key.

## Verification

- ✅ 6 new unit tests in `inbound/webhook/tests.rs` — body-hash determinism, signed `id` precedence, distinct bodies → distinct keys, SHA-256 rather than `DefaultHasher`, signed type beats an injected header, header still used when the body carries none
- ✅ New live-PG regression test `tests/webhook_replay_header_dedup_pg.rs`: drives the **real handler** against a real database with a genuinely signed GitHub body and proves a replay under a fresh `x-github-delivery` collapses onto **one** delivery row. This is the seam the audit found unguarded — the unit tests pin the key-derivation function, only this proves the property that matters. Self-skips without `DATABASE_URL`, so the database-free `test` leg stays green.
- ✅ Wired into the Dagger `integration: server` suite (`--test-threads=1`; it truncates the shared webhooks ledger on setup)
- ✅ `cargo test -p fraiseql-server --features inbound --lib inbound::webhook` — 12 passed, 0 failed
- ✅ `cargo check -p fraiseql-server --features inbound --tests` clean

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)