### PR TITLE
fix(core): close two CRITICAL analytics SQL-injection holes (#794, #795)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -835,6 +835,13 @@ func (m *FraiseqlCi) integrationServer(ctx context.Context, source *dagger.Direc
 		// idempotency claim — the defect it guards lived precisely where no
 		// real-system test reached.
 		"cargo test -p fraiseql-server --features inbound --test webhook_replay_header_dedup_pg -- --test-threads=1",
+		// #794/#795 (CRITICAL): the analytics injection guards. Both holes were reachable
+		// by any client that can POST a GraphQL query, and both were invisible to unit
+		// tests because the allowlist that "covered" them was only ever consulted by a
+		// planner the shipped binary never calls. This drives the real handler against a
+		// real database and asserts both that the request is refused and that no catalog
+		// data reaches the response.
+		"cargo test -p fraiseql-server --test analytics_injection_e2e_pg -- --test-threads=1",
 		// pipeline_e2e is env-gated (FRAISEQL_PIPELINE_E2E); it compiles a schema and drives a server.
 		"cargo test -p fraiseql-server --test pipeline_e2e_test -- --test-threads=1",
 		"echo 'test-integration OK: server suite passed'",

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -1455,7 +1455,8 @@ func (m *FraiseqlCi) integrationHTTPE2e(ctx context.Context, source *dagger.Dire
 // test container can reach it. Dagger starts the Postgres dependency (and waits for
 // its port) before the server starts, and the caller waits for :8815 before testing.
 func (m *FraiseqlCi) serverE2eService(source *dagger.Directory) *dagger.Service {
-	const targetVol = "fraiseql-rust-target-integ3-1-92"
+	// `integ4-` bump (2026-07-27): see the note on the sibling volume below.
+	const targetVol = "fraiseql-rust-target-integ4-1-92"
 	dbURL := fmt.Sprintf("postgresql://%s:%s@%s:5432/%s", pgUser, pgPassword, pgBindHost, pgDatabase)
 
 	// Build the binary and copy it out of the (cache-mounted) target dir to a plain
@@ -1668,7 +1669,20 @@ func (m *FraiseqlCi) integrationBase(source *dagger.Directory, rust string) *dag
 	// `integ3-` bump (2026-06-30): bust the stale integ2 target cache that reused
 	// pre-#501 fraiseql-db artifacts, hiding `execute_function_call_dry_run` → false
 	// E0599 in the integration postgres leg. Mirrors the `test2-` bump above.
-	targetVol := "fraiseql-rust-target-integ3-" + strings.ReplaceAll(toolchain, ".", "-")
+	//
+	// `integ4-` bump (2026-07-27): the same class recurred, and far more dangerously.
+	// The #794/#795 analytics-injection fix was committed, the leg checked out the right
+	// SHA, and cargo then reported EVERY crate fresh — zero `Compiling` lines in the whole
+	// run — so the new test binary linked a pre-fix `fraiseql-core` and the leg reported
+	// the injections still succeeding. Last time this surfaced as a compile error; this
+	// time it silently validated stale code, which is the failure mode that matters:
+	// a green integration leg does not prove the committed source was the source tested.
+	// Reproduced across two dispatches of the same commit before the bump.
+	//
+	// A volume bump only clears the current drift. The durable fix (tracked separately)
+	// is to stop trusting mtime-based freshness across a Dagger mount + persistent
+	// target volume.
+	targetVol := "fraiseql-rust-target-integ4-" + strings.ReplaceAll(toolchain, ".", "-")
 	return m.rustBaseFor(toolchain).
 		WithMountedDirectory("/src", source).
 		WithWorkdir("/src").

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **CRITICAL: closed two unauthenticated SQL-injection holes on the analytics execution
+  path (#794, #795).** Both were reachable by any client able to POST a GraphQL query, on
+  any deployment whose compiled schema declares at least one fact table, and both were
+  verified against live PostgreSQL 16 exfiltrating `pg_authid` contents.
+
+  - **#794 — window aliases and dimension paths were interpolated raw.** Four sinks on the
+    live `*_window` path wrote request-supplied strings straight into the SELECT list: the
+    dimension select arm and the `PARTITION BY` arm both built `format!("{}->>'{}'", …)`
+    with no charset check, and `alias` was cloned through untouched for measure, dimension,
+    filter and window-function selections before being emitted as `<expr> AS <alias>`.
+    Because `WindowProjector::project` copies every returned column into the response, an
+    injected column was handed back to the caller.
+
+    Every alias and dimension path is now rejected unless it matches
+    `[_A-Za-z][_0-9A-Za-z]*`, through a single entry point that all sinks share — the
+    defect existed because one arm carried a check its four siblings did not. The
+    `WindowAllowlist` is additionally consulted wherever the schema enumerates dimension
+    paths. It existed and was documented as the defence for this path, but was only ever
+    called by `WindowFunctionPlanner`, which nothing in the shipped binary invokes; the
+    live planner is `WindowPlanner`, which never built one.
+
+  - **#795 — the `table` request key selected the FROM target.** The relation is already
+    determined by the GraphQL root field (`sales_window` → `tf_sales`), but a second,
+    unchecked channel could name any relation or substitute an entire subquery. Worse, the
+    RLS policy was looked up by that same attacker-controlled name, so naming a table with
+    no configured policy yielded `None` and composed **no tenant WHERE clause at all**.
+
+    Both the aggregate and window planners now reject a `table` that does not match the
+    resolved fact table, every FROM sink emits the resolved name, and the RLS policy is
+    evaluated against the resolved name — which matters independently, because RLS is
+    evaluated before the planner runs.
+
+  Regression coverage runs against real PostgreSQL in the Dagger `integration: server`
+  suite (`analytics_injection_e2e_pg`), driving the real HTTP handler and asserting both
+  that each payload is refused and that no catalog data reaches the response.
+
 ### Breaking
 
 - **`fraiseql run`, `fraiseql validate facts`, and `fraiseql introspect facts` no longer

--- a/crates/fraiseql-core/src/compiler/aggregation.rs
+++ b/crates/fraiseql-core/src/compiler/aggregation.rs
@@ -369,6 +369,24 @@ impl AggregationPlanner {
         request: AggregationRequest,
         metadata: FactTableMetadata,
     ) -> Result<AggregationPlan> {
+        // SECURITY (#795): the relation is determined by the GraphQL root field, which
+        // already resolved `metadata`. The request's `table` key was a second, unchecked
+        // channel selecting the same thing, so it could name any relation — or a whole
+        // subquery — and the RLS policy, looked up by that same name
+        // (`runners/aggregate.rs` `policy.evaluate(ctx, &request.table_name)`), returned
+        // `None` for an unpolicied table and composed no WHERE clause at all.
+        if request.table_name != metadata.table_name {
+            return Err(FraiseQLError::Validation {
+                message: format!(
+                    "aggregate query 'table' ({}) does not match the fact table resolved from \
+                     the query field ({}); the relation is determined by the schema, not the \
+                     request",
+                    request.table_name, metadata.table_name
+                ),
+                path:    None,
+            });
+        }
+
         // Validate and convert GROUP BY selections
         let group_by_expressions = Self::validate_group_by(&request.group_by, &metadata)?;
 

--- a/crates/fraiseql-core/src/compiler/window_functions/codegen.rs
+++ b/crates/fraiseql-core/src/compiler/window_functions/codegen.rs
@@ -3,6 +3,7 @@ use super::{
     WindowExecutionPlan, WindowFunction, WindowFunctionRequest, WindowFunctionSpec,
     WindowFunctionType, WindowOrderBy, WindowRequest, WindowSelectColumn,
 };
+use crate::compiler::window_allowlist::WindowAllowlist;
 
 // =============================================================================
 // WindowPlanner - Converts high-level WindowRequest to WindowExecutionPlan
@@ -41,17 +42,40 @@ impl WindowPlanner {
         request: WindowRequest,
         metadata: &FactTableMetadata,
     ) -> Result<WindowExecutionPlan> {
+        // SECURITY (#795): the FROM target must be the fact table the root field already
+        // resolved, never the client's `table` key. Two separate channels selected the
+        // relation; only this one was checked, so a request could name any relation — or a
+        // whole subquery — and, because the RLS policy is looked up by that same name,
+        // naming an unpolicied table dropped the tenant filter entirely.
+        if request.table_name != metadata.table_name {
+            return Err(FraiseQLError::Validation {
+                message: format!(
+                    "window query 'table' ({}) does not match the fact table resolved from the \
+                     query field ({}); the relation is determined by the schema, not the request",
+                    request.table_name, metadata.table_name
+                ),
+                path:    None,
+            });
+        }
+
+        // SECURITY (#794): defence-in-depth on top of the unconditional charset checks
+        // below. Built here, in the planner the shipped binary actually calls — the
+        // allowlist existed but only `WindowFunctionPlanner::plan` consulted it, and
+        // nothing outside tests calls that.
+        let allowlist = WindowAllowlist::from_metadata(metadata);
+
         // Convert select columns to SQL expressions
-        let select = Self::convert_select_columns(&request.select, metadata)?;
+        let select = Self::convert_select_columns(&request.select, metadata, &allowlist)?;
 
         // Convert window functions to SQL expressions
-        let windows = Self::convert_window_functions(&request.windows, metadata)?;
+        let windows = Self::convert_window_functions(&request.windows, metadata, &allowlist)?;
 
         // Convert final ORDER BY to SQL expressions
         let order_by = Self::convert_order_by(&request.order_by, metadata)?;
 
         Ok(WindowExecutionPlan {
-            table: request.table_name,
+            // Use the resolved name, not the request's — belt and braces with the check above.
+            table: metadata.table_name.clone(),
             select,
             windows,
             where_clause: request.where_clause,
@@ -65,17 +89,23 @@ impl WindowPlanner {
     fn convert_select_columns(
         columns: &[WindowSelectColumn],
         metadata: &FactTableMetadata,
+        allowlist: &WindowAllowlist,
     ) -> Result<Vec<SelectColumn>> {
         columns
             .iter()
-            .map(|col| Self::convert_single_select_column(col, metadata))
+            .map(|col| Self::convert_single_select_column(col, metadata, allowlist))
             .collect()
     }
 
     fn convert_single_select_column(
         column: &WindowSelectColumn,
         metadata: &FactTableMetadata,
+        allowlist: &WindowAllowlist,
     ) -> Result<SelectColumn> {
+        // SECURITY (#794): every arm below emits `<expr> AS <alias>` verbatim, so the alias
+        // is validated once here rather than in each arm — the bug was that one arm carried
+        // a check its siblings did not.
+        Self::validate_alias(column.alias())?;
         match column {
             WindowSelectColumn::Measure { name, alias } => {
                 // Validate measure exists
@@ -95,7 +125,9 @@ impl WindowPlanner {
                 })
             },
             WindowSelectColumn::Dimension { path, alias } => {
-                // Dimension from JSONB - generate extraction expression
+                // SECURITY (#794): `path` is interpolated as a single-quoted JSONB key, so an
+                // embedded quote breaks out of the literal and appends arbitrary SQL.
+                Self::validate_dimension_path(path, metadata, allowlist)?;
                 let expression = format!("{}->>'{}'", metadata.dimensions.name, path);
                 Ok(SelectColumn {
                     expression,
@@ -126,17 +158,22 @@ impl WindowPlanner {
     fn convert_window_functions(
         windows: &[WindowFunctionRequest],
         metadata: &FactTableMetadata,
+        allowlist: &WindowAllowlist,
     ) -> Result<Vec<WindowFunction>> {
         windows
             .iter()
-            .map(|w| Self::convert_single_window_function(w, metadata))
+            .map(|w| Self::convert_single_window_function(w, metadata, allowlist))
             .collect()
     }
 
     fn convert_single_window_function(
         request: &WindowFunctionRequest,
         metadata: &FactTableMetadata,
+        allowlist: &WindowAllowlist,
     ) -> Result<WindowFunction> {
+        // SECURITY (#794): emitted by `write!(sql, " AS {}", window.alias)`.
+        Self::validate_alias(&request.alias)?;
+
         // Convert function spec to function type
         let function = Self::convert_function_spec(&request.function, metadata)?;
 
@@ -144,7 +181,7 @@ impl WindowPlanner {
         let partition_by = request
             .partition_by
             .iter()
-            .map(|p| Self::convert_partition_by(p, metadata))
+            .map(|p| Self::convert_partition_by(p, metadata, allowlist))
             .collect::<Result<Vec<_>>>()?;
 
         // Convert ORDER BY within window to SQL expressions
@@ -269,9 +306,13 @@ impl WindowPlanner {
     fn convert_partition_by(
         partition: &PartitionByColumn,
         metadata: &FactTableMetadata,
+        allowlist: &WindowAllowlist,
     ) -> Result<String> {
         match partition {
             PartitionByColumn::Dimension { path } => {
+                // SECURITY (#794): the same unvalidated JSONB-key interpolation as the
+                // select arm. Both sinks now go through one entry point.
+                Self::validate_dimension_path(path, metadata, allowlist)?;
                 Ok(format!("{}->>'{}'", metadata.dimensions.name, path))
             },
             PartitionByColumn::Filter { name } => {
@@ -336,6 +377,74 @@ impl WindowPlanner {
 
         // Dimension path
         Ok(format!("{}->>'{}'", metadata.dimensions.name, field))
+    }
+
+    /// Validate a result alias before it is emitted as `<expr> AS <alias>` (#794).
+    ///
+    /// Aliases reach `write!(sql, "{} AS {}", …)` in `runtime/window.rs` with no quoting,
+    /// so an alias of `c, (SELECT … FROM pg_authid) AS leak` appends an entire extra
+    /// SELECT column — and `WindowProjector::project` copies every returned column into
+    /// the GraphQL response, so the attacker reads the result.
+    ///
+    /// Rejects rather than quotes: the alias is also the response key, so rejecting keeps
+    /// legitimate keys byte-identical, matching `aggregate_parser::validate_dimension_key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FraiseQLError::Validation`] if `alias` is outside `[_A-Za-z][_0-9A-Za-z]*`.
+    fn validate_alias(alias: &str) -> Result<()> {
+        Self::validate_identifier_charset(alias, "window alias")
+    }
+
+    /// Validate a JSONB dimension path before it is interpolated into `data->>'path'` (#794).
+    ///
+    /// Two layers, in this order:
+    /// 1. **Charset** — unconditional, and the load-bearing guard. It has to be, because the
+    ///    allowlist below no-ops when the schema declares no dimension paths, which is the
+    ///    realistic default (the same reasoning `aggregate_parser` records for its own parse-time
+    ///    check).
+    /// 2. **Allowlist** — defence-in-depth against the declared schema, applied only when the
+    ///    schema actually enumerates dimension paths. Where it declares none there is no constraint
+    ///    to enforce, and requiring membership would reject legitimate undeclared paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FraiseQLError::Validation`] if `path` is outside `[_A-Za-z][_0-9A-Za-z]*`,
+    /// or is not a declared dimension when the schema enumerates them.
+    fn validate_dimension_path(
+        path: &str,
+        metadata: &FactTableMetadata,
+        allowlist: &WindowAllowlist,
+    ) -> Result<()> {
+        Self::validate_identifier_charset(path, "window dimension path")?;
+        if metadata.dimensions.paths.is_empty() {
+            return Ok(());
+        }
+        allowlist.validate(path, "dimension")
+    }
+
+    /// The single charset check for every client-supplied identifier on the window path.
+    ///
+    /// `[_A-Za-z][_0-9A-Za-z]*`, rejected rather than escaped. Every caller that
+    /// interpolates a request-supplied string into SQL — aliases, dimension paths, order-by
+    /// fields — routes through here, so a new sink cannot quietly acquire a different
+    /// (or absent) rule. #794 existed because `resolve_field_to_sql` had a check and its
+    /// four sibling sinks did not.
+    fn validate_identifier_charset(value: &str, context: &str) -> Result<()> {
+        let mut chars = value.chars();
+        let first_ok = chars.next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
+        let rest_ok = chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+        if first_ok && rest_ok {
+            Ok(())
+        } else {
+            Err(FraiseQLError::Validation {
+                message: format!(
+                    "{context} '{value}' contains invalid characters; \
+                     only [_A-Za-z][_0-9A-Za-z]* is allowed"
+                ),
+                path:    None,
+            })
+        }
     }
 
     /// Validate that `field` is a safe GraphQL identifier: `[_A-Za-z][_0-9A-Za-z]*`.

--- a/crates/fraiseql-core/src/compiler/window_functions/tests.rs
+++ b/crates/fraiseql-core/src/compiler/window_functions/tests.rs
@@ -562,3 +562,183 @@ fn test_resolve_field_rejects_injection_in_order_by() {
         "error should mention invalid characters: {msg}"
     );
 }
+
+// =============================================================================
+// #794 / #795 — SQL injection on the LIVE window path
+//
+// These drive the same three calls the shipped binary makes —
+// `WindowQueryParser::parse` -> `WindowPlanner::plan` -> `WindowSqlGenerator::generate`
+// — with the payloads verbatim from the issue bodies. They are deliberately *not*
+// written against `WindowFunctionPlanner`, the planner that consults `WindowAllowlist`,
+// because nothing in the shipped binary calls it: testing that one is what let this ship.
+// =============================================================================
+
+#[cfg(test)]
+mod live_path_injection {
+    use super::*;
+    use crate::runtime::{WindowQueryParser, window::WindowSqlGenerator};
+
+    /// Everything a client controls arrives as the raw `variables` JSON object.
+    fn plan_from_variables(variables: &serde_json::Value) -> Result<WindowExecutionPlan> {
+        let metadata = create_test_metadata();
+        let request = WindowQueryParser::parse(variables, &metadata)?;
+        WindowPlanner::plan(request, &metadata)
+    }
+
+    fn sql_from_variables(variables: &serde_json::Value) -> Result<String> {
+        let plan = plan_from_variables(variables)?;
+        Ok(WindowSqlGenerator::new(crate::db::DatabaseType::PostgreSQL)
+            .generate(&plan)?
+            .raw_sql)
+    }
+
+    /// #794 sink 3: `alias` on a measure select is cloned through untouched and emitted
+    /// by `write!(sql, "{} AS {}", …)`. The issue's payload appends a whole scalar
+    /// subquery against `pg_authid`.
+    #[test]
+    fn measure_alias_cannot_smuggle_a_subquery() {
+        let variables = serde_json::json!({
+            "table": "tf_sales",
+            "select": [{
+                "type":  "measure",
+                "name":  "revenue",
+                "alias": "c, (SELECT string_agg(rolname, ',') FROM pg_authid) AS leak"
+            }]
+        });
+
+        let result = sql_from_variables(&variables);
+
+        assert!(
+            result.is_err(),
+            "a measure alias carrying a subquery must be rejected, got SQL: {:?}",
+            result.ok()
+        );
+    }
+
+    /// #794 sink 1: the Dimension select arm builds `format!("{}->>'{}'", …, path)` with
+    /// no charset check, so a quote in `path` breaks out of the JSONB key literal.
+    #[test]
+    fn dimension_path_cannot_break_out_of_the_jsonb_key() {
+        let variables = serde_json::json!({
+            "table": "tf_sales",
+            "select": [{
+                "type":  "dimension",
+                "path":  "category'||(SELECT rolname FROM pg_authid LIMIT 1)||'",
+                "alias": "d"
+            }]
+        });
+
+        let result = sql_from_variables(&variables);
+
+        assert!(
+            result.is_err(),
+            "a dimension path containing a quote must be rejected, got SQL: {:?}",
+            result.ok()
+        );
+    }
+
+    /// #794 sink 3: the window-function `alias` reaches `write!(sql, " AS {}", …)`.
+    #[test]
+    fn window_function_alias_cannot_smuggle_a_subquery() {
+        let variables = serde_json::json!({
+            "table":   "tf_sales",
+            "select":  [],
+            "windows": [{
+                "function": {"type": "row_number"},
+                "alias":    "rank, (SELECT current_user) AS whoami"
+            }]
+        });
+
+        let result = sql_from_variables(&variables);
+
+        assert!(
+            result.is_err(),
+            "a window alias carrying a subquery must be rejected, got SQL: {:?}",
+            result.ok()
+        );
+    }
+
+    /// #794 sink 2: `PartitionByColumn::Dimension` repeats the unvalidated `format!`.
+    #[test]
+    fn partition_by_dimension_path_cannot_break_out_of_the_jsonb_key() {
+        let variables = serde_json::json!({
+            "table":   "tf_sales",
+            "select":  [],
+            "windows": [{
+                "function":    {"type": "row_number"},
+                "alias":       "rank",
+                "partitionBy": [{"type": "dimension", "path": "x'||(SELECT version())||'"}]
+            }]
+        });
+
+        let result = sql_from_variables(&variables);
+
+        assert!(
+            result.is_err(),
+            "a partitionBy dimension path containing a quote must be rejected, got SQL: {:?}",
+            result.ok()
+        );
+    }
+
+    /// #795: the FROM target comes from the client's `table` key and is never reconciled
+    /// against the fact table the root field already resolved. A subquery substitutes the
+    /// relation outright; naming a different table also drops the RLS policy, which is
+    /// looked up by that same unvalidated name.
+    #[test]
+    fn table_cannot_substitute_the_relation_with_a_subquery() {
+        let variables = serde_json::json!({
+            "table": "(SELECT jsonb_build_object('category', rolname) AS dimensions \
+                      FROM pg_authid) AS x",
+            "select": [{"type": "measure", "name": "revenue", "alias": "r"}]
+        });
+
+        let result = sql_from_variables(&variables);
+
+        assert!(
+            result.is_err(),
+            "a subquery in `table` must be rejected, got SQL: {:?}",
+            result.ok()
+        );
+    }
+
+    /// #795: even a plain, well-formed identifier must be refused when it is not the fact
+    /// table the root field resolved — that is the RLS-bypass half of the issue.
+    #[test]
+    fn table_cannot_name_a_different_relation() {
+        let variables = serde_json::json!({
+            "table":  "pg_authid",
+            "select": [{"type": "measure", "name": "revenue", "alias": "r"}]
+        });
+
+        let result = sql_from_variables(&variables);
+
+        assert!(
+            result.is_err(),
+            "a `table` other than the resolved fact table must be rejected, got SQL: {:?}",
+            result.ok()
+        );
+    }
+
+    /// The guard must not break the legitimate query shape it protects.
+    #[test]
+    fn a_well_formed_window_query_still_plans_and_generates() {
+        let variables = serde_json::json!({
+            "table":   "tf_sales",
+            "select":  [
+                {"type": "measure",   "name": "revenue",  "alias": "revenue"},
+                {"type": "dimension", "path": "category", "alias": "category"}
+            ],
+            "windows": [{
+                "function":    {"type": "row_number"},
+                "alias":       "rank",
+                "partitionBy": [{"type": "dimension", "path": "category"}]
+            }]
+        });
+
+        let sql =
+            sql_from_variables(&variables).expect("a legitimate window query must still work");
+
+        assert!(sql.contains("FROM tf_sales"), "expected the resolved fact table: {sql}");
+        assert!(sql.contains("ROW_NUMBER()"), "expected the window function: {sql}");
+    }
+}

--- a/crates/fraiseql-core/src/runtime/aggregation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/aggregation/mod.rs
@@ -286,7 +286,10 @@ impl AggregationSqlGenerator {
 
         let select_sql =
             self.build_select_clause(&plan.group_by_expressions, &plan.aggregate_expressions)?;
-        let from_sql = format!("FROM {}", plan.request.table_name);
+        // SECURITY (#795): emit the *resolved* fact table, never the request's `table` key.
+        // `AggregationPlanner::plan` rejects a mismatch; sourcing the name from metadata
+        // here means a future planner change cannot silently re-open the sink.
+        let from_sql = format!("FROM {}", plan.metadata.table_name);
 
         let where_sql = if let Some(ref wc) = plan.request.where_clause {
             self.build_where_clause_parameterized(wc, &plan.metadata, &mut params)?

--- a/crates/fraiseql-core/src/runtime/aggregation/partial_period_builder.rs
+++ b/crates/fraiseql-core/src/runtime/aggregation/partial_period_builder.rs
@@ -70,7 +70,8 @@ impl AggregationSqlGenerator {
         if let Some((gte, lt)) = branch_plan.complete_middle {
             let sql = self.build_branch(
                 plan,
-                &plan.request.table_name,
+                // SECURITY (#795): the resolved fact table, not the request's `table` key.
+                &plan.metadata.table_name,
                 &config.time_grain_column,
                 None, // no DATE_TRUNC — already period-aligned
                 gte,

--- a/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/aggregate.rs
@@ -189,7 +189,12 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
         if let Some(ctx) = security_context {
             let rls_where: Option<RlsWhereClause> =
                 if let Some(ref policy) = self.ctx.config.rls_policy {
-                    policy.evaluate(ctx, &request.table_name)?
+                    // SECURITY (#795): look the policy up by the fact table the root field
+                    // resolved, never the client's `table` key. This runs *before* the
+                    // planner's reconciliation check, so it must be correct on its own:
+                    // an unpolicied name returns `None`, which composed no WHERE clause at
+                    // all and silently dropped the tenant filter.
+                    policy.evaluate(ctx, &metadata.table_name)?
                 } else {
                     None
                 };
@@ -394,7 +399,12 @@ impl<A: DatabaseAdapter> AggregateRunner<A> {
         if let Some(ctx) = security_context {
             let rls_where: Option<RlsWhereClause> =
                 if let Some(ref policy) = self.ctx.config.rls_policy {
-                    policy.evaluate(ctx, &request.table_name)?
+                    // SECURITY (#795): look the policy up by the fact table the root field
+                    // resolved, never the client's `table` key. This runs *before* the
+                    // planner's reconciliation check, so it must be correct on its own:
+                    // an unpolicied name returns `None`, which composed no WHERE clause at
+                    // all and silently dropped the tenant filter.
+                    policy.evaluate(ctx, &metadata.table_name)?
                 } else {
                     None
                 };

--- a/crates/fraiseql-core/src/runtime/window.rs
+++ b/crates/fraiseql-core/src/runtime/window.rs
@@ -26,10 +26,23 @@ use crate::{
 /// Generated SQL for window function query
 #[derive(Debug, Clone)]
 pub struct WindowSql {
-    /// Parameterized SQL template. WHERE clause values use dialect-specific
-    /// placeholders (`$1`, `?`, `@P1`); column names are schema-derived and
-    /// allowlist-validated via [`crate::compiler::window_allowlist::WindowAllowlist`]
-    /// and are not user-controlled at runtime.
+    /// Parameterized SQL template. WHERE-clause **values** use dialect-specific
+    /// placeholders (`$1`, `?`, `@P1`) and are never interpolated.
+    ///
+    /// **Identifiers here are user-controlled.** Aliases and dimension paths come from the
+    /// request, so they are constrained rather than trusted: every one is rejected unless
+    /// it matches `[_A-Za-z][_0-9A-Za-z]*` (`WindowPlanner::validate_identifier_charset`),
+    /// and dimension paths are additionally checked against
+    /// [`crate::compiler::window_allowlist::WindowAllowlist`] wherever the schema
+    /// enumerates them. The FROM target is the resolved fact table, not the request's
+    /// `table` key.
+    ///
+    /// This comment previously claimed the identifiers were "schema-derived",
+    /// "allowlist-validated" and "not user-controlled at runtime". All three were false on
+    /// this path: the allowlist was only ever consulted by `WindowFunctionPlanner`, which
+    /// nothing outside tests calls, and four sinks interpolated request strings verbatim
+    /// (#794). Keep this description honest — it is load-bearing for anyone auditing the
+    /// emitters below.
     pub raw_sql: String,
 
     /// Bind parameters in placeholder order, passed to

--- a/crates/fraiseql-core/tests/e2e_aggregate_queries.rs
+++ b/crates/fraiseql-core/tests/e2e_aggregate_queries.rs
@@ -1115,3 +1115,70 @@ fn test_native_measures_with_where_filter() {
     );
     assert!(result.params.contains(&json!("sensor-42")));
 }
+
+// =============================================================================
+// #795 — the aggregate FROM target must be the resolved fact table
+//
+// `executor/runners/aggregate.rs` resolves `FactTableMetadata` from the GraphQL root
+// field (`sales_aggregate` -> `tf_sales`), but the FROM target was taken from a separate
+// client-controlled `table` key that nothing reconciled against it. Beyond reading an
+// arbitrary relation, `policy.evaluate(ctx, &request.table_name)` is looked up by that
+// same unvalidated name — naming an unpolicied table yields `None`, so no RLS WHERE is
+// composed and the tenant filter disappears.
+// =============================================================================
+
+mod table_reconciliation {
+    use super::*;
+
+    fn plan_with_table(table: &serde_json::Value) -> fraiseql_core::error::Result<()> {
+        let metadata = create_sales_metadata();
+        let query = json!({
+            "table":      table,
+            "aggregates": [{"count": {}}]
+        });
+        let parsed =
+            AggregateQueryParser::parse(&query, &metadata, &std::collections::HashMap::new())?;
+        fraiseql_core::compiler::aggregation::AggregationPlanner::plan(parsed, metadata)?;
+        Ok(())
+    }
+
+    #[test]
+    fn a_subquery_cannot_substitute_the_relation() {
+        let result = plan_with_table(&json!(
+            "(SELECT jsonb_build_object('category', rolname) AS dimensions FROM pg_authid) AS x"
+        ));
+        assert!(
+            result.is_err(),
+            "a subquery in `table` must be rejected before it reaches `FROM`"
+        );
+    }
+
+    #[test]
+    fn another_relation_cannot_be_named() {
+        let result = plan_with_table(&json!("pg_authid"));
+        assert!(
+            result.is_err(),
+            "`table` must not select a relation other than the resolved one"
+        );
+    }
+
+    /// The RLS-bypass half: another tenant's fact table is a well-formed identifier, so
+    /// only reconciliation against the resolved metadata catches it.
+    #[test]
+    fn another_tenants_fact_table_cannot_be_named() {
+        let result = plan_with_table(&json!("tf_sales_tenant_b"));
+        assert!(
+            result.is_err(),
+            "naming another tenant's fact table must be rejected — the RLS policy is looked \
+             up by this same name, so an unpolicied table silently drops the tenant filter"
+        );
+    }
+
+    #[test]
+    fn the_resolved_fact_table_is_still_accepted() {
+        assert!(
+            plan_with_table(&json!("tf_sales")).is_ok(),
+            "the legitimate table name must still plan"
+        );
+    }
+}

--- a/crates/fraiseql-server/tests/analytics_injection_e2e_pg.rs
+++ b/crates/fraiseql-server/tests/analytics_injection_e2e_pg.rs
@@ -1,0 +1,375 @@
+//! #794 / #795 regression: the analytics path must not let a client inject SQL.
+//!
+//! This is the gate for both CRITICALs. The unit tests in
+//! `fraiseql-core/src/compiler/window_functions/tests.rs` pin the planner's validation
+//! functions; only this test proves the property that actually matters — that a request
+//! arriving over **HTTP `/graphql`**, against a **real database**, through the **real
+//! handler**, cannot read a relation it was not granted.
+//!
+//! Why the response assertion is load-bearing as well as the error assertion:
+//! `WindowProjector::project` copies *every* column the database returned into the
+//! GraphQL response, regardless of what the plan asked for. So "the query errored" and
+//! "the injected column is absent" are genuinely different claims, and a fix that only
+//! made the query fail *later* would satisfy the first while still leaking. Both are
+//! asserted for every payload.
+//!
+//! The payloads are taken verbatim from the issue bodies, where each was verified to
+//! generate SQL that executes against PostgreSQL 16 and returns `pg_authid` contents.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: server` suite.
+//!
+//! **Execution engine:** `PostgreSQL` · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** creates and drops its own `tf_injprobe` fixture → run
+//! `--test-threads=1`.
+#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use std::sync::Arc;
+
+use axum::{Router, body::Body, routing::post};
+use fraiseql_core::{
+    compiler::fact_table::{
+        DimensionColumn, DimensionPath, FactTableMetadata, MeasureColumn, SqlType,
+    },
+    db::postgres::PostgresAdapter,
+    prelude::DatabaseAdapter as _,
+    runtime::Executor,
+    schema::CompiledSchema,
+};
+use fraiseql_server::routes::graphql::{AppState, graphql_handler};
+use fraiseql_test_support::try_database_url;
+use http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt as _;
+
+/// The fact table the root field `injprobe_window` / `injprobe_aggregate` resolves to.
+///
+/// Deliberately **not** `tf_sales`: that name is a seeded fixture in
+/// `docker/init/postgres-test.sql` which `fraiseql-core`'s `fact_table_integration`
+/// suite introspects. Dropping and recreating it here would silently break those tests
+/// against the shared database.
+const FACT_TABLE: &str = "tf_injprobe";
+
+/// Metadata as the compiled schema would carry it: one measure, one declared dimension.
+fn sales_metadata() -> FactTableMetadata {
+    FactTableMetadata {
+        table_name:               FACT_TABLE.to_string(),
+        measures:                 vec![MeasureColumn {
+            name:     "revenue".to_string(),
+            sql_type: SqlType::Decimal,
+            nullable: false,
+        }],
+        dimensions:               DimensionColumn {
+            name:  "dimensions".to_string(),
+            paths: vec![DimensionPath {
+                name:      "category".to_string(),
+                json_path: "dimensions->>'category'".to_string(),
+                data_type: "text".to_string(),
+            }],
+        },
+        denormalized_filters:     vec![],
+        calendar_dimensions:      vec![],
+        partial_period:           None,
+        native_measures:          std::collections::HashMap::new(),
+        native_dimension_mapping: std::collections::HashMap::new(),
+    }
+}
+
+/// Create the fact table the analytics path needs, so a *successful* injection would
+/// really execute rather than fail on a missing relation.
+async fn setup() -> Option<Router> {
+    let url = try_database_url()?;
+    let adapter = PostgresAdapter::new(&url).await.expect("connect to the test database");
+
+    for stmt in [
+        "DROP TABLE IF EXISTS tf_injprobe",
+        "CREATE TABLE tf_injprobe (revenue numeric NOT NULL, dimensions jsonb NOT NULL)",
+        "INSERT INTO tf_injprobe VALUES (100, '{\"category\":\"Electronics\"}')",
+    ] {
+        let _: Vec<std::collections::HashMap<String, serde_json::Value>> =
+            adapter.execute_raw_query(stmt).await.expect("fixture setup");
+    }
+
+    let mut schema = CompiledSchema::new();
+    schema.add_fact_table(FACT_TABLE.to_string(), sales_metadata());
+
+    let state = AppState::new(Arc::new(Executor::new(schema, Arc::new(adapter))));
+    Some(
+        Router::new()
+            .route("/graphql", post(graphql_handler::<PostgresAdapter>))
+            .with_state(state),
+    )
+}
+
+async fn post_graphql(router: Router, body: &Value) -> (StatusCode, Value) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/graphql")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+/// Assert the request was refused **and** that nothing the attacker asked for came back.
+///
+/// Two different claims, checked against two different scopes:
+///
+/// * `injected_keys` — attacker-chosen alias names (`leak`, `whoami`). A validation error
+///   legitimately quotes the input it rejected, so these are asserted absent from `data` only;
+///   finding one there would mean the column was actually projected.
+/// * `catalog_values` — data that only exists inside the database (`pg_database_owner`, a
+///   `version()` string). These must not appear **anywhere** in the response, in any field, under
+///   any circumstances: their presence is proof of exfiltration.
+async fn assert_injection_refused(
+    router: Router,
+    body: &Value,
+    injected_keys: &[&str],
+    catalog_values: &[&str],
+    label: &str,
+) {
+    let (status, response) = post_graphql(router, body).await;
+
+    assert!(
+        response.get("errors").is_some(),
+        "{label}: expected a GraphQL error, got {status} {response}"
+    );
+
+    let data = response.get("data").map(ToString::to_string).unwrap_or_default();
+    for needle in injected_keys {
+        assert!(
+            !data.contains(needle),
+            "{label}: injected column '{needle}' was projected into data: {data}"
+        );
+    }
+
+    let serialized = response.to_string();
+    for needle in catalog_values {
+        assert!(
+            !serialized.contains(needle),
+            "{label}: database contents '{needle}' reached the response: {serialized}"
+        );
+    }
+}
+
+/// #794 sink 3 — a measure alias that appends a whole extra SELECT column.
+#[tokio::test]
+async fn window_measure_alias_cannot_exfiltrate_pg_authid() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_window { rank } }",
+        "variables": {
+            "table":  FACT_TABLE,
+            "select": [{
+                "type":  "measure",
+                "name":  "revenue",
+                "alias": "c, (SELECT string_agg(rolname, ',') FROM pg_authid) AS leak"
+            }]
+        }
+    });
+
+    assert_injection_refused(
+        router,
+        &body,
+        &["leak"],
+        &["pg_database_owner"],
+        "#794 measure alias",
+    )
+    .await;
+}
+
+/// #794 sink 1 — a dimension path that breaks out of the single-quoted JSONB key.
+#[tokio::test]
+async fn window_dimension_path_cannot_break_out_of_the_jsonb_key() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_window { rank } }",
+        "variables": {
+            "table":  FACT_TABLE,
+            "select": [{
+                "type":  "dimension",
+                "path":  "category'||(SELECT rolname FROM pg_authid LIMIT 1)||'",
+                "alias": "d"
+            }]
+        }
+    });
+
+    assert_injection_refused(
+        router,
+        &body,
+        &["d"],
+        &["pg_database_owner", "Electronicspg"],
+        "#794 dimension path",
+    )
+    .await;
+}
+
+/// #794 sink 3 — the window-function alias reaches `write!(sql, " AS {}", …)`.
+#[tokio::test]
+async fn window_function_alias_cannot_exfiltrate_the_current_user() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_window { rank } }",
+        "variables": {
+            "table":   FACT_TABLE,
+            "select":  [],
+            "windows": [{
+                "function": {"type": "row_number"},
+                "alias":    "rank, (SELECT current_user) AS whoami"
+            }]
+        }
+    });
+
+    assert_injection_refused(router, &body, &["whoami"], &[], "#794 window alias").await;
+}
+
+/// #794 sink 2 — the PARTITION BY dimension path repeats the same interpolation.
+#[tokio::test]
+async fn window_partition_by_path_cannot_break_out_of_the_jsonb_key() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_window { rank } }",
+        "variables": {
+            "table":   FACT_TABLE,
+            "select":  [],
+            "windows": [{
+                "function":    {"type": "row_number"},
+                "alias":       "rank",
+                "partitionBy": [{"type": "dimension", "path": "x'||(SELECT version())||'"}]
+            }]
+        }
+    });
+
+    assert_injection_refused(router, &body, &[], &["PostgreSQL 1"], "#794 partitionBy path").await;
+}
+
+/// #795 — a subquery substituted for the FROM target on the window path.
+#[tokio::test]
+async fn window_table_cannot_substitute_the_relation() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_window { rank } }",
+        "variables": {
+            "table": "(SELECT jsonb_build_object('category', rolname) AS dimensions \
+                      FROM pg_authid) AS x",
+            // Select a *dimension*, not a measure: the substituted subquery exposes a
+            // `dimensions` column, so pre-fix this SQL is valid and returns role names.
+            // Asking for `revenue` instead would fail on a missing column, and the test
+            // would pass for the wrong reason.
+            "select": [{"type": "dimension", "path": "category", "alias": "r"}]
+        }
+    });
+
+    assert_injection_refused(router, &body, &[], &["pg_database_owner"], "#795 window table").await;
+}
+
+/// #795 — the aggregate half, which is also the RLS-bypass half: the policy is looked
+/// up by this same name, so an unpolicied relation composed no tenant filter at all.
+#[tokio::test]
+async fn aggregate_table_cannot_substitute_the_relation() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_aggregate { count } }",
+        "variables": {
+            "table": "(SELECT jsonb_build_object('category', rolname) AS dimensions \
+                      FROM pg_authid) AS x",
+            "groupBy":    {"category": true},
+            "aggregates": [{"count": {}}]
+        }
+    });
+
+    assert_injection_refused(router, &body, &[], &["pg_database_owner"], "#795 aggregate table")
+        .await;
+}
+
+/// #795 — a plain identifier naming another relation is the RLS-bypass shape, and only
+/// reconciliation against the resolved metadata catches it.
+#[tokio::test]
+async fn aggregate_table_cannot_name_another_relation() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_aggregate { count } }",
+        "variables": {
+            "table":      "pg_authid",
+            "aggregates": [{"count": {}}]
+        }
+    });
+
+    assert_injection_refused(
+        router,
+        &body,
+        &[],
+        &["pg_database_owner"],
+        "#795 aggregate foreign table",
+    )
+    .await;
+}
+
+/// The guard must not break the query shape it protects — otherwise "everything errors"
+/// would pass every assertion above.
+#[tokio::test]
+async fn a_legitimate_window_query_still_succeeds_over_http() {
+    let Some(router) = setup().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    let body = json!({
+        "query": "{ injprobe_window { rank } }",
+        "variables": {
+            "table":   FACT_TABLE,
+            "select":  [
+                {"type": "measure",   "name": "revenue",  "alias": "revenue"},
+                {"type": "dimension", "path": "category", "alias": "category"}
+            ],
+            "windows": [{
+                "function":    {"type": "row_number"},
+                "alias":       "rank",
+                "partitionBy": [{"type": "dimension", "path": "category"}]
+            }]
+        }
+    });
+
+    let (status, response) = post_graphql(router, &body).await;
+
+    assert_eq!(status, StatusCode::OK, "legitimate query must succeed: {response}");
+    assert!(
+        response.get("errors").is_none(),
+        "legitimate window query must not error: {response}"
+    );
+}


