### PR TITLE
P12 — MSRV 1.94 + wasmtime 46.0.2 (#933)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -19,14 +19,6 @@ ignore = [
   "RUSTSEC-2026-0099",
   # rustls-webpki 0.101.7 CRL parsing panic; same root cause as 0098/0099. Deadline 2026-06-15.
   "RUSTSEC-2026-0104",
-  # wasmtime-wasi FilePerms bypass (hard-link/rename); transitive via fraiseql-functions'
-  # opt-in runtime-wasm feature only (wasmtime pinned to 44, NOT in default build). Patched in
-  # 45.0.3/46.0.1 — needs a wasmtime 44->45+ major bump tracked separately. Deadline 2026-10-01.
-  "RUSTSEC-2026-0188",
-  # wasmtime cross-Engine type-index confusion (GHSA-hgjw-h833-99q9); opt-in runtime-wasm
-  # only, single Engine per process, no cross-engine value flow. Patched lines (46.0.2/47.0.3)
-  # require Rust 1.94 > MSRV 1.92 — bump blocked on the MSRV raise (#933). Deadline 2026-10-01.
-  "RUSTSEC-2026-0222",
   # quick-xml DoS pair (published 2026-07-02); transitive via samael 0.0.21 (auth-saml opt-in
   # only, NOT default build); samael pins quick-xml 0.37.5, no fix in range. Deadline 2026-10-01.
   "RUSTSEC-2026-0194",

--- a/.dagger/feature-combos.go
+++ b/.dagger/feature-combos.go
@@ -12,7 +12,7 @@ package main
 // These are `cargo check` (and, for the functions combos, `cargo clippy`) only —
 // no test binaries run, so no backing services are needed. That makes this matrix
 // immune to the Docker Hub anonymous pull rate-limit that gates the integration
-// suites (it only ever pulls the already-cached rust:1.92 base). See parity-notes.md.
+// suites (it only ever pulls the already-cached rust:1.94 base). See parity-notes.md.
 
 import (
 	"context"
@@ -285,9 +285,9 @@ func (m *FraiseqlCi) runCombo(
 	cmd := strings.Join(c.cargoArgs(), " ")
 	var setup string
 	if c.clippy {
-		// rustBaseFor pins RUSTUP_TOOLCHAIN=1.92, but rustBase installs clippy on the
+		// rustBaseFor pins RUSTUP_TOOLCHAIN=1.94, but rustBase installs clippy on the
 		// base image's *default* toolchain — not the instance RUSTUP_TOOLCHAIN selects
-		// (`1.92-x86_64-unknown-linux-gnu`), which ships only rustc. So ensure clippy
+		// (`1.94-x86_64-unknown-linux-gnu`), which ships only rustc. So ensure clippy
 		// for the active toolchain before running it (idempotent: a no-op once present).
 		// Scoped here, not in rustBase: the Phase-02 clippy/fmt gates use rustBase()
 		// directly (no RUSTUP_TOOLCHAIN) and are unaffected; only these clippy combos hit

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -17,7 +17,7 @@ import (
 type FraiseqlCi struct{}
 
 const (
-	// rustImage pins the toolchain to the workspace MSRV (rust-toolchain.toml channel = 1.92).
+	// rustImage pins the toolchain to the workspace MSRV (rust-toolchain.toml channel = 1.94).
 	// The default (non-slim) variant is buildpack-deps-based, so gcc/perl/curl/git are present.
 	// (Later: pin by digest — see parity-notes.md Phase 02.)
 	//
@@ -27,7 +27,7 @@ const (
 	// them anonymously. Every ghcr.io/fraiseql/* tag below MUST have a matching entry in that
 	// workflow's IMAGES list. (mcr.microsoft.com/* and the Apollo router stay as-is — not
 	// Docker Hub, not rate-limited.)
-	rustImage = "ghcr.io/fraiseql/rust:1.92"
+	rustImage = "ghcr.io/fraiseql/rust:1.94"
 	// ubuntuImage backs shellBase (the toolchain-free shell-gate container).
 	ubuntuImage = "ghcr.io/fraiseql/ubuntu:24.04"
 	// unwrapAllowLimit: the ShellGates `make lint-unwrap` budget (see Makefile).
@@ -35,7 +35,7 @@ const (
 	// sccacheVersion pins the prebuilt sccache binary fetched into rustBase.
 	sccacheVersion = "v0.8.2"
 	// rustMsrv mirrors Cargo.toml workspace rust-version and rust-toolchain.toml channel.
-	rustMsrv = "1.92"
+	rustMsrv = "1.94"
 
 	// SYNC:* feature sets — this file is the single authority since the legacy
 	// ci.yml was retired (#951); the SYNC tags mark every use site in this file.
@@ -362,7 +362,7 @@ func (m *FraiseqlCi) shellBase() *dagger.Container {
 //
 // The workspace test leg: a full `cargo build --all-features`
 // followed by the feature-scoped `cargo test -p …` invocations (the SYNC:* lists)
-// and the doctest pass. Parameterized by toolchain (stable | MSRV 1.92).
+// and the doctest pass. Parameterized by toolchain (stable | MSRV 1.94).
 
 // Test runs the workspace test suite for the given toolchain. `rust` is "msrv"
 // (default — the pinned floor, == rust-toolchain.toml) or "stable" (latest stable).
@@ -382,7 +382,7 @@ func (m *FraiseqlCi) Test(
 	rust string,
 ) (string, error) {
 	toolchain := resolveToolchain(rust)
-	// Per-toolchain target cache: stable and 1.92 produce incompatible artifacts,
+	// Per-toolchain target cache: stable and 1.94 produce incompatible artifacts,
 	// so they must not share a target dir (kept separate from the Phase-02 gates'
 	// `fraiseql-rust-target`, which holds clippy/rustdoc check artifacts).
 	// `test2-` bump (2026-06-30): the `test-` volume held stale fraiseql-cli/-db

--- a/.github/workflows/dagger-feature-matrix.yml
+++ b/.github/workflows/dagger-feature-matrix.yml
@@ -4,7 +4,7 @@ name: Dagger — feature matrix
 # `cargo check --features …` combos (feature-matrix / database-matrix /
 # storage-matrix / functions-matrix) onto one parameterized Dagger fn, with the
 # combo list as typed Go data (.dagger/feature-combos.go). cargo check / clippy only
-# — no test binaries, so NO backing services: it only pulls the rust:1.92 base (from
+# — no test binaries, so NO backing services: it only pulls the rust:1.94 base (from
 # the private ghcr.io/fraiseql mirror, see mirror-base-images.yml). Runs on the
 # self-hosted runner (fraiseql-8core) at ~$0/min, reusing the box's cargo/sccache
 # cache volumes (warm = fast). See parity-notes.md.

--- a/.github/workflows/dagger-test.yml
+++ b/.github/workflows/dagger-test.yml
@@ -1,7 +1,7 @@
 name: Dagger — test
 
 # Phase 03 workspace test suite (Track 0). Runs the workspace test suite
-# on the self-hosted runner (fraiseql-8core) at ~$0/min, for both the MSRV (1.92)
+# on the self-hosted runner (fraiseql-8core) at ~$0/min, for both the MSRV (1.94)
 # and latest-stable toolchains. `dagger call test --rust=<tc>` does the full
 # cargo build --all-features + the feature-scoped cargo test invocations + doctests,
 # reusing the box's cargo/target/sccache cache volumes (warm = fast).

--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -4,7 +4,7 @@ name: Mirror base images to ghcr.io
 # periodically red-lines the self-hosted runner — one authenticated `fraiseql`
 # Docker Hub account is shared across the whole release+CI load, so a busy day
 # (a release + Dependabot + a few pushes) exhausts the 6-hour pull budget and every
-# `dagger call` leg fails resolving `rust:1.92` / `postgres:16` / etc.
+# `dagger call` leg fails resolving `rust:1.94` / `postgres:16` / etc.
 #
 # This job mirrors each of those images into ghcr.io/fraiseql/*, which the Dagger
 # engine then pulls anonymously (public packages) with NO Docker Hub involvement —
@@ -57,7 +57,7 @@ jobs:
           set -euo pipefail
           # src (Docker Hub) | dst (ghcr.io/fraiseql, org/name flattened to fraiseql/<name>)
           IMAGES="
-          docker.io/library/rust:1.92|ghcr.io/fraiseql/rust:1.92
+          docker.io/library/rust:1.94|ghcr.io/fraiseql/rust:1.94
           docker.io/library/ubuntu:24.04|ghcr.io/fraiseql/ubuntu:24.04
           docker.io/library/postgres:16|ghcr.io/fraiseql/postgres:16
           docker.io/pgvector/pgvector:pg16|ghcr.io/fraiseql/pgvector:pg16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **The minimum supported Rust version is now 1.94 (was 1.92) (#933).** Required to clear
+  RUSTSEC-2026-0222 (`wasmtime`: stores can mix up type indices between engines): the 44.x
+  line we shipped has no patched release, and every patched line (46.0.2 / 47.0.3) pulls
+  cranelift 0.133, which requires 1.94. The same bump also clears **RUSTSEC-2026-0188**
+  (`wasmtime-wasi`: WASI hard links and renames bypass `FilePerms` on the destination path),
+  whose fix likewise landed outside the 44.x line — both advisory ignores are removed from
+  `deny.toml` and `.cargo/audit.toml`, and no wasmtime advisory is accepted any more.
+  Raised now rather than at the 2026-10-01 ignore deadline, because an expiring ignore
+  reddens the *required* `security` check on a date rather than on a push, i.e. on every
+  branch at once.
+
+  `wasmtime` and `wasmtime-wasi` move together to 46.0.2 (opt-in `runtime-wasm` feature;
+  not in a default build). `rust-version`, `rust-toolchain.toml`, the Dagger MSRV leg and
+  its mirrored `rust:1.94` base image all move in lockstep. Two published crates carried
+  MSRV metadata that was already untrue and now inherit the workspace value:
+  `fraiseql-storage` claimed `1.75`, and `fraiseql-federation` declared no `rust-version`
+  at all.
+
 - **`computed` is pinned as an authoring-only flag (#927).** Python's
   `@fraiseql.field(computed=True)` and F#'s `[<GraphQLField(Computed = true)>]` both used to
   serialize a `computed` key into `schema.json`. `IntermediateField` has no such member and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1792,16 +1792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.6",
-]
-
-[[package]]
 name = "cap-std"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2304,27 +2294,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
+checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
+checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
+checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -2332,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
+checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2343,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
+checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -2357,13 +2347,16 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash 2.1.2",
  "serde",
+ "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -2371,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
+checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -2384,24 +2377,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
+checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
+checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
+checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -2411,11 +2404,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
+checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -2423,15 +2417,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
+checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
+checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2440,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.3"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
+checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
 
 [[package]]
 name = "crc"
@@ -3088,7 +3082,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3303,7 +3297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3397,17 +3391,6 @@ name = "fax"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.4",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "fdeflate"
@@ -4598,8 +4581,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -4611,6 +4592,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4939,7 +4922,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5275,7 +5258,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5698,12 +5681,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -6053,7 +6033,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7051,7 +7031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7111,9 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34dff5fd3d9ac4845939fcb4597cd413cb244bc530448ed4766d11b1725e53d0"
+checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -7123,9 +7103,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c60fb1c885bdb1efd7c50e8e973714de558b75a65f20c3e9a41398c652aa44b"
+checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7197,7 +7177,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.42",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7234,7 +7214,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7603,6 +7583,7 @@ dependencies = [
  "hashbrown 0.17.0",
  "log",
  "rustc-hash 2.1.2",
+ "serde",
  "smallvec",
 ]
 
@@ -7927,7 +7908,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8657,7 +8638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8941,7 +8922,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9454,22 +9435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.11.1",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.52.0",
- "winx",
-]
-
-[[package]]
 name = "tabwriter"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9516,7 +9481,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10635,9 +10600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
+checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -10645,8 +10610,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
@@ -10662,22 +10627,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
+version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+checksum = "9b524283fb5df62eec102ed0574838961bdd7ba5ac9c50d38e2756c51c971a42"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.248.0",
+ "wasmparser 0.255.0",
 ]
 
 [[package]]
@@ -10706,12 +10671,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "semver 1.0.28",
  "serde",
@@ -10719,9 +10684,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.248.0"
+version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap 2.14.0",
@@ -10730,20 +10695,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d807f646bfecc1dbb4990d8c864beebccbdb3f2cd1b39b2b82957b4e294c6058"
+checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -10774,8 +10739,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -10787,16 +10752,16 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b945309908f22473ebcd585ac2993948044228491cd96941d367aa81a49c3f"
+checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -10804,7 +10769,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "log",
  "object 0.39.1",
@@ -10816,8 +10781,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -10825,9 +10790,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14b8b93c2137c88ed84114d9a09cb11cb8bf9394aba4856e48f5304a4f99eec"
+checksum = "bb07d96412d6958817749712969cfd6416cbce11639c3f3431dc659816d84ace"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -10845,9 +10810,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7307dec6251a18ffa9df03120d2945ac2476ce150b5b099f39b199e8f81464dc"
+checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -10855,32 +10820,32 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3d899b0270bcf04852f141bd9538cb162a436e7f56b2c6e0f4e57ecc70743a"
+checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
+checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512fd846630c064bfc42909eeba90a7d26703b6ded09ad4778ff6afcbdc868dd"
+checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -10896,7 +10861,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -10905,9 +10870,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15629ea71394be5812a52cb8fbc6cd039484ab1dd48fce5e1ef58ae89606289a"
+checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
 dependencies = [
  "cc",
  "cfg-if",
@@ -10920,9 +10885,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fce5fedc1c952a64cdf3c87e4632af072d2aca0bc2c460d53296fb2654757d"
+checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -10932,9 +10897,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
+checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
 dependencies = [
  "cfg-if",
  "libc",
@@ -10944,9 +10909,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f3e0f474281b405a3e9d97239f83f643b572324d292e1ef9dc5e3e0ab04c68"
+checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -10957,9 +10922,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910e5393af4aca456113581a5913b8d499cd2189013e983f8764d06ebc42b2ed"
+checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10967,55 +10932,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "44.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55481651bea5b8336fb200fa49914ccf802f5e7617ba9ab0b4691f16d4f97ff8"
-dependencies = [
- "cranelift-codegen",
- "gimli 0.33.0",
- "log",
- "object 0.39.1",
- "target-lexicon",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d890c3804d0e46000fa901c86ac1a9fdedf684e72dfd64e582b56bb4a78a6746"
+checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa7f927779d92863a1447c1d88192b2242080608cb91ece69c177321488948b"
+checksum = "b88f243a21e600902fd03bd970df7e4671d760d724c9fad202166fd98c842548"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
- "fs-set-times",
+ "cfg-if",
  "futures",
  "io-extras",
  "io-lifetimes",
+ "rand 0.10.1",
  "rustix 1.1.4",
- "system-interface",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11028,9 +10975,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6fd8b702c2aa82bb4907da5ad44120b4385048f6a20731908a6e2485ea7567e"
+checksum = "0373c9dc92c9373aa9cee05963ea438bc318bf07bb284bede77a9ce24b39f682"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11050,24 +10997,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "248.0.0"
+version = "255.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
+checksum = "55ffec530f199bd3d553ac442c13dd108353cad533cad8514bc41e1f1f0fe686"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.248.0",
+ "wasm-encoder 0.255.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.248.0"
+version = "1.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
+checksum = "dda82c82e1486c7eed42a0465e544d80fff37abc3b39482e0d34dbaabe2fe5b1"
 dependencies = [
- "wast 248.0.0",
+ "wast 255.0.0",
 ]
 
 [[package]]
@@ -11152,9 +11099,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165512f7870210d0fd45911990b832782b5fb82d40f4ce28cf86b40aaecd453c"
+checksum = "9914a7e8ac8cb37be90753103e2aa96959e9e5d2f549a2d081bcfeb8fa97e08d"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -11166,9 +11113,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f63d06fdf2e9a133407b318574574f66ea6590ea7a42c4a7554c029824454a"
+checksum = "789b4c6d82c1ae0f5003eb6c5b9d3c9fb80112c4be50ad2690eb7347f0edd852"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -11180,9 +11127,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.3"
+version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b976b7285ca32a637e21721021442691a2d7938ab4650cb99472a672e9def6c"
+checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11212,7 +11159,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11220,25 +11167,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "44.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436a7fa4109b13b0e555d01ec615ab8b928b7834639aca7b2fdc1f55d70a1f0c"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli 0.33.0",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows-core"
@@ -11668,12 +11596,12 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "id-arena",
  "indexmap 2.14.0",
  "log",
@@ -11682,7 +11610,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,5 +372,5 @@ homepage = "https://fraiseql.dev"
 keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
-rust-version = "1.92"  # MSRV — fraiseql-error@2.1.0 on crates.io requires 1.92
+rust-version = "1.94"  # MSRV — wasmtime 46's cranelift 0.133 requires 1.94 (#933)
 version = "2.14.1"

--- a/crates/fraiseql-arrow/fuzz/Cargo.lock
+++ b/crates/fraiseql-arrow/fuzz/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.19",
@@ -1039,6 +1040,9 @@ dependencies = [
 [[package]]
 name = "fraiseql-guard"
 version = "2.14.1"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "futures"
@@ -2575,6 +2579,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/fraiseql-auth/fuzz/Cargo.lock
+++ b/crates/fraiseql-auth/fuzz/Cargo.lock
@@ -801,6 +801,9 @@ dependencies = [
 [[package]]
 name = "fraiseql-guard"
 version = "2.14.1"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "futures-channel"

--- a/crates/fraiseql-core/fuzz/Cargo.lock
+++ b/crates/fraiseql-core/fuzz/Cargo.lock
@@ -661,6 +661,9 @@ dependencies = [
 [[package]]
 name = "fraiseql-guard"
 version = "2.14.1"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "futures"

--- a/crates/fraiseql-federation/Cargo.toml
+++ b/crates/fraiseql-federation/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [[bench]]

--- a/crates/fraiseql-federation/fuzz/Cargo.lock
+++ b/crates/fraiseql-federation/fuzz/Cargo.lock
@@ -447,6 +447,9 @@ dependencies = [
 [[package]]
 name = "fraiseql-guard"
 version = "2.14.1"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "futures"

--- a/crates/fraiseql-functions/Cargo.toml
+++ b/crates/fraiseql-functions/Cargo.toml
@@ -59,12 +59,12 @@ host-live = ["fraiseql-core", "fraiseql-db", "sqlparser", "reqwest"]
 host-storage = ["fraiseql-storage"]
 
 [dependencies.wasmtime]
-version = "44"
+version = "46"
 optional = true
 features = ["component-model"]
 
 [dependencies.wasmtime-wasi]
-version = "44"
+version = "46"
 optional = true
 
 [dependencies.deno_core]

--- a/crates/fraiseql-secrets/fuzz/Cargo.lock
+++ b/crates/fraiseql-secrets/fuzz/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.18",
@@ -692,6 +693,9 @@ dependencies = [
 [[package]]
 name = "fraiseql-guard"
 version = "2.14.1"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "fraiseql-secrets"
@@ -2144,6 +2148,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/fraiseql-server/fuzz/Cargo.lock
+++ b/crates/fraiseql-server/fuzz/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.18",
@@ -1279,6 +1280,9 @@ dependencies = [
 [[package]]
 name = "fraiseql-guard"
 version = "2.14.1"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "fraiseql-observers"

--- a/crates/fraiseql-storage/Cargo.toml
+++ b/crates/fraiseql-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fraiseql-storage"
 version.workspace = true
 edition = "2021"
-rust-version = "1.75"
+rust-version.workspace = true
 license = "Apache-2.0"
 repository.workspace = true
 homepage = "https://fraiseql.dev"

--- a/crates/fraiseql-storage/src/routes/uploads.rs
+++ b/crates/fraiseql-storage/src/routes/uploads.rs
@@ -421,7 +421,7 @@ async fn load_owned_session(
 /// The uniform refusal for a session the caller cannot see: `401` for an
 /// unauthenticated caller (who can never own a session), `404` otherwise.
 fn session_not_visible(user: Option<&Extension<StorageUser>>) -> Response {
-    if user.map_or(true, |Extension(u)| u.user_id.is_none()) {
+    if user.is_none_or(|Extension(u)| u.user_id.is_none()) {
         error_response(StatusCode::UNAUTHORIZED, "unauthorized", "Authentication required")
     } else {
         error_response(StatusCode::NOT_FOUND, "not_found", "Upload not found")

--- a/deny.toml
+++ b/deny.toml
@@ -345,8 +345,8 @@ version = "=0.21.12"
 
 [[bans.skip-tree]]
 name = "wasmtime"
-reason = "wasmtime v44 pulls in older debug utilities (addr2line, gimli, object, etc.) via backtrace/dhat; upgrade tracked for 2026-12-01"
-version = "=44.0.3"
+reason = "wasmtime pulls in older debug utilities (addr2line, gimli, object, etc.) via backtrace/dhat, plus its own wasm-tooling versions (wasm-encoder, wasmparser, wast). NOTE: this is an exact-version pin — a wasmtime bump that forgets to move it un-skips the whole tree and `cargo deny check bans` reports every duplicate under it (#933)."
+version = "=46.0.2"
 
 [[bans.skip-tree]]
 name = "windows-sys"

--- a/deny.toml
+++ b/deny.toml
@@ -11,9 +11,6 @@
 # Re-evaluate by: 2026-10-01
 # - thiserror 1.x — graphql-parser 0.4 pins thiserror 1.x; blocked on upstream update.
 # Re-evaluate by: 2026-12-01 — migrate off graphql-parser if still blocked.
-# - wasmtime 44  — RUSTSEC-2026-0222 patched lines (46.0.2/47.0.3) require Rust 1.94;
-# workspace MSRV is 1.92. Blocked on the MSRV raise (#933).
-# Re-evaluate by: 2026-10-01
 #
 # See docs/dependency-risk-policy.md for the full acceptance policy.
 
@@ -25,14 +22,6 @@ ignore = [
   # Mitigation: mysql feature is non-default; TLS termination at load balancer layer.
   # deadline: 2026-10-01 — re-evaluate sqlx 0.9 release status; escalate if still blocked.
   {id = "RUSTSEC-2023-0071", reason = "No upstream fix; only affects optional mysql feature path; deadline 2026-10-01"},
-  # wasmtime: type-index confusion between multiple Engines in one process
-  # (GHSA-hgjw-h833-99q9). Every patched line (46.0.2 / 47.0.3) requires Rust 1.94 via
-  # cranelift 0.133+, above the workspace MSRV of 1.92, so the bump is blocked on the
-  # next MSRV raise (#933). Exposure: fraiseql-functions (optional runtime-wasm)
-  # constructs a single wasmtime Engine per WasmRuntime and guest values never cross
-  # Engine instances — the cross-engine confusion has no in-repo trigger path.
-  # deadline: 2026-10-01 — raise MSRV to 1.94 and bump wasmtime/wasmtime-wasi to >= 46.0.2.
-  {id = "RUSTSEC-2026-0222", reason = "wasmtime cross-Engine type confusion; fix requires Rust 1.94 (> MSRV 1.92); single-Engine usage, no cross-engine value flow; bump tracked in #933, deadline 2026-10-01"},
   # rustls-pemfile: blocked on upstream bollard migration from pem 0.x to rustls-pem.
   # Re-evaluated 2026-07-02: rustls-pemfile 2.2.0 is a DEV-dependency only (fraiseql-wire
   # test deps / bollard test infra) — no production runtime exposure; low-severity
@@ -56,15 +45,6 @@ ignore = [
   # Affects optional aws-s3 feature only; same root cause as RUSTSEC-2026-0098/0099.
   # deadline: 2026-09-01 — resolved when aws-sdk migrates to rustls 0.23.
   {id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic; transitive via aws-smithy-http-client (rustls 0.21); optional aws-s3 feature only. Deadline 2026-09-01."},
-  # wasmtime-wasi: WASI hard-link/rename bypasses FilePerms on the destination path.
-  # Transitive via fraiseql-functions' opt-in `runtime-wasm` feature only (wasmtime/wasmtime-wasi
-  # are pinned to major "44"); NOT in the default build, no exposure for a standard FraiseQL server.
-  # Patched in 45.0.3 / 46.0.1 — there is no fix within the 44.x line, so resolution requires a
-  # wasmtime 44 -> 45+ MAJOR bump that also moves the `wasmtime::component::bindgen!` glue, tracked
-  # as standalone work (out of scope for an advisory-hygiene pass; the env can't build/verify the
-  # wasmtime stack safely here).
-  # deadline: 2026-10-01 — re-evaluate when the standalone wasmtime 45+ bump lands.
-  {id = "RUSTSEC-2026-0188", reason = "wasmtime-wasi FilePerms bypass; transitive via opt-in runtime-wasm feature only (wasmtime pinned to 44); patched in 45.0.3/46.0.1 needs a major bump tracked separately. Deadline 2026-10-01."},
   # quick-xml DoS pair (published 2026-07-02): RUSTSEC-2026-0194 (quadratic run time when checking
   # a start tag for duplicate attribute names) + RUSTSEC-2026-0195 (unbounded namespace-declaration
   # allocation in NsReader → memory-exhaustion DoS). Transitive ONLY via samael 0.0.21 (SAML SP,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -514,7 +514,7 @@ struct MockDatabaseAdapter {
 }
 
 // Note: #[async_trait] is currently required for dyn-compatible async traits.
-// Native dyn-async-trait with Send is not yet stable in Rust 1.92 (MSRV),
+// Native dyn-async-trait with Send is not yet stable in Rust 1.94 (MSRV),
 // and dynosaur is incompatible due to Tokio's Send requirement on futures.
 #[async_trait]
 impl DatabaseAdapter for MockDatabaseAdapter {

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -8,7 +8,7 @@ PostgreSQL (`tools/quickstart-smoke.sh`), so if it is printed here, it works.
 
 ## Prerequisites
 
-- **Rust** 1.92+ (install via [rustup](https://rustup.rs))
+- **Rust** 1.94+ (install via [rustup](https://rustup.rs))
 - **PostgreSQL** 14+ running locally (or Docker: `docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16`)
 - **Python 3.11+** for schema authoring
 

--- a/docs/operations/compiled-schema-lifecycle.md
+++ b/docs/operations/compiled-schema-lifecycle.md
@@ -62,7 +62,7 @@ Deployment: Server downloads from S3 at startup
 ### Option B: Compile into Docker image
 
 ```dockerfile
-FROM rust:1.92 AS builder
+FROM rust:1.94 AS builder
 COPY fraiseql.toml types.json ./
 RUN fraiseql compile fraiseql.toml
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,5 +5,5 @@
 # Nightly is required only for rustfmt (some advanced formatting options).
 # Use `cargo +nightly fmt` or `make fmt` for formatting; all other commands
 # (check, clippy, test, build) use this stable toolchain.
-channel = "1.92"
+channel = "1.94"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Wave 4 · 1 issue (#933) · **calendar-bound: the RUSTSEC ignore expires 2026-10-01**

## Why now

RUSTSEC-2026-0222 (`wasmtime`: stores can mix up type indices between engines) has **no patched release in the 44.x line** we shipped. Every patched line (46.0.2 / 47.0.3) pulls cranelift 0.133, which requires **Rust 1.94**.

Raised now rather than at the deadline because an expiring `deny.toml` ignore reddens the **required** `security` check *on a date, not on a push* — blocking every branch at once, with no commit to point at (the #978 shape). Gate **G2 was already answered YES**.

## Scope beyond the issue

- **RUSTSEC-2026-0188** (`wasmtime-wasi`: WASI hard links and renames bypass `FilePerms` on the destination) is cleared by the same bump — its fix also landed outside 44.x. The issue does not mention it. **No wasmtime advisory is accepted any more**; both ignores are gone from `deny.toml` *and* `.cargo/audit.toml`.
- **Two published crates carried false MSRV metadata**: `fraiseql-storage` claimed `rust-version = "1.75"`, `fraiseql-federation` declared none at all. Both now inherit the workspace value. That false floor was actively suppressing a real lint — clippy withheld the `is_none_or` suggestion (`unnecessary_map_or`) because the crate claimed 1.75 and the method needs 1.82.
- **The mirrored base image** had to move first: the Dagger legs pull `ghcr.io/fraiseql/rust:*` from GHCR, not Docker Hub, so `rust:1.94` is mirrored in a separate leading commit (the tag is now published) — otherwise every leg fails resolving the image.

## Verification

| Check | Result |
|---|---|
| `cargo audit` **before** (ignores removed, wasmtime 44) | **RED** — 2 vulnerabilities, exit 1 |
| `cargo audit` **after** | exit 0, both advisories gone |
| `cargo deny check advisories` | `advisories ok` |
| `rustup run 1.94 cargo build --workspace --all-features` | exit 0 — genuine 1.94, not floating stable |
| `cargo test -p fraiseql-functions --features runtime-wasm,host-live` | 324 passed — incl. 10 tests that instantiate and execute **real WASM components** on 46.0.2 |
| `cargo test -p fraiseql-storage` | 131 + 4 passed |
| 8 fuzz sub-workspace lockfiles | all resolve `--locked` (7 of 8 were already stale on dev) |
| `make preflight` | passes |

The single-`Engine`-per-`WasmRuntime` exposure claim was re-verified: one `Engine::new`, and `EpochTicker` takes a clone of that same engine.

Lockfile churn is confined to the wasmtime/cranelift/wasm-tooling cluster — nothing unrelated moved. wasmtime 46 drops the winch backend.

Closes #933