### PR TITLE
fix(security): P04 — fail-closed sweep (#984 #882 #898 #903 #887 #934)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -773,6 +773,10 @@ func (m *FraiseqlCi) integrationPostgres(ctx context.Context, source *dagger.Dir
 		"cargo test -p fraiseql-auth --test password_reset -- --test-threads=1",
 		// #368 social auto-link trust policy ∘ PostgresAccountStore (trusted vs untrusted → merge vs distinct).
 		"cargo test -p fraiseql-auth --test social_linking -- --test-threads=1",
+		// #984 single-use consume of OTP codes / MFA challenge tokens: a BEFORE DELETE
+		// trigger poisons only the consuming statement, proving both stores fail closed
+		// instead of reporting a single-use guarantee the failed DELETE did not establish.
+		"cargo test -p fraiseql-auth --test postgres_single_use_consume -- --test-threads=1",
 		// #389 session-state store (_system.session_state: TTL visibility, upsert, atomic
 		// summary collapse, eviction sweep vs real PG).
 		"cargo test -p fraiseql-auth --test session_state_integration -- --test-threads=1",

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -1080,6 +1080,11 @@ func (m *FraiseqlCi) integrationServer(ctx context.Context, source *dagger.Direc
 		// (admin REST management + live authenticator on one store).
 		"echo '### cargo test -p fraiseql-server --test api_key_postgres_e2e_pg (#627 postgres api keys)'",
 		"cargo test -p fraiseql-server --features '" + serverTestFeatures + "' --test api_key_postgres_e2e_pg -- --test-threads=1",
+		// #934 service accounts under [auth_hs256]: the bearer-less x-api-key request
+		// must reach the handler's ADR-0018 seam, while a credential-less request, an
+		// invalid bearer and an unmatched secret all still 401 at the layer.
+		"echo '### cargo test -p fraiseql-server --test hs256_service_account_e2e_pg (#934)'",
+		"cargo test -p fraiseql-server --features '" + serverTestFeatures + "' --test hs256_service_account_e2e_pg -- --test-threads=1",
 		// #368 P26 — social login through the shipped mount, against a stub IdP:
 		// Google OIDC full loop, the GitHub /user/emails second hop (email-keyed
 		// linking), the auth_start path bucket on /auth/v1/authorize (#788), and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,6 +3902,8 @@ name = "fraiseql-guard"
 version = "2.14.1"
 dependencies = [
  "temp-env",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4187,6 +4187,7 @@ dependencies = [
  "sha2 0.11.0",
  "socket2 0.6.5",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",

--- a/crates/fraiseql-auth/Cargo.toml
+++ b/crates/fraiseql-auth/Cargo.toml
@@ -49,6 +49,9 @@ fraiseql-test-support = {path = "../fraiseql-test-support"}
 proptest = {workspace = true}
 temp-env = {workspace = true}
 tokio-test = "0.4"
+# Lets the live-PG MFA suite (#984) drive the real TOTP path; same version as the
+# runtime dependency above, so it adds nothing to the tree.
+totp-rs = {version = "5", features = ["gen_secret", "otpauth"]}
 wiremock = "0.6"
 
 [features]

--- a/crates/fraiseql-auth/src/constant_time_tests.rs
+++ b/crates/fraiseql-auth/src/constant_time_tests.rs
@@ -381,3 +381,62 @@ mod oidc_issuer_corpus {
         });
     }
 }
+
+// ── #882: the escape hatch is refused in production, at this call site ────────
+
+#[cfg(test)]
+mod oidc_insecure_hatch {
+    /// Request the bypass, then set the posture. `oidc_issuer_corpus` clears the
+    /// bypass so the guard is exercised; this sets it, so the *hatch* is.
+    fn with_bypass_requested<T>(
+        env: Option<&str>,
+        f: impl FnOnce() -> T + std::panic::UnwindSafe,
+    ) -> T {
+        let mut out = None;
+        temp_env::with_vars(
+            [
+                ("FRAISEQL_OIDC_ALLOW_INSECURE", Some("1")),
+                ("FRAISEQL_ENV", env),
+                ("FRAISEQL_PROFILE", None),
+                ("KUBERNETES_SERVICE_HOST", None),
+            ],
+            || out = Some(f()),
+        );
+        out.expect("temp_env ran the closure")
+    }
+
+    /// With the hatch honoured, an OIDC issuer URL may be plain `http://` and may
+    /// point anywhere — including the instance-metadata service.
+    const METADATA_SERVICE: &str = "http://169.254.169.254/";
+
+    #[test]
+    fn oidc_allow_insecure_is_refused_under_production_posture() {
+        assert!(
+            with_bypass_requested(Some("production"), || {
+                crate::oidc_provider::validate_oidc_issuer_url(METADATA_SERVICE)
+            })
+            .is_err(),
+            "#882: FRAISEQL_OIDC_ALLOW_INSECURE must not disable the issuer SSRF \
+             guard in production"
+        );
+        assert!(
+            with_bypass_requested(None, || {
+                crate::oidc_provider::validate_oidc_issuer_url(METADATA_SERVICE)
+            })
+            .is_err(),
+            "unset FRAISEQL_ENV is production: the hatch must not be honoured by default"
+        );
+    }
+
+    #[test]
+    fn oidc_allow_insecure_is_still_honoured_in_a_declared_development_environment() {
+        assert!(
+            with_bypass_requested(Some("development"), || {
+                crate::oidc_provider::validate_oidc_issuer_url(METADATA_SERVICE)
+            })
+            .is_ok(),
+            "the hatch must keep working where it is meant to — otherwise the test \
+             above would pass with the hatch simply deleted"
+        );
+    }
+}

--- a/crates/fraiseql-auth/src/oidc_provider.rs
+++ b/crates/fraiseql-auth/src/oidc_provider.rs
@@ -114,11 +114,11 @@ pub const OIDC_ALLOW_INSECURE_ENV: &str = "FRAISEQL_OIDC_ALLOW_INSECURE";
 /// Read in one place so the URL check and the redirect policy agree. This used
 /// to honour the variable on its own, with no production check — the same shape
 /// as #836, and the reason that guard now runs through
-/// [`fraiseql_guard::deployment`].
+/// [`fraiseql_guard::deployment`], which also reports the decision so a refusal
+/// is visible in the log stream rather than surfacing as an opaque connection
+/// failure (#882).
 fn oidc_ssrf_guards_disabled() -> bool {
-    fraiseql_guard::deployment::insecure_bypass_allowed(fraiseql_guard::deployment::env_opt_in(
-        OIDC_ALLOW_INSECURE_ENV,
-    ))
+    fraiseql_guard::deployment::insecure_bypass(OIDC_ALLOW_INSECURE_ENV).is_honoured()
 }
 
 /// Validate an OIDC issuer URL against SSRF-prone destinations.

--- a/crates/fraiseql-auth/src/otp/postgres.rs
+++ b/crates/fraiseql-auth/src/otp/postgres.rs
@@ -155,21 +155,28 @@ impl OtpStore for PgOtpStore {
         let expires_at: i64 = row.get("expires_at");
         let attempts: i32 = row.get("attempts");
 
+        // The DELETE is what makes the code single-use, so its failure must fail
+        // the verification (#984): returning Ok after a failed consume reports a
+        // guarantee that does not hold and leaves the code replayable until it
+        // expires. Propagated on every path — a consume that silently does
+        // nothing is the same defect wherever it sits.
         let consume = || async {
-            let _ = sqlx::query("DELETE FROM core.tb_otp_code WHERE email = $1")
+            sqlx::query("DELETE FROM core.tb_otp_code WHERE email = $1")
                 .bind(email)
                 .execute(&self.db)
-                .await;
+                .await
+                .map_err(db_err)
+                .map(|_| ())
         };
 
         if now >= expires_at as u64 {
-            consume().await;
+            consume().await?;
             return Err(AuthError::InvalidToken {
                 reason: "OTP has expired".into(),
             });
         }
         if attempts > MAX_VERIFY_ATTEMPTS as i32 {
-            consume().await;
+            consume().await?;
             return Err(AuthError::RateLimited {
                 retry_after_secs: OTP_RATE_WINDOW_SECS,
             });
@@ -185,7 +192,7 @@ impl OtpStore for PgOtpStore {
         }
 
         // Correct — consume it (single-use).
-        consume().await;
+        consume().await?;
         Ok(())
     }
 }

--- a/crates/fraiseql-auth/src/totp_mfa/postgres.rs
+++ b/crates/fraiseql-auth/src/totp_mfa/postgres.rs
@@ -274,15 +274,21 @@ impl MfaStore for PgMfaStore {
 
         let user_id: String = challenge.get("user_id");
         let expires_at: i64 = challenge.get("expires_at");
+        // The DELETE is what makes the challenge single-use, so its failure must
+        // fail the verification (#984): the success path charges no attempt, so a
+        // swallowed error leaves the token replayable with any current-window code
+        // for the rest of CHALLENGE_TTL_SECS. Propagated on every path.
         let consume = |hash: Vec<u8>| async move {
-            let _ = sqlx::query("DELETE FROM core.tb_mfa_challenge WHERE token_hash = $1")
+            sqlx::query("DELETE FROM core.tb_mfa_challenge WHERE token_hash = $1")
                 .bind(hash)
                 .execute(&self.db)
-                .await;
+                .await
+                .map_err(db_err)
+                .map(|_| ())
         };
 
         if now >= expires_at as u64 {
-            consume(hash).await;
+            consume(hash).await?;
             return Err(AuthError::InvalidToken {
                 reason: "challenge token expired".into(),
             });
@@ -292,7 +298,7 @@ impl MfaStore for PgMfaStore {
             reason: "user has no MFA enrollment".into(),
         })?;
         if let Some(retry_after_secs) = Self::lockout_remaining(&row, now) {
-            consume(hash).await;
+            consume(hash).await?;
             return Err(AuthError::RateLimited { retry_after_secs });
         }
         if !row.confirmed {
@@ -302,7 +308,7 @@ impl MfaStore for PgMfaStore {
         }
 
         if verify_totp_code(&row.secret_base32, code)? {
-            consume(hash).await;
+            consume(hash).await?;
             self.clear_failures(&user_id).await?;
             return Ok(user_id);
         }
@@ -320,7 +326,7 @@ impl MfaStore for PgMfaStore {
             .execute(&self.db)
             .await
             .map_err(db_err)?;
-            consume(hash).await;
+            consume(hash).await?;
             self.clear_failures(&user_id).await?;
             return Ok(user_id);
         }
@@ -339,7 +345,7 @@ impl MfaStore for PgMfaStore {
         .map_or(i32::MAX, |r| r.get::<i32, _>("attempts"));
         #[allow(clippy::cast_possible_wrap)] // Reason: MAX_CHALLENGE_ATTEMPTS is a small constant
         if attempts >= MAX_CHALLENGE_ATTEMPTS as i32 {
-            consume(hash).await;
+            consume(hash).await?;
         }
 
         Err(AuthError::InvalidToken {

--- a/crates/fraiseql-auth/tests/postgres_single_use_consume.rs
+++ b/crates/fraiseql-auth/tests/postgres_single_use_consume.rs
@@ -1,0 +1,205 @@
+//! Live-PostgreSQL tests for the single-use consume of OTP codes and MFA
+//! challenge tokens (#984).
+//!
+//! Both [`PgOtpStore::verify_otp`] and [`PgMfaStore::verify_challenge`] establish
+//! their single-use guarantee with a `DELETE` on the success path. If that
+//! `DELETE` fails and the function still returns `Ok`, the credential stays
+//! replayable while the caller is told the guarantee held — the program's
+//! fabricated-success shape.
+//!
+//! The issue notes that no test can inject a failure into *only* the `DELETE`.
+//! It can, with no production seam: a `BEFORE DELETE` trigger that
+//! `RAISE EXCEPTION`s leaves `SELECT`/`INSERT`/`UPDATE` on the same table
+//! working, and — unlike `REVOKE` — still bites the rig's `rolsuper` role.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in
+//! the database-free `test` leg and runs in the Dagger `integration: postgres`
+//! suite, which binds Postgres and injects `DATABASE_URL`.
+//!
+//! **Execution engine:** PostgreSQL · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** installs table-scoped triggers and truncates the shared
+//! `core` tables on setup → run `--test-threads=1`.
+#![allow(clippy::unwrap_used, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use fraiseql_auth::{MfaStore, OtpStore, PgMfaStore, PgOtpStore};
+use fraiseql_test_support::try_database_url;
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use totp_rs::{Algorithm, Secret, TOTP};
+
+/// Name of the `BEFORE DELETE` trigger this suite installs. One name per table,
+/// dropped on every setup so a panicking test cannot poison the next one.
+const POISON_TRIGGER: &str = "trg_fraiseql_test_poison_delete";
+
+/// Connect, apply both stores' DDL, drop any leaked poison triggers, and clear
+/// the tables. Returns `None` (skip) when unconfigured.
+async fn fresh() -> Option<(PgOtpStore, PgMfaStore, PgPool)> {
+    let url = try_database_url()?;
+    let db = PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap();
+
+    let otp = PgOtpStore::new(db.clone());
+    otp.init().await.unwrap();
+    let mfa = PgMfaStore::new(db.clone());
+    mfa.init().await.unwrap();
+
+    for table in [
+        "core.tb_otp_code",
+        "core.tb_mfa_challenge",
+        "core.tb_mfa_enrollment",
+    ] {
+        unpoison_deletes(&db, table).await;
+    }
+    sqlx::query(
+        "TRUNCATE core.tb_otp_code, core.tb_otp_send_budget,
+                  core.tb_mfa_challenge, core.tb_mfa_enrollment",
+    )
+    .execute(&db)
+    .await
+    .unwrap();
+
+    Some((otp, mfa, db))
+}
+
+macro_rules! skip_if_no_db {
+    () => {
+        match fresh().await {
+            Some(triple) => triple,
+            None => {
+                eprintln!("skipping #984 single-use consume test: DATABASE_URL not set");
+                return;
+            },
+        }
+    };
+}
+
+/// Make every `DELETE` against `table` fail, and nothing else. This is the
+/// transient database failure the issue describes (statement timeout, failover,
+/// connection drop) narrowed to the one statement under test.
+async fn poison_deletes(db: &PgPool, table: &str) {
+    sqlx::query(
+        "CREATE OR REPLACE FUNCTION core.fn_fraiseql_test_poison_delete() RETURNS trigger
+         LANGUAGE plpgsql AS $$
+         BEGIN RAISE EXCEPTION 'poisoned DELETE (test injection)'; END $$",
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "CREATE TRIGGER {POISON_TRIGGER} BEFORE DELETE ON {table}
+         FOR EACH ROW EXECUTE FUNCTION core.fn_fraiseql_test_poison_delete()"
+    ))
+    .execute(db)
+    .await
+    .unwrap();
+}
+
+async fn unpoison_deletes(db: &PgPool, table: &str) {
+    sqlx::query(&format!("DROP TRIGGER IF EXISTS {POISON_TRIGGER} ON {table}"))
+        .execute(db)
+        .await
+        .unwrap();
+}
+
+async fn row_count(db: &PgPool, table: &str) -> i64 {
+    sqlx::query(&format!("SELECT count(*) FROM {table}"))
+        .fetch_one(db)
+        .await
+        .unwrap()
+        .get(0)
+}
+
+/// Current TOTP code for a base32 secret, matching `build_totp`'s parameters
+/// (SHA-1, 6 digits, 30s step).
+fn totp_now(secret_base32: &str) -> String {
+    let bytes = Secret::Encoded(secret_base32.to_string()).to_bytes().unwrap();
+    TOTP::new(Algorithm::SHA1, 6, 1, 30, bytes, None, String::new())
+        .unwrap()
+        .generate_current()
+        .unwrap()
+}
+
+// ── OTP — otp/postgres.rs verify_otp ──────────────────────────────────────────
+
+#[tokio::test]
+async fn otp_verify_fails_closed_when_the_single_use_delete_fails() {
+    let (otp, _mfa, db) = skip_if_no_db!();
+    let email = "consume-otp@example.com";
+    let code = otp.create_otp(email).await.unwrap();
+
+    poison_deletes(&db, "core.tb_otp_code").await;
+    let result = otp.verify_otp(email, &code).await;
+    unpoison_deletes(&db, "core.tb_otp_code").await;
+
+    assert!(
+        result.is_err(),
+        "#984: the DELETE that makes the OTP single-use failed, so the code is still \
+         replayable — verify_otp must fail closed, not report a successful verification"
+    );
+    assert_eq!(
+        row_count(&db, "core.tb_otp_code").await,
+        1,
+        "precondition: the poisoned DELETE really did leave the row behind"
+    );
+}
+
+#[tokio::test]
+async fn otp_verify_consumes_the_code_when_the_delete_succeeds() {
+    let (otp, _mfa, db) = skip_if_no_db!();
+    let email = "happy-otp@example.com";
+    let code = otp.create_otp(email).await.unwrap();
+
+    otp.verify_otp(email, &code).await.unwrap();
+    assert_eq!(row_count(&db, "core.tb_otp_code").await, 0, "the code is consumed");
+    assert!(
+        otp.verify_otp(email, &code).await.is_err(),
+        "single-use: the same code must not verify twice"
+    );
+}
+
+// ── MFA — totp_mfa/postgres.rs verify_challenge ───────────────────────────────
+
+/// Enroll a user and confirm the enrollment through the real API.
+async fn enrolled(mfa: &PgMfaStore, user_id: &str) -> String {
+    let enrollment = mfa.begin_enrollment(user_id, "fraiseql", user_id).await.unwrap();
+    let secret = enrollment.secret_base32;
+    mfa.confirm_enrollment(user_id, &totp_now(&secret)).await.unwrap();
+    secret
+}
+
+#[tokio::test]
+async fn mfa_verify_fails_closed_when_the_challenge_delete_fails() {
+    let (_otp, mfa, db) = skip_if_no_db!();
+    let user_id = "user_consume_mfa";
+    let secret = enrolled(&mfa, user_id).await;
+    let challenge = mfa.create_challenge(user_id).await.unwrap();
+
+    poison_deletes(&db, "core.tb_mfa_challenge").await;
+    let result = mfa.verify_challenge(&challenge, &totp_now(&secret)).await;
+    unpoison_deletes(&db, "core.tb_mfa_challenge").await;
+
+    assert!(
+        result.is_err(),
+        "#984: the DELETE that consumes the challenge failed, so the challenge token stays \
+         valid for the rest of its TTL — verify_challenge must fail closed"
+    );
+    assert_eq!(
+        row_count(&db, "core.tb_mfa_challenge").await,
+        1,
+        "precondition: the poisoned DELETE really did leave the challenge behind"
+    );
+}
+
+#[tokio::test]
+async fn mfa_verify_consumes_the_challenge_when_the_delete_succeeds() {
+    let (_otp, mfa, db) = skip_if_no_db!();
+    let user_id = "user_happy_mfa";
+    let secret = enrolled(&mfa, user_id).await;
+    let challenge = mfa.create_challenge(user_id).await.unwrap();
+
+    let verified = mfa.verify_challenge(&challenge, &totp_now(&secret)).await.unwrap();
+    assert_eq!(verified, user_id);
+    assert_eq!(row_count(&db, "core.tb_mfa_challenge").await, 0, "the challenge is consumed");
+    assert!(
+        mfa.verify_challenge(&challenge, &totp_now(&secret)).await.is_err(),
+        "single-use: the same challenge token must not verify twice"
+    );
+}

--- a/crates/fraiseql-core/src/graphql/value_json.rs
+++ b/crates/fraiseql-core/src/graphql/value_json.rs
@@ -128,6 +128,29 @@ pub fn resolve_variables(value: Value, variables: &HashMap<String, Value>) -> Va
     resolve_at(value, variables, 0)
 }
 
+/// Read a stored `value_json` back into JSON **with its variable references
+/// substituted** — the form a consumer that wants values almost always means.
+///
+/// [`decode`] alone yields a value that may still contain `{"$var": "name"}`
+/// markers. Every consumer that then compares, filters or authorizes on the
+/// result must pair it with [`resolve_variables`]; the field authorizer did not,
+/// so a policy matching on an argument compared against the marker and silently
+/// took its default branch for every client that passes arguments as variables —
+/// which is every generated client (#903).
+///
+/// Use [`decode`] directly only when the marker itself is the subject, as
+/// `resolve_inline_arg` does: it distinguishes a whole-argument variable the
+/// request omitted (drop the argument, fall back to the query default) from one
+/// bound to null.
+///
+/// # Errors
+///
+/// Returns `FraiseQLError::Internal` if the stored string is not valid JSON.
+#[allow(clippy::implicit_hasher)] // Reason: as resolve_variables — one hasher, no generic leak.
+pub fn decode_resolved(value_json: &str, variables: &HashMap<String, Value>) -> Result<Value> {
+    Ok(resolve_variables(decode(value_json)?, variables))
+}
+
 fn resolve_at(value: Value, variables: &HashMap<String, Value>, depth: usize) -> Value {
     if depth >= MAX_DEPTH {
         return value;

--- a/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/mutation/mod.rs
@@ -51,6 +51,7 @@ fn enforce_mutation_field_authz<A: DatabaseAdapter>(
     selections: &[FieldSelection],
     entity: &serde_json::Value,
     projected: &mut serde_json::Value,
+    variables: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<()> {
     use crate::security::field_authorizer as authz;
 
@@ -87,7 +88,8 @@ fn enforce_mutation_field_authz<A: DatabaseAdapter>(
             resource: Some(type_name.to_string()),
         });
     }
-    let gated = authz::collect_top_level_gated_fields(&ctx.schema, type_name, selections)?;
+    let gated =
+        authz::collect_top_level_gated_fields(&ctx.schema, type_name, selections, variables)?;
     let pass = authz::FieldAuthzPass {
         authorizer: authorizer.as_ref(),
         principal,
@@ -189,6 +191,7 @@ fn build_cascade_payload<A: DatabaseAdapter>(
     cascade: Option<&serde_json::Value>,
     updated_fields: &[String],
     selections: &[FieldSelection],
+    variables: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<serde_json::Value> {
     let mut out = serde_json::Map::new();
     for sel in effective_selections(selections, payload_type, &ctx.schema) {
@@ -209,11 +212,18 @@ fn build_cascade_payload<A: DatabaseAdapter>(
                     &sel.nested_fields,
                     entity,
                     &mut projected,
+                    variables,
                 )?;
                 out.insert(sel.response_key().to_string(), projected);
             },
             "cascade" => {
-                let built = build_cascade_updates(ctx, security_ctx, cascade, &sel.nested_fields)?;
+                let built = build_cascade_updates(
+                    ctx,
+                    security_ctx,
+                    cascade,
+                    &sel.nested_fields,
+                    variables,
+                )?;
                 out.insert(sel.response_key().to_string(), built);
             },
             "updatedFields" => {
@@ -239,6 +249,7 @@ fn build_cascade_updates<A: DatabaseAdapter>(
     security_ctx: Option<&SecurityContext>,
     cascade: Option<&serde_json::Value>,
     selections: &[FieldSelection],
+    variables: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<serde_json::Value> {
     let cascade_obj = cascade.and_then(serde_json::Value::as_object);
     let empty: Vec<serde_json::Value> = Vec::new();
@@ -277,7 +288,13 @@ fn build_cascade_updates<A: DatabaseAdapter>(
                 );
             },
             "updated" => {
-                let arr = build_updated_entities(ctx, security_ctx, updated, &sel.nested_fields)?;
+                let arr = build_updated_entities(
+                    ctx,
+                    security_ctx,
+                    updated,
+                    &sel.nested_fields,
+                    variables,
+                )?;
                 out.insert(sel.response_key().to_string(), arr);
             },
             "deleted" => {
@@ -435,6 +452,7 @@ fn build_updated_entities<A: DatabaseAdapter>(
     security_ctx: Option<&SecurityContext>,
     entries: &[serde_json::Value],
     selections: &[FieldSelection],
+    variables: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<serde_json::Value> {
     let effective = effective_selections(selections, UPDATED_ENTITY_TYPE, &ctx.schema);
     let mut result = Vec::with_capacity(entries.len());
@@ -528,6 +546,7 @@ fn build_updated_entities<A: DatabaseAdapter>(
                         &sel.nested_fields,
                         &entity_blob,
                         &mut projected,
+                        variables,
                     )?;
                     item.insert(sel.response_key().to_string(), projected);
                 },
@@ -931,6 +950,11 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
         added.then_some(serde_json::Value::Object(obj))
     };
     let variables = merged_variables.as_ref().or(variables);
+
+    // The same map, in the shape the field authorizer resolves against: a policy
+    // that matches on a gated field's argument must see the value the client sent,
+    // not the `{"$var": …}` reference marker (#903).
+    let authz_variables = crate::runtime::matcher::QueryMatcher::extract_arguments(variables);
 
     let vars_obj = variables.and_then(|v| v.as_object());
 
@@ -1410,6 +1434,7 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
                 cascade.as_ref(),
                 &updated_fields,
                 selections,
+                &authz_variables,
             )?
         },
         MutationOutcome::Success {
@@ -1450,6 +1475,7 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
                 selections,
                 &entity,
                 &mut projected,
+                &authz_variables,
             )?;
 
             // Cascade is opt-in (`cascade = true`, handled by the guarded arm
@@ -1561,6 +1587,7 @@ pub(in super::super) async fn execute_mutation_impl<A: DatabaseAdapter>(
                     selections,
                     &source,
                     &mut result,
+                    &authz_variables,
                 )?;
             }
 

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -465,8 +465,15 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
                     resource: Some(return_type.clone()),
                 });
             }
-            let gated =
-                authz::collect_top_level_gated_fields(&self.ctx.schema, return_type, root_fields)?;
+            // `query_match.arguments` is the request's variables, already merged
+            // with whole-argument inline values — the same map every other
+            // consumer resolves against (#903).
+            let gated = authz::collect_top_level_gated_fields(
+                &self.ctx.schema,
+                return_type,
+                root_fields,
+                &query_match.arguments,
+            )?;
             let pass = authz::FieldAuthzPass {
                 authorizer:        authorizer.as_ref(),
                 principal:         security_context,

--- a/crates/fraiseql-core/src/security/field_authorizer.rs
+++ b/crates/fraiseql-core/src/security/field_authorizer.rs
@@ -30,6 +30,8 @@
 //! [`with_field_authorizer`](crate::runtime::RuntimeConfig::with_field_authorizer),
 //! exactly parallel to [`with_rls_policy`](crate::runtime::RuntimeConfig::with_rls_policy).
 
+use std::collections::HashMap;
+
 use serde_json::Value as JsonValue;
 
 use crate::{
@@ -160,19 +162,32 @@ fn object_type_of(field_type: &FieldType) -> Option<&str> {
 
 /// Build a JSON object of a selection's GraphQL arguments, or `None` if it has none.
 ///
+/// Variable references are substituted against `variables`: an argument written
+/// `mask: $level` is an authorization input only once it carries the value the
+/// client sent. Decoding without resolving handed the policy the reference marker
+/// `{"$var": "level"}`, so a policy matching on the argument never matched and
+/// silently took its default branch — for every client that passes arguments as
+/// variables, which is every generated client (#903).
+///
 /// # Errors
 ///
 /// Returns `FraiseQLError::Internal` if a stored argument is not valid JSON. This
 /// is an authorization input: substituting the raw text for the value it failed to
 /// parse (the previous behaviour) hands the policy something other than what the
 /// client sent, and a policy that matches on an argument then decides on a lie.
-fn field_arguments_json(sel: &FieldSelection) -> Result<Option<JsonValue>> {
+fn field_arguments_json(
+    sel: &FieldSelection,
+    variables: &HashMap<String, JsonValue>,
+) -> Result<Option<JsonValue>> {
     if sel.arguments.is_empty() {
         return Ok(None);
     }
     let mut map = serde_json::Map::with_capacity(sel.arguments.len());
     for arg in &sel.arguments {
-        map.insert(arg.name.clone(), crate::graphql::value_json::decode(&arg.value_json)?);
+        map.insert(
+            arg.name.clone(),
+            crate::graphql::value_json::decode_resolved(&arg.value_json, variables)?,
+        );
     }
     Ok(Some(JsonValue::Object(map)))
 }
@@ -257,6 +272,7 @@ pub(crate) fn collect_top_level_gated_fields(
     schema: &CompiledSchema,
     type_name: &str,
     fields: &[FieldSelection],
+    variables: &HashMap<String, JsonValue>,
 ) -> Result<Vec<GatedField>> {
     let Some(type_def) = schema.find_type(type_name) else {
         return Ok(Vec::new());
@@ -268,7 +284,7 @@ pub(crate) fn collect_top_level_gated_fields(
             Ok(GatedField {
                 field_name: sel.name.clone(),
                 alias:      sel.alias.clone(),
-                arguments:  field_arguments_json(sel)?,
+                arguments:  field_arguments_json(sel, variables)?,
             })
         })
         .collect()

--- a/crates/fraiseql-core/src/security/field_authorizer/tests.rs
+++ b/crates/fraiseql-core/src/security/field_authorizer/tests.rs
@@ -192,8 +192,94 @@ fn gated_field_inside_inline_fragment_is_detected() {
         super::selection_set_selects_gated_field(&schema, "User", &selections),
         "a gated field inside a same-type inline fragment must be detected"
     );
-    let gated = super::collect_top_level_gated_fields(&schema, "User", &selections)
-        .expect("arguments are well-formed");
+    let gated = super::collect_top_level_gated_fields(
+        &schema,
+        "User",
+        &selections,
+        &std::collections::HashMap::new(),
+    )
+    .expect("arguments are well-formed");
     assert_eq!(gated.len(), 1, "the fragment-wrapped gated field must be collected");
     assert_eq!(gated[0].field_name, "ssn");
+}
+
+// ── #903: a policy must see the argument the client sent ──────────────────────
+
+/// A gated field carrying `mask: $level` — the shape every generated client
+/// produces, since clients pass arguments as variables rather than inlining them.
+fn gated_field_with_variable_argument() -> Vec<crate::graphql::FieldSelection> {
+    let mut ssn = field("ssn");
+    ssn.arguments = vec![crate::graphql::GraphQLArgument {
+        name:       "mask".to_string(),
+        value_type: "variable".to_string(),
+        value_json: crate::graphql::value_json::variable_ref("level").to_string(),
+    }];
+    vec![field("id"), ssn]
+}
+
+#[test]
+fn a_gated_field_argument_reaches_the_authorizer_as_its_value() {
+    let schema = schema_with_gated_ssn();
+    let variables = std::collections::HashMap::from([("level".to_string(), json!("full"))]);
+
+    let gated = super::collect_top_level_gated_fields(
+        &schema,
+        "User",
+        &gated_field_with_variable_argument(),
+        &variables,
+    )
+    .expect("arguments are well-formed");
+
+    assert_eq!(gated.len(), 1);
+    assert_eq!(
+        gated[0].arguments.as_ref().expect("the gated field carries one argument"),
+        &json!({"mask": "full"}),
+        "#903: a policy written as `arguments.mask == \"full\"` must compare against the \
+         value the client sent. Delivering the variable reference marker instead makes \
+         every such policy silently take its `otherwise` branch, on data nobody sent"
+    );
+}
+
+#[test]
+fn an_omitted_variable_reaches_the_authorizer_as_null_not_as_a_marker() {
+    let schema = schema_with_gated_ssn();
+    let gated = super::collect_top_level_gated_fields(
+        &schema,
+        "User",
+        &gated_field_with_variable_argument(),
+        &std::collections::HashMap::new(),
+    )
+    .expect("arguments are well-formed");
+
+    assert_eq!(
+        gated[0].arguments.as_ref().unwrap(),
+        &json!({"mask": null}),
+        "an undefined variable is GraphQL null — the marker must never survive into a \
+         policy input, whether or not the variable was supplied"
+    );
+}
+
+#[test]
+fn an_inline_argument_is_unaffected_by_resolution() {
+    let schema = schema_with_gated_ssn();
+    let mut ssn = field("ssn");
+    ssn.arguments = vec![crate::graphql::GraphQLArgument {
+        name:       "mask".to_string(),
+        value_type: "string".to_string(),
+        value_json: json!("full").to_string(),
+    }];
+
+    let gated = super::collect_top_level_gated_fields(
+        &schema,
+        "User",
+        &[field("id"), ssn],
+        &std::collections::HashMap::from([("level".to_string(), json!("ignored"))]),
+    )
+    .expect("arguments are well-formed");
+
+    assert_eq!(
+        gated[0].arguments.as_ref().unwrap(),
+        &json!({"mask": "full"}),
+        "an inline literal must pass through untouched"
+    );
 }

--- a/crates/fraiseql-guard/Cargo.toml
+++ b/crates/fraiseql-guard/Cargo.toml
@@ -1,7 +1,11 @@
 [dependencies]
+# Facade only: lets a refused escape hatch be reported from the single place that
+# decides it (#882), without making this crate unreachable from any leaf crate.
+tracing = "0.1"
 
 [dev-dependencies]
 temp-env = {workspace = true}
+tracing-subscriber = {workspace = true}
 
 [lints]
 workspace = true

--- a/crates/fraiseql-guard/src/deployment.rs
+++ b/crates/fraiseql-guard/src/deployment.rs
@@ -72,11 +72,74 @@ pub const fn declares_production(value: &str) -> bool {
 /// both request the bypass *and* be in a declared development environment.
 /// Returns `false` in production no matter how the variable is set.
 ///
-/// The caller is responsible for logging — a refused bypass must be visible, and
-/// an honoured one must be too.
+/// Prefer [`insecure_bypass`], which reads the variable and logs the outcome.
+/// This entry point is for callers that already have the request as a `bool` and
+/// do their own logging — a refused bypass must be visible, and an honoured one
+/// must be too.
 #[must_use]
 pub fn insecure_bypass_allowed(requested: bool) -> bool {
     requested && !is_production()
+}
+
+/// What happened when an insecure-mode escape hatch was consulted.
+///
+/// Distinguishing "not requested" from "refused" is what lets the refusal be
+/// logged without putting a line in every log stream for the overwhelmingly
+/// common case of a hatch nobody set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassDecision {
+    /// The operator did not request the bypass. Guards engaged, nothing to report.
+    NotRequested,
+    /// The bypass was requested and refused: this is a production deployment.
+    RefusedInProduction,
+    /// The bypass was requested in a declared development environment, and stands.
+    Honoured,
+}
+
+impl BypassDecision {
+    /// Whether the guards this hatch controls should be skipped.
+    #[must_use]
+    pub const fn is_honoured(self) -> bool {
+        matches!(self, Self::Honoured)
+    }
+}
+
+/// Consult an insecure-mode escape hatch, and log what was decided.
+///
+/// `var` is the environment variable that requests the bypass (`1`/`true`,
+/// case-insensitively — see [`env_opt_in`]). The bypass is honoured only in a
+/// declared development environment.
+///
+/// # Why the logging lives here
+///
+/// #882: two of the product's four hatches disabled their SSRF guard on the
+/// environment variable alone, with no production check at all. Routing them
+/// through [`insecure_bypass_allowed`] fixed the policy but left the second half
+/// of the defect — a refused bypass reaching the operator as an unexplained
+/// connection failure, with nothing in the log stream saying the guard is the
+/// reason. A caller can forget to log; it cannot forget to call this.
+#[must_use]
+pub fn insecure_bypass(var: &str) -> BypassDecision {
+    if !env_opt_in(var) {
+        return BypassDecision::NotRequested;
+    }
+    if is_production() {
+        tracing::error!(
+            target: "fraiseql_guard::deployment",
+            "{var} was set in a production environment (FRAISEQL_ENV/FRAISEQL_PROFILE \
+             declares production, or KUBERNETES_SERVICE_HOST is set). The bypass is \
+             REFUSED and the guards remain engaged — it is for local development and \
+             integration testing only. Connections this variable was meant to permit \
+             will be rejected."
+        );
+        return BypassDecision::RefusedInProduction;
+    }
+    tracing::warn!(
+        target: "fraiseql_guard::deployment",
+        "{var} is set — the guards it controls are BYPASSED. This must never be set \
+         in production."
+    );
+    BypassDecision::Honoured
 }
 
 /// Parses an environment variable's value as a boolean opt-in.

--- a/crates/fraiseql-guard/src/deployment/tests.rs
+++ b/crates/fraiseql-guard/src/deployment/tests.rs
@@ -6,7 +6,8 @@
 //! assertions the whole workspace now shares.
 
 use super::{
-    declares_development, declares_production, env_opt_in, insecure_bypass_allowed, is_production,
+    BypassDecision, declares_development, declares_production, env_opt_in, insecure_bypass,
+    insecure_bypass_allowed, is_production,
 };
 
 /// Every variable this module reads, cleared, then overlaid with `overrides`.
@@ -117,5 +118,178 @@ fn the_two_declaration_predicates_are_disjoint() {
     }
     for value in ["production", "prod"] {
         assert!(declares_production(value) && !declares_development(value));
+    }
+}
+
+// ── #882: an escape hatch that is refused must say so ─────────────────────────
+
+/// Posture markers cleared, then the bypass requested, so `insecure_bypass`
+/// decides on the posture the test sets and nothing else.
+fn with_posture<T>(env: Option<&str>, f: impl FnOnce() -> T + std::panic::UnwindSafe) -> T {
+    let mut out = None;
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_TEST_HATCH", Some("1")),
+            ("FRAISEQL_ENV", env),
+            ("FRAISEQL_PROFILE", None),
+            ("KUBERNETES_SERVICE_HOST", None),
+        ],
+        || out = Some(f()),
+    );
+    out.expect("temp_env ran the closure")
+}
+
+#[test]
+fn a_requested_bypass_is_honoured_only_in_a_declared_development_environment() {
+    assert_eq!(
+        with_posture(Some("development"), || insecure_bypass("FRAISEQL_TEST_HATCH")),
+        BypassDecision::Honoured
+    );
+    assert_eq!(
+        with_posture(Some("production"), || insecure_bypass("FRAISEQL_TEST_HATCH")),
+        BypassDecision::RefusedInProduction,
+        "#882: a bypass honoured in production is not a bypass, it is a vulnerability"
+    );
+    assert_eq!(
+        with_posture(None, || insecure_bypass("FRAISEQL_TEST_HATCH")),
+        BypassDecision::RefusedInProduction,
+        "unset FRAISEQL_ENV is production — the hatch must not be honoured by default"
+    );
+}
+
+#[test]
+fn an_unrequested_bypass_is_not_reported_as_refused() {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_TEST_HATCH", None::<&str>),
+            ("FRAISEQL_ENV", Some("production")),
+        ],
+        || {
+            assert_eq!(
+                insecure_bypass("FRAISEQL_TEST_HATCH"),
+                BypassDecision::NotRequested,
+                "nothing was requested, so there is nothing to warn an operator about"
+            );
+        },
+    );
+}
+
+#[test]
+fn a_refused_bypass_is_logged_at_error_naming_the_variable() {
+    let events = capture::install();
+    with_posture(Some("production"), || {
+        assert!(!insecure_bypass("FRAISEQL_TEST_HATCH").is_honoured());
+    });
+    let logged = events.take();
+    assert!(
+        logged
+            .iter()
+            .any(|(level, msg)| *level == tracing::Level::ERROR
+                && msg.contains("FRAISEQL_TEST_HATCH")),
+        "#882: a refused bypass must be visible in the log stream — otherwise it \
+         reaches the operator as an unexplained connection failure. Captured: {logged:?}"
+    );
+}
+
+#[test]
+fn an_honoured_bypass_is_logged_at_warn_naming_the_variable() {
+    let events = capture::install();
+    with_posture(Some("development"), || {
+        assert!(insecure_bypass("FRAISEQL_TEST_HATCH").is_honoured());
+    });
+    let logged = events.take();
+    assert!(
+        logged
+            .iter()
+            .any(|(level, msg)| *level == tracing::Level::WARN
+                && msg.contains("FRAISEQL_TEST_HATCH")),
+        "an active bypass must be visible too — guards are off. Captured: {logged:?}"
+    );
+}
+
+#[test]
+fn an_unrequested_bypass_logs_nothing() {
+    let events = capture::install();
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_TEST_HATCH", None::<&str>),
+            ("FRAISEQL_ENV", Some("production")),
+        ],
+        || {
+            let _ = insecure_bypass("FRAISEQL_TEST_HATCH");
+        },
+    );
+    assert!(
+        events.take().is_empty(),
+        "the overwhelmingly common case must not add a line to every log stream"
+    );
+}
+
+/// Captures `tracing` events emitted on the current thread.
+///
+/// Scoped to the calling thread (`set_default`, not `set_global_default`) so the
+/// log-assertion tests do not observe each other's events under the default
+/// parallel test harness.
+mod capture {
+    use std::sync::{Arc, Mutex};
+
+    use tracing::{Level, Subscriber, subscriber::DefaultGuard};
+    use tracing_subscriber::{Layer, Registry, layer::Context, prelude::*};
+
+    type Events = Arc<Mutex<Vec<(Level, String)>>>;
+
+    /// Holds the captured events and keeps the subscriber installed until dropped.
+    pub struct Captured {
+        events: Events,
+        _guard: DefaultGuard,
+    }
+
+    impl Captured {
+        /// Every event recorded so far, as `(level, rendered message)`.
+        pub fn take(&self) -> Vec<(Level, String)> {
+            self.events.lock().expect("capture mutex").clone()
+        }
+    }
+
+    struct CapturingLayer {
+        events: Events,
+    }
+
+    impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer<S>
+        for CapturingLayer
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            struct MessageVisitor<'a>(&'a mut String);
+            impl tracing::field::Visit for MessageVisitor<'_> {
+                fn record_debug(
+                    &mut self,
+                    field: &tracing::field::Field,
+                    value: &dyn std::fmt::Debug,
+                ) {
+                    if field.name() == "message" {
+                        use std::fmt::Write as _;
+                        let _ = write!(self.0, "{value:?}");
+                    }
+                }
+            }
+            let mut message = String::new();
+            event.record(&mut MessageVisitor(&mut message));
+            self.events
+                .lock()
+                .expect("capture mutex")
+                .push((*event.metadata().level(), message));
+        }
+    }
+
+    /// Install a thread-local capturing subscriber for the rest of the test.
+    pub fn install() -> Captured {
+        let events: Events = Arc::default();
+        let guard = tracing::subscriber::set_default(Registry::default().with(CapturingLayer {
+            events: Arc::clone(&events),
+        }));
+        Captured {
+            events,
+            _guard: guard,
+        }
     }
 }

