### PR TITLE
fix(security): P05 — the Flight surface gate (#953 #954 #908 #1001)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -1800,6 +1800,19 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// only leg that runs fraiseql-arrow with a live DATABASE_URL — the test
 		// leg's arrow run has no database and its DB-backed tests self-skip.
 		"cargo test -p fraiseql-arrow --all-features --test insert_sql_pg -- --ignored --test-threads=1",
+		// #953 Flight Upload gate. Two halves, each against the bound Postgres:
+		// the decision half over a real Flight socket (which tables are refused,
+		// and that an adapter with no atomic-write seam refuses even an
+		// allow-listed one), and the write half at the server's adapter (the rows
+		// AND their change-log outbox rows, or neither). The hole these close was
+		// reachable in the shipped binary, so both drive the mounted path.
+		"echo '### #953: Flight Upload gate + Change Spine outbox (against the bound Postgres)'",
+		"cargo test -p fraiseql-arrow --all-features --test flight_upload_gate_pg -- --ignored --test-threads=1",
+		// `--features arrow` deliberately, NOT serverTestFeatures: that set includes
+		// `wire-backend`, under which this suite is `cfg`'d out entirely (the wire
+		// adapter has no atomic-upload seam) and would run zero tests while reading
+		// green — the #940-class trap.
+		"cargo test -p fraiseql-server --features arrow --test flight_upload_outbox_pg -- --ignored --test-threads=1",
 		"echo 'test-integration OK: observers suite passed'",
 	}, "\n")
 

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -1813,6 +1813,17 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// adapter has no atomic-upload seam) and would run zero tests while reading
 		// green — the #940-class trap.
 		"cargo test -p fraiseql-server --features arrow --test flight_upload_outbox_pg -- --ignored --test-threads=1",
+		// #908/#1001: the three DB-backed Flight suites. They self-skipped on a
+		// missing DATABASE_URL and the test leg has none, so all 31 tests read as
+		// passing while running nothing — and two of the three asserted a
+		// hardcoded registry constant even when they did run. Rewritten to drive
+		// real do_get/do_exchange RPCs, marked #[ignore] so a no-database leg
+		// cannot show them green, and named here so they either execute or the
+		// leg fails. Each CREATE DATABASEs its own fixture: --test-threads=1.
+		"echo '### #908/#1001: Flight DoGet e2e + error handling + adapter integration (real RPCs)'",
+		"cargo test -p fraiseql-arrow --all-features --test flight_e2e_test -- --ignored --test-threads=1",
+		"cargo test -p fraiseql-arrow --all-features --test flight_error_handling_test -- --ignored --test-threads=1",
+		"cargo test -p fraiseql-arrow --all-features --test flight_integration -- --ignored --test-threads=1",
 		"echo 'test-integration OK: observers suite passed'",
 	}, "\n")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2275,6 +2275,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Arrow Flight `do_exchange` `Upload` is gated on an operator allow-list, and every
+  allow-listed write reaches the Change Spine (#953).** Any caller holding a valid Flight
+  session token could send `Upload { table, batch }` with an **arbitrary client-supplied
+  table name** and have the rows land: `handle_upload` went from session validation
+  straight to `build_insert_query` and `execute_raw_query`. That path had no table
+  allow-list, no tenant scoping, no RLS, no operation authorizer, no field RBAC, no
+  mutation-audit event and no change-log outbox row — an unauthorized-write surface onto
+  every table the connection role can write, `_system`, audit and outbox tables included.
+  (Escaping was correct throughout, so this was never SQL injection.) It was reachable in
+  the shipped binary: `create_flight_service` passes the live database adapter.
+
+  `Upload` is now **disabled by default** and refused unless its table appears in the new
+  `flight_upload_tables` config key, mirroring the existing `BulkExport` allow-list —
+  which, unlike it, is wired from the config file rather than a library-only setter. An
+  allow-listed Upload writes its rows and one `core.tb_entity_change_log` outbox row per
+  row **in a single transaction**, stamped with the session's tenant, the ingress
+  `transport` and the Flight subject, and emits the `fraiseql::mutation_audit` event the
+  mutation pipeline emits for every other write path.
+
+  ```toml
+  # Empty (the default) leaves Upload disabled.
+  flight_upload_tables = ["ta_measurements", "ta_events"]
+  ```
+
+  The atomic write is a new `ArrowDatabaseAdapter::execute_gated_upload`, whose **default
+  implementation refuses**: an adapter that cannot write the rows and the outbox row
+  together must be unable to serve an Upload, rather than quietly writing rows the Change
+  Spine never sees. Allow-listing a table for an adapter that has not implemented it —
+  the `wire-backend` build, for one — therefore still cannot open the surface.
+
 - **A project-wide `[inject_defaults]` tenant predicate reaches the operations it configures
   (#847).** Python, Go, Java, PHP, C#, Elixir and F# each ship a `ConfigLoader` that parses
   `[inject_defaults]` from `fraiseql.toml` and emits it as a top-level key. No compiler code

--- a/crates/fraiseql-arrow/src/db.rs
+++ b/crates/fraiseql-arrow/src/db.rs
@@ -1,8 +1,7 @@
 //! Database adapter trait for Arrow Flight service.
 //!
-//! This module defines a minimal database adapter interface for executing
-//! raw SQL queries and returning results as JSON. It's designed to be independent
-//! of fraiseql-core to avoid circular dependencies.
+//! This module defines a minimal database adapter interface for the Arrow Flight
+//! layer: raw SQL reads, and the one atomic write path a gated `Upload` needs.
 //!
 //! # Note
 //!
@@ -53,9 +52,13 @@ pub type DatabaseResult<T> = Result<T, DatabaseError>;
 ///
 /// # Why a separate trait?
 ///
-/// `fraiseql-arrow` must not take a compile-time dependency on `fraiseql-core` (to avoid
-/// circular crate dependencies). `ArrowDatabaseAdapter` carries only what the Flight layer
-/// needs; `fraiseql-server` wraps a core adapter to satisfy both traits.
+/// `ArrowDatabaseAdapter` carries only what the Flight layer needs, so a consumer can
+/// back Flight with something that is not a full `fraiseql_db::DatabaseAdapter`;
+/// `fraiseql-server` wraps a core adapter to satisfy both traits.
+///
+/// (This trait's separateness is **not** about avoiding a dependency: `fraiseql-arrow`
+/// does depend on `fraiseql-core`, and the Flight handlers use `SecurityContext`
+/// directly. The module docs said otherwise until #953.)
 ///
 /// # Example
 ///
@@ -99,4 +102,62 @@ pub trait ArrowDatabaseAdapter: Send + Sync {
         &self,
         sql: &str,
     ) -> DatabaseResult<Vec<HashMap<String, serde_json::Value>>>;
+
+    /// Execute one allow-listed Flight `Upload`: the client's rows **and** the
+    /// `core.tb_entity_change_log` outbox rows that record them, in a **single
+    /// transaction** (#953).
+    ///
+    /// # Why this is not `execute_raw_query`
+    ///
+    /// An `Upload` is a client-directed write that never passes through the mutation
+    /// pipeline, so nothing else will write its Change Spine rows. Running the INSERT
+    /// and the outbox write as two statements would let the rows commit while the
+    /// outbox write failed — the split brain the Change Spine exists to prevent, and
+    /// invisible to CDC and every observer downstream.
+    ///
+    /// # The default refuses, deliberately
+    ///
+    /// An adapter that has not implemented this **cannot** serve a gated Upload. The
+    /// tempting default — run the statements one after another — is fail-open: it
+    /// produces exactly the silent split brain above, on every adapter that forgot to
+    /// override it. Refusing means an unimplemented adapter is loudly unable to
+    /// Upload rather than quietly writing unrecorded rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DatabaseError` when the adapter cannot write atomically (the default),
+    /// or when the transaction fails — in which case **nothing** has been written.
+    async fn execute_gated_upload(&self, upload: &GatedUpload<'_>) -> DatabaseResult<u64> {
+        Err(DatabaseError::new(format!(
+            "This database adapter cannot write a Flight Upload and its change-log row \
+             atomically, so the Upload into '{}' is refused. An adapter must implement \
+             ArrowDatabaseAdapter::execute_gated_upload before Upload can be allow-listed \
+             for it.",
+            upload.table
+        )))
+    }
+}
+
+/// One allow-listed Flight `Upload`, ready for the atomic write (#953).
+///
+/// Carries what the outbox row needs beyond the INSERT itself: who is writing, and
+/// under which tenant. The `insert_sql` is already built and escaped by
+/// `build_insert_query`; the adapter's job is to run it and the change-log write in
+/// one transaction, not to re-derive it.
+///
+/// Intentionally **not** `#[non_exhaustive]`: this is the *call shape* of
+/// [`ArrowDatabaseAdapter::execute_gated_upload`], and adding a field is a breaking
+/// trait change regardless. Callers construct it with a struct literal so that
+/// omitting a field — a new piece of provenance an outbox row must carry — is a hard
+/// compile error at every call site rather than a silently defaulted NULL.
+#[derive(Debug)]
+pub struct GatedUpload<'a> {
+    /// Target table — allow-listed by the operator, already verified by the caller.
+    pub table:      &'a str,
+    /// The multi-row `INSERT INTO "<table>" …` to execute.
+    pub insert_sql: &'a str,
+    /// Authenticated Flight session subject, recorded on the outbox row.
+    pub user_id:    &'a str,
+    /// Tenant this write belongs to, or `None` for a single-tenant deployment.
+    pub tenant_id:  Option<&'a str>,
 }

--- a/crates/fraiseql-arrow/src/flight_server/handlers/do_exchange.rs
+++ b/crates/fraiseql-arrow/src/flight_server/handlers/do_exchange.rs
@@ -90,17 +90,76 @@ async fn handle_query(
     }
 }
 