### PR DESCRIPTION
Closes #794. Closes #795.

Both are **CRITICAL** and reachable by any client able to POST a GraphQL query — no credentials — on any deployment whose compiled schema declares at least one fact table. Both were verified in the issue bodies against live PostgreSQL 16, exfiltrating `pg_authid` contents.

## #794 — window aliases and dimension paths were interpolated raw

Four sinks on the live `*_window` path wrote request-supplied strings straight into the SELECT list. `WindowProjector::project` copies every returned column into the response, so an injected column came back to the caller.

This is the meta-pattern at its purest: **`WindowAllowlist` existed, was documented as this path's defence, and was never called on it.** Its only callers were two test files. The live planner is `WindowPlanner`, which never built one. The doc comment on `WindowSql::raw_sql` asserted the identifiers were "schema-derived", "allowlist-validated" and "not user-controlled at runtime" — all three false.

- Every alias and dimension path is rejected unless it matches `[_A-Za-z][_0-9A-Za-z]*`, via **one** `validate_identifier_charset` entry point shared by all sinks. The defect existed precisely because `resolve_field_to_sql` carried the check and its four siblings did not; a second implementation would let instance N+1 recur.
- `WindowAllowlist` is now built in `WindowPlanner::plan` and consulted wherever the schema enumerates dimension paths.
- Reject rather than quote, matching the already-hardened aggregate path (`aggregate_parser::validate_dimension_key`), whose doc records the reason: the alias is also the response key, so rejecting keeps legitimate keys byte-identical. With a strict charset there is no character left that quoting would defend against.