--- a/crates/fraiseql-guard/src/lib.rs
+++ b/crates/fraiseql-guard/src/lib.rs
@@ -19,9 +19,11 @@
 //! collectively exploitable: a bypass refused by one crate was honoured by its
 //! neighbour.
 //!
-//! This crate depends on `std` only, so it sits at the bottom of the dependency
-//! graph and every crate can reach it. Nothing here may grow a dependency that
-//! would make it unreachable from a leaf crate.
+//! This crate sits at the bottom of the dependency graph so every crate can
+//! reach it: `std`, plus the `tracing` facade, which every leaf crate in the
+//! workspace already depends on and which is what lets a refused escape hatch be
+//! reported from the one place that decides it (#882). Nothing here may grow a
+//! dependency that would make it unreachable from a leaf crate.
 
 #![forbid(unsafe_code)]
 

--- a/crates/fraiseql-secrets/src/secrets_manager/backends/vault/tests.rs
+++ b/crates/fraiseql-secrets/src/secrets_manager/backends/vault/tests.rs
@@ -814,3 +814,55 @@ fn allowlist_admits_exact_hosts_case_insensitively() {
         "no suffix/wildcard matching — exact hosts only"
     );
 }
+
+// ── #882: the escape hatch is refused in production, at this call site ────────
+
+/// Request the bypass, then set the posture. The corpus tests above clear the
+/// bypass so the guard is exercised; these set it, so the *hatch* is exercised.
+fn with_bypass_requested<T>(
+    env: Option<&str>,
+    f: impl FnOnce() -> T + std::panic::UnwindSafe,
+) -> T {
+    let mut out = None;
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_VAULT_ALLOW_INSECURE", Some("1")),
+            ("FRAISEQL_ENV", env),
+            ("FRAISEQL_PROFILE", None),
+            ("KUBERNETES_SERVICE_HOST", None),
+            ("FRAISEQL_VAULT_ALLOWED_HOSTS", None),
+        ],
+        || out = Some(f()),
+    );
+    out.expect("temp_env ran the closure")
+}
+
+/// The address the bypass used to expose: `validate_vault_addr` returned `Ok`
+/// on the env var alone, under every environment including an explicit
+/// `FRAISEQL_ENV=production`.
+const METADATA_SERVICE: &str = "http://169.254.169.254:8200";
+
+#[test]
+fn vault_allow_insecure_is_refused_under_production_posture() {
+    assert!(
+        with_bypass_requested(Some("production"), || validate_vault_addr(METADATA_SERVICE))
+            .is_err(),
+        "#882: FRAISEQL_VAULT_ALLOW_INSECURE must not disable the SSRF guard in \
+         production — a stray .env line or Dockerfile ENV must not open the \
+         instance-metadata service"
+    );
+    assert!(
+        with_bypass_requested(None, || validate_vault_addr(METADATA_SERVICE)).is_err(),
+        "unset FRAISEQL_ENV is production: the hatch must not be honoured by default"
+    );
+}
+
+#[test]
+fn vault_allow_insecure_is_still_honoured_in_a_declared_development_environment() {
+    assert!(
+        with_bypass_requested(Some("development"), || validate_vault_addr(METADATA_SERVICE))
+            .is_ok(),
+        "the hatch must keep working where it is meant to — otherwise the test \
+         above would pass with the hatch simply deleted"
+    );
+}