+/// Decide whether `table` may be written by an `Upload`, and **say so** when it may not.
+///
+/// Fail-closed by construction (#953): an absent allow-list disables `Upload`
+/// entirely, and a table not on the list is refused. Deciding and reporting are one
+/// call so a caller cannot take the decision and forget to log it — an operator who
+/// allow-listed nothing must find the reason in the log, not an unexplained write
+/// that never happened.
+///
+/// Returns `Err(message)` with the message to send the client; the same message is
+/// logged at `warn`.
+fn authorize_upload(
+    allowed_tables: Option<&std::collections::HashSet<String>>,
+    user_id: &str,
+    table: &str,
+) -> Result<(), String> {
+    let refusal = match allowed_tables {
+        None => format!(
+            "Upload is disabled, so table '{table}' cannot be written. Allow-list specific \
+             tables with with_upload_tables()."
+        ),
+        Some(allowed) if !allowed.contains(table) => {
+            format!("Upload is not permitted for table '{table}'.")
+        },
+        Some(_) => return Ok(()),
+    };
+    warn!(user_id, table = %table, "Refused Flight Upload: {}", refusal);
+    Err(refusal)
+}
+
+/// What an `Upload` needs from its `do_exchange` session to be authorized and
+/// attributed: the operator's allow-list, and who is writing under which tenant.
+///
+/// Grouped rather than passed positionally so a new piece of provenance is added in
+/// one place and cannot be dropped at the call site.
+struct UploadSession<'a> {
+    /// Operator-configured tables `Upload` may write; `None` disables Upload.
+    allowed_tables: Option<&'a std::collections::HashSet<String>>,
+    /// Tenant the write belongs to, from the session's `SecurityContext`.
+    tenant_id:      Option<&'a str>,
+    /// Authenticated Flight session subject.
+    user_id:        &'a str,
+    /// Correlates the response with the client's request.
+    correlation_id: &'a str,
+}
+
 /// Process an `Upload` exchange request: decode Arrow batch and INSERT into target table.
 #[allow(clippy::cognitive_complexity)] // Reason: multi-step upload protocol with sequential validation and error handling
 async fn handle_upload(
     tx: &Sender<Result<FlightData, Status>>,
     db_adapter: &Option<Arc<dyn crate::db::ArrowDatabaseAdapter>>,
-    user_id: &str,
-    correlation_id: &str,
+    session: &UploadSession<'_>,
     table: String,
     batch: Vec<u8>,
 ) {
+    let UploadSession {
+        allowed_tables,
+        tenant_id,
+        user_id,
+        correlation_id,
+    } = *session;
     info!(user_id, correlation_id, table = %table, "Processing exchange upload");
+
+    // #953: the table is named by the *client* and the rows bypass the mutation
+    // pipeline entirely, so the allow-list is checked before anything else — before
+    // the batch is even decoded. A refused Upload must do no work and leave no trace
+    // beyond the refusal.
+    if let Err(message) = authorize_upload(allowed_tables, user_id, &table) {
+        send_exchange_error(tx, correlation_id, &message).await;
+        return;
+    }
 
     let Some(ref adapter) = db_adapter else {
         warn!("Database adapter not configured");
@@ -126,10 +185,34 @@ async fn handle_upload(
         },
     };
 
-    match adapter.execute_raw_query(&sql).await {
+    // #953: the rows and their change-log outbox rows commit together or not at all.
+    // `execute_raw_query` is deliberately no longer on this path — it cannot express
+    // the transaction, and using it left the Change Spine blind to every Upload.
+    let upload = crate::db::GatedUpload {
+        table: &table,
+        insert_sql: &sql,
+        user_id,
+        tenant_id,
+    };
+    match adapter.execute_gated_upload(&upload).await {
         Ok(_) => {
             let rows_inserted = record_batch.num_rows();
             info!(user_id, table = %table, rows = rows_inserted, "Upload successful");
+            // The mutation-audit event (#953). `runners/mutation` emits this for every
+            // path that goes through the mutation pipeline; an Upload does not, so it
+            // emits its own with the same target and shape — otherwise the one write
+            // surface that skips the authorizer is also the one absent from the audit.
+            tracing::info!(
+                target: "fraiseql::mutation_audit",
+                mutation_name = "flightUpload",
+                entity_type = %table,
+                operation = "INSERT",
+                tenant_id = tenant_id.unwrap_or(""),
+                actor = user_id,
+                transport = "flight",
+                rows = rows_inserted,
+                "mutation.executed"
+            );
             let success_msg = format!("Inserted {} rows", rows_inserted).into_bytes();
             let response = ExchangeMessage::Response {
                 correlation_id: correlation_id.to_string(),
@@ -248,6 +331,7 @@ pub(super) async fn handle(
     let (tx, rx) = tokio::sync::mpsc::channel(100);
 
     let db_adapter = svc.db_adapter.clone();
+    let upload_allowed_tables = svc.upload_allowed_tables.clone();
     let executor = svc.executor.clone();
     let subscription_manager = svc.subscription_manager.clone();
     let user_id = authenticated_user.user_id.0;
@@ -274,8 +358,13 @@ pub(super) async fn handle(
                         .await;
                     },
                     RequestType::Upload { table, batch } => {
-                        handle_upload(&tx, &db_adapter, &user_id, &correlation_id, table, batch)
-                            .await;
+                        let session = UploadSession {
+                            allowed_tables: upload_allowed_tables.as_ref(),
+                            tenant_id:      security_context.tenant_id.as_ref().map(|t| t.0.as_str()),
+                            user_id:        &user_id,
+                            correlation_id: &correlation_id,
+                        };
+                        handle_upload(&tx, &db_adapter, &session, table, batch).await;
                     },
                     RequestType::Subscribe {
                         entity_type,

--- a/crates/fraiseql-arrow/src/flight_server/handlers/do_exchange.rs
+++ b/crates/fraiseql-arrow/src/flight_server/handlers/do_exchange.rs
@@ -360,7 +360,10 @@ pub(super) async fn handle(
                     RequestType::Upload { table, batch } => {
                         let session = UploadSession {
                             allowed_tables: upload_allowed_tables.as_ref(),
-                            tenant_id:      security_context.tenant_id.as_ref().map(|t| t.0.as_str()),
+                            tenant_id:      security_context
+                                .tenant_id
+                                .as_ref()
+                                .map(|t| t.0.as_str()),
                             user_id:        &user_id,
                             correlation_id: &correlation_id,
                         };

--- a/crates/fraiseql-arrow/src/flight_server/mod.rs
+++ b/crates/fraiseql-arrow/src/flight_server/mod.rs
@@ -177,6 +177,18 @@ pub struct FraiseQLFlightService {
     /// `with_bulk_export_tables`. Only allow-list tables whose full contents every
     /// `BulkExport`-capable client is permitted to read.
     pub(crate) bulk_export_allowed_tables: Option<std::collections::HashSet<String>>,
+    /// Tables an authenticated client may `Upload` into via `do_exchange` (#953).
+    ///
+    /// **SECURITY**: `None` (the default) disables `Upload` entirely. An Upload is a
+    /// raw client-directed INSERT — it does not pass through the mutation pipeline, so
+    /// it carries no operation authorizer and no field RBAC, and the target table is
+    /// named by the *client*. Left ungated, a caller holding any valid Flight session
+    /// token could write to every table the connection role can write, `_system`, audit
+    /// and outbox tables included. It is therefore fail-closed: a request is refused
+    /// unless its table is explicitly allow-listed here via
+    /// [`with_upload_tables`](FraiseQLFlightService::with_upload_tables). Only
+    /// allow-list tables every `Upload`-capable client is permitted to write.
+    pub(crate) upload_allowed_tables: Option<std::collections::HashSet<String>>,
     /// HMAC-SHA256 secret used to sign and verify Flight session tokens.
     ///
     /// Read once at service construction from `FLIGHT_SESSION_SECRET` environment

--- a/crates/fraiseql-arrow/src/flight_server/service.rs
+++ b/crates/fraiseql-arrow/src/flight_server/service.rs
@@ -449,14 +449,16 @@ impl FraiseQLFlightService {
     ///
     /// The executor must be passed as `Arc<Executor<A>>` wrapped in Arc for shared ownership.
     ///
-    /// **fraiseql-server deliberately never calls this.** Without an executor,
-    /// the Flight GraphQL paths (`do_get`, `do_exchange` `Query`) refuse
-    /// fail-closed — and that refusal is the intended state until the wiring
-    /// goes through the server's tenant-dispatch/policy seam (tenant
-    /// resolution, suspended-tenant gate, quotas, trusted-documents mode).
-    /// Attaching a bare executor here bypasses every one of those controls;
-    /// the executor's own GATE-1 and `[security.cost_budget] per_request_max`
-    /// (#379) still apply, but they are the floor, not the policy.
+    /// **What you attach here decides the transport's policy.** Without an
+    /// executor the Flight GraphQL paths (`do_get`, `do_exchange` `Query`) refuse
+    /// fail-closed. A **bare** executor bypasses tenant resolution, the
+    /// suspended-tenant gate, per-tenant quotas and trusted-documents mode — the
+    /// executor's own GATE-1 and `[security.cost_budget] per_request_max` (#379)
+    /// still apply, but they are the floor, not the policy.
+    ///
+    /// fraiseql-server therefore attaches its `PolicyGatedExecutor` at serve
+    /// time, which runs the same chokepoints the HTTP handler runs (#954). Any
+    /// other consumer wiring this seam owes its transport the same.
     ///
     /// # Example
     ///

--- a/crates/fraiseql-arrow/src/flight_server/service.rs
+++ b/crates/fraiseql-arrow/src/flight_server/service.rs
@@ -127,6 +127,7 @@ impl FraiseQLFlightService {
             subscription_manager: Arc::new(SubscriptionManager::new()),
             allow_raw_sql: false,
             bulk_export_allowed_tables: None,
+            upload_allowed_tables: None,
             session_secret: read_flight_session_secret(),
             stream_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_STREAMS)),
         }
@@ -176,6 +177,7 @@ impl FraiseQLFlightService {
             subscription_manager: Arc::new(SubscriptionManager::new()),
             allow_raw_sql: false,
             bulk_export_allowed_tables: None,
+            upload_allowed_tables: None,
             session_secret: read_flight_session_secret(),
             stream_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_STREAMS)),
         }
@@ -223,6 +225,7 @@ impl FraiseQLFlightService {
             subscription_manager: Arc::new(SubscriptionManager::new()),
             allow_raw_sql: false,
             bulk_export_allowed_tables: None,
+            upload_allowed_tables: None,
             session_secret: read_flight_session_secret(),
             stream_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_STREAMS)),
         }
@@ -306,6 +309,7 @@ impl FraiseQLFlightService {
             subscription_manager: Arc::new(SubscriptionManager::new()),
             allow_raw_sql: false,
             bulk_export_allowed_tables: None,
+            upload_allowed_tables: None,
             session_secret: Some(session_secret),
             stream_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_STREAMS)),
         }
@@ -406,6 +410,39 @@ impl FraiseQLFlightService {
                 .collect::<std::collections::HashSet<String>>(),
         );
         self
+    }
+
+    /// Allow-list the tables an authenticated client may `Upload` into (#953).
+    ///
+    /// **SECURITY WARNING**: an `Upload` is a raw, client-directed INSERT. The target
+    /// table comes from the request, and the rows do not pass through the mutation
+    /// pipeline — no operation authorizer, no field RBAC. `Upload` is disabled by
+    /// default (the allow-list is `None`); call this only for tables every
+    /// `Upload`-capable client is permitted to write. Allow-listing an audit, `_system`
+    /// or outbox table hands those clients the ledger.
+    #[must_use]
+    pub fn with_upload_tables<I, S>(mut self, tables: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.upload_allowed_tables = Some(
+            tables
+                .into_iter()
+                .map(Into::into)
+                .collect::<std::collections::HashSet<String>>(),
+        );
+        self
+    }
+
+    /// The tables `Upload` may write, or `None` when `Upload` is disabled (#953).
+    ///
+    /// Exposed so a consumer can assert what its own configuration produced —
+    /// "the operator wrote an allow-list and the service received it" is otherwise
+    /// only observable by attempting a write.
+    #[must_use]
+    pub const fn upload_allowed_tables(&self) -> Option<&std::collections::HashSet<String>> {
+        self.upload_allowed_tables.as_ref()
     }
 
     /// Set the query executor for GraphQL query execution.

--- a/crates/fraiseql-arrow/tests/flight_e2e_test.rs
+++ b/crates/fraiseql-arrow/tests/flight_e2e_test.rs
@@ -1,48 +1,58 @@
-//! End-to-end integration tests for Arrow Flight `DoGet` flows.
+//! End-to-end `DoGet` flows: a real Flight server on a real socket, a real
+//! session token, and a real PostgreSQL behind it.
 //!
-//! These tests verify complete request→response cycles for:
-//! - Optimized view queries with cache
-//! - Batched multi-query execution
-//! - Large result set streaming
-//! - Concurrent client requests
+//! Until #1001 these six tests carried numbered "1. Create `FlightTicket` 2. Send
+//! `DoGet` request 3. Receive schema message 4. Receive data batches" doc comments
+//! and called **no Flight RPC at all** — each reduced to
+//! `assert!(service.schema_registry().contains("ta_users"))`, which
+//! `register_defaults()` makes true for any service, with or without a database.
+//! Every one of them created a fixture database it never queried. The `do_get`
+//! path could have been broken in every way they named and all six passed.
+//!
+//! Each test now performs the flow its name describes and asserts on the rows that
+//! come back.
+//!
+//! `#[ignore]` — needs `DATABASE_URL` (a real PostgreSQL, with permission to
+//! `CREATE DATABASE`). Named explicitly by the Dagger `integration` leg (`observers` suite, which
+//! binds a Postgres),
+//! so these either run or the leg fails; they can no longer self-skip into a false
+//! green. Run with:
+//! `cargo test -p fraiseql-arrow --all-features --test flight_e2e_test --
+//! --ignored --test-threads=1`.
 #![allow(clippy::unwrap_used, clippy::print_stdout, clippy::print_stderr)] // Reason: test code, panics are acceptable
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use arrow::record_batch::RecordBatch;
+use arrow_flight::{Ticket, flight_service_client::FlightServiceClient};
+use fraiseql_arrow::{FlightTicket, flight_server::FraiseQLFlightService};
 use sqlx::postgres::PgPoolOptions;
+use tonic::transport::{Endpoint, Server};
+
+const TEST_FLIGHT_SECRET: &str = "flight-e2e-session-secret";
 
 /// Test database setup and teardown (reused from `flight_integration.rs`).
 struct TestDb {
-    #[allow(dead_code)] // Reason: pool held alive to keep connection open; not read directly
-    pool: sqlx::PgPool,
+    pool:          sqlx::PgPool,
     database_name: String,
 }
 
 impl TestDb {
     /// Create a test database and set up tables.
     ///
-    /// Returns `Ok(None)` when `DATABASE_URL` is not set, allowing the test
-    /// to be skipped gracefully in environments without PostgreSQL.
+    /// Returns `Ok(None)` when `DATABASE_URL` is not set. These tests are
+    /// `#[ignore]`d and named explicitly by the leg, so this is the local
+    /// convenience path, not a way for CI to skip them.
     async fn setup() -> Result<Option<Self>, Box<dyn std::error::Error>> {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "debug".into()),
-            )
-            .try_init();
-
         let Ok(db_url) = std::env::var("DATABASE_URL") else {
             eprintln!("Skipping: DATABASE_URL not set");
             return Ok(None);
         };
 
-        tracing::info!("Connecting to PostgreSQL: {}", db_url);
-
         let pool = PgPoolOptions::new().max_connections(1).connect(&db_url).await?;
 
         let test_db_name =
             format!("fraiseql_arrow_e2e_{}", uuid::Uuid::new_v4().to_string().replace('-', "_"));
-        tracing::info!("Creating test database: {}", test_db_name);
 
         sqlx::query(&format!("CREATE DATABASE \"{}\"", test_db_name))
             .execute(&pool)
@@ -62,11 +72,10 @@ impl TestDb {
         }))
     }
 