## #795 — the `table` request key selected the FROM target

The relation is already determined by the root field (`sales_window` → `tf_sales`), but a second unchecked channel could name any relation or substitute a whole subquery. Worse: the RLS policy was looked up by that same attacker-controlled name, so naming a table with no configured policy yielded `None` and composed **no tenant WHERE clause at all**.

- Both planners reject a `table` that does not match the resolved fact table; every FROM sink emits the resolved name.
- RLS is evaluated against the resolved name. That matters independently — RLS runs *before* the planner, so the reconciliation guard alone would not have fixed it.

## Verification gate

`crates/fraiseql-server/tests/analytics_injection_e2e_pg.rs` drives the **real HTTP handler** against **real PostgreSQL** with the issue payloads verbatim, and asserts two distinct things per payload: that the request is refused, *and* that no catalog data reaches the response. A fix that merely failed later would satisfy the first alone. Wired into the Dagger `integration: server` suite.

**The gate was proven to fail.** With the guards reverted, all 7 injection tests go red, emitting the exact exploit SQL from the issues; the legitimate-query test passes in both states, so this is not "everything errors".

One test needed strengthening after that check: `window_table_cannot_substitute_the_relation` initially passed pre-fix for the wrong reason (it selected a measure the substituted subquery didn't expose, so it failed on a missing column rather than leaking). It now selects a dimension, which is the issue's actual proof shape.

## Class sweep

No other request-controlled SQL interpolation remains in `fraiseql-core`: `FactTableDetector::generate_json_path` is compile-time introspection, and all three `partial_period_builder` FROM arguments are schema-derived. Nothing new to file.

## Verification
✅ `make preflight` — fmt, 12 shell gates, rustdoc `-D warnings`, clippy `--all-targets --all-features -D warnings`
✅ `cargo test -p fraiseql-core --all-features` — 2700 lib, 43 integration binaries green (with `DATABASE_URL` + `MYSQL_URL`)
✅ `analytics_injection_e2e_pg` — 8/8 against real PostgreSQL

## Note for review

`WindowFunctionPlanner` (the dead planner) is **not** removed here. Deleting it means deleting or porting 61 tests across 1329 lines whose JSON shape is incompatible with the live path, which would materially enlarge a security patch. It is called by nothing in the shipped binary, so it is not part of the vulnerability — but it *is* the structural root cause, and it should be dealt with separately.