--- a/crates/fraiseql-secrets/src/secrets_manager/backends/vault/validation.rs
+++ b/crates/fraiseql-secrets/src/secrets_manager/backends/vault/validation.rs
@@ -46,10 +46,10 @@ pub(super) fn validate_vault_addr(addr: &str) -> Result<(), SecretsError> {
     // development and integration testing. It is honoured only in a declared
     // development environment: this used to return `Ok(())` on the env var alone,
     // with no production check of any kind, so a stray `.env` line disabled the
-    // guard on a Vault address in production.
-    if fraiseql_guard::deployment::insecure_bypass_allowed(fraiseql_guard::deployment::env_opt_in(
-        VAULT_ALLOW_INSECURE_ENV,
-    )) {
+    // guard on a Vault address in production. `insecure_bypass` also reports the
+    // decision, so a refusal reaches the operator as a log line rather than as an
+    // unexplained connection failure (#882).
+    if fraiseql_guard::deployment::insecure_bypass(VAULT_ALLOW_INSECURE_ENV).is_honoured() {
         return Ok(());
     }
 

--- a/crates/fraiseql-server/src/middleware/hs256_auth.rs
+++ b/crates/fraiseql-server/src/middleware/hs256_auth.rs
@@ -24,16 +24,37 @@ use super::oidc_auth::AuthUser;
 #[derive(Clone)]
 pub struct Hs256AuthState {
     /// The local JWT validator configured with an HS256 signing key.
-    pub validator: Arc<AuthMiddleware>,
+    pub validator:        Arc<AuthMiddleware>,
     /// Realm advertised in `WWW-Authenticate` challenges.
-    pub realm:     String,
+    pub realm:            String,
+    /// Service-account authenticator, when `[security.service_accounts]` declares any.
+    ///
+    /// Consulted only to decide whether a **bearer-less** request may proceed to the
+    /// handler, which is where the principal is actually resolved (ADR-0018). This
+    /// layer never builds a `SecurityContext` from it — it decides pass or refuse.
+    pub service_accounts: Option<Arc<crate::service_account::ServiceAccountAuthenticator>>,
 }
 
 impl Hs256AuthState {
     /// Create new HS256 auth state.
     #[must_use]
     pub const fn new(validator: Arc<AuthMiddleware>, realm: String) -> Self {
-        Self { validator, realm }
+        Self {
+            validator,
+            realm,
+            service_accounts: None,
+        }
+    }
+
+    /// Attach the service-account authenticator so bearer-less service-account
+    /// requests reach the handler's seam instead of being refused here (#934).
+    #[must_use]
+    pub fn with_service_accounts(
+        mut self,
+        authenticator: Option<Arc<crate::service_account::ServiceAccountAuthenticator>>,
+    ) -> Self {
+        self.service_accounts = authenticator;
+        self
     }
 }
 
@@ -54,6 +75,34 @@ pub async fn hs256_auth_middleware(
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .map(ToOwned::to_owned);
+
+    // #934: a service account presents its secret on `x-api-key` and carries NO
+    // bearer, because the seam that resolves it lives in the GraphQL handler
+    // (ADR-0018). This layer is a `route_layer`, so it ran first and refused the
+    // request before that seam was reached — service accounts worked under `[auth]`
+    // and were unreachable under `[auth_hs256]`.
+    //
+    // The deferral is deliberately narrower than the OIDC layer's pass-through: it
+    // applies only when there is no `Authorization` header AND the secret presented
+    // resolves to a declared account. A bearer that is present but invalid still
+    // 401s here, and a request with no credentials at all still 401s here — so this
+    // cannot become an anonymous door into an authenticated transport. The handler
+    // re-resolves the same secret to build the principal; this layer only decides
+    // whether the request may reach it.
+    if auth_header.is_none() {
+        if let Some(ref sa) = auth_state.service_accounts {
+            if matches!(
+                sa.resolve(request.headers(), false),
+                crate::service_account::SaAuth::Authenticated(_)
+            ) {
+                tracing::debug!(
+                    "bearer-less request carries a valid service-account secret — deferring \
+                     to the handler's ADR-0018 seam"
+                );
+                return next.run(request).await;
+            }
+        }
+    }
 
     let auth_req = AuthRequest::new(auth_header);
 

--- a/crates/fraiseql-server/src/server/routing/mod.rs
+++ b/crates/fraiseql-server/src/server/routing/mod.rs
@@ -92,7 +92,10 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                 .as_ref()
                 .and_then(|h| h.issuer.clone())
                 .unwrap_or_else(|| "fraiseql".to_string());
-            let auth_state = Hs256AuthState::new(Arc::clone(validator), realm);
+            // #934: without the authenticator, this layer refuses a bearer-less
+            // service-account request before the handler's ADR-0018 seam runs.
+            let auth_state = Hs256AuthState::new(Arc::clone(validator), realm)
+                .with_service_accounts(self.service_account_authenticator.clone());
             return router.route_layer(from_fn_with_state(auth_state, hs256_auth_middleware));
         }
 

--- a/crates/fraiseql-server/src/server/tests.rs
+++ b/crates/fraiseql-server/src/server/tests.rs
@@ -897,6 +897,96 @@ mod rate_limit_boot_guard_tests {
             .unwrap();
         assert_eq!(limiter.config().rps_per_ip, 250);
     }
+
+    // ── #898: a configured Redis backend must not silently become per-process ──
+    //
+    // `redis_url` exists only because per-process budgets are wrong for a
+    // multi-replica deployment. Falling back to in-memory on a connection failure
+    // makes N replicas enforce N times the configured rate, with an `error!` line
+    // at boot as the only evidence. These pin the refusal at the seam the server
+    // constructors actually call.
+    //
+    // Deliberately not gated on `redis-rate-limiting`: with the feature the
+    // connection to a closed port fails, without it the URL names a backend the
+    // binary cannot run. Both are "the operator asked for a shared budget and
+    // would not get one", both must refuse, and an ungated test runs in every leg
+    // rather than only the all-features one.
+
+    /// Well-formed URL, nothing listening — the deploy-window Redis outage from
+    /// the issue, and the k8s pod-ordering race from #777.
+    fn schema_with_redis_rate_limiting() -> CompiledSchema {
+        schema_with_rate_limiting(json!({
+            "enabled": true,
+            "requests_per_second": 100,
+            "burst_size": 50,
+            "redis_url": "redis://127.0.0.1:6391",
+        }))
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_redis_rate_limiter_refuses_to_boot_in_production() {
+        let err = resolve_rate_limiter_in(
+            &schema_with_redis_rate_limiting(),
+            &ServerConfig::default(),
+            PRODUCTION,
+        )
+        .await
+        .err()
+        .expect(
+            "#898: a configured-but-unavailable rate-limit Redis must refuse to boot — \
+             downgrading to in-memory enforces N times the configured rate across N \
+             replicas while every startup log reads healthy",
+        );
+        assert!(
+            err.to_string().contains("security.rate_limiting"),
+            "the refusal must name the config section so the operator can act on it; got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_redis_rate_limiter_downgrades_only_in_development() {
+        let limiter = resolve_rate_limiter_in(
+            &schema_with_redis_rate_limiting(),
+            &ServerConfig::default(),
+            DEVELOPMENT,
+        )
+        .await
+        .expect("a declared development environment still boots, on the in-memory fallback")
+        .expect("rate limiting is enabled");
+        assert!(
+            !limiter.is_distributed(),
+            "the development fallback is the per-process limiter — which is exactly why \
+             the production path above must refuse instead"
+        );
+    }
+
+    /// The downgrade and the `FRAISEQL_REQUIRE_REDIS` gate meet here: an operator
+    /// who asserted "all shared state is distributed" must not get a development
+    /// downgrade silently, either. Composed through the pure decision fn so no
+    /// test mutates the real env var (the parallel runner would race it).
+    #[tokio::test]
+    async fn a_downgraded_limiter_violates_the_require_redis_assertion() {
+        let limiter = resolve_rate_limiter_in(
+            &schema_with_redis_rate_limiting(),
+            &ServerConfig::default(),
+            DEVELOPMENT,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let violations = crate::server::initialization::SharedStateBackends {
+            pkce_in_memory:         false,
+            rate_limiter_in_memory: !limiter.is_distributed(),
+            revocation_in_memory:   false,
+        }
+        .per_process_subsystems();
+        assert!(
+            violations.iter().any(|s| s.contains("rate_limiting")),
+            "a limiter that fell back to per-process must be named by the \
+             FRAISEQL_REQUIRE_REDIS gate; got {violations:?}"
+        );
+    }
 }
 
 /// #770/#777 class — a configured Redis backend that cannot be provided must refuse

--- a/crates/fraiseql-server/tests/hs256_service_account_e2e_pg.rs
+++ b/crates/fraiseql-server/tests/hs256_service_account_e2e_pg.rs
@@ -1,0 +1,152 @@
+//! #934: a service account must be able to authenticate under `[auth_hs256]`.
+//!
+//! The service-account seam (ADR-0018) resolves an `x-api-key` secret **inside the
+//! GraphQL handler**. A service-account request carries that header and no
+//! `Authorization` bearer. The HS256 middleware is attached as a `route_layer`, so
+//! it runs first — and it returned 401 for any request without a valid bearer,
+//! before the handler's seam was ever reached. Net: service accounts worked under
+//! `[auth]` (OIDC) and were unreachable under `[auth_hs256]`.
+//!
+//! The fix must not weaken the layer, so this suite pins all four corners at once:
+//! the deferral, and the three refusals that must survive it.
+//!
+//! Driven through `Server::serve_on_listener` over a real socket — the mount the
+//! binary actually serves, not a hand-assembled router. A request that gets past
+//! the auth layer answers with a GraphQL error, never 401; that status is the whole
+//! assertion, so the query body deliberately need not resolve.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: server` suite.
+//!
+//! **Execution engine:** `PostgreSQL` · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** binds an ephemeral port and sets a process-global env var for
+//! the secrets → run `--test-threads=1`.
+#![allow(clippy::unwrap_used, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use std::sync::Arc;
+
+use fraiseql_core::{db::postgres::PostgresAdapter, schema::CompiledSchema};
+use fraiseql_server::{Server, server_config::ServerConfig};
+use fraiseql_test_support::try_database_url;
+use serde_json::json;
+
+/// Env var naming the service account's secret, and the secret itself.
+const SA_SECRET_ENV: &str = "FRAISEQL_TEST_P04_SA_SECRET";
+const SA_SECRET: &str = "p04-service-account-secret";
+/// Env var naming the HS256 signing key.
+const HS256_SECRET_ENV: &str = "FRAISEQL_TEST_P04_HS256_SECRET";
+const HS256_SECRET: &str = "p04-hs256-signing-key-at-least-32-bytes";
+
+fn schema() -> CompiledSchema {
+    serde_json::from_value(json!({
+        "version": "2.0.0",
+        "types": [],
+        "queries": [],
+        "mutations": [],
+        "security": {
+            "service_accounts": {
+                "reconciler": {
+                    "secret_env": SA_SECRET_ENV,
+                    "roles": ["ledger:read"],
+                    "scopes": [],
+                    "static_enriched": { "user_id": "svc-reconciler" }
+                }
+            }
+        },
+    }))
+    .expect("compiled schema")
+}
+
+/// Boot the real mount and return its base URL plus a shutdown handle.
+async fn serve(url: &str) -> (String, tokio::sync::oneshot::Sender<()>) {
+    let config = ServerConfig {
+        // #874: production validate() refuses cors_enabled = true with no origins.
+        cors_enabled: false,
+        database_url: url.to_string(),
+        auth_hs256: Some(fraiseql_server::server_config::Hs256Config {
+            secret_env: HS256_SECRET_ENV.to_string(),
+            issuer:     Some("fraiseql-test".to_string()),
+            audience:   Some("fraiseql-test-api".to_string()),
+        }),
+        ..ServerConfig::default()
+    };
+    let adapter = Arc::new(PostgresAdapter::new(url).await.expect("PostgresAdapter::new"));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("local addr").port();
+
+    let server = Box::pin(Server::new(config, schema(), adapter, None))
+        .await
+        .expect("Server::new with [auth_hs256] and a declared service account");
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        server
+            .serve_on_listener(listener, async {
+                let _ = rx.await;
+            })
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    (format!("http://127.0.0.1:{port}"), tx)
+}
+
+/// POST a trivial GraphQL document with the given headers, returning the status.
+async fn post_status(base: &str, headers: &[(&str, &str)]) -> u16 {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(format!("{base}/graphql"))
+        .json(&json!({ "query": "{ __typename }" }));
+    for (name, value) in headers {
+        req = req.header(*name, *value);
+    }
+    req.send().await.expect("request").status().as_u16()
+}
+
+#[tokio::test]
+async fn service_accounts_are_reachable_under_hs256() {
+    let Some(url) = try_database_url() else {
+        eprintln!("skipping #934 HS256 service-account e2e: DATABASE_URL not set");
+        return;
+    };
+    // Fixed valid values, set unconditionally: safe under the runner because this
+    // suite is the only reader of these two names, and both are read at boot.
+    std::env::set_var(SA_SECRET_ENV, SA_SECRET);
+    std::env::set_var(HS256_SECRET_ENV, HS256_SECRET);
+
+    let (base, shutdown) = serve(&url).await;
+
+    // 1. The defect: x-api-key alone, no bearer — the documented service-account request shape.
+    //    Must reach the handler's seam and authenticate.
+    assert_ne!(
+        post_status(&base, &[("x-api-key", SA_SECRET)]).await,
+        401,
+        "#934: a service account presenting its secret on x-api-key with no bearer must \
+         authenticate under [auth_hs256], as it already does under [auth]. The HS256 \
+         middleware ran first and 401'd before the handler's ADR-0018 seam was reached"
+    );
+
+    // 2. No credentials at all must still be refused — the deferral must not become an anonymous
+    //    door into an authenticated transport.
+    assert_eq!(
+        post_status(&base, &[]).await,
+        401,
+        "a request with neither a bearer nor a service-account secret must still be refused"
+    );
+
+    // 3. An *invalid* bearer must still be refused at the layer. Only bearer-absent defers; a bad
+    //    token is a bad token.
+    assert_eq!(
+        post_status(&base, &[("authorization", "Bearer not-a-valid-jwt")]).await,
+        401,
+        "an invalid bearer must still 401 — the deferral applies to absence, not to failure"
+    );
+
+    // 4. An unmatched secret is not a free pass into the handler.
+    assert_eq!(
+        post_status(&base, &[("x-api-key", "wrong-secret")]).await,
+        401,
+        "a service-account secret that matches no account must be refused, not treated as \
+         an anonymous request"
+    );
+
+    let _ = shutdown.send(());
+}

--- a/crates/fraiseql-wire/Cargo.toml
+++ b/crates/fraiseql-wire/Cargo.toml
@@ -67,6 +67,8 @@ metrics-exporter-prometheus = "0.18"
 # local-testcontainers spawn). Dagger provides the Postgres service in CI.
 fraiseql-test-support = {path = "../fraiseql-test-support"}
 proptest = {workspace = true}
+# CA-file fixtures for the #887 load_custom_ca tests.
+tempfile = {workspace = true}
 tokio-postgres = "0.7"
 tokio-test = "0.4"
 

--- a/crates/fraiseql-wire/src/connection/tls/mod.rs
+++ b/crates/fraiseql-wire/src/connection/tls/mod.rs
@@ -203,11 +203,18 @@ impl TlsConfigBuilder {
                     let _ = store.add_parsable_certificates(std::iter::once(cert));
                 }
 
-                // Log warnings if there were errors, but don't fail
-                if !result.errors.is_empty() && store.is_empty() {
-                    return Err(WireError::Config(
-                        "Failed to load any system root certificates".to_string(),
-                    ));
+                // An empty store trusts nothing, so every subsequent connection
+                // fails certificate verification. That is the condition that
+                // matters — whether the loader also reported errors is beside the
+                // point, and gating on it let an error-free load that added
+                // nothing through (#887).
+                if store.is_empty() {
+                    return Err(WireError::Config(format!(
+                        "Failed to load any system root certificates ({} loader error(s)); \
+                         no server certificate could be verified. Set a CA file explicitly \
+                         if this host has no system trust store.",
+                        result.errors.len()
+                    )));
                 }
 
                 store
@@ -245,8 +252,15 @@ impl TlsConfigBuilder {
         loop {
             match rustls_pemfile::read_one(&mut reader) {
                 Ok(Some(Item::X509Certificate(cert))) => {
-                    let _ = root_store.add_parsable_certificates(std::iter::once(cert));
-                    found_certs += 1;
+                    // Count what rustls ACCEPTED, not what the PEM reader yielded
+                    // (#887). The reader only base64-decodes the armour; whether the
+                    // DER is a usable certificate is decided here. Counting items
+                    // read made `found_certs > 0` answer "did the file contain
+                    // something shaped like a certificate" instead of "does the
+                    // trust store now trust anything".
+                    let (added, _ignored) =
+                        root_store.add_parsable_certificates(std::iter::once(cert));
+                    found_certs += added;
                 }
                 Ok(Some(_)) => {
                     // Skip non-certificate items (private keys, etc.)

--- a/crates/fraiseql-wire/src/connection/tls/tests.rs
+++ b/crates/fraiseql-wire/src/connection/tls/tests.rs
@@ -101,3 +101,103 @@ fn test_normal_tls_config_works() {
 
     assert!(!config.danger_accept_invalid_certs());
 }
+
+// ── #887: load_custom_ca must report what it actually loaded ──────────────────
+//
+// `found_certs` counted PEM *items read*, not certificates rustls *accepted*, so a
+// CA file whose certificates are all rejected returned `Ok` with an empty trust
+// store. Not a bypass — an empty store rejects every server certificate — but the
+// operator then debugs an opaque verification failure attributed to the server,
+// while the actual fault is the CA file they configured. Fabricated success:
+// a function reporting work it did not do.
+//
+// This replaces the empty `test_tls_config_builder_with_custom_ca` body that
+// #895 deleted.
+
+/// Valid PEM armour around bytes that are not a parsable certificate.
+///
+/// `rustls_pemfile` yields this as `Item::X509Certificate` — it only base64-decodes
+/// the body — and `add_parsable_certificates` then rejects the DER. That gap is
+/// exactly where the miscount lived.
+const UNPARSABLE_DER_IN_VALID_PEM: &str = "-----BEGIN CERTIFICATE-----\n\
+     bm90IGEgY2VydGlmaWNhdGUsIGp1c3Qgc29tZSBieXRlcyB3aXRoIHZhbGlkIFBF\n\
+     TSBhcm1vdXIgYXJvdW5kIHRoZW0u\n\
+     -----END CERTIFICATE-----\n";
+
+fn ca_file(contents: &str) -> tempfile::NamedTempFile {
+    use std::io::Write as _;
+    let mut f = tempfile::NamedTempFile::new().expect("temp file");
+    f.write_all(contents.as_bytes()).expect("write CA fixture");
+    f.flush().expect("flush CA fixture");
+    f
+}
+
+#[test]
+fn a_ca_file_whose_certificates_are_all_rejected_is_an_error() {
+    install_crypto_provider();
+    let file = ca_file(UNPARSABLE_DER_IN_VALID_PEM);
+    let path = file.path().to_string_lossy().to_string();
+
+    let err = TlsConfig::builder().ca_cert_path(&path).build().expect_err(
+        "#887: every certificate in the file was rejected, so the trust store is empty \
+             and nothing is trusted — load_custom_ca must not report success",
+    );
+
+    assert!(
+        err.to_string().contains(&path),
+        "the error must name the CA file so the operator debugs their configuration rather \
+         than the server's certificate; got: {err}"
+    );
+}
+
+#[test]
+fn a_ca_file_with_no_certificate_items_is_an_error() {
+    install_crypto_provider();
+    let file = ca_file("-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n");
+    let path = file.path().to_string_lossy().to_string();
+
+    let err = TlsConfig::builder()
+        .ca_cert_path(&path)
+        .build()
+        .expect_err("a file with no certificate in it cannot establish trust");
+    assert!(
+        err.to_string().contains(&path),
+        "the error must name the CA file; got: {err}"
+    );
+}
+
+/// A real, parsable self-signed CA. The counterweight that keeps the two tests
+/// above honest: without it they would also pass if `load_custom_ca` had simply
+/// been changed to reject everything.
+const USABLE_CA: &str = "-----BEGIN CERTIFICATE-----
+MIIDGTCCAgGgAwIBAgIUDrN/jDVUI95u8it2un64FpFHc2UwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQRnJhaXNlUUwgVGVzdCBDQTAgFw0yNjA4MDYyMDEwMDZa
+GA8yMTI2MDcxMzIwMTAwNlowGzEZMBcGA1UEAwwQRnJhaXNlUUwgVGVzdCBDQTCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKiSb6y6/Yg3eQFQakQCZpRD
+7fbm8sK+cSQT73bB7O2dNnBm7zrN5qvGg9CvyPFaKMQOLVx956rtEHlgP1wjdz8C
+f4jdG7VrM22JEMshHak46LAMFDpCBK6eWf7QMpy0G9yG/0xek5LgBWlO8vVwmHmR
+ILjG5Ae/q6nJm7f0BBrSjmrvhy22MHYDqdijKRMA7VQSkKPZ1/mX9gHqgSpmtlMa
+JGRo6J+MJNX+ibTfz6wVdp0ulerNUCl7xfNXfcj61RQsVOCs4oUbbW9ExO1ZcKn/
+Mm/ipXFgUCT60sON1E+ie4Xnqt6gdOJmQU0qMU74ZT5Q566QOlYub3HKWuhGZsUC
+AwEAAaNTMFEwHQYDVR0OBBYEFDtPIOLuwXtMpyTYXtjpJKs6/OXGMB8GA1UdIwQY
+MBaAFDtPIOLuwXtMpyTYXtjpJKs6/OXGMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI
+hvcNAQELBQADggEBAE526DVZnjV0aNH38Sjq14hfNG/yJ66phLuYWE3ZDJ6Q4nPi
+k7mrAcy+xK45vioU0KMsZEWP3aCEQB46jheSgAQMMS/kEbUuAdNLwheb+XoRGGqY
+me/7ndvCXOWD+8zZIHPrJ2xr/iLvagWQyU+m3N9Z8i7eAaSFbhe4Y7n2y8wwWO15
+QqzB1cDe+JlFTiRYDrn6SZ0CYsXV8DJu0PZxH+vO7mbL1qKyu5+EFu0SAUnrziOs
+U9sod4SSOJlvyGK1rw1HVjoIrH8c6hXe49EZ1f7w4fMP6/lsgiHGSA6QlsAPzNFj
+Kvuc+jiufKtrxRCMGB+jj+fauwzws1mII2skvRU=
+-----END CERTIFICATE-----
+";
+
+#[test]
+fn a_ca_file_with_a_usable_certificate_loads() {
+    install_crypto_provider();
+    let file = ca_file(USABLE_CA);
+    let path = file.path().to_string_lossy().to_string();
+
+    TlsConfig::builder()
+        .ca_cert_path(&path)
+        .build()
+        .expect("a CA file rustls can parse must load");
+}

--- a/tools/check-guard-parity.sh
+++ b/tools/check-guard-parity.sh
@@ -138,8 +138,51 @@ if [ -n "$bypass_matches" ]; then
   echo "ERROR: insecure-mode escape hatch read without a production gate:" >&2
   echo "$bypass_matches" >&2
   echo "" >&2
-  echo "  Use fraiseql_guard::deployment::insecure_bypass_allowed(env_opt_in(VAR))." >&2
+  echo "  Use fraiseql_guard::deployment::insecure_bypass(VAR)." >&2
   echo "  A bypass honoured in production is not a bypass, it is a vulnerability." >&2
+  found=1
+fi
+
+# ---------------------------------------------------------------------------
+# 3b. The same, for hatches named by a constant rather than a literal.
+#
+# The check above matches `env::var("FRAISEQL_X_ALLOW_INSECURE")`. Both hatches
+# that shipped ungated (#882) spelled it `env_opt_in(VAULT_ALLOW_INSECURE_ENV)`
+# — a named constant — so the literal scan never saw them. #882's own repro is
+# the rule encoded here: a file that consults a hatch and mentions no production
+# check anywhere is the defect. `insecure_bypass` satisfies it (it decides and
+# logs); so does an explicit `is_production` in the same file, which is how the
+# observers guard composes its per-dispatch logging on top of the same policy.
+# ---------------------------------------------------------------------------
+hatch_files=$(
+  scan_source_lines \
+    | grep -E 'env_opt_in\(\s*[A-Za-z_:]*(ALLOW_INSECURE|ALLOW_PLAINTEXT|SKIP_VERIFY|DISABLE_TLS)[A-Z_]*\s*[,)]' \
+    | grep -v "^${GUARD_CRATE}" \
+    | drop_exempt \
+    | grep -v '^$' \
+    | cut -d: -f1 | sort -u || true
+)
+# Comments are stripped before looking for the production check: a doc comment
+# that merely *names* `insecure_bypass` is prose, not a gate. (The async-trait
+# ratchet was fooled exactly this way.)
+ungated_hatch_files=""
+for file in $hatch_files; do
+  if ! awk '
+        /#\[cfg\(test\)\]/ { exit }
+        /^[[:space:]]*(\/\/|\*)/ { next }
+        { print }
+      ' "$file" | grep -qE 'insecure_bypass|is_production'; then
+    ungated_hatch_files="${ungated_hatch_files}${file}"$'\n'
+  fi
+done
+ungated_hatch_files=$(printf '%s' "$ungated_hatch_files" | grep -v '^$' || true)
+if [ -n "$ungated_hatch_files" ]; then
+  echo "ERROR: escape hatch consulted with no production check in the file:" >&2
+  echo "$ungated_hatch_files" >&2
+  echo "" >&2
+  echo "  Use fraiseql_guard::deployment::insecure_bypass(VAR), which applies the" >&2
+  echo "  policy AND reports the decision. #882 shipped twice because the variable" >&2
+  echo "  was read through a named constant and nothing near it asked about prod." >&2
   found=1
 fi
 

--- a/tools/check-suite-coverage.py
+++ b/tools/check-suite-coverage.py
@@ -128,6 +128,16 @@ def parse_cargo_toml(crate_dir: Path) -> dict:
         return tomllib.load(f)
 
 
+def strip_line_comments(src: str) -> str:
+    """Drop `//`, `///` and `//!` comment text, keeping line structure.
+
+    Deliberately naive — it does not understand `//` inside a string literal —
+    because it is only used to count attributes, which cannot appear in a string
+    that matters here. Block comments are left alone for the same reason.
+    """
+    return "\n".join(line.split("//", 1)[0] for line in src.splitlines())
+
+
 def discover_binaries(crate_dir: Path, crate: str, manifest: dict) -> list[TestBinary]:
     tests_dir = crate_dir / "tests"
     if not tests_dir.is_dir():
@@ -144,8 +154,16 @@ def discover_binaries(crate_dir: Path, crate: str, manifest: dict) -> list[TestB
         src = f.read_text(encoding="utf-8", errors="replace")
         # Count the binary's own tests BEFORE appending shared-harness sources:
         # a helper-only file with zero tests is not a suite.
-        b.n_tests = len(re.findall(r"#\[(?:tokio::)?test[\]\(]", src))
-        b.n_ignored = len(re.findall(r"#\[ignore\b", src))
+        #
+        # Counted over the code, not the comments: a module doc that explains the
+        # suite self-skips "(no `#[ignore]`)" is prose, and counting it made a
+        # single-test suite look entirely #[ignore]d — a false ORPHAN. Attributes
+        # never legitimately live in a comment, so stripping them is lossless here.
+        # Service detection below deliberately still scans the raw source: over-
+        # detecting a service need is the fail-closed direction.
+        code = strip_line_comments(src)
+        b.n_tests = len(re.findall(r"#\[(?:tokio::)?test[\]\(]", code))
+        b.n_ignored = len(re.findall(r"#\[ignore\b", code))
         # Shared harness modules can hold the service getter for the binary.
         if re.search(r"^\s*(pub\s+)?mod common\b", src, re.M):
             for cf in sorted((tests_dir / "common").glob("**/*.rs")):


### PR DESCRIPTION
Wave 1 of the open-finding remediation program. Six issues, one self-contained
commit each, closing the remaining known fail-open / fabricated-success paths on
the auth and guard surfaces. Every fix lands with the real-system test that would
have caught it.

## The six

- **#984** `fix(auth)` — a failed single-use DELETE now fails the verification. The
  OTP/MFA consume swallowed the DELETE's error, so a verification whose consume
  never landed still answered success and the code stayed **replayable**.
- **#882** `fix(guard)` — a refused escape hatch says so, and the gate sees hatches
  named by a constant. The production refusal had landed; it never **logged**, and
  `check-guard-parity.sh` matched only `env::var("…LITERAL")` while both hatches
  used a named constant — **the gate would have passed on the defect it cites**.
- **#898** `test(server)` — pins the rate-limiter Redis refusal at the seam the
  constructors call. Both refusal branches in `build_rate_limiter` were untested.
- **#903** `fix(core)` — field-authorization policies see argument values, not
  variable markers. `arguments.mask == "full"` could never match for any client
  that sends arguments as variables, so the policy silently took its `otherwise`
  branch. Reached through **four** call sites: the cascade arms are a separate
  chain from the plain success/error arms.
- **#887** `fix(wire)` — `load_custom_ca` counts certificates rustls accepted, not
  PEM items read. A CA file rustls rejected entirely returned `Ok` with an empty
  `RootCertStore`, and the operator debugged an opaque verification failure
  attributed to the server.
- **#934** `fix(server)` — service accounts reach their seam under `[auth_hs256]`.
  The HS256 `route_layer` 401'd every bearer-less request, so the documented
  `x-api-key` seam was unreachable under HS256.

## ⚠ #934: the issue's own suggested fix opens an anonymous hole

The issue says to mirror "the OIDC middleware's pass-through". Implemented
literally, a request with **no credentials at all** answers **200** —
`authenticate` returns `Ok(None)` and execution proceeds anonymously. OIDC's
pass-through is safe only because it is gated on `is_required()` being false;
under `[auth_hs256]` the layer *is* the requirement. The shipped deferral is
narrower by construction: no `Authorization` header **AND** a secret resolving to
a declared account. The e2e pins all four corners in one test, and the blanket
form fails it on "must still be refused".

## Also

`tools/check-suite-coverage.py` counted `#[ignore]` occurrences inside **comments**,
so a module doc explaining that a suite self-skips "(no `#[ignore]`)" made a
single-test binary look entirely ignored and reported a false ORPHAN. Counts now
run over comment-stripped source; service detection deliberately still scans raw
source, since over-detecting a service need is the fail-closed direction.

## Verification

✅ Acceptance on a `make db-reset` rig: **13610 passed, 0 failed, 175 skipped**
   (`--no-fail-fast`)
✅ `make preflight` exit 0 · doctests exit 0 · MSRV clippy exit 0 · stable
   workspace build exit 0
✅ Every fix **red-proven by reverting it alone** and watching this phase's own
   assertion fail — #934 red-proven twice (the defect, and the hole the issue's
   suggested fix would have opened)
✅ New suites wired into their Dagger legs (`hs256_service_account_e2e_pg` →
   `integration: server`)

Closes #984
Closes #882
Closes #898
Closes #903
Closes #887
Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)