-    /// Create `ta_users` and `ta_orders` tables with additional test data.
+    /// Create `ta_users` and `ta_orders` with the columns the registry's
+    /// pre-compiled Arrow schemas declare — the conversion step matches rows to
+    /// that schema by name, so the table must carry those columns.
     async fn create_tables(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
-        tracing::info!("Creating test tables");
-
-        // Create ta_users table
         sqlx::query(
             r"
             CREATE TABLE ta_users (
@@ -81,7 +90,6 @@ impl TestDb {
         .execute(pool)
         .await?;
 
-        // Create ta_orders table
         sqlx::query(
             r"
             CREATE TABLE ta_orders (
@@ -96,7 +104,6 @@ impl TestDb {
         .execute(pool)
         .await?;
 
-        // Insert test data into ta_users
         sqlx::query(
             r"
             INSERT INTO ta_users (id, name, email, created_at)
@@ -111,7 +118,6 @@ impl TestDb {
         .execute(pool)
         .await?;
 
-        // Insert test data into ta_orders
         sqlx::query(
             r"
             INSERT INTO ta_orders (id, total, created_at, customer_name)
@@ -126,16 +132,9 @@ impl TestDb {
         .execute(pool)
         .await?;
 
-        tracing::info!("Tables created and populated with test data");
         Ok(())
     }
 
-    /// Get the database URL for fraiseql-core adapter.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `DATABASE_URL` is not set. This is safe because `setup()`
-    /// already verified its presence.
     fn connection_string(&self) -> String {
         let db_url =
             std::env::var("DATABASE_URL").expect("DATABASE_URL must be set — setup() checks this");
@@ -149,18 +148,15 @@ impl TestDb {
 impl Drop for TestDb {
     fn drop(&mut self) {
         let db_name = self.database_name.clone();
-        let default_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
-            "postgresql://fraiseql_test:fraiseql_test_password@localhost:5433/test_fraiseql"
-                .to_string()
-        });
+        let Ok(default_url) = std::env::var("DATABASE_URL") else {
+            return;
+        };
 
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
-                if let Ok(pool) = PgPoolOptions::new()
-                    .max_connections(1)
-                    .connect(&default_url)
-                    .await
+                if let Ok(pool) =
+                    PgPoolOptions::new().max_connections(1).connect(&default_url).await
                 {
                     let _ = sqlx::query(&format!(
                         "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '{}' AND pid <> pg_backend_pid()",
@@ -172,220 +168,324 @@ impl Drop for TestDb {
                     let _ = sqlx::query(&format!("DROP DATABASE \"{}\"", db_name))
                         .execute(&pool)
                         .await;
-
-                    tracing::info!("Test database {} cleaned up", db_name);
                 }
             });
         });
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// ------------------------------------------------------------- flight harness
 
-    /// Test adapter that wraps `PostgresAdapter` for Arrow Flight integration tests.
-    ///
-    /// Arrow Flight operates on raw SQL, so it always uses PostgreSQL directly.
-    struct TestFlightAdapter {
-        inner: fraiseql_core::db::PostgresAdapter,
+/// The adapter shape the shipped server passes to the Flight service.
+struct TestFlightAdapter {
+    inner: fraiseql_core::db::PostgresAdapter,
+}
+
+#[async_trait::async_trait]
+impl fraiseql_arrow::ArrowDatabaseAdapter for TestFlightAdapter {
+    async fn execute_raw_query(
+        &self,
+        sql: &str,
+    ) -> fraiseql_arrow::db::DatabaseResult<Vec<HashMap<String, serde_json::Value>>> {
+        use fraiseql_core::db::traits::DatabaseAdapter as _;
+        self.inner
+            .execute_raw_query(sql)
+            .await
+            .map_err(|e| fraiseql_arrow::db::DatabaseError::new(e.to_string()))
+    }
+}
+
+async fn flight_adapter(conn_string: &str) -> Arc<dyn fraiseql_arrow::ArrowDatabaseAdapter> {
+    let pg = fraiseql_core::db::PostgresAdapter::new(conn_string).await.unwrap();
+    Arc::new(TestFlightAdapter { inner: pg })
+}
+
+fn session_token() -> String {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct Claims {
+        sub:          String,
+        exp:          i64,
+        iat:          i64,
+        scopes:       Vec<String>,
+        session_type: String,
     }
 
-    #[async_trait::async_trait]
-    impl fraiseql_arrow::ArrowDatabaseAdapter for TestFlightAdapter {
-        async fn execute_raw_query(
-            &self,
-            sql: &str,
-        ) -> fraiseql_arrow::db::DatabaseResult<
-            Vec<std::collections::HashMap<String, serde_json::Value>>,
-        > {
-            use fraiseql_core::db::traits::DatabaseAdapter as _;
-            self.inner
-                .execute_raw_query(sql)
-                .await
-                .map_err(|e| fraiseql_arrow::db::DatabaseError::new(e.to_string()))
+    let now = chrono::Utc::now();
+    encode(
+        &Header::new(Algorithm::HS256),
+        &Claims {
+            sub:          "e2e-user".to_string(),
+            exp:          (now + chrono::Duration::minutes(5)).timestamp(),
+            iat:          now.timestamp(),
+            scopes:       vec!["user".to_string()],
+            session_type: "flight".to_string(),
+        },
+        &EncodingKey::from_secret(TEST_FLIGHT_SECRET.as_bytes()),
+    )
+    .unwrap()
+}
+
+/// Serve `service` on an ephemeral port; returns the endpoint URL.
+async fn serve(service: FraiseQLFlightService) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(service.into_server())
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+async fn connect(addr: &str) -> FlightServiceClient<tonic::transport::Channel> {
+    let channel = Endpoint::from_shared(addr.to_string()).unwrap().connect().await.unwrap();
+    FlightServiceClient::new(channel)
+}
+
+/// Send one authenticated `do_get` and decode the whole stream into batches.
+///
+/// The first `FlightData` is the schema message, the rest are batches — this is
+/// the "receive schema message → receive data batches" the old doc comments
+/// described and never performed.
+async fn do_get(addr: &str, ticket: &FlightTicket) -> Result<Vec<RecordBatch>, tonic::Status> {
+    let mut client = connect(addr).await;
+    let mut request = tonic::Request::new(Ticket {
+        ticket: ticket.encode().unwrap().into(),
+    });
+    request
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {}", session_token()).parse().unwrap());
+
+    let mut stream = client.do_get(request).await?.into_inner();
+    let mut frames = Vec::new();
+    while let Some(data) = stream.message().await? {
+        frames.push(data);
+    }
+    Ok(arrow_flight::utils::flight_data_to_batches(&frames)
+        .expect("the server's own stream must decode as Arrow"))
+}
+
+fn total_rows(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(RecordBatch::num_rows).sum()
+}
+
+/// Collect one string column across all batches.
+fn column_values(batches: &[RecordBatch], column: &str) -> Vec<String> {
+    use arrow::array::{Array as _, StringArray};
+    let mut out = Vec::new();
+    for batch in batches {
+        let Some(idx) = batch.schema().index_of(column).ok() else {
+            continue;
+        };
+        let array = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("column is Utf8");
+        for i in 0..array.len() {
+            out.push(array.value(i).to_string());
         }
     }
+    out
+}
 
-    /// Create a PostgreSQL-backed Arrow Flight adapter for testing.
-    async fn create_flight_adapter(
-        conn_string: &str,
-    ) -> Result<Arc<dyn fraiseql_arrow::ArrowDatabaseAdapter>, Box<dyn std::error::Error>> {
-        let pg_adapter = fraiseql_core::db::PostgresAdapter::new(conn_string).await?;
-        let adapter: Arc<dyn fraiseql_arrow::ArrowDatabaseAdapter> =
-            Arc::new(TestFlightAdapter { inner: pg_adapter });
-        Ok(adapter)
+fn view_ticket(view: &str, limit: Option<usize>) -> FlightTicket {
+    FlightTicket::OptimizedView {
+        view: view.to_string(),
+        filter: None,
+        order_by: None,
+        limit,
+        offset: None,
     }
+}
 
-    /// Test complete `DoGet` flow: create ticket → execute → stream results
-    ///
-    /// This test verifies the end-to-end path:
-    /// 1. Create `FlightTicket` for optimized view
-    /// 2. Send `DoGet` request with ticket
-    /// 3. Receive schema message
-    /// 4. Receive data batches
-    /// 5. Verify data integrity
-    #[tokio::test]
-    async fn test_do_get_optimized_view_full_flow() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+// -------------------------------------------------------------------- tests
 
-        // Create adapters
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+/// Complete `DoGet` flow: ticket → request → schema message → data batches →
+/// the rows that are actually in the table.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn do_get_optimized_view_returns_the_rows_in_the_table() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-        // Create Flight service with database
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
+    let batches = do_get(&addr, &view_ticket("ta_users", None)).await.unwrap();
 
-        // Verify schema registry contains ta_users
-        assert!(service.schema_registry().contains("ta_users"), "Should have ta_users schema");
+    assert_eq!(total_rows(&batches), 5, "ta_users holds five seeded rows");
+    let mut ids = column_values(&batches, "id");
+    ids.sort();
+    assert_eq!(ids, ["user-1", "user-2", "user-3", "user-4", "user-5"]);
+    let names = column_values(&batches, "name");
+    assert!(
+        names.contains(&"Alice Johnson".to_string()),
+        "row values must survive the round trip"
+    );
+}
 
-        tracing::info!("✓ DoGet optimized view full flow test passed");
-        Ok(())
-    }
+/// A cache **hit** serves the earlier result without touching the database.
+///
+/// Proven by deleting every row between the two requests: with a cold cache the
+/// second request would return nothing, so five rows can only have come from the
+/// cache.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn do_get_serves_a_repeat_request_from_cache() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service =
+        FraiseQLFlightService::new_with_cache(flight_adapter(&db.connection_string()).await, 60)
+            .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
+    let ticket = view_ticket("ta_users", None);
 
-    /// Test cache hit scenario in `DoGet` flow
-    ///
-    /// This test verifies:
-    /// 1. Execute query without cache (first request)
-    /// 2. Execute same query with cache enabled (second request)
-    /// 3. Verify cache hit (same result, no database query)
-    #[tokio::test]
-    async fn test_do_get_with_cache_hit() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+    let first = do_get(&addr, &ticket).await.unwrap();
+    assert_eq!(total_rows(&first), 5);
 
-        // Create adapters
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+    sqlx::query("DELETE FROM ta_users").execute(&db.pool).await.unwrap();
 
-        // Create Flight service with 60-second cache
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_cache(flight_adapter, 60);
+    let second = do_get(&addr, &ticket).await.unwrap();
+    assert_eq!(
+        total_rows(&second),
+        5,
+        "the repeat request must be served from cache — the table is now empty"
+    );
+}
 
-        // Verify cache is enabled
-        let schema = service.schema_registry().get("ta_users")?;
-        assert!(!schema.fields.is_empty(), "Schema should have fields");
+/// A cache **miss** goes to the database.
+///
+/// The cache is keyed by SQL text, so a different `limit` is a different key. The
+/// row inserted after the first request is invisible to the cached entry and must
+/// appear under the new one.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn a_differently_keyed_request_misses_the_cache_and_reads_the_database() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service =
+        FraiseQLFlightService::new_with_cache(flight_adapter(&db.connection_string()).await, 60)
+            .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-        tracing::info!("✓ DoGet cache hit test passed");
-        Ok(())
-    }
+    let warm = do_get(&addr, &view_ticket("ta_users", Some(5))).await.unwrap();
+    assert_eq!(total_rows(&warm), 5);
 
-    /// Test cache miss scenario in `DoGet` flow
-    ///
-    /// This test verifies:
-    /// 1. Cache is enabled but empty
-    /// 2. Query is executed and result is cached
-    /// 3. Verify cache now contains result
-    #[tokio::test]
-    async fn test_do_get_with_cache_miss() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+    sqlx::query(
+        "INSERT INTO ta_users (id, name, email, created_at)
+         VALUES ('user-6', 'Frank Castle', 'frank@example.com', NOW())",
+    )
+    .execute(&db.pool)
+    .await
+    .unwrap();
 
-        // Create adapters
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+    let cached = do_get(&addr, &view_ticket("ta_users", Some(5))).await.unwrap();
+    assert_eq!(total_rows(&cached), 5, "the identical request is still the cached one");
 
-        // Create Flight service with cache
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_cache(flight_adapter, 60);
+    let fresh = do_get(&addr, &view_ticket("ta_users", Some(6))).await.unwrap();
+    assert_eq!(total_rows(&fresh), 6, "a different key must miss and re-read the database");
+    assert!(column_values(&fresh, "id").contains(&"user-6".to_string()));
+}
 
-        // Verify service is functional
-        assert!(service.schema_registry().contains("ta_orders"), "Should have ta_orders schema");
+/// A `BatchedQueries` ticket returns every query's rows in one stream.
+///
+/// Raw SQL is disabled by default, so this enables it explicitly — which is also
+/// the point: the surface exists only when an operator opts in.
+///
+/// ⚠ **Single column, deliberately (#1002).** The inferred schema takes its field
+/// order from a `HashMap` iteration, so two queries with an identical column set
+/// can produce differently-*ordered* schemas and be refused by the #717
+/// heterogeneous-schema guard — intermittently, since the order varies per process.
+/// A one-column projection has only one possible order, so this test measures the
+/// batched-stream path rather than that lottery. Widen it once #1002 lands.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn batched_queries_stream_every_query_in_one_response() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET)
+        .with_raw_sql_enabled();
+    let addr = serve(service).await;
 
-        tracing::info!("✓ DoGet cache miss test passed");
-        Ok(())
-    }
+    let ticket = FlightTicket::BatchedQueries {
+        queries: vec![
+            "SELECT id FROM ta_users ORDER BY id LIMIT 2".to_string(),
+            "SELECT id FROM ta_users ORDER BY id OFFSET 2".to_string(),
+        ],
+    };
 
-    /// Test batched queries full flow: multiple queries → combined streaming
-    ///
-    /// This test verifies:
-    /// 1. Create `BatchedQueries` ticket with 2+ queries
-    /// 2. Send `DoGet` request
-    /// 3. Receive combined Arrow stream
-    /// 4. Verify results from all queries are streamed
-    #[tokio::test]
-    async fn test_batched_queries_full_flow() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+    let batches = do_get(&addr, &ticket).await.unwrap();
 
-        // Create adapters
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+    assert_eq!(total_rows(&batches), 5, "both queries' rows must reach the client");
+    let mut ids = column_values(&batches, "id");
+    ids.sort();
+    assert_eq!(ids, ["user-1", "user-2", "user-3", "user-4", "user-5"]);
+}
 
-        // Create Flight service
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
+/// A large result set streams in full.
+///
+/// Note the honest scope: `execute_optimized_view` derives its batch size from the
+/// request's `limit` (`limit.unwrap_or(10_000)`), so an `OptimizedView` response is
+/// a single batch by construction — the old body's claim to "verify streaming
+/// produces multiple batches" was untestable through this path as well as untested.
+/// What is real, and what this asserts, is that every one of 1 500 rows arrives.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn a_large_result_set_streams_every_row() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    sqlx::query(
+        "INSERT INTO ta_users (id, name, email, created_at)
+         SELECT 'bulk-' || g, 'Bulk User ' || g, 'bulk' || g || '@example.com', NOW()
+         FROM generate_series(1, 1495) AS g",
+    )
+    .execute(&db.pool)
+    .await
+    .unwrap();
 
-        // Verify both tables exist
-        assert!(service.schema_registry().contains("ta_users"), "Should have ta_users");
-        assert!(service.schema_registry().contains("ta_orders"), "Should have ta_orders");
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-        tracing::info!("✓ Batched queries full flow test passed");
-        Ok(())
-    }
+    let batches = do_get(&addr, &view_ticket("ta_users", None)).await.unwrap();
 
-    /// Test large result set streaming (1000+ rows across multiple batches)
-    ///
-    /// This test verifies:
-    /// 1. Insert 1000+ rows into a table
-    /// 2. Execute query that returns all rows
-    /// 3. Verify streaming produces multiple batches
-    /// 4. Verify all rows are streamed correctly
-    /// 5. Verify batch size limits are respected
-    #[tokio::test]
-    async fn test_large_result_set_streaming() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+    assert_eq!(total_rows(&batches), 1500, "every row must arrive, none dropped by chunking");
+    assert_eq!(column_values(&batches, "id").len(), 1500);
+}
 
-        // Create adapters
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+/// Ten concurrent clients each get a correct, complete result.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn concurrent_do_get_requests_each_return_the_full_result() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-        // Create Flight service
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let addr = addr.clone();
+            tokio::spawn(async move { do_get(&addr, &view_ticket("ta_orders", None)).await })
+        })
+        .collect();
 
-        // Verify service is functional
-        assert!(
-            !service.schema_registry().contains("nonexistent_table"),
-            "Should reject unknown tables"
-        );
-
-        tracing::info!("✓ Large result set streaming test passed");
-        Ok(())
-    }
-
-    /// Test concurrent `DoGet` requests from multiple clients
-    ///
-    /// This test verifies:
-    /// 1. Launch 10+ concurrent requests to same service
-    /// 2. Each request executes independently
-    /// 3. All requests complete successfully
-    /// 4. No data corruption or race conditions
-    /// 5. Cache is thread-safe if enabled
-    #[tokio::test]
-    async fn test_concurrent_do_get_requests() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
-
-        // Create adapters
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
-
-        // Create Flight service
-        let service = Arc::new(fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter));
-
-        // Verify service is shared safely
-        let schema1 = service.schema_registry().get("ta_users")?;
-        let schema2 = service.schema_registry().get("ta_orders")?;
-
-        assert!(!schema1.fields.is_empty(), "ta_users should have fields");
-        assert!(!schema2.fields.is_empty(), "ta_orders should have fields");
-
-        tracing::info!("✓ Concurrent DoGet requests test passed");
-        Ok(())
+    for handle in handles {
+        let batches = handle.await.unwrap().expect("every concurrent request must succeed");
+        assert_eq!(total_rows(&batches), 5, "no request may see a partial or crossed result");
     }
 }

--- a/crates/fraiseql-arrow/tests/flight_error_handling_test.rs
+++ b/crates/fraiseql-arrow/tests/flight_error_handling_test.rs
@@ -1,51 +1,58 @@
-//! Error handling tests for Arrow Flight service.
+//! Error handling on the Arrow Flight `do_get` path, exercised over a real socket
+//! against a real PostgreSQL.
 //!
-//! These tests verify proper error reporting and recovery for:
-//! - Invalid view names
-//! - Database connection failures
-//! - Arrow conversion errors
-//! - IPC encoding failures
-//! - Batched query validation errors
-//! - Partial batch failures
+//! Until #1001 these tests asserted schema-registry membership —
+//! `assert!(service.schema_registry().contains("ta_users"))`, true for any service
+//! with or without a database, since `register_defaults()` hardcodes it — while
+//! their doc comments claimed to verify that "request fails gracefully without
+//! panicking", "appropriate error is returned to client" and so on. No Flight RPC
+//! was ever issued and no error was ever produced. Each one still created a fixture
+//! database it never queried.
+//!
+//! Each test now provokes the failure it names and asserts on the `Status` the
+//! client actually receives. `test_ipc_encoding_failure` was **deleted** rather than
+//! rewritten: there is no way to force an IPC encoding failure from outside the
+//! service, so the honest options were a lie or nothing.
+//!
+//! `#[ignore]` — needs `DATABASE_URL`. Named explicitly by the Dagger
+//! `integration` leg (`observers` suite, which binds a Postgres). Run with:
+//! `cargo test -p fraiseql-arrow --all-features --test flight_error_handling_test --
+//! --ignored --test-threads=1`.
 #![allow(clippy::unwrap_used, clippy::print_stdout, clippy::print_stderr)] // Reason: test code, panics are acceptable
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use arrow_flight::{Ticket, flight_service_client::FlightServiceClient};
+use fraiseql_arrow::{FlightTicket, flight_server::FraiseQLFlightService};
 use sqlx::postgres::PgPoolOptions;
+use tonic::{
+    Code,
+    transport::{Endpoint, Server},
+};
+
+const TEST_FLIGHT_SECRET: &str = "flight-error-handling-session-secret";
 
 /// Test database setup and teardown.
 struct TestDb {
-    #[allow(dead_code)] // Reason: pool held alive to keep connection open; not read directly
-    pool: sqlx::PgPool,
+    pool:          sqlx::PgPool,
     database_name: String,
 }
 
 impl TestDb {
     /// Create a test database and set up tables.
     ///
-    /// Returns `Ok(None)` when `DATABASE_URL` is not set, allowing the test
-    /// to be skipped gracefully in environments without PostgreSQL.
+    /// Returns `Ok(None)` when `DATABASE_URL` is not set. These tests are
+    /// `#[ignore]`d and named explicitly by the leg, so this is the local
+    /// convenience path, not a way for CI to skip them.
     async fn setup() -> Result<Option<Self>, Box<dyn std::error::Error>> {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "debug".into()),
-            )
-            .try_init();
-
         let Ok(db_url) = std::env::var("DATABASE_URL") else {
             eprintln!("Skipping: DATABASE_URL not set");
             return Ok(None);
         };
 
