### PR TITLE
fix(test-support): P00 — service availability means reachable, not configured (#879)

### DIFF
--- a/crates/fraiseql-server/src/identity/tests.rs
+++ b/crates/fraiseql-server/src/identity/tests.rs
@@ -543,11 +543,17 @@ async fn cache_key_discriminates_by_bound_params() {
 
 /// Connect to the harness-provided Postgres (Dagger-bound in CI; a local spawn
 /// with the `local-testcontainers` feature). `None` when no service is available
-/// so the test skips cleanly.
+/// so the test skips cleanly — including when the connection itself fails, which
+/// is announced rather than panicking inside test setup (#879).
 async fn connect_pool() -> Option<(sqlx::PgPool, fraiseql_test_support::Service)> {
     let svc = fraiseql_test_support::postgres().await?;
-    let pool = sqlx::PgPool::connect(svc.url()).await.unwrap();
-    Some((pool, svc))
+    match sqlx::PgPool::connect(svc.url()).await {
+        Ok(pool) => Some((pool, svc)),
+        Err(e) => {
+            eprintln!("SKIP: postgres reachable but connect failed ({e}); skipping");
+            None
+        },
+    }
 }
 
 /// Create a fresh, uniquely-named actor table so parallel runs stay independent.

--- a/crates/fraiseql-test-support/src/db.rs
+++ b/crates/fraiseql-test-support/src/db.rs
@@ -1,10 +1,9 @@
 //! Canonical database-URL resolution.
 //!
 //! This is the one place the database test-URL policy lives — `DATABASE_URL` for
-//! PostgreSQL, `MYSQL_URL` for MySQL, `SQLSERVER_URL` for SQL Server. `fraiseql-test-utils`
-//! re-exports these so its existing callers keep working without a second copy. Each
-//! `*_url()` panics loudly when unset; each `try_*_url()` returns `None` for self-skipping
-//! tests.
+//! PostgreSQL (the only supported backend since v2.15.0's de-scope, #374).
+//! [`database_url`] panics loudly when unset; [`try_database_url`] returns `None`
+//! for self-skipping tests.
 
 #![allow(clippy::panic)] // Reason: test infrastructure — panics with an actionable message are acceptable
 
@@ -29,39 +28,6 @@ pub fn database_url() -> String {
 #[must_use]
 pub fn try_database_url() -> Option<String> {
     env_url("DATABASE_URL")
-}
-
-/// Returns the MySQL test URL from the `MYSQL_URL` environment variable.
-///
-/// # Panics
-///
-/// Panics with an actionable message if `MYSQL_URL` is not set (see [`database_url`]).
-#[must_use]
-pub fn mysql_url() -> String {
-    resolve_or_panic("MYSQL_URL", "mysql://...", try_mysql_url())
-}
-
-/// Returns the MySQL test URL if `MYSQL_URL` is set, or `None` otherwise.
-#[must_use]
-pub fn try_mysql_url() -> Option<String> {
-    env_url("MYSQL_URL")
-}
-
-/// Returns the SQL Server test connection string from the `SQLSERVER_URL` environment
-/// variable (ADO form, e.g. `server=host,1433;database=...;user=...;password=...`).
-///
-/// # Panics
-///
-/// Panics with an actionable message if `SQLSERVER_URL` is not set (see [`database_url`]).
-#[must_use]
-pub fn sqlserver_url() -> String {
-    resolve_or_panic("SQLSERVER_URL", "server=host,1433;database=...", try_sqlserver_url())
-}
-
-/// Returns the SQL Server test connection string if `SQLSERVER_URL` is set, or `None`.
-#[must_use]
-pub fn try_sqlserver_url() -> Option<String> {
-    env_url("SQLSERVER_URL")
 }
 
 /// Resolve a database URL or panic loudly. Split out so the loud-failure contract is

--- a/crates/fraiseql-test-support/src/db/tests.rs
+++ b/crates/fraiseql-test-support/src/db/tests.rs
@@ -10,9 +10,9 @@ fn resolve_or_panic_is_loud_when_unset() {
 }
 
 #[test]
-#[should_panic(expected = "MYSQL_URL is not set")]
+#[should_panic(expected = "SOME_URL is not set")]
 fn resolve_or_panic_names_the_missing_var() {
-    let _ = resolve_or_panic("MYSQL_URL", "mysql://...", None);
+    let _ = resolve_or_panic("SOME_URL", "scheme://...", None);
 }
 
 #[test]

--- a/crates/fraiseql-test-support/src/lib.rs
+++ b/crates/fraiseql-test-support/src/lib.rs
@@ -7,7 +7,9 @@
 //!
 //! Every service getter follows the same rule:
 //!
-//! 1. If the service's env URL is set (e.g. `DATABASE_URL`), use it.
+//! 1. If the service's env URL is set (e.g. `DATABASE_URL`) **and its host:port is reachable**
+//!    (short-timeout TCP probe), use it. A configured-but-unreachable service reads as absent,
+//!    announced on stderr — availability means *reachable*, not *configured* (#879).
 //! 2. Otherwise, with the `local-testcontainers` feature, spawn an ephemeral container on the local
 //!    Docker daemon (Ryuk reaper on) and use that.
 //! 3. Otherwise return `None` — the caller skips.
@@ -35,9 +37,5 @@
 pub mod db;
 pub mod services;
 
-pub use db::{
-    database_url, mysql_url, sqlserver_url, try_database_url, try_mysql_url, try_sqlserver_url,
-};
-pub use services::{
-    Service, Vault, azure_blob, gcs, minio, mysql, nats, postgres, redis, sqlserver, vault,
-};
+pub use db::{database_url, try_database_url};
+pub use services::{Service, Vault, azure_blob, gcs, minio, nats, postgres, redis, vault};

--- a/crates/fraiseql-test-support/src/services.rs
+++ b/crates/fraiseql-test-support/src/services.rs
@@ -3,17 +3,22 @@
 //! Env var names are canonical and match the legacy CI job environment as well as
 //! the URLs the Dagger module injects, so a test reads the same variable whether it
 //! runs under `dagger call test-integration` locally or in CI.
+//!
+//! "Available" means **reachable**, not merely configured: every getter probes the
+//! URL's host:port with a short-timeout TCP connect and treats an unreachable
+//! service as absent, so the documented skip path skips instead of hard-failing in
+//! test setup (#879).
 
-use std::any::Any;
+use std::{
+    any::Any,
+    net::{TcpStream, ToSocketAddrs},
+    time::Duration,
+};
 
 /// `postgres()` env var.
 const POSTGRES_URL_ENV: &str = "DATABASE_URL";
-/// `mysql()` env var.
-const MYSQL_URL_ENV: &str = "MYSQL_URL";
 /// `redis()` env var.
 const REDIS_URL_ENV: &str = "REDIS_URL";
-/// `sqlserver()` env var.
-const SQLSERVER_URL_ENV: &str = "SQLSERVER_URL";
 /// `nats()` env var.
 const NATS_URL_ENV: &str = "NATS_URL";
 /// `minio()` endpoint env var.
@@ -84,24 +89,14 @@ fn normalize(raw: Option<String>) -> Option<String> {
 /// PostgreSQL. Env: `DATABASE_URL`. Local spawn: yes (with `local-testcontainers`).
 pub async fn postgres() -> Option<Service> {
     if let Some(url) = env_url(POSTGRES_URL_ENV) {
-        return Some(Service::from_url(url));
+        return reachable_service(POSTGRES_URL_ENV, url);
     }
     spawn_postgres().await
-}
-
-/// MySQL. Env: `MYSQL_URL`.
-pub async fn mysql() -> Option<Service> {
-    resolve_env(MYSQL_URL_ENV).await
 }
 
 /// Redis. Env: `REDIS_URL`.
 pub async fn redis() -> Option<Service> {
     resolve_env(REDIS_URL_ENV).await
-}
-
-/// SQL Server. Env: `SQLSERVER_URL`.
-pub async fn sqlserver() -> Option<Service> {
-    resolve_env(SQLSERVER_URL_ENV).await
 }
 
 /// NATS. Env: `NATS_URL`.
@@ -137,10 +132,93 @@ pub fn vault() -> Option<Vault> {
 
 /// Env-only resolver for services in the spawnable family that do not yet have a
 /// local spawn path. Kept `async` so wiring one up later is not a caller-facing
-/// signature change.
-#[allow(clippy::unused_async)] // Reason: uniform async getter family; mysql/redis/sqlserver/nats gain local spawn in a later Phase-04 slice
+/// signature change. Every getter funnels through [`reachable_service`], so a new
+/// service getter cannot reintroduce the presence-means-available shape (#879).
+#[allow(clippy::unused_async)] // Reason: uniform async getter family; redis/nats gain local spawn in a later slice
 async fn resolve_env(name: &str) -> Option<Service> {
-    env_url(name).map(Service::from_url)
+    let url = env_url(name)?;
+    reachable_service(name, url)
+}
+
+/// How long the reachability probe waits per resolved address before treating the
+/// service as absent. Live services accept within milliseconds; a closed local
+/// port refuses immediately, so the full wait applies only to blackholed hosts.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Wrap an env-provided URL as a [`Service`] only if its host:port accepts TCP
+/// connections; otherwise announce the skip and return `None`. This is what makes
+/// "available" mean *reachable* rather than *configured* (#879).
+#[allow(clippy::print_stderr)] // Reason: a silent skip is the failure mode this crate exists to prevent; stderr is the test log
+fn reachable_service(name: &str, url: String) -> Option<Service> {
+    match probe(&url) {
+        Ok(()) => Some(Service::from_url(url)),
+        Err(reason) => {
+            eprintln!(
+                "SKIP: {name} is set but the service is unreachable ({reason}); \
+                 treating it as unavailable"
+            );
+            None
+        },
+    }
+}
+
+/// Attempt one short-timeout TCP connect to the URL's host:port.
+fn probe(url: &str) -> Result<(), String> {
+    let (host, port) = host_port(url)?;
+    let addrs = (host.as_str(), port)
+        .to_socket_addrs()
+        .map_err(|e| format!("cannot resolve {host}:{port}: {e}"))?;
+    let mut last = format!("{host}:{port} did not resolve to any address");
+    for addr in addrs {
+        match TcpStream::connect_timeout(&addr, PROBE_TIMEOUT) {
+            Ok(_) => return Ok(()),
+            Err(e) => last = format!("connect to {addr} failed: {e}"),
+        }
+    }
+    Err(last)
+}
+
+/// Extract `(host, port)` from a service URL, defaulting the port by scheme.
+/// Pure; unit-tested. Errors name what is missing so the skip line is actionable.
+fn host_port(url: &str) -> Result<(String, u16), String> {
+    let (scheme, rest) =
+        url.split_once("://").ok_or_else(|| format!("no scheme in URL {url:?}"))?;
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let hostport = authority.rsplit_once('@').map_or(authority, |(_, hp)| hp);
+    let (host, explicit_port) = if let Some(bracketed) = hostport.strip_prefix('[') {
+        // IPv6 literal: [::1] or [::1]:5433
+        let (inside, after) = bracketed
+            .split_once(']')
+            .ok_or_else(|| format!("unclosed IPv6 bracket in URL {url:?}"))?;
+        (inside.to_string(), after.strip_prefix(':'))
+    } else {
+        match hostport.rsplit_once(':') {
+            Some((h, p)) => (h.to_string(), Some(p)),
+            None => (hostport.to_string(), None),
+        }
+    };
+    if host.is_empty() {
+        return Err(format!("no host in URL {url:?}"));
+    }
+    let port = match explicit_port {
+        Some(p) => p.parse::<u16>().map_err(|_| format!("invalid port {p:?} in URL {url:?}"))?,
+        None => default_port(scheme).ok_or_else(|| {
+            format!("no port in URL {url:?} and no default for scheme {scheme:?}")
+        })?,
+    };
+    Ok((host, port))
+}
+
+/// Default ports for the schemes this harness provisions.
+fn default_port(scheme: &str) -> Option<u16> {
+    match scheme {
+        "postgres" | "postgresql" => Some(5432),
+        "redis" | "rediss" => Some(6379),
+        "nats" => Some(4222),
+        "http" => Some(80),
+        "https" => Some(443),
+        _ => None,
+    }
 }
 
 #[cfg(feature = "local-testcontainers")]

--- a/crates/fraiseql-test-support/src/services/tests.rs
+++ b/crates/fraiseql-test-support/src/services/tests.rs
@@ -1,4 +1,125 @@
-use super::normalize;
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(clippy::await_holding_lock)] // Reason: the env lock must span the awaited getter — that is what serializes env access
+
+use std::sync::Mutex;
+
+use super::{host_port, normalize, postgres, redis};
+
+/// Serializes the tests that mutate process env (env vars are process-global;
+/// two parallel env tests would race each other).
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Locks [`ENV_LOCK`] even when a previous holder panicked — the guard's Drop
+/// restores env state, so a poisoned lock is still consistent.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Sets an env var for the test's scope and restores the previous value on drop.
+struct EnvGuard {
+    name: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let prev = std::env::var(name).ok();
+        std::env::set_var(name, value);
+        Self { name, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => std::env::set_var(self.name, v),
+            None => std::env::remove_var(self.name),
+        }
+    }
+}
+
+/// A 127.0.0.1 port that was just observed closed (bound then released).
+fn closed_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// #879: "available" must mean *reachable*, not merely *configured*. A
+/// `DATABASE_URL` pointing at a closed port must read as no-database so the
+/// documented skip path skips instead of hard-failing in test setup.
+#[tokio::test]
+async fn postgres_with_unreachable_url_reads_as_unavailable() {
+    let _lock = env_lock();
+    let url = format!("postgresql://u:p@127.0.0.1:{}/db", closed_port());
+    let _guard = EnvGuard::set("DATABASE_URL", &url);
+    assert!(
+        postgres().await.is_none(),
+        "postgres() returned Some for an unreachable DATABASE_URL"
+    );
+}
+
+/// The positive direction: a URL whose host:port accepts TCP connections is
+/// returned as-is (the probe checks reachability, not protocol).
+#[tokio::test]
+async fn postgres_with_reachable_url_is_returned() {
+    let _lock = env_lock();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let url = format!("postgresql://u:p@{}/db", listener.local_addr().unwrap());
+    let _guard = EnvGuard::set("DATABASE_URL", &url);
+    let svc = postgres().await.expect("reachable DATABASE_URL must resolve");
+    assert_eq!(svc.url(), url);
+}
+
+/// The siblings share the policy: an unreachable `REDIS_URL` also skips.
+#[tokio::test]
+async fn redis_with_unreachable_url_reads_as_unavailable() {
+    let _lock = env_lock();
+    let url = format!("redis://127.0.0.1:{}", closed_port());
+    let _guard = EnvGuard::set("REDIS_URL", &url);
+    assert!(redis().await.is_none(), "redis() returned Some for an unreachable REDIS_URL");
+}
+
+#[test]
+fn host_port_explicit_port() {
+    assert_eq!(
+        host_port("postgresql://u:p@db.example:5433/test_fraiseql"),
+        Ok(("db.example".to_string(), 5433))
+    );
+}
+
+#[test]
+fn host_port_scheme_defaults() {
+    assert_eq!(host_port("postgres://u@h/db"), Ok(("h".to_string(), 5432)));
+    assert_eq!(host_port("redis://h"), Ok(("h".to_string(), 6379)));
+    assert_eq!(host_port("nats://h"), Ok(("h".to_string(), 4222)));
+    assert_eq!(host_port("http://minio"), Ok(("minio".to_string(), 80)));
+    assert_eq!(host_port("https://gcs"), Ok(("gcs".to_string(), 443)));
+}
+
+#[test]
+fn host_port_ipv6_literal() {
+    assert_eq!(host_port("postgresql://u:p@[::1]:5433/db"), Ok(("::1".to_string(), 5433)));
+    assert_eq!(host_port("redis://[::1]"), Ok(("::1".to_string(), 6379)));
+}
+
+#[test]
+fn host_port_query_only_url() {
+    assert_eq!(
+        host_port("http://azurite:10000/devstoreaccount1?sslmode=disable"),
+        Ok(("azurite".to_string(), 10000))
+    );
+}
+
+#[test]
+fn host_port_rejects_unparseable() {
+    assert!(host_port("not-a-url").is_err(), "URL without scheme must be an error");
+    assert!(host_port("postgresql://u:p@:5432/db").is_err(), "empty host must be an error");
+    assert!(host_port("postgresql://h:notaport/db").is_err(), "bad port must be an error");
+    assert!(
+        host_port("weird://h/db").is_err(),
+        "unknown scheme without port must be an error"
+    );
+}
 
 #[test]
 fn normalize_drops_empty() {


### PR DESCRIPTION
Phase 00 of the 2026-08-06 open-finding remediation program: baseline + the fail-open skip-guard.

## Changes

- **#879**: `fraiseql_test_support::postgres()` and every env-resolved sibling (redis/nats/minio/azure_blob/gcs) now probe the URL's host:port with a short-timeout TCP connect. A configured-but-unreachable service reads as **absent** (announced on stderr), so the documented skip path skips instead of hard-failing `PoolTimedOut` inside test setup. All getters funnel through one `reachable_service()` helper — a new getter cannot reintroduce the presence-means-available shape.
- `identity/tests.rs::connect_pool` propagates a failed connect as an announced skip instead of `.unwrap()`.
- Deleted the `mysql()`/`sqlserver()` getters and `mysql_url()`/`sqlserver_url()` helpers — post-#374 de-scope leftovers with zero callers.

## Red-capability proof

The new `postgres_with_unreachable_url_reads_as_unavailable` test **failed against the pre-fix code** (returned `Some` for a closed port) — RED first, then the probe made it green. Positive direction covered (`postgres_with_reachable_url_is_returned` against a live listener), plus `host_port` parser unit tests (explicit port, scheme defaults, IPv6 literal, rejects).

## Also in this phase (no code in this PR)

- #937 / #891 verified on head and closed with linked evidence (3/3 green post-`db-reset`, `- 1` revert reddens, module executing 355 tests in `integration (postgres)` run 31073585468).
- Baseline snapshot recorded; #990 filed (lint.sh orphaned/drifted gate surface).

## Verification

✅ RED first (see above)
✅ `cargo test -p fraiseql-test-support` — 15 lib + 1 doctest
✅ Full `cargo nextest run -p fraiseql-server --all-features --test-threads=1 --no-fail-fast`: 3276/3278 — the 2 fails are the pre-existing documented findings #981 and #942/#982 (owned by P01/P03)
✅ `cargo test --doc --workspace --all-features` — 16 crates green
✅ `make preflight` green (fmt, ShellGates, rustdoc, clippy all-features on MSRV toolchain)
✅ `dagger-test` leg dispatched on this branch: run 31079844459

🤖 Generated with [Claude Code](https://claude.com/claude-code)