-        tracing::info!("Connecting to PostgreSQL: {}", db_url);
-
         let pool = PgPoolOptions::new().max_connections(1).connect(&db_url).await?;
-
         let test_db_name =
             format!("fraiseql_arrow_err_{}", uuid::Uuid::new_v4().to_string().replace('-', "_"));
-        tracing::info!("Creating test database: {}", test_db_name);
-
         sqlx::query(&format!("CREATE DATABASE \"{}\"", test_db_name))
             .execute(&pool)
             .await?;
@@ -55,7 +62,6 @@ impl TestDb {
             None => format!("{}/{}", db_url, test_db_name),
         };
         let test_pool = PgPoolOptions::new().max_connections(5).connect(&test_db_url).await?;
-
         Self::create_tables(&test_pool).await?;
 
         Ok(Some(TestDb {
@@ -64,10 +70,7 @@ impl TestDb {
         }))
     }
 
-    /// Create test tables.
     async fn create_tables(pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
-        tracing::info!("Creating test tables");
-
         sqlx::query(
             r"
             CREATE TABLE ta_users (
@@ -93,16 +96,9 @@ impl TestDb {
         .execute(pool)
         .await?;
 
-        tracing::info!("Tables created");
         Ok(())
     }
 
-    /// Get the database URL for fraiseql-core adapter.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `DATABASE_URL` is not set. This is safe because `setup()`
-    /// already verified its presence.
     fn connection_string(&self) -> String {
         let db_url =
             std::env::var("DATABASE_URL").expect("DATABASE_URL must be set — setup() checks this");
@@ -116,18 +112,14 @@ impl TestDb {
 impl Drop for TestDb {
     fn drop(&mut self) {
         let db_name = self.database_name.clone();
-        let default_url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
-            "postgresql://fraiseql_test:fraiseql_test_password@localhost:5433/test_fraiseql"
-                .to_string()
-        });
-
+        let Ok(default_url) = std::env::var("DATABASE_URL") else {
+            return;
+        };
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
-                if let Ok(pool) = PgPoolOptions::new()
-                    .max_connections(1)
-                    .connect(&default_url)
-                    .await
+                if let Ok(pool) =
+                    PgPoolOptions::new().max_connections(1).connect(&default_url).await
                 {
                     let _ = sqlx::query(&format!(
                         "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '{}' AND pid <> pg_backend_pid()",
@@ -135,209 +127,248 @@ impl Drop for TestDb {
                     ))
                     .execute(&pool)
                     .await;
-
                     let _ = sqlx::query(&format!("DROP DATABASE \"{}\"", db_name))
                         .execute(&pool)
                         .await;
-
-                    tracing::info!("Test database {} cleaned up", db_name);
                 }
             });
         });
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// ------------------------------------------------------------- flight harness
 
-    /// Test adapter that wraps `PostgresAdapter` for Arrow Flight integration tests.
-    ///
-    /// Arrow Flight operates on raw SQL, so it always uses PostgreSQL directly.
-    struct TestFlightAdapter {
-        inner: fraiseql_core::db::PostgresAdapter,
+struct TestFlightAdapter {
+    inner: fraiseql_core::db::PostgresAdapter,
+}
+
+#[async_trait::async_trait]
+impl fraiseql_arrow::ArrowDatabaseAdapter for TestFlightAdapter {
+    async fn execute_raw_query(
+        &self,
+        sql: &str,
+    ) -> fraiseql_arrow::db::DatabaseResult<Vec<HashMap<String, serde_json::Value>>> {
+        use fraiseql_core::db::traits::DatabaseAdapter as _;
+        self.inner
+            .execute_raw_query(sql)
+            .await
+            .map_err(|e| fraiseql_arrow::db::DatabaseError::new(e.to_string()))
+    }
+}
+
+async fn flight_adapter(conn: &str) -> Arc<dyn fraiseql_arrow::ArrowDatabaseAdapter> {
+    let pg = fraiseql_core::db::PostgresAdapter::new(conn).await.unwrap();
+    Arc::new(TestFlightAdapter { inner: pg })
+}
+
+fn session_token() -> String {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct Claims {
+        sub:          String,
+        exp:          i64,
+        iat:          i64,
+        scopes:       Vec<String>,
+        session_type: String,
     }
 
-    #[async_trait::async_trait]
-    impl fraiseql_arrow::ArrowDatabaseAdapter for TestFlightAdapter {
-        async fn execute_raw_query(
-            &self,
-            sql: &str,
-        ) -> fraiseql_arrow::db::DatabaseResult<
-            Vec<std::collections::HashMap<String, serde_json::Value>>,
-        > {
-            use fraiseql_core::db::traits::DatabaseAdapter as _;
-            self.inner
-                .execute_raw_query(sql)
-                .await
-                .map_err(|e| fraiseql_arrow::db::DatabaseError::new(e.to_string()))
-        }
+    let now = chrono::Utc::now();
+    encode(
+        &Header::new(Algorithm::HS256),
+        &Claims {
+            sub:          "error-handling-user".to_string(),
+            exp:          (now + chrono::Duration::minutes(5)).timestamp(),
+            iat:          now.timestamp(),
+            scopes:       vec!["user".to_string()],
+            session_type: "flight".to_string(),
+        },
+        &EncodingKey::from_secret(TEST_FLIGHT_SECRET.as_bytes()),
+    )
+    .unwrap()
+}
+
+async fn serve(service: FraiseQLFlightService) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(service.into_server())
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+/// Issue one authenticated `do_get` and drain the stream, returning the first
+/// error the client sees (errors can surface at call time or mid-stream).
+async fn do_get(addr: &str, ticket: &FlightTicket) -> Result<usize, tonic::Status> {
+    let channel = Endpoint::from_shared(addr.to_string()).unwrap().connect().await.unwrap();
+    let mut client = FlightServiceClient::new(channel);
+
+    let mut request = tonic::Request::new(Ticket {
+        ticket: ticket.encode().unwrap().into(),
+    });
+    request
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {}", session_token()).parse().unwrap());
+
+    let mut stream = client.do_get(request).await?.into_inner();
+    let mut frames = 0;
+    while let Some(_data) = stream.message().await? {
+        frames += 1;
     }
+    Ok(frames)
+}
 
-    /// Create a PostgreSQL-backed Arrow Flight adapter for testing.
-    async fn create_flight_adapter(
-        conn_string: &str,
-    ) -> Result<Arc<dyn fraiseql_arrow::ArrowDatabaseAdapter>, Box<dyn std::error::Error>> {
-        let pg_adapter = fraiseql_core::db::PostgresAdapter::new(conn_string).await?;
-        let adapter: Arc<dyn fraiseql_arrow::ArrowDatabaseAdapter> =
-            Arc::new(TestFlightAdapter { inner: pg_adapter });
-        Ok(adapter)
+fn view_ticket(view: &str, limit: Option<usize>) -> FlightTicket {
+    FlightTicket::OptimizedView {
+        view: view.to_string(),
+        filter: None,
+        order_by: None,
+        limit,
+        offset: None,
     }
+}
 
-    /// Test invalid view name returns appropriate error
-    ///
-    /// Verifies:
-    /// 1. Request for non-existent view returns `NotFound` error
-    /// 2. Error message includes view name
-    /// 3. Service remains functional after error
-    #[tokio::test]
-    async fn test_invalid_view_name_error() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+// -------------------------------------------------------------------- tests
 
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+/// A ticket naming a view the registry does not know is refused with `NotFound`,
+/// the message names the view, and the service serves the next request normally.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn an_unknown_view_is_refused_and_the_service_survives_it() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
+    let status = do_get(&addr, &view_ticket("nonexistent_view", None))
+        .await
+        .expect_err("an unknown view must be refused");
 
-        // Verify non-existent view is properly rejected
-        let result = service.schema_registry().get("nonexistent_view");
-        assert!(result.is_err(), "Should reject non-existent view");
+    assert_eq!(status.code(), Code::NotFound, "got: {status:?}");
+    assert!(
+        status.message().contains("nonexistent_view"),
+        "the error must name the view the client asked for, got: {}",
+        status.message()
+    );
 
-        // Verify service is still functional
-        let valid = service.schema_registry().get("ta_users");
-        assert!(valid.is_ok(), "Service should still work after error");
+    // Recovery: the same server still answers a valid request.
+    let frames = do_get(&addr, &view_ticket("ta_users", None)).await.unwrap();
+    assert!(frames >= 2, "schema message plus at least one batch");
+}
 
-        tracing::info!("✓ Invalid view name error test passed");
-        Ok(())
-    }
+/// When the database is gone, the client gets an error — not a panic, not an
+/// empty-but-successful stream that reads as "no rows".
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn a_failing_database_surfaces_as_an_error_not_an_empty_success() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-    /// Test database connection failure error handling
-    ///
-    /// Verifies:
-    /// 1. Service detects database connectivity issues
-    /// 2. Error message is informative
-    /// 3. Request fails gracefully without panicking
-    #[tokio::test]
-    async fn test_database_connection_failure() -> Result<(), Box<dyn std::error::Error>> {
-        // Create a Flight service without database adapter
-        let service = fraiseql_arrow::FraiseQLFlightService::new();
+    // Take the table away underneath the running service.
+    sqlx::query("DROP TABLE ta_users").execute(&db.pool).await.unwrap();
 
-        // Service should still have schema registry
-        assert!(service.schema_registry().contains("ta_users"), "Should have default schemas");
+    let status = do_get(&addr, &view_ticket("ta_users", None))
+        .await
+        .expect_err("a query against a missing table must not answer success");
 
-        tracing::info!("✓ Database connection failure test passed");
-        Ok(())
-    }
+    assert_eq!(status.code(), Code::Internal, "got: {status:?}");
+    assert!(
+        status.message().contains("Database query failed"),
+        "the error must say the database failed, got: {}",
+        status.message()
+    );
+}
 
-    /// Test Arrow conversion error handling
-    ///
-    /// Verifies:
-    /// 1. Invalid data types are handled gracefully
-    /// 2. Error message describes conversion problem
-    /// 3. Streaming can continue or fails gracefully
-    #[tokio::test]
-    async fn test_arrow_conversion_error() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+/// `limit = 0` is refused up front (H38) rather than reaching the chunker, where a
+/// zero-sized chunk used to panic.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn a_zero_limit_is_refused_before_it_reaches_the_chunker() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
 
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+    let status = do_get(&addr, &view_ticket("ta_users", Some(0)))
+        .await
+        .expect_err("limit = 0 is a meaningless request and must be refused");
 
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
+    assert_eq!(status.code(), Code::InvalidArgument, "got: {status:?}");
+    assert!(
+        status.message().contains("greater than 0"),
+        "the error must tell the client what is wrong with the limit, got: {}",
+        status.message()
+    );
+}
 
-        // Verify schema conversion works for valid table
-        let result = service.schema_registry().get("ta_users");
-        assert!(result.is_ok(), "Should convert valid table schema");
+/// An empty `BatchedQueries` ticket is refused rather than answered with an empty
+/// stream.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn an_empty_batched_queries_ticket_is_refused() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET)
+        .with_raw_sql_enabled();
+    let addr = serve(service).await;
 
-        let schema = result?;
-        assert!(!schema.fields.is_empty(), "Schema should have fields");
+    let status = do_get(&addr, &FlightTicket::BatchedQueries { queries: vec![] })
+        .await
+        .expect_err("an empty batch is not a request");
 
-        tracing::info!("✓ Arrow conversion error test passed");
-        Ok(())
-    }
+    assert_eq!(status.code(), Code::InvalidArgument, "got: {status:?}");
+}
 
-    /// Test IPC encoding failure handling
-    ///
-    /// Verifies:
-    /// 1. IPC encoding errors are caught
-    /// 2. Appropriate error is returned to client
-    /// 3. Service recovers and can handle subsequent requests
-    #[tokio::test]
-    async fn test_ipc_encoding_failure() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
+/// One bad query fails the **whole** batch — the client is never handed a partial
+/// result it cannot tell apart from a complete one.
+///
+/// The old doc comment claimed the opposite ("partial results are streamed
+/// correctly", "error doesn't break the entire batch"). It asserted neither, and
+/// the service does neither: a Flight stream carries one schema header, so there is
+/// no way to signal "query 2 of 3 failed" mid-stream. All-or-nothing is the correct
+/// behaviour and this pins it.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn one_bad_query_fails_the_whole_batch_rather_than_returning_part_of_it() {
+    let Some(db) = TestDb::setup().await.unwrap() else {
+        return;
+    };
+    let service = FraiseQLFlightService::new_with_db(flight_adapter(&db.connection_string()).await)
+        .with_session_secret(TEST_FLIGHT_SECRET)
+        .with_raw_sql_enabled();
+    let addr = serve(service).await;
 
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
+    let ticket = FlightTicket::BatchedQueries {
+        queries: vec![
+            "SELECT id FROM ta_users ORDER BY id".to_string(),
+            "SELECT id FROM table_that_does_not_exist".to_string(),
+        ],
+    };
 
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
+    let status = do_get(&addr, &ticket)
+        .await
+        .expect_err("a batch containing a failing query must fail as a whole");
 
-        // Verify schema can be encoded
-        let schema = service.schema_registry().get("ta_users")?;
-        assert!(!schema.fields.is_empty(), "Schema should be valid for encoding");
-
-        tracing::info!("✓ IPC encoding failure test passed");
-        Ok(())
-    }
-
-    /// Test empty batched queries validation
-    ///
-    /// Verifies:
-    /// 1. Empty query vector is rejected
-    /// 2. Error message indicates invalid argument
-    /// 3. Service is ready for next request
-    #[tokio::test]
-    async fn test_batched_queries_empty_error() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
-
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
-
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
-
-        // Verify service handles empty batches gracefully
-        // In a real implementation, empty query vectors should be rejected
-        assert!(
-            service.schema_registry().contains("ta_users"),
-            "Service should remain functional"
-        );
-
-        tracing::info!("✓ Batched queries empty error test passed");
-        Ok(())
-    }
-
-    /// Test partial batch failure (some queries succeed, some fail)
-    ///
-    /// Verifies:
-    /// 1. Successful queries return results
-    /// 2. Failed queries return appropriate errors
-    /// 3. Partial results are streamed correctly
-    /// 4. Error doesn't break the entire batch
-    #[tokio::test]
-    async fn test_batched_queries_partial_failure() -> Result<(), Box<dyn std::error::Error>> {
-        let Some(test_db) = TestDb::setup().await? else {
-            return Ok(());
-        };
-        let conn_string = test_db.connection_string();
-
-        let flight_adapter = create_flight_adapter(&conn_string).await?;
-
-        let service = fraiseql_arrow::FraiseQLFlightService::new_with_db(flight_adapter);
-
-        // Verify both valid schemas exist
-        assert!(service.schema_registry().contains("ta_users"), "Should have ta_users");
-        assert!(
-            !service.schema_registry().contains("nonexistent"),
-            "Should reject nonexistent table"
-        );
-
-        tracing::info!("✓ Batched queries partial failure test passed");
-        Ok(())
-    }
+    assert_eq!(status.code(), Code::Internal, "got: {status:?}");
+    assert!(
+        status.message().contains("Database query failed"),
+        "the error must name the database failure, got: {}",
+        status.message()
+    );
 }

--- a/crates/fraiseql-arrow/tests/flight_integration.rs
+++ b/crates/fraiseql-arrow/tests/flight_integration.rs
@@ -253,6 +253,7 @@ mod tests {
 
     /// Test that Flight database adapter can connect and execute queries
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_flight_adapter_executes_query() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -287,6 +288,7 @@ mod tests {
 
     /// Test querying ta_users table with Flight service
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_query_ta_users() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -311,6 +313,7 @@ mod tests {
 
     /// Test querying ta_orders table with Flight service
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_query_ta_orders() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -335,6 +338,7 @@ mod tests {
 
     /// Test that adapter correctly handles pagination with LIMIT
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_query_with_limit() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -360,6 +364,7 @@ mod tests {
 
     /// Test that adapter correctly handles OFFSET for pagination
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_query_with_offset() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -392,6 +397,7 @@ mod tests {
 
     /// Test that adapter can handle WHERE clauses
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_query_with_filter() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -421,6 +427,7 @@ mod tests {
 
     /// Test that adapter returns data in correct JSON format
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_query_returns_json_format() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -456,6 +463,7 @@ mod tests {
 
     /// Test that ta_orders data is correctly persisted
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_orders_data_integrity() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -483,6 +491,7 @@ mod tests {
 
     /// Test that ta_users data is correctly persisted
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_users_data_integrity() -> Result<(), Box<dyn std::error::Error>> {
         let Some(test_db) = TestDb::setup().await? else {
             return Ok(());
@@ -603,6 +612,7 @@ mod tests {
 
     /// Test Flight service with caching enabled
     #[tokio::test]
+    #[ignore = "requires DATABASE_URL"]
     async fn test_flight_service_with_cache() -> Result<(), Box<dyn std::error::Error>> {
         use fraiseql_arrow::FraiseQLFlightService;
 

--- a/crates/fraiseql-arrow/tests/flight_upload_gate_pg.rs
+++ b/crates/fraiseql-arrow/tests/flight_upload_gate_pg.rs
@@ -1,0 +1,320 @@
+//! #953 — the Flight `do_exchange` Upload write gate, against a real PostgreSQL.
+//!
+//! Before this gate, any caller holding a valid Flight session token could send
+//! `RequestType::Upload { table, batch }` with an **arbitrary client-supplied table
+//! name** and have the rows land: `handle_upload` went straight from session
+//! validation to `build_insert_query` to `adapter.execute_raw_query`, with no table
+//! allow-list, no tenant scoping, no authorizer, no audit event and no change-log
+//! row. The escaping was correct, so this was never SQL injection — it was an
+//! unauthorized-write surface that bypassed every control the mutation pipeline
+//! enforces, including writes to `_system`, audit and outbox tables.
+//!
+//! These tests drive the **real** service over a **real** socket with a **real**
+//! session token — not the handler in isolation — because the defect is reachable
+//! in the shipped binary (`create_flight_service` passes the live adapter) and only
+//! the mounted path proves it.
+//!
+//! `#[ignore]` — needs `DATABASE_URL` (a real Postgres). Named explicitly by the
+//! Dagger `integration` leg (`observers` suite, which binds a Postgres), so it either
+//! runs or the leg fails; it can
+//! never self-skip into a false green. Run with:
+//! `cargo test -p fraiseql-arrow --all-features --test flight_upload_gate_pg --
+//! --ignored --test-threads=1`.
+
+#![allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)] // Reason: test code, panics acceptable
+#![allow(clippy::items_after_statements)] // Reason: test helper items defined near use site
+
+use std::{collections::HashMap, sync::Arc};
+
+use arrow::{
+    array::{ArrayRef, StringArray},
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use arrow_flight::{FlightData, flight_service_client::FlightServiceClient};
+use fraiseql_arrow::{
+    db::{ArrowDatabaseAdapter, DatabaseError, DatabaseResult},
+    exchange_protocol::{ExchangeMessage, RequestType},
+    flight_server::FraiseQLFlightService,
+};
+use sqlx::{
+    Row,
+    postgres::{PgPool, PgPoolOptions},
+};
+use tonic::transport::{Endpoint, Server};
+
+const TEST_FLIGHT_SECRET: &str = "flight-upload-gate-session-secret";
+
+// ---------------------------------------------------------------- fixtures
+
+async fn pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for --ignored runs");
+    PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap()
+}
+
+/// A table this test owns outright, so a run can never depend on — or damage —
+/// the shared fixtures the other suites assert on.
+fn unique_table(kind: &str) -> String {
+    format!("ta_upload_gate_{}_{}", kind, uuid::Uuid::new_v4().simple())
+}
+
+async fn create_table(pool: &PgPool, table: &str) {
+    sqlx::query(&format!("CREATE TABLE \"{table}\" (id TEXT PRIMARY KEY, note TEXT)"))
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn drop_table(pool: &PgPool, table: &str) {
+    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS \"{table}\"")).execute(pool).await;
+}
+
+async fn row_count(pool: &PgPool, table: &str) -> i64 {
+    sqlx::query(&format!("SELECT count(*) AS n FROM \"{table}\""))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .get::<i64, _>("n")
+}
+
+/// One row: `('gate-1', 'planted by an unauthorized Upload')`.
+fn one_row_batch() -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("note", DataType::Utf8, true),
+    ]));
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from(vec!["gate-1"])),
+        Arc::new(StringArray::from(vec!["planted by an unauthorized Upload"])),
+    ];
+    RecordBatch::try_new(schema, columns).unwrap()
+}
+
+/// Arrow IPC stream bytes, the encoding `decode_upload_batch` expects.
+fn encode_batch(batch: &RecordBatch) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut writer =
+            arrow::ipc::writer::StreamWriter::try_new(&mut buf, batch.schema().as_ref()).unwrap();
+        writer.write(batch).unwrap();
+        writer.finish().unwrap();
+    }
+    buf
+}
+
+/// The adapter the shipped server passes to the Flight service: a real
+/// PostgreSQL connection, no sandbox and no allow-list of its own.
+struct PgFlightAdapter {
+    inner: fraiseql_core::db::PostgresAdapter,
+}
+
+#[async_trait::async_trait]
+impl ArrowDatabaseAdapter for PgFlightAdapter {
+    async fn execute_raw_query(
+        &self,
+        sql: &str,
+    ) -> DatabaseResult<Vec<HashMap<String, serde_json::Value>>> {
+        use fraiseql_core::db::traits::DatabaseAdapter as _;
+        self.inner
+            .execute_raw_query(sql)
+            .await
+            .map_err(|e| DatabaseError::new(e.to_string()))
+    }
+}
+
+async fn flight_adapter() -> Arc<dyn ArrowDatabaseAdapter> {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for --ignored runs");
+    let inner = fraiseql_core::db::PostgresAdapter::new(&url).await.unwrap();
+    Arc::new(PgFlightAdapter { inner })
+}
+
+/// A session token of exactly the shape `validate_session_token` accepts —
+/// this is the "valid Flight session token" the finding turns on.
+fn session_token() -> String {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct Claims {
+        sub:          String,
+        exp:          i64,
+        iat:          i64,
+        scopes:       Vec<String>,
+        session_type: String,
+    }
+
+    let now = chrono::Utc::now();
+    let claims = Claims {
+        // An ordinary user, deliberately: no admin scope, nothing privileged.
+        sub:          "upload-gate-user".to_string(),
+        exp:          (now + chrono::Duration::minutes(5)).timestamp(),
+        iat:          now.timestamp(),
+        scopes:       vec!["user".to_string()],
+        session_type: "flight".to_string(),
+    };
+
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(TEST_FLIGHT_SECRET.as_bytes()),
+    )
+    .unwrap()
+}
+
+/// Serve `service` on an ephemeral port; returns the endpoint URL.
+async fn serve(service: FraiseQLFlightService) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(service.into_server())
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+/// Drive one `Upload` through `do_exchange` and return the server's
+/// `ExchangeMessage::Response` result — `Ok(message)` or `Err(message)`.
+async fn upload(addr: &str, table: &str, batch: &RecordBatch) -> Result<String, String> {
+    let channel = Endpoint::from_shared(addr.to_string()).unwrap().connect().await.unwrap();
+    let mut client = FlightServiceClient::new(channel);
+
+    let request_msg = ExchangeMessage::Request {
+        correlation_id: "gate-corr-1".to_string(),
+        request_type:   RequestType::Upload {
+            table: table.to_string(),
+            batch: encode_batch(batch),
+        },
+    };
+    let outbound = tokio_stream::iter(vec![FlightData {
+        app_metadata: request_msg.to_json_bytes().unwrap().into(),
+        ..Default::default()
+    }]);
+
+    let mut request = tonic::Request::new(outbound);
+    request
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {}", session_token()).parse().unwrap());
+
+    let mut inbound = client.do_exchange(request).await.unwrap().into_inner();
+
+    while let Some(data) = inbound.message().await.unwrap() {
+        if let Ok(ExchangeMessage::Response { result, .. }) =
+            ExchangeMessage::from_json_bytes(data.app_metadata.as_ref())
+        {
+            return result.map(|bytes| String::from_utf8_lossy(&bytes).into_owned());
+        }
+    }
+    panic!("do_exchange closed without answering the Upload");
+}
+
+// ------------------------------------------------------------------- tests
+
+/// **The finding.** A session-authenticated caller names a table it has no
+/// business writing — the stand-in here for `_system`, an audit table or the CDC
+/// outbox — and the rows must not land.
+///
+/// Before the gate this passed the rows straight through: the assertion that
+/// fails first is the row count, which is the whole point of #953. The refusal
+/// must also *say* why, so an operator who allow-listed nothing does not debug a
+/// silent write.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn upload_into_a_non_allow_listed_table_is_refused_and_writes_nothing() {
+    let pool = pool().await;
+    let forbidden = unique_table("forbidden");
+    create_table(&pool, &forbidden).await;
+
+    let service = FraiseQLFlightService::new_with_db(flight_adapter().await)
+        .with_session_secret(TEST_FLIGHT_SECRET);
+    let addr = serve(service).await;
+
+    let result = upload(&addr, &forbidden, &one_row_batch()).await;
+
+    let landed = row_count(&pool, &forbidden).await;
+    drop_table(&pool, &forbidden).await;
+
+    assert_eq!(
+        landed, 0,
+        "a session token alone must not be able to INSERT into an arbitrary table — {landed} \
+         row(s) landed in a table no operator allow-listed"
+    );
+    let message = result.expect_err("the Upload must be refused, not answered with a row count");
+    assert!(
+        message.contains(&forbidden),
+        "the refusal must name the table it refused, got: {message}"
+    );
+}
+
+/// Allow-listing is necessary but not sufficient: an adapter that cannot write the
+/// rows and their change-log outbox rows in one transaction must refuse, even for a
+/// table the operator named.
+///
+/// `PgFlightAdapter` here implements only `execute_raw_query` — exactly the shape
+/// every `ArrowDatabaseAdapter` had before #953 — so it takes
+/// `execute_gated_upload`'s default. That default **refuses**. The fail-open
+/// alternative (run the INSERT, skip the outbox) would write rows the Change Spine
+/// never sees, silently, on every adapter that had not been updated.
+///
+/// The counterweight — an allow-listed Upload that really does write its rows and
+/// its outbox rows — lives in `fraiseql-server`'s `flight_upload_outbox_pg`, where
+/// the adapter that implements the seam lives.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn an_allow_listed_upload_is_still_refused_by_an_adapter_that_cannot_write_atomically() {
+    let pool = pool().await;
+    let allowed = unique_table("allowed");
+    create_table(&pool, &allowed).await;
+
+    let service = FraiseQLFlightService::new_with_db(flight_adapter().await)
+        .with_session_secret(TEST_FLIGHT_SECRET)
+        .with_upload_tables([allowed.clone()]);
+    let addr = serve(service).await;
+
+    let result = upload(&addr, &allowed, &one_row_batch()).await;
+
+    let landed = row_count(&pool, &allowed).await;
+    drop_table(&pool, &allowed).await;
+
+    assert_eq!(
+        landed, 0,
+        "an adapter with no atomic-upload seam must write nothing, not write the rows \
+         and skip the change-log"
+    );
+    let message = result.expect_err("the Upload must be refused");
+    assert!(
+        message.contains("execute_gated_upload"),
+        "the refusal must name what the adapter is missing, got: {message}"
+    );
+}
+
+/// Allow-listing one table must not allow-list its neighbours. The gate is a
+/// membership test, not an on/off switch for the whole surface.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn an_allow_list_admits_only_the_tables_it_names() {
+    let pool = pool().await;
+    let allowed = unique_table("allowed");
+    let other = unique_table("other");
+    create_table(&pool, &allowed).await;
+    create_table(&pool, &other).await;
+
+    let service = FraiseQLFlightService::new_with_db(flight_adapter().await)
+        .with_session_secret(TEST_FLIGHT_SECRET)
+        .with_upload_tables([allowed.clone()]);
+    let addr = serve(service).await;
+
+    let result = upload(&addr, &other, &one_row_batch()).await;
+
+    let landed = row_count(&pool, &other).await;
+    drop_table(&pool, &allowed).await;
+    drop_table(&pool, &other).await;
+
+    assert_eq!(landed, 0, "a table absent from the allow-list must stay untouched");
+    result.expect_err("an unlisted table must be refused even when the allow-list is non-empty");
+}

--- a/crates/fraiseql-server/src/arrow/database_adapter.rs
+++ b/crates/fraiseql-server/src/arrow/database_adapter.rs
@@ -127,6 +127,88 @@ impl ArrowDatabaseAdapter for FlightDatabaseAdapter {
             .await
             .map_err(|e: fraiseql_core::error::FraiseQLError| DatabaseError::new(e.to_string()))
     }
+
+    /// Write the Upload's rows and their `core.tb_entity_change_log` outbox rows in
+    /// one PostgreSQL transaction (#953).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseError`] if the transaction fails, in which case **neither**
+    /// the rows nor the outbox rows were written.
+    async fn execute_gated_upload(
+        &self,
+        upload: &fraiseql_arrow::db::GatedUpload<'_>,
+    ) -> Result<u64, DatabaseError> {
+        let sql = build_upload_outbox_cte(upload.insert_sql);
+
+        let mut client = self
+            .inner
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::new(format!("Failed to acquire connection: {e}")))?;
+        let tx = client
+            .build_transaction()
+            .start()
+            .await
+            .map_err(|e| DatabaseError::new(format!("Failed to begin transaction: {e}")))?;
+
+        let row = tx
+            .query_one(sql.as_str(), &[&upload.table, &upload.tenant_id, &upload.user_id])
+            .await
+            .map_err(|e| DatabaseError::new(format!("Upload failed: {e}")))?;
+        let inserted: i64 = row.get("n");
+
+        tx.commit()
+            .await
+            .map_err(|e| DatabaseError::new(format!("Failed to commit Upload: {e}")))?;
+
+        Ok(inserted.unsigned_abs())
+    }
+}
+
+/// Wrap `insert_sql` so it and its change-log outbox rows are one statement.
+///
+/// Mirrors the mutation executor's Change Spine CTE
+/// (`build_changelog_cte_sql`): the data INSERT is a `RETURNING *` CTE, a
+/// data-modifying CTE writes one outbox row per inserted row from it, and the
+/// primary `SELECT` returns the count. One statement inside one transaction, so
+/// the rows and the Change Spine cannot diverge.
+///
+/// Parameters are positional and fixed, so the text is deterministic per
+/// `insert_sql`: `$1` = `object_type` (the table), `$2` = `tenant_id`, `$3` = the
+/// Flight session subject.
+///
+/// `$2::text::uuid` rather than `$2::uuid`: a cast applied straight to a parameter
+/// makes PostgreSQL infer the *parameter's* type as `uuid`, so the client is then
+/// required to send uuid-encoded bytes and a bound `&str` fails with "error
+/// serializing parameter". Going through `::text` pins the parameter as text and
+/// performs the cast server-side.
+///
+/// `object_id` is the row's `id` **only when it is a UUID** — an Upload target need
+/// not have one, and a `TEXT` key must not fail the whole write. The full row is in
+/// `object_data` either way, so nothing is lost by a NULL here.
+#[cfg(all(feature = "arrow", not(feature = "wire-backend")))]
+fn build_upload_outbox_cte(insert_sql: &str) -> String {
+    format!(
+        "WITH r AS ({insert_sql} RETURNING *), \
+         _changelog AS ( \
+           INSERT INTO core.tb_entity_change_log \
+             (object_type, modification_type, object_id, object_data, tenant_id, \
+              extra_metadata, commit_time) \
+           SELECT \
+             $1, 'INSERT', \
+             CASE WHEN to_jsonb(r)->>'id' ~ \
+                    '^[0-9a-fA-F]{{8}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{4}}-[0-9a-fA-F]{{12}}$' \
+                  THEN (to_jsonb(r)->>'id')::uuid ELSE NULL END, \
+             to_jsonb(r), $2::text::uuid, \
+             jsonb_build_object('transport', 'flight', 'flight_user_id', $3::text), \
+             clock_timestamp() \
+           FROM r \
+           RETURNING 1 \
+         ) \
+         SELECT count(*)::bigint AS n FROM r"
+    )
 }
 
 #[cfg(all(feature = "arrow", feature = "wire-backend"))]

--- a/crates/fraiseql-server/src/arrow/mod.rs
+++ b/crates/fraiseql-server/src/arrow/mod.rs
@@ -68,9 +68,16 @@ use fraiseql_core::db::postgres::PostgresAdapter;
 /// - `wire-backend` feature: FraiseQL Wire adapter for streaming JSON queries with low memory
 ///   overhead
 ///
+/// `upload_tables` is the operator's `flight_upload_tables` allow-list (#953). An
+/// empty slice leaves `Upload` **disabled**, which is the default and the only safe
+/// one: the target table is named by the client and the write skips the mutation
+/// pipeline. This is the config seam — without it `with_upload_tables` would be a
+/// library-only setter with no caller, and no operator could reach the feature.
+///
 /// # Arguments
 ///
 /// * `adapter` - Database adapter from fraiseql-core (PostgreSQL or Wire depending on features)
+/// * `upload_tables` - Tables an authenticated client may `Upload` into; empty disables Upload
 ///
 /// # Returns
 ///
@@ -81,19 +88,41 @@ use fraiseql_core::db::postgres::PostgresAdapter;
 /// ```text
 /// // PostgreSQL (default)
 /// let pg_adapter = PostgresAdapter::new(&db_url).await?;
-/// let flight_service = create_flight_service(Arc::new(pg_adapter));
+/// let flight_service = create_flight_service(Arc::new(pg_adapter), &config.flight_upload_tables);
 ///
 /// // FraiseQL Wire (with the `wire-backend` feature)
 /// let wire_adapter = FraiseWireAdapter::new(&db_url);
-/// let flight_service = create_flight_service(Arc::new(wire_adapter));
+/// let flight_service = create_flight_service(Arc::new(wire_adapter), &[]);
 /// ```
 #[cfg(all(feature = "arrow", not(feature = "wire-backend")))]
 #[must_use]
-pub fn create_flight_service(adapter: Arc<PostgresAdapter>) -> FraiseQLFlightService {
+pub fn create_flight_service(
+    adapter: Arc<PostgresAdapter>,
+    upload_tables: &[String],
+) -> FraiseQLFlightService {
     let flight_adapter = FlightDatabaseAdapter::from_arc(adapter);
 
     // Create Flight service with PostgreSQL adapter
-    FraiseQLFlightService::new_with_db(Arc::new(flight_adapter))
+    let service = FraiseQLFlightService::new_with_db(Arc::new(flight_adapter));
+    apply_upload_allow_list(service, upload_tables)
+}
+
+/// Apply the operator's Upload allow-list, leaving `Upload` disabled when empty.
+///
+/// An empty list must stay `None` on the service, not `Some(∅)`: both refuse every
+/// table, but only `None` reports "Upload is disabled" rather than "not permitted
+/// for this table", and that is the message that tells an operator they configured
+/// nothing.
+#[cfg(feature = "arrow")]
+fn apply_upload_allow_list(
+    service: FraiseQLFlightService,
+    upload_tables: &[String],
+) -> FraiseQLFlightService {
+    if upload_tables.is_empty() {
+        service
+    } else {
+        service.with_upload_tables(upload_tables.iter().cloned())
+    }
 }
 
 /// Create an Arrow Flight service backed by the fraiseql-wire streaming adapter.
@@ -101,9 +130,16 @@ pub fn create_flight_service(adapter: Arc<PostgresAdapter>) -> FraiseQLFlightSer
 /// Requires both the `arrow` and `wire-backend` features.
 #[cfg(all(feature = "arrow", feature = "wire-backend"))]
 #[must_use]
-pub fn create_flight_service(adapter: Arc<FraiseWireAdapter>) -> FraiseQLFlightService {
+pub fn create_flight_service(
+    adapter: Arc<FraiseWireAdapter>,
+    upload_tables: &[String],
+) -> FraiseQLFlightService {
     let flight_adapter = FlightDatabaseAdapter::from_arc(adapter);
 
-    // Create Flight service with FraiseQL Wire adapter
-    FraiseQLFlightService::new_with_db(Arc::new(flight_adapter))
+    // Create Flight service with FraiseQL Wire adapter. Note that the wire adapter
+    // does not implement `execute_gated_upload`, so an allow-listed Upload is still
+    // refused for want of an atomic write path — allow-listing it here cannot open
+    // the surface (#953).
+    let service = FraiseQLFlightService::new_with_db(Arc::new(flight_adapter));
+    apply_upload_allow_list(service, upload_tables)
 }

--- a/crates/fraiseql-server/src/arrow/mod.rs
+++ b/crates/fraiseql-server/src/arrow/mod.rs
@@ -37,6 +37,10 @@
 pub mod database_adapter;
 #[cfg(feature = "arrow")]
 pub mod executor_wrapper;
+#[cfg(feature = "arrow")]
+pub mod policy_seam;
+#[cfg(all(test, feature = "arrow"))]
+mod policy_seam_tests;
 
 #[cfg(test)]
 mod tests;
@@ -54,14 +58,20 @@ use fraiseql_arrow::FraiseQLFlightService;
 use fraiseql_core::db::FraiseWireAdapter;
 #[cfg(all(feature = "arrow", not(feature = "wire-backend")))]
 use fraiseql_core::db::postgres::PostgresAdapter;
+#[cfg(feature = "arrow")]
+pub use policy_seam::PolicyGatedExecutor;
 
 /// Create an Arrow Flight service with a real database adapter.
 ///
-/// **No `QueryExecutor` is attached — deliberately.** The Flight GraphQL paths
-/// therefore refuse every ad-hoc query fail-closed ("no executor configured").
-/// Wiring one in must go through the tenant-dispatch/policy seam (tenant
-/// resolution, suspension, quotas, trusted documents), not a bare
-/// `set_executor`, or Flight becomes the one transport that skips them.
+/// **No `QueryExecutor` is attached here** — the service is built before there is
+/// an `AppState` to enforce policy from. The server attaches
+/// [`PolicyGatedExecutor`] at serve time (`server::lifecycle`), so the Flight
+/// GraphQL paths run through tenant resolution, the suspended-tenant gate,
+/// per-tenant quotas and trusted documents like every other transport (#954).
+/// A service that never reaches `serve()` keeps refusing GraphQL fail-closed
+/// ("no executor configured"). Do **not** attach a bare
+/// [`ExecutorQueryAdapter`] instead: that is precisely the shape that makes
+/// Flight the one transport skipping all of the above.
 ///
 /// Supports both PostgreSQL and FraiseQL Wire adapters depending on feature flags:
 /// - Default: PostgreSQL adapter for traditional database connections

--- a/crates/fraiseql-server/src/arrow/policy_seam.rs
+++ b/crates/fraiseql-server/src/arrow/policy_seam.rs
@@ -1,0 +1,119 @@
+//! #954 — the policy seam the Flight GraphQL path executes through.
+//!
+//! The Flight `do_get` GraphQL path and the `do_exchange` `Query` arm both run
+//! through a [`QueryExecutor`]. Attaching a **bare** executor — which
+//! [`ExecutorQueryAdapter`](super::ExecutorQueryAdapter) is — would make Flight the
+//! one transport that skips tenant resolution, the suspended-tenant gate, per-tenant
+//! concurrency/RPS/cost quotas and trusted documents. Those are not executor-level
+//! concerns: they live in `AppState`, which the executor does not have.
+//!
+//! [`PolicyGatedExecutor`] is what the server mounts instead. It runs the same
+//! chokepoint sequence the HTTP handler runs, in the same order, from the same
+//! functions — trusted documents → tenant resolution → dispatch (suspension +
+//! quotas) → cost charge → execute — so a policy that changes for HTTP changes for
+//! Flight, rather than being reimplemented here and drifting.
+//!
+//! The executor-level floors (#379 GATE-1 depth/complexity from `[validation]`, and
+//! `[security.cost_budget] per_request_max`) still apply beneath this; they are the
+//! floor, not the policy.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use fraiseql_arrow::QueryExecutor;
+use fraiseql_core::{db::traits::DatabaseAdapter, security::SecurityContext};
+use http::HeaderMap;
+
+use crate::routes::graphql::{app_state::AppState, tenant_dispatch};
+
+/// A [`QueryExecutor`] that enforces the transport-independent policy before it
+/// executes anything.
+pub struct PolicyGatedExecutor<A: DatabaseAdapter> {
+    /// The full request-handling state: tenant registry, trusted-document store,
+    /// per-tenant executors and quotas.
+    state: AppState<A>,
+}
+
+impl<A: DatabaseAdapter> PolicyGatedExecutor<A> {
+    /// Wrap `state` as the Flight service's executor.
+    #[must_use]
+    pub const fn new(state: AppState<A>) -> Self {
+        Self { state }
+    }
+}
+
+// Reason: QueryExecutor is defined with #[async_trait]; all implementations must match
+// its transformed method signatures to satisfy the trait contract
+// async_trait: dyn-dispatch required; remove when RTN + Send is stable (RFC 3425)
+#[async_trait]
+impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> QueryExecutor for PolicyGatedExecutor<A> {
+    /// # Errors
+    ///
+    /// Returns the refusal as a `String` — the Flight protocol's error channel — for
+    /// a document the trusted-document store forbids, a tenant that cannot be
+    /// resolved, one that is suspended or unregistered, an exhausted quota, or an
+    /// over-budget request. Only a request that passes all of them is executed.
+    async fn execute_with_security(
+        &self,
+        query: &str,
+        variables: Option<&serde_json::Value>,
+        security_context: &SecurityContext,
+    ) -> Result<serde_json::Value, String> {
+        // 1. Trusted documents / `persisted_queries_only`. Flight carries no `documentId`, so every
+        //    Flight GraphQL request is ad-hoc text by construction — which is exactly what a store
+        //    in strict mode must refuse. Passing `None` as the document ID is not a shortcut: it is
+        //    the honest statement that this transport has no persisted-document channel.
+        if let Some(ref store) = self.state.trusted_docs {
+            store.resolve(None, Some(query)).map_err(|e| match e {
+                crate::trusted_documents::TrustedDocumentError::ForbiddenRawQuery => {
+                    crate::trusted_documents::record_rejected();
+                    "Ad-hoc GraphQL documents are forbidden (persisted queries only). The Arrow \
+                     Flight transport cannot supply a persisted document ID."
+                        .to_string()
+                },
+                other => format!("Trusted document rejection: {other}"),
+            })?;
+        }
+
+        // 2. Tenant resolution, through the seam MCP and HTTP use (#858). Flight has no HTTP
+        //    headers at this point, so resolution rests on the session's `SecurityContext` alone;
+        //    when the schema declares RLS the resolver is strict and an unresolvable tenant is
+        //    refused rather than defaulted.
+        let tenant_key = tenant_dispatch::resolve_tenant_key(
+            &self.state,
+            Some(security_context),
+            &HeaderMap::new(),
+        )
+        .map_err(|e| format!("Tenant resolution failed: {e}"))?;
+
+        // 3. Dispatch: the suspended-tenant gate and per-tenant concurrency/RPS quotas. `dispatch`
+        //    holds the concurrency permit for the rest of this call and releases it on drop. An
+        //    unregistered key errors here — never a silent fallback to the default executor, which
+        //    would serve another tenant's data.
+        let dispatch = tenant_dispatch::dispatch_to_tenant(&self.state, tenant_key.as_deref())
+            .map_err(|e| format!("Tenant dispatch refused: {e}"))?;
+        let executor = &dispatch.executor;
+
+        // 4. Per-tenant cost budget, charged at the same chokepoint as the other quotas and from
+        //    the same estimate.
+        let estimated_cost = tenant_dispatch::estimate_request_cost(query, variables, executor);
+        tenant_dispatch::charge_cost_budget(&self.state, tenant_key.as_deref(), estimated_cost)
+            .map_err(|e| format!("Cost budget refused: {e}"))?;
+
+        // 5. Execute on the *tenant's* executor, not the default one.
+        executor
+            .execute_with_security(query, variables, security_context)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Build the Flight service's policy-gated executor from a server's state.
+///
+/// This is the wiring #954 exists for: the shipped binary attaches **this**, and
+/// never a bare `ExecutorQueryAdapter`.
+pub(crate) fn policy_gated_executor<A: DatabaseAdapter + Clone + Send + Sync + 'static>(
+    state: AppState<A>,
+) -> Arc<dyn QueryExecutor> {
+    Arc::new(PolicyGatedExecutor::new(state))
+}

--- a/crates/fraiseql-server/src/arrow/policy_seam_tests.rs
+++ b/crates/fraiseql-server/src/arrow/policy_seam_tests.rs
@@ -1,0 +1,194 @@
+//! #954 — the Flight GraphQL path is refused **by policy**, not by accident.
+//!
+//! The companion to `server/routing/persisted_only_transport_tests.rs`, which pins
+//! the same mode across POST/GET/QUERY. Flight is the transport that had no such
+//! test: it refused every GraphQL request, but only because nothing had ever
+//! attached an executor. That refusal is indistinguishable from a policy decision
+//! and disappears the moment someone wires one — which is the whole of #954.
+//!
+//! So these assert on **which** refusal happens. A test that accepted any error
+//! would have passed before this seam existed, and would keep passing if the seam
+//! were replaced by a bare `ExecutorQueryAdapter` tomorrow.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Reason: test code, panics acceptable
+
+use std::sync::Arc;
+
+use fraiseql_arrow::QueryExecutor;
+use fraiseql_core::{
+    cache::CachedDatabaseAdapter, schema::CompiledSchema, security::SecurityContext, types::UserId,
+};
+use fraiseql_test_utils::failing_adapter::FailingAdapter;
+
+use super::policy_seam::PolicyGatedExecutor;
+use crate::{server::Server, server_config::ServerConfig};
+
+/// The one document the manifest allows.
+const PERSISTED_DOC: &str = "{ users { id } }";
+/// A document the manifest does not contain — what every Flight client must send,
+/// since the transport has no persisted-document channel.
+const ADHOC_DOC: &str = "{ adhoc { id } }";
+
+/// A server in `persisted_queries_only` mode with a real manifest file, exactly as
+/// an operator would ship it (the same fixture as the HTTP transport tests).
+async fn persisted_only_server(
+    dir: &tempfile::TempDir,
+) -> Server<CachedDatabaseAdapter<FailingAdapter>> {
+    use sha2::Digest as _;
+    let hash = hex::encode(sha2::Sha256::digest(PERSISTED_DOC.as_bytes()));
+    let manifest = serde_json::json!({
+        "version": 1,
+        "documents": { format!("sha256:{hash}"): PERSISTED_DOC }
+    });
+    let manifest_path = dir.path().join("manifest.json");
+    std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+    let mut schema = CompiledSchema::new();
+    schema.security = Some(fraiseql_core::schema::SecurityConfig {
+        persisted_queries_only: true,
+        trusted_documents: Some(fraiseql_core::schema::TrustedDocumentsConfig {
+            enabled: true,
+            mode: fraiseql_core::schema::TrustedDocumentMode::Permissive,
+            manifest_path: Some(manifest_path.to_str().unwrap().to_string()),
+            ..Default::default()
+        }),
+        ..fraiseql_core::schema::SecurityConfig::default()
+    });
+
+    let config = ServerConfig {
+        cors_enabled: false,
+        ..ServerConfig::default()
+    };
+    Box::pin(Server::new(config, schema, Arc::new(FailingAdapter::new()), None))
+        .await
+        .expect("Server::new should succeed with a trusted-documents manifest")
+}
+
+/// The context a Flight `do_exchange` builds after validating a session token —
+/// `SecurityContext::from_user` on the session's subject, which is what the handler
+/// does.
+fn flight_session_context() -> SecurityContext {
+    let user = fraiseql_core::security::auth_middleware::AuthenticatedUser {
+        user_id:      UserId::new("flight-policy-user"),
+        scopes:       vec!["user".to_string()],
+        expires_at:   chrono::Utc::now() + chrono::Duration::hours(1),
+        email:        None,
+        display_name: None,
+        extra_claims: std::collections::HashMap::new(),
+    };
+    SecurityContext::from_user(&user, "req-flight-1".to_string())
+}
+
+/// An ad-hoc document over Flight is refused **because it is not persisted** — not
+/// because no executor is configured.
+///
+/// The message assertion is the point. "No executor configured" was the old
+/// behaviour and would satisfy any is-error check, while meaning the transport is
+/// simply unimplemented; this pins that a *mode* refused the request.
+#[tokio::test]
+async fn an_adhoc_document_is_refused_by_the_persisted_only_policy() {
+    let dir = tempfile::tempdir().unwrap();
+    let server = persisted_only_server(&dir).await;
+    let seam = PolicyGatedExecutor::new(server.build_app_state());
+
+    let error = seam
+        .execute_with_security(ADHOC_DOC, None, &flight_session_context())
+        .await
+        .expect_err("persisted-only mode must refuse an ad-hoc document over Flight too");
+
+    assert!(
+        error.contains("persisted queries only"),
+        "the refusal must name the policy that refused, got: {error}"
+    );
+    assert!(
+        !error.contains("No executor configured"),
+        "an unwired transport is not a policy decision, got: {error}"
+    );
+}
+
+/// Under `persisted_queries_only`, **every** Flight GraphQL request is refused —
+/// including one whose text is byte-for-byte an allow-listed document.
+///
+/// This is a consequence operators need stated rather than discovered: a trusted-
+/// document store in strict mode resolves by document **ID**, and Flight has no
+/// channel to carry one, so matching text is not enough and cannot be made enough
+/// without inventing a Flight-only bypass. The mode therefore turns Flight GraphQL
+/// off, which is the fail-closed reading of "persisted queries only" and the one
+/// this seam implements.
+#[tokio::test]
+async fn under_persisted_only_even_the_allow_listed_text_is_refused_over_flight() {
+    let dir = tempfile::tempdir().unwrap();
+    let server = persisted_only_server(&dir).await;
+    let seam = PolicyGatedExecutor::new(server.build_app_state());
+
+    let error = seam
+        .execute_with_security(PERSISTED_DOC, None, &flight_session_context())
+        .await
+        .expect_err("strict mode resolves by document ID; matching text is not a substitute");
+
+    assert!(
+        error.contains("persisted queries only"),
+        "the refusal must name the policy, got: {error}"
+    );
+}
+
+/// The counterweight: the seam is not simply refusing everything.
+///
+/// With no trusted-document store configured, the same document reaches execution.
+/// It still fails there — `FailingAdapter` is the point of the fixture, and the
+/// empty schema cannot resolve `users` — but it must fail **past** the policy.
+/// Without this, a seam that refused unconditionally would satisfy every other test
+/// in this file.
+#[tokio::test]
+async fn without_a_trusted_document_store_the_query_reaches_execution() {
+    let server = Box::pin(Server::new(
+        ServerConfig {
+            cors_enabled: false,
+            ..ServerConfig::default()
+        },
+        CompiledSchema::new(),
+        Arc::new(FailingAdapter::new()),
+        None,
+    ))
+    .await
+    .expect("Server::new should succeed without trusted documents");
+    let seam = PolicyGatedExecutor::new(server.build_app_state());
+
+    let outcome = seam.execute_with_security(PERSISTED_DOC, None, &flight_session_context()).await;
+
+    if let Err(error) = outcome {
+        assert!(
+            !error.contains("persisted queries only"),
+            "with no store configured nothing may be refused as unpersisted, got: {error}"
+        );
+        assert!(
+            !error.contains("Tenant resolution failed") && !error.contains("Tenant dispatch"),
+            "an unconfigured single-tenant deployment must not be refused by tenancy, got: {error}"
+        );
+    }
+}
+
+/// The seam is what a service ends up holding — the wiring, not just the type.
+///
+/// `create_flight_service` deliberately builds the service with no executor; the
+/// policy seam is attached at serve time, when `AppState` first exists. This pins
+/// that the attach is possible and observable, so "Flight executes GraphQL" and
+/// "Flight enforces policy" cannot come apart silently.
+#[tokio::test]
+async fn the_policy_seam_attaches_to_a_flight_service() {
+    let dir = tempfile::tempdir().unwrap();
+    let server = persisted_only_server(&dir).await;
+
+    let mut service = fraiseql_arrow::FraiseQLFlightService::new();
+    assert!(
+        !service.has_executor(),
+        "precondition: a freshly built Flight service refuses GraphQL for want of an executor"
+    );
+
+    service.set_executor(super::policy_seam::policy_gated_executor(server.build_app_state()));
+
+    assert!(
+        service.has_executor(),
+        "after the serve-time attach the Flight service executes GraphQL — through the seam"
+    );
+}

--- a/crates/fraiseql-server/src/arrow/tests.rs
+++ b/crates/fraiseql-server/src/arrow/tests.rs
@@ -14,3 +14,62 @@ mod database_adapter_tests {
         // If this compiles, the struct is properly defined
     }
 }
+
+/// #953 — the operator's `flight_upload_tables` really reaches the Flight service.
+///
+/// Without these, `with_upload_tables` would be a setter with no caller and the
+/// allow-list would be unconfigurable from a config file — the shape that made
+/// `with_bulk_export_tables` library-only, and the class of defect P26 found
+/// repeatedly ("shipped" meaning the library, with nothing mounting it).
+#[cfg(feature = "arrow")]
+mod upload_allow_list_config {
+    #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+    use fraiseql_arrow::FraiseQLFlightService;
+
+    use super::super::apply_upload_allow_list;
+    use crate::server_config::ServerConfig;
+
+    /// The default configuration leaves Upload **disabled**, not merely empty.
+    ///
+    /// `None` and `Some(∅)` both refuse every table, but only `None` reports
+    /// "Upload is disabled", which is what tells an operator they configured
+    /// nothing — so the distinction is load-bearing and pinned here.
+    #[test]
+    fn an_absent_allow_list_leaves_upload_disabled() {
+        let config = ServerConfig::default();
+        assert!(
+            config.flight_upload_tables.is_empty(),
+            "Upload must be off by default — it is a raw client-directed INSERT"
+        );
+
+        let service = apply_upload_allow_list(FraiseQLFlightService::new(), &[]);
+        assert!(
+            service.upload_allowed_tables().is_none(),
+            "an empty config must leave the service's allow-list None (disabled), not Some(empty)"
+        );
+    }
+
+    /// A TOML file naming tables produces a service that admits exactly those.
+    #[test]
+    fn a_configured_allow_list_reaches_the_service() {
+        let toml = r#"
+            schema_path = "schema.compiled.json"
+            flight_upload_tables = ["ta_measurements", "ta_events"]
+        "#;
+        let config: ServerConfig = toml::from_str(toml).expect("config must parse");
+        assert_eq!(config.flight_upload_tables, ["ta_measurements", "ta_events"]);
+
+        let service =
+            apply_upload_allow_list(FraiseQLFlightService::new(), &config.flight_upload_tables);
+        let allowed = service.upload_allowed_tables().expect("the allow-list must be set");
+
+        assert!(allowed.contains("ta_measurements"));
+        assert!(allowed.contains("ta_events"));
+        assert_eq!(allowed.len(), 2, "the service must admit exactly the configured tables");
+        assert!(
+            !allowed.contains("core.tb_entity_change_log"),
+            "nothing must be admitted that the operator did not name"
+        );
+    }
+}

--- a/crates/fraiseql-server/src/main.rs
+++ b/crates/fraiseql-server/src/main.rs
@@ -719,8 +719,22 @@ async fn run_postgres(
     #[cfg(feature = "arrow")]
     {
         use fraiseql_server::arrow::create_flight_service;
-        let flight_service = create_flight_service(adapter.clone());
-        tracing::info!("Arrow Flight service initialized with real database adapter");
+        // #953: the Upload allow-list is an operator decision, read from
+        // `flight_upload_tables`. Empty (the default) leaves Upload disabled.
+        let flight_service = create_flight_service(adapter.clone(), &config.flight_upload_tables);
+        if config.flight_upload_tables.is_empty() {
+            tracing::info!(
+                "Arrow Flight service initialized with real database adapter (Upload disabled: \
+                 flight_upload_tables is empty)"
+            );
+        } else {
+            tracing::warn!(
+                tables = ?config.flight_upload_tables,
+                "Arrow Flight service initialized with real database adapter; Upload is ENABLED \
+                 for these tables — clients may INSERT into them without passing the mutation \
+                 pipeline's authorizer or field RBAC"
+            );
+        }
         let server =
             Server::with_flight_service(config, schema, adapter, db_pool, Some(flight_service))
                 .await?;

--- a/crates/fraiseql-server/src/server/lifecycle.rs
+++ b/crates/fraiseql-server/src/server/lifecycle.rs
@@ -747,8 +747,23 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
 
         // Start both HTTP and gRPC servers concurrently if Arrow Flight is enabled
         #[cfg(feature = "arrow")]
-        if let Some(flight_service) = self.flight_service.take() {
+        if let Some(mut flight_service) = self.flight_service.take() {
             let flight_addr = self.config.flight_bind_addr;
+
+            // #954: attach the policy seam, never a bare executor. This is the
+            // first point where both halves exist — `create_flight_service` builds
+            // the service before there is any `AppState` to enforce policy from —
+            // so the wiring lives here rather than in the constructor. Without it
+            // Flight is the one transport that skips tenant resolution, the
+            // suspended-tenant gate, per-tenant quotas and trusted documents.
+            flight_service.set_executor(crate::arrow::policy_seam::policy_gated_executor(
+                self.build_app_state(),
+            ));
+            info!(
+                "Arrow Flight GraphQL execution enabled through the policy seam (tenant \
+                 dispatch, trusted documents, per-tenant quotas)"
+            );
+
             info!("Arrow Flight server listening on grpc://{}", flight_addr);
 
             // Spawn Flight server in background, registered on the server's

--- a/crates/fraiseql-server/src/server/routing/persisted_only_transport_tests.rs
+++ b/crates/fraiseql-server/src/server/routing/persisted_only_transport_tests.rs
@@ -7,8 +7,10 @@
 //! refused on each of them — a persisted-only mode one transport ignores is
 //! not a mode. The out-of-band transports are pinned elsewhere: MCP and REST
 //! never execute client-authored documents, subscriptions honor only the root
-//! field name, and the Flight service refuses GraphQL outright (no executor is
-//! ever attached).
+//! field name, and Arrow Flight enforces the same mode through its policy seam
+//! (`arrow::policy_seam_tests`, #954) — Flight used to refuse GraphQL only
+//! because no executor was ever attached, which is not a policy and stopped
+//! being true the moment one was.
 #![allow(clippy::unwrap_used)] // Reason: test code, panics acceptable
 
 use std::sync::Arc;

--- a/crates/fraiseql-server/src/server_config/mod.rs
+++ b/crates/fraiseql-server/src/server_config/mod.rs
@@ -93,6 +93,30 @@ pub struct ServerConfig {
     #[serde(default = "defaults::default_flight_bind_addr")]
     pub flight_bind_addr: SocketAddr,
 
+    /// Tables an authenticated Arrow Flight client may `Upload` into (#953).
+    ///
+    /// **Empty (the default) disables `Upload` entirely** — the fail-closed
+    /// position, and the only safe default: an `Upload` is a raw, client-directed
+    /// INSERT whose target table is named by the *request*, and it does not pass
+    /// through the mutation pipeline, so it carries no operation authorizer and no
+    /// field RBAC. Ungated, any holder of a valid Flight session token could write
+    /// every table the connection role can write.
+    ///
+    /// Allow-list only tables every `Upload`-capable client is permitted to write.
+    /// Naming an audit, `_system` or outbox table here hands those clients the
+    /// ledger.
+    ///
+    /// The rows and their `core.tb_entity_change_log` outbox rows are written in one
+    /// transaction, so an allow-listed Upload is visible to the Change Spine and to
+    /// CDC like any other write.
+    ///
+    /// ```toml
+    /// flight_upload_tables = ["ta_measurements", "ta_events"]
+    /// ```
+    #[cfg(feature = "arrow")]
+    #[serde(default)]
+    pub flight_upload_tables: Vec<String>,
+
     /// Enable CORS.
     #[serde(default = "defaults::default_true")]
     pub cors_enabled: bool,
@@ -1090,6 +1114,9 @@ impl Default for ServerConfig {
             bind_addr: default_bind_addr(),
             #[cfg(feature = "arrow")]
             flight_bind_addr: defaults::default_flight_bind_addr(),
+            // #953: fail-closed — Upload is off until an operator names tables.
+            #[cfg(feature = "arrow")]
+            flight_upload_tables: Vec::new(),
             cors_enabled: true,
             cors_origins: Vec::new(),
             compression_enabled: false,

--- a/crates/fraiseql-server/tests/config_coverage_manifest_test.rs
+++ b/crates/fraiseql-server/tests/config_coverage_manifest_test.rs
@@ -177,6 +177,11 @@ const MANIFEST: &[(&str, &str)] = &[
     // long enough that four remediation phases recorded it as a pre-existing failure
     // rather than a missing row. Naming the consumer is the whole job.
     ("flight_bind_addr", "Arrow Flight gRPC listener (lifecycle.rs, `arrow` feature)"),
+    (
+        "flight_upload_tables",
+        "Arrow Flight `Upload` allow-list — main.rs → create_flight_service → \
+         with_upload_tables (#953); empty leaves Upload disabled",
+    ),
     ("mailbox", "inbound email IMAP pollers + startup probes (lifecycle.rs)"),
     (
         "send.challenge_suppress_after",

--- a/crates/fraiseql-server/tests/flight_upload_outbox_pg.rs
+++ b/crates/fraiseql-server/tests/flight_upload_outbox_pg.rs
@@ -1,0 +1,235 @@
+//! #953 — an allow-listed Flight `Upload` writes its rows **and** their Change Spine
+//! outbox rows, in one transaction, against a real PostgreSQL.
+//!
+//! `fraiseql-arrow`'s `flight_upload_gate_pg` pins the decision half over a real
+//! Flight socket: which tables are refused, and that an adapter without this seam
+//! refuses even an allow-listed one. This suite pins the half that only exists here,
+//! where the adapter that implements the seam lives — that the write actually happens,
+//! that the Change Spine sees it, and that the two cannot come apart.
+//!
+//! Before #953 an Upload ran `adapter.execute_raw_query(insert_sql)` and nothing else:
+//! the rows landed and the change log stayed empty, so every Upload was invisible to
+//! CDC, to the observers and to any consumer reading the spine.
+//!
+//! `#[ignore]` — needs `DATABASE_URL`. Named explicitly by the Dagger
+//! `integration` leg (`observers` suite, which binds a Postgres), so it either runs
+//! or the leg fails. Run with:
+//! `cargo test -p fraiseql-server --features arrow --test flight_upload_outbox_pg --
+//! --ignored --test-threads=1`.
+
+// PostgreSQL build only. Under `wire-backend`, `FlightDatabaseAdapter` wraps a
+// `FraiseWireAdapter`, which does not implement `execute_gated_upload` — so an
+// allow-listed Upload is refused there for want of an atomic write path, and there
+// is no outbox behaviour to assert. ⚠ This means the leg that runs this suite must
+// **not** pass `wire-backend`, or the whole binary compiles to zero tests and reads
+// green; the Dagger line uses `--features arrow` for exactly that reason.
+#![cfg(all(feature = "arrow", not(feature = "wire-backend")))]
+#![allow(clippy::unwrap_used, clippy::expect_used)] // Reason: test code, panics acceptable
+
+use fraiseql_arrow::db::{ArrowDatabaseAdapter, GatedUpload};
+use fraiseql_server::arrow::FlightDatabaseAdapter;
+use sqlx::{
+    Row,
+    postgres::{PgPool, PgPoolOptions},
+};
+
+const TENANT: &str = "6f1b2c34-5d6e-4f70-8a91-b2c3d4e5f607";
+
+async fn pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for --ignored runs");
+    PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap()
+}
+
+/// The change-log table from the ONE shared provisioner (#942/#982) — the
+/// migration-08 contract byte-for-byte, so this suite cannot assert against a
+/// shape no deployment has.
+async fn provision_changelog(pool: &PgPool) {
+    sqlx::raw_sql(&fraiseql_test_support::changelog::entity_change_log_provision_sql())
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+fn unique_table() -> String {
+    format!("ta_upload_outbox_{}", uuid::Uuid::new_v4().simple())
+}
+
+async fn create_table(pool: &PgPool, table: &str) {
+    sqlx::query(&format!("CREATE TABLE \"{table}\" (id UUID PRIMARY KEY, note TEXT)"))
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn drop_table(pool: &PgPool, table: &str) {
+    let _ = sqlx::query(&format!("DROP TABLE IF EXISTS \"{table}\"")).execute(pool).await;
+}
+
+async fn count(pool: &PgPool, sql: &str) -> i64 {
+    sqlx::query(sql).fetch_one(pool).await.unwrap().get::<i64, _>("n")
+}
+
+async fn adapter() -> FlightDatabaseAdapter {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for --ignored runs");
+    FlightDatabaseAdapter::new(fraiseql_core::db::PostgresAdapter::new(&url).await.unwrap())
+}
+
+/// Two rows with real UUID keys, the shape `build_insert_query` emits.
+fn insert_two(table: &str) -> String {
+    format!(
+        "INSERT INTO \"{table}\" (id, note) VALUES \
+         ('11111111-1111-4111-8111-111111111111', 'one'), \
+         ('22222222-2222-4222-8222-222222222222', 'two')"
+    )
+}
+
+/// The rows land **and** the Change Spine records each of them.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn an_allow_listed_upload_writes_its_rows_and_one_outbox_row_per_row() {
+    let pool = pool().await;
+    provision_changelog(&pool).await;
+    let table = unique_table();
+    create_table(&pool, &table).await;
+
+    let sql = insert_two(&table);
+    let written = adapter()
+        .await
+        .execute_gated_upload(&GatedUpload {
+            table:      &table,
+            insert_sql: &sql,
+            user_id:    "upload-outbox-user",
+            tenant_id:  Some(TENANT),
+        })
+        .await;
+
+    let written = written.expect("the gated Upload must succeed");
+
+    let rows = count(&pool, &format!("SELECT count(*) AS n FROM \"{table}\"")).await;
+    let logged = count(
+        &pool,
+        &format!(
+            "SELECT count(*) AS n FROM core.tb_entity_change_log WHERE object_type = '{table}'"
+        ),
+    )
+    .await;
+    let log_row = sqlx::query(
+        "SELECT object_id, object_data, tenant_id, modification_type, extra_metadata
+         FROM core.tb_entity_change_log WHERE object_type = $1 ORDER BY object_id LIMIT 1",
+    )
+    .bind(&table)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    drop_table(&pool, &table).await;
+
+    assert_eq!(written, 2, "the seam must report the rows it wrote");
+    assert_eq!(rows, 2, "the Upload's rows must land");
+    assert_eq!(logged, 2, "the Change Spine must record one row per uploaded row");
+
+    // The outbox row must be usable by a consumer, not just present.
+    assert_eq!(log_row.get::<String, _>("modification_type"), "INSERT");
+    assert_eq!(
+        log_row.get::<uuid::Uuid, _>("object_id").to_string(),
+        "11111111-1111-4111-8111-111111111111",
+        "a UUID key must reach object_id, so consumers can address the entity"
+    );
+    assert_eq!(
+        log_row.get::<uuid::Uuid, _>("tenant_id").to_string(),
+        TENANT,
+        "the write's tenant must partition its outbox row"
+    );
+    let data: serde_json::Value = log_row.get("object_data");
+    assert_eq!(data["note"], "one", "object_data must carry the row that was written");
+    let meta: serde_json::Value = log_row.get("extra_metadata");
+    assert_eq!(
+        meta["transport"], "flight",
+        "the ingress transport must be recorded, so an operator can tell Flight writes apart"
+    );
+    assert_eq!(meta["flight_user_id"], "upload-outbox-user");
+}
+
+/// **Atomicity.** With the change-log table absent, the outbox write fails — and the
+/// data rows must not be there either.
+///
+/// Without this, "in the same transaction" is untested prose: two sequential
+/// statements would pass every other assertion in this file and still leave the rows
+/// committed with the spine blind, which is the exact defect #953 names.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn a_failing_outbox_write_takes_the_rows_with_it() {
+    let pool = pool().await;
+    let table = unique_table();
+    create_table(&pool, &table).await;
+    // Remove the outbox table the CTE writes to — the second half of the
+    // transaction can no longer succeed.
+    sqlx::raw_sql("DROP TABLE IF EXISTS core.tb_entity_change_log CASCADE")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let sql = insert_two(&table);
+    let result = adapter()
+        .await
+        .execute_gated_upload(&GatedUpload {
+            table:      &table,
+            insert_sql: &sql,
+            user_id:    "upload-outbox-user",
+            tenant_id:  None,
+        })
+        .await;
+
+    let rows = count(&pool, &format!("SELECT count(*) AS n FROM \"{table}\"")).await;
+    drop_table(&pool, &table).await;
+    provision_changelog(&pool).await; // restore for whatever runs next
+
+    result.expect_err("the Upload must fail when its outbox row cannot be written");
+    assert_eq!(
+        rows, 0,
+        "the rows must roll back with the outbox write — {rows} row(s) committed while the \
+         Change Spine recorded nothing"
+    );
+}
+
+/// A non-UUID primary key must not fail the write: `object_id` is NULL and the whole
+/// row still reaches `object_data`. An Upload target is an arbitrary allow-listed
+/// table and need not use UUID keys.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn a_non_uuid_key_logs_a_null_object_id_rather_than_failing() {
+    let pool = pool().await;
+    provision_changelog(&pool).await;
+    let table = unique_table();
+    sqlx::query(&format!("CREATE TABLE \"{table}\" (id TEXT PRIMARY KEY, note TEXT)"))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let sql = format!("INSERT INTO \"{table}\" (id, note) VALUES ('not-a-uuid', 'one')");
+    let written = adapter()
+        .await
+        .execute_gated_upload(&GatedUpload {
+            table:      &table,
+            insert_sql: &sql,
+            user_id:    "upload-outbox-user",
+            tenant_id:  None,
+        })
+        .await;
+
+    let logged = sqlx::query(
+        "SELECT object_id, object_data FROM core.tb_entity_change_log WHERE object_type = $1",
+    )
+    .bind(&table)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    drop_table(&pool, &table).await;
+
+    assert_eq!(written.unwrap(), 1);
+    assert!(
+        logged.get::<Option<uuid::Uuid>, _>("object_id").is_none(),
+        "a TEXT key must log NULL, not abort the Upload"
+    );
+    let data: serde_json::Value = logged.get("object_data");
+    assert_eq!(data["id"], "not-a-uuid", "the key is still recoverable from object_data");
+}


### PR DESCRIPTION
Wave 1's second phase, and the program's **highest-severity open finding**. Gate G1
was answered *gate, do not delete*, so nothing here is removed — the Flight surfaces
are kept and made to obey the same policy every other transport obeys. **No
`### Breaking` entries.**

## #953 — Upload was an unauthorized write onto any table

Any caller holding a valid Flight session token could send `Upload { table, batch }`
with an **arbitrary client-supplied table name** and have the rows land.
`handle_upload` went from session validation straight to `build_insert_query` →
`execute_raw_query`: no table allow-list, no tenant scoping, no RLS, no operation
authorizer, no field RBAC, no mutation-audit event, no change-log outbox row.
Escaping was correct throughout, so this was never SQL injection — it was an
unauthorized-write surface onto every table the connection role can write,
`_system`, audit and outbox tables included, reachable in the shipped binary.

**RED first, over the wire.** `flight_upload_gate_pg` drives the real service over a
real socket with a real session token. Run before any gate code, it failed on
exactly the assertion that matters — `1 row(s) landed in a table no operator
allow-listed`. The hole was demonstrated, not inferred.

Now: `Upload` is **disabled by default**, refused unless its table appears in the
new `flight_upload_tables` config key; an allow-listed Upload writes its rows and
one `core.tb_entity_change_log` outbox row per row **in a single transaction**,
stamped with tenant, `transport: "flight"` and the Flight subject, and emits the
`fraiseql::mutation_audit` event.

**The default refuses, deliberately.** The new
`ArrowDatabaseAdapter::execute_gated_upload` has a refusing default impl. Running
the INSERT and the outbox write sequentially is fail-open — it produces the split
brain (rows committed, Change Spine blind) silently on every adapter that did not
override it. So allow-listing a table on an adapter without the seam (the
`wire-backend` build) still cannot open the surface.

## #954 — the Flight GraphQL refusal was accidental, not policy

Nothing in fraiseql-server ever attached a `QueryExecutor`, so Flight refused every
GraphQL request with "no executor configured". That is indistinguishable from an
unimplemented transport and disappears the moment anyone calls `set_executor` —
creating the one transport that skips tenant resolution, the suspended-tenant gate,
per-tenant quotas and trusted documents.

`PolicyGatedExecutor` now runs the same chokepoints the HTTP handler runs, in the
same order, **calling the same functions**: trusted documents → `resolve_tenant_key`
→ `dispatch_to_tenant` → `estimate_request_cost` + `charge_cost_budget` → execute on
the tenant's executor. Attached at serve time, the first point where both halves
exist. `ExecutorQueryAdapter` stays, documented as the bare form the server does not
mount.

The tests assert **which** refusal happened — a test that accepted any error would
have passed before the seam existed. Red-proven by removing the trusted-documents
stage alone: both policy tests then fail with `Query 'adhoc' not found in schema`,
i.e. the ad-hoc document reached execution.

⚠ **Consequence worth stating**: under `persisted_queries_only`, Flight GraphQL is
refused **entirely**, including text byte-identical to an allow-listed document —
strict mode resolves by document ID and Flight has no channel to carry one. Pinned
by a test so it is a decision, not a surprise.

## #908 / #1001 — the suites executed nowhere, and two of three were fabricated

No Dagger leg ran the three DB-backed Flight suites; all 31 tests reported `ok`
while running nothing. And wiring them as they stood would have produced *false*
evidence: `flight_e2e_test`'s six tests carried numbered "1. Create FlightTicket
2. Send DoGet request 3. Receive schema message" doc comments and called **no Flight
RPC at all** — each reduced to `assert!(schema_registry().contains("ta_users"))`,
which `register_defaults()` hardcodes. Each still `CREATE DATABASE`d a fixture it
never queried.

All rewritten to drive real RPCs and assert on real rows; `test_ipc_encoding_failure`
deleted (no honest way to force it from outside). `flight_integration`'s 10 DB tests
are now `#[ignore]`d so a no-database leg shows them *ignored* rather than passed.
21 tests now execute in `integration: postgres`.

## Filed along the way

- **#1002** — `infer_schema_from_rows` takes column order from `HashMap::iter()`, so
  two batched queries with **identical** columns are refused as "heterogeneous
  schemas", intermittently by hash seeding. Found by the rewritten test.

## Verification

✅ `flight_upload_gate_pg` 3/3 (real socket) · `flight_upload_outbox_pg` 3/3 (real
   PostgreSQL, incl. rollback) · `flight_e2e_test` 6/6 · `flight_error_handling_test`
   5/5 · `flight_integration` 10/10+9 · `arrow::policy_seam_tests` 4/4
✅ `make preflight` exit 0 · doctests 42/0 · `cargo test -p fraiseql-arrow
   --all-features` 16 suites / 0 failures · `fraiseql-server --lib` 1028/0
✅ `tools/check-suite-coverage.py` OK · clippy clean · `cargo +nightly fmt`
✅ Red-proven per fix, each on its own assertion. The first atomicity revert-check
   was **rejected** — it failed for an unrelated reason (two rows into `query_one`),
   so it proved nothing; the corrected one gives `2 row(s) committed while the Change
   Spine recorded nothing`.
✅ Preflight caught a real defect during the rebase: under `--all-features`,
   `wire-backend` changes `FlightDatabaseAdapter::new`'s parameter type. The outbox
   suite is now `cfg`'d to the PG build, and its Dagger line uses `--features arrow`
   rather than `serverTestFeatures` — the latter includes `wire-backend`, under which
   the binary would compile to zero tests and read green.

## Still open

A Flight session carries **no tenant**: `SessionTokenClaims` has no tenant claim and
`SecurityContext::from_user` hard-codes `tenant_id: None`, so the outbox stamp is
`NULL` until the handshake captures one. The plumbing is in place and the column is
written from the context — a claims change, not a rework.

Closes #953
Closes #954
Closes #908
Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
