### PR TITLE
P13: auth correctness completion (#950 #949)

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -785,6 +785,9 @@ func (m *FraiseqlCi) integrationPostgres(ctx context.Context, source *dagger.Dir
 		// trigger poisons only the consuming statement, proving both stores fail closed
 		// instead of reporting a single-use guarantee the failed DELETE did not establish.
 		"cargo test -p fraiseql-auth --test postgres_single_use_consume -- --test-threads=1",
+		// #950 expiry sweeps for the MFA/OTP tables. Two-sided: the expired row goes and
+		// the live one stays, so a sweep that deleted everything would fail here.
+		"cargo test -p fraiseql-auth --test postgres_expiry_sweep -- --test-threads=1",
 		// #389 session-state store (_system.session_state: TTL visibility, upsert, atomic
 		// summary collapse, eviction sweep vs real PG).
 		"cargo test -p fraiseql-auth --test session_state_integration -- --test-threads=1",
@@ -920,6 +923,13 @@ func (m *FraiseqlCi) integrationSaml(ctx context.Context, source *dagger.Directo
 		"cargo test -p fraiseql-auth --features auth-saml --lib saml:: -- --test-threads=1",
 		// Tenant-bounded trust policy ∘ PostgresAccountStore (reads DATABASE_URL via harness).
 		"cargo test -p fraiseql-auth --features auth-saml --test saml_sso -- --test-threads=1",
+		// #949 cross-replica SAML replay refusal. Two PgSamlReplayStores over two pools
+		// stand in for two replicas: an assertion consumed by one must be refused by the
+		// other. That assertion is structurally impossible for a single-process suite,
+		// which is why the in-process DashMap survived this long. It lives here, not in
+		// the `postgres` suite: the store is behind `auth-saml`, which only this leg
+		// enables, and this leg binds Postgres too.
+		"cargo test -p fraiseql-auth --features auth-saml --test postgres_saml_replay -- --test-threads=1",
 		// #381 P26: the SERVER mount — [saml] config → boot provisioning →
 		// /auth/saml/login redirect with SAMLRequest; configured-but-broken
 		// shapes (no pool, dud metadata) refuse to boot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1716,6 +1716,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`POST /auth/v1/mfa/confirm` is mounted, so MFA can be finished through the API (#950).**
+  `MfaStore::confirm_enrollment` existed and both stores implemented it, but
+  `mount_auth_routes` mounted only enroll/challenge/verify/unenroll. An operator could
+  therefore begin an enrollment over HTTP and never complete it: the row stayed
+  `confirmed = false`, `create_challenge` refuses to issue against an unconfirmed
+  enrollment, and MFA was enrollable but unusable. The e2e had been reaching past the
+  surface an operator has — calling `PgMfaStore::confirm_enrollment` directly, with a
+  comment saying the endpoint was not mounted — which is why it kept passing; it now
+  confirms through the route, and the `use fraiseql_auth::MfaStore as _` that workaround
+  needed is gone with it.
+
+- **Expired MFA and OTP rows are swept (#950).** `core.tb_mfa_challenge`,
+  `core.tb_otp_code` and `core.tb_otp_send_budget` were never pruned. Correctness was
+  never at stake — every read checks expiry — but a challenge that is minted and simply
+  abandoned is never consumed and never observed expired, and the send-budget table kept
+  one row for every address that had ever requested a code, forever. `MfaStore` and
+  `OtpStore` gain a required `sweep_expired`, spawned per configured store on a
+  five-minute ticker into the server's `JoinSet` so graceful shutdown awaits it, beside
+  the PKCE cleanup that already worked this way. Required rather than defaulted: a
+  no-op default would let a new backend inherit unbounded growth in silence.
+
 - **TypeScript: `@Observer` and `@Source` read the decorated member's name under both
   decorator protocols (#925).** Both were written for the legacy three-argument form
   (`target, propertyKey, descriptor`) that `tsc` emits with `experimentalDecorators`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1716,6 +1716,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SAML replay protection is shared across replicas (#949).** `SamlReplayCache` was an
+  in-process `DashMap`, and its own module doc said so: "replay protection therefore holds
+  within a single process". Behind more than one replica that is a real weakening, not a
+  theoretical one — an attacker who captures a signed `SAMLResponse` replays it against a
+  **different** replica, which has never seen that assertion ID and accepts it. The
+  signature is valid; only the replay cache would have stopped it. A restart has the same
+  shape. `SamlReplayStore` is now a trait: the `DashMap` remains the single-node
+  implementation, and the server builds `PgSamlReplayStore` over the pool `[saml]` already
+  requires for sessions and account linking, so no new infrastructure. The check is a
+  single `INSERT … ON CONFLICT` — atomic in Postgres, rather than a read-then-write two
+  replicas could interleave — and a row whose window has closed is reclaimable, so a stale
+  entry cannot permanently burn an assertion ID. Fail-closed: a backend error refuses the
+  assertion, deliberately unlike the JWT `jti` cache's fail-open default, because here the
+  store lives in the same database the session mint needs one statement later.
+  `FRAISEQL_REQUIRE_REDIS` now covers the replay store too, so an operator asserting
+  distributed state cannot silently get per-process replay protection. `verify_saml_response`
+  is now `async`.
+
 - **`POST /auth/v1/mfa/confirm` is mounted, so MFA can be finished through the API (#950).**
   `MfaStore::confirm_enrollment` existed and both stores implemented it, but
   `mount_auth_routes` mounted only enroll/challenge/verify/unenroll. An operator could

--- a/crates/fraiseql-auth/Cargo.toml
+++ b/crates/fraiseql-auth/Cargo.toml
@@ -43,6 +43,17 @@ zeroize = "1.8"
 harness = false
 name = "auth_bench"
 
+# `PgSamlReplayStore` and friends live behind `auth-saml`, so this suite cannot
+# build without it. Declared here rather than as a file-level `#![cfg]` because
+# the two fail in opposite directions: an inner `cfg` compiles to an empty
+# binary and reads GREEN in a leg that forgot the feature, while
+# `required-features` makes cargo refuse the target by name and makes the
+# mismatch visible to tools/check-suite-coverage.py, which reads this key and
+# will report an ORPHAN unless some leg enables the feature.
+[[test]]
+name = "postgres_saml_replay"
+required-features = ["auth-saml"]
+
 [dev-dependencies]
 criterion = {version = "0.5", features = ["html_reports"]}
 fraiseql-test-support = {path = "../fraiseql-test-support"}

--- a/crates/fraiseql-auth/src/lib.rs
+++ b/crates/fraiseql-auth/src/lib.rs
@@ -121,9 +121,10 @@ pub use proxy::ProxyConfig;
 pub use rate_limiting::{AuthRateLimitConfig, Clock, KeyedRateLimiter, RateLimiters, SystemClock};
 #[cfg(feature = "auth-saml")]
 pub use saml::{
-    SamlAttributeMapping, SamlAuthState, SamlError, SamlIdpConfig, SamlIdpConfigBuilder,
-    SamlReplayCache, VerifiedAssertion, effective_saml_email_verified, saml_acs, saml_login,
-    saml_provider_key, saml_routes, verify_saml_response,
+    PgSamlReplayStore, SamlAttributeMapping, SamlAuthState, SamlError, SamlIdpConfig,
+    SamlIdpConfigBuilder, SamlReplayCache, SamlReplayStore, VerifiedAssertion,
+    effective_saml_email_verified, saml_acs, saml_login, saml_provider_key, saml_routes,
+    verify_saml_response,
 };
 pub use security_config::{
     AuditLoggingSettings, ErrorSanitizationSettings, SecurityConfigFromSchema,

--- a/crates/fraiseql-auth/src/lib.rs
+++ b/crates/fraiseql-auth/src/lib.rs
@@ -142,6 +142,6 @@ pub use state_encryption::{
 pub use state_store::{InMemoryStateStore, StateStore};
 pub use totp_mfa::{
     EnrollmentResponse, InMemoryMfaStore, MfaRouteState, MfaStore, TotpEnrollment, mfa_challenge,
-    mfa_enroll, mfa_unenroll, mfa_verify,
+    mfa_confirm, mfa_enroll, mfa_unenroll, mfa_verify,
     postgres::{PG_MFA_SCHEMA_SQL, PgMfaStore},
 };

--- a/crates/fraiseql-auth/src/otp/mod.rs
+++ b/crates/fraiseql-auth/src/otp/mod.rs
@@ -99,6 +99,17 @@ struct RateRecord {
 // dyn-compatibility async_trait: dyn-dispatch required; remove when RTN + Send is stable (RFC 3425)
 #[async_trait]
 pub trait OtpStore: Send + Sync {
+    /// Delete expired codes and stale send-budget rows. Returns the number removed.
+    ///
+    /// Required rather than defaulted, for the reason [`crate::MfaStore::sweep_expired`]
+    /// gives. `tb_otp_send_budget` is the sharper case: it holds one row per address that
+    /// has ever requested a code and nothing removed them (#950).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::DatabaseError`] if the store fails.
+    async fn sweep_expired(&self) -> Result<u64>;
+
     /// Generate and store a new `OTP` for the given email.
     ///
     /// # Returns
@@ -163,6 +174,16 @@ impl Default for InMemoryOtpStore {
 // Reason: async_trait required for dyn-compatibility; remove when RTN + Send is stable
 #[async_trait]
 impl OtpStore for InMemoryOtpStore {
+    async fn sweep_expired(&self) -> Result<u64> {
+        let now = unix_now()?;
+        let before = self.codes.len() + self.rate_limits.len();
+        self.codes.retain(|_, r| r.expires > now);
+        // A budget row whose window has closed is dead weight: the next send for that
+        // address opens a fresh window regardless of what this row says.
+        self.rate_limits.retain(|_, r| now < r.window_start + OTP_RATE_WINDOW_SECS);
+        Ok((before - (self.codes.len() + self.rate_limits.len())) as u64)
+    }
+
     async fn create_otp(&self, email: &str) -> Result<String> {
         let now = unix_now()?;
 

--- a/crates/fraiseql-auth/src/otp/postgres.rs
+++ b/crates/fraiseql-auth/src/otp/postgres.rs
@@ -78,6 +78,31 @@ impl PgOtpStore {
 // Reason: async_trait required for dyn-compatibility; remove when RTN + Send is stable
 #[async_trait]
 impl OtpStore for PgOtpStore {
+    #[allow(clippy::cast_possible_wrap)] // Reason: expiry is only ever written from unix_now()
+    async fn sweep_expired(&self) -> Result<u64> {
+        let now = unix_now()? as i64;
+        let codes = sqlx::query("DELETE FROM core.tb_otp_code WHERE expires_at <= $1")
+            .bind(now)
+            .execute(&self.db)
+            .await
+            .map_err(db_err)?
+            .rows_affected();
+
+        // See the in-memory twin: a closed window is dead weight, and this table is the
+        // one that otherwise keeps a row for every address that ever asked for a code.
+        let window = i64::try_from(crate::otp::OTP_RATE_WINDOW_SECS).unwrap_or(i64::MAX);
+        let budgets =
+            sqlx::query("DELETE FROM core.tb_otp_send_budget WHERE window_start + $1 <= $2")
+                .bind(window)
+                .bind(now)
+                .execute(&self.db)
+                .await
+                .map_err(db_err)?
+                .rows_affected();
+
+        Ok(codes + budgets)
+    }
+
     #[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)] // Reason: unix seconds and small counters fit i64/i32
     async fn create_otp(&self, email: &str) -> Result<String> {
         let now = unix_now()?;

--- a/crates/fraiseql-auth/src/saml/handler.rs
+++ b/crates/fraiseql-auth/src/saml/handler.rs
@@ -18,7 +18,8 @@ use axum::{
 use serde::Deserialize;
 
 use super::{
-    SamlIdpConfig, SamlReplayCache, effective_saml_email_verified, verify::verify_saml_response,
+    SamlIdpConfig, SamlReplayCache, effective_saml_email_verified, replay::SamlReplayStore,
+    verify::verify_saml_response,
 };
 use crate::{
     account_linking::AccountStore,
@@ -59,8 +60,9 @@ pub struct SamlAuthState {
     /// Account store for resolving the assertion to a stable local user. When absent the
     /// raw `"saml:<idp>:<NameID>"` is used as the user ID.
     user_store:    Option<Arc<dyn AccountStore>>,
-    /// Single-use assertion replay cache.
-    replay:        Arc<SamlReplayCache>,
+    /// Single-use assertion replay store. In-process by default; the server swaps in
+    /// the Postgres-backed store so replay protection holds across replicas (#949).
+    replay:        Arc<dyn SamlReplayStore>,
 }
 
 impl SamlAuthState {
@@ -74,6 +76,24 @@ impl SamlAuthState {
             user_store: None,
             replay: Arc::new(SamlReplayCache::new()),
         }
+    }
+
+    /// Swap in a shared replay store.
+    ///
+    /// The default is the in-process [`SamlReplayCache`], which is correct for exactly
+    /// one server instance. Behind more than one replica a captured assertion replays
+    /// against a replica that has never seen its ID, so the server passes the
+    /// Postgres-backed store here (#949).
+    #[must_use]
+    pub fn with_replay_store(mut self, replay: Arc<dyn SamlReplayStore>) -> Self {
+        self.replay = replay;
+        self
+    }
+
+    /// Whether replay protection is shared across processes.
+    #[must_use]
+    pub fn replay_is_distributed(&self) -> bool {
+        self.replay.is_distributed()
     }
 
     /// Register an IdP under its [`SamlIdpConfig::idp_name`]. Builder-style; ignores a
@@ -221,9 +241,11 @@ pub async fn saml_acs(State(state): State<SamlAuthState>, Form(form): Form<AcsFo
         idp,
         &form.saml_response,
         &[request_id.as_str()],
-        &state.replay,
+        state.replay.as_ref(),
         chrono::Utc::now(),
-    ) {
+    )
+    .await
+    {
         Ok(a) => a,
         Err(e) => {
             tracing::warn!(idp = %idp_name, error = %e, "SAML assertion verification failed");

--- a/crates/fraiseql-auth/src/saml/mod.rs
+++ b/crates/fraiseql-auth/src/saml/mod.rs
@@ -50,7 +50,7 @@ mod verify;
 pub use config::{SamlAttributeMapping, SamlIdpConfig, SamlIdpConfigBuilder};
 pub use handler::{SamlAuthState, saml_acs, saml_login, saml_routes};
 pub use linking::{effective_saml_email_verified, saml_provider_key};
-pub use replay::SamlReplayCache;
+pub use replay::{PG_SAML_REPLAY_SCHEMA_SQL, PgSamlReplayStore, SamlReplayCache, SamlReplayStore};
 pub use verify::{VerifiedAssertion, verify_saml_response};
 
 #[cfg(test)]

--- a/crates/fraiseql-auth/src/saml/replay.rs
+++ b/crates/fraiseql-auth/src/saml/replay.rs
@@ -4,20 +4,73 @@
 //! tell that a *valid* assertion has already been consumed. Without a replay guard, an
 //! attacker who captures one valid `SAMLResponse` (e.g. from a proxy log or the browser
 //! POST) can replay it until the `NotOnOrAfter` window closes and obtain a session each
-//! time. [`SamlReplayCache`] records each assertion `ID` for the remainder of its validity
-//! window so a second presentation is rejected.
+//! time. A [`SamlReplayStore`] records each assertion `ID` for the remainder of its
+//! validity window so a second presentation is rejected.
 //!
-//! # Scope
+//! # Why this is a store and not a map
 //!
-//! v1 is an in-process [`DashMap`]; replay protection therefore holds within a single
-//! server instance. A multi-instance deployment needs a shared backend (Redis/Postgres) —
-//! a forward-compatible extension, mirroring the single-node posture of the rest of the
-//! v2.9.0 auth foundation. Documented rather than silently assumed.
+//! It was a map — an in-process [`DashMap`] whose own module doc admitted "replay
+//! protection therefore holds within a single process". Behind more than one replica that
+//! is a real weakening rather than a theoretical one: an attacker who captures a signed
+//! `Response` replays it against a **different** replica, which has never seen that
+//! assertion ID and accepts it. The signature is valid; only the replay cache would have
+//! stopped it. A restart has the same shape — the map is empty afterwards, so an assertion
+//! captured beforehand is replayable until its `NotOnOrAfter` passes (#949).
+//!
+//! [`PgSamlReplayStore`] closes that. `[saml]` already requires a pool for sessions and
+//! account linking, so Postgres adds no infrastructure, and `INSERT … ON CONFLICT DO
+//! NOTHING` makes "have I seen this?" a single atomic statement rather than a
+//! read-then-write that two replicas could interleave.
+//!
+//! # Failure posture
+//!
+//! **Fail-closed.** A backend error refuses the assertion. This is deliberately unlike
+//! `fraiseql_core::security::oidc::ReplayCache`, whose default `FailurePolicy::FailOpen`
+//! trades replay protection for auth availability during a Redis outage: there the token
+//! was already signature-verified *and* short-lived, and the blast radius of a refusal is
+//! every request. Here the store lives in the same Postgres the session mint needs one
+//! statement later, so an unreachable backend means the login could not have completed
+//! anyway — and accepting an assertion we cannot prove is fresh is the whole defect.
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::{DashMap, mapref::entry::Entry};
+use sqlx::PgPool;
 
-/// Records consumed SAML assertion IDs until their validity window expires.
+use super::SamlError;
+
+/// A backend that records consumed SAML assertion IDs.
+#[async_trait]
+pub trait SamlReplayStore: Send + Sync + std::fmt::Debug {
+    /// Atomically check-and-record an assertion ID.
+    ///
+    /// Returns `Ok(true)` if the ID is **fresh** (and is now recorded), `Ok(false)` if it
+    /// was already present — a replay.
+    ///
+    /// Implementations must make the check and the record one atomic step. A
+    /// read-then-write leaves a window in which two concurrent presentations of the same
+    /// assertion both read "fresh".
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SamlError::Verification`] if the backend fails. Callers treat that as a
+    /// refusal — see the module's failure-posture note.
+    async fn check_and_record(
+        &self,
+        assertion_id: &str,
+        expires_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<bool, SamlError>;
+
+    /// Whether this store is shared across processes.
+    ///
+    /// The server refuses to boot a multi-replica posture on a single-process store, the
+    /// way it already does for rate limiting and token revocation: an operator who has
+    /// asserted distributed state must not silently get per-process replay protection.
+    fn is_distributed(&self) -> bool;
+}
+
+/// In-process replay store. Correct for exactly one server instance.
 #[derive(Debug, Default)]
 pub struct SamlReplayCache {
     /// assertion `ID` → instant after which the entry may be pruned (the assertion's
@@ -33,32 +86,6 @@ impl SamlReplayCache {
         Self::default()
     }
 
-    /// Atomically check-and-record an assertion ID.
-    ///
-    /// Returns `true` if the ID is **fresh** (now recorded) and `false` if it was already
-    /// present — i.e. a replay. Entries whose window has closed (`expires_at <= now`) are
-    /// pruned first, so memory is bounded by the number of assertions seen within one
-    /// validity window.
-    #[must_use]
-    pub fn check_and_record(
-        &self,
-        assertion_id: &str,
-        expires_at: DateTime<Utc>,
-        now: DateTime<Utc>,
-    ) -> bool {
-        // Prune expired entries. An assertion whose window has closed is rejected by the
-        // signature time-check anyway, so forgetting it cannot enable a replay.
-        self.seen.retain(|_, expiry| *expiry > now);
-
-        match self.seen.entry(assertion_id.to_owned()) {
-            Entry::Occupied(_) => false,
-            Entry::Vacant(slot) => {
-                slot.insert(expires_at);
-                true
-            },
-        }
-    }
-
     /// Number of assertion IDs currently tracked (primarily for tests/metrics).
     #[must_use]
     pub fn len(&self) -> usize {
@@ -69,5 +96,129 @@ impl SamlReplayCache {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.seen.is_empty()
+    }
+}
+
+#[async_trait]
+impl SamlReplayStore for SamlReplayCache {
+    async fn check_and_record(
+        &self,
+        assertion_id: &str,
+        expires_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<bool, SamlError> {
+        // Prune expired entries. An assertion whose window has closed is rejected by the
+        // signature time-check anyway, so forgetting it cannot enable a replay.
+        self.seen.retain(|_, expiry| *expiry > now);
+
+        Ok(match self.seen.entry(assertion_id.to_owned()) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(slot) => {
+                slot.insert(expires_at);
+                true
+            },
+        })
+    }
+
+    fn is_distributed(&self) -> bool {
+        false
+    }
+}
+
+/// DDL for the shared replay table. Executed at boot, which is what keeps it valid
+/// PostgreSQL (the `#748` precedent).
+pub const PG_SAML_REPLAY_SCHEMA_SQL: &str = r"
+CREATE SCHEMA IF NOT EXISTS core;
+CREATE TABLE IF NOT EXISTS core.tb_saml_replay (
+    assertion_id TEXT PRIMARY KEY,
+    expires_at   TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_saml_replay_expires ON core.tb_saml_replay(expires_at);
+REVOKE ALL ON core.tb_saml_replay FROM PUBLIC;
+";
+
+/// Postgres-backed replay store, shared by every replica over one database.
+#[derive(Debug, Clone)]
+pub struct PgSamlReplayStore {
+    db: PgPool,
+}
+
+impl PgSamlReplayStore {
+    /// Create a store over an existing pool.
+    #[must_use]
+    pub const fn new(db: PgPool) -> Self {
+        Self { db }
+    }
+
+    /// Execute the table DDL. Idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SamlError::Config`] if a statement fails.
+    pub async fn init(&self) -> Result<(), SamlError> {
+        for stmt in PG_SAML_REPLAY_SCHEMA_SQL.split(';').map(str::trim).filter(|s| !s.is_empty()) {
+            sqlx::query(stmt)
+                .execute(&self.db)
+                .await
+                .map_err(|e| SamlError::Config(format!("saml replay table: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Delete rows whose validity window has closed. Returns the number removed.
+    ///
+    /// An assertion past its `NotOnOrAfter` is refused by the signature time-check, so
+    /// forgetting it cannot enable a replay — this only bounds the table.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SamlError::Verification`] if the delete fails.
+    pub async fn sweep_expired(&self, now: DateTime<Utc>) -> Result<u64, SamlError> {
+        sqlx::query("DELETE FROM core.tb_saml_replay WHERE expires_at <= $1")
+            .bind(now)
+            .execute(&self.db)
+            .await
+            .map(|r| r.rows_affected())
+            .map_err(|e| SamlError::Verification(format!("saml replay sweep: {e}")))
+    }
+}
+
+#[async_trait]
+impl SamlReplayStore for PgSamlReplayStore {
+    async fn check_and_record(
+        &self,
+        assertion_id: &str,
+        expires_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<bool, SamlError> {
+        // One statement does the whole check. `ON CONFLICT DO NOTHING` reports zero rows
+        // affected when the ID is already present, so "have I seen this?" is answered by
+        // Postgres' own uniqueness rather than by a read this process then acts on — two
+        // replicas presenting the same assertion at once cannot both see "fresh".
+        //
+        // The `WHERE expires_at <= $3` on the conflict target lets a *stale* row be
+        // reclaimed: past its window the assertion is refused by the signature check
+        // anyway, so treating the ID as fresh again is safe and keeps the table from
+        // rejecting a legitimately new assertion that reuses an old ID.
+        let inserted = sqlx::query(
+            "INSERT INTO core.tb_saml_replay (assertion_id, expires_at)
+             VALUES ($1, $2)
+             ON CONFLICT (assertion_id) DO UPDATE
+                SET expires_at = EXCLUDED.expires_at
+              WHERE core.tb_saml_replay.expires_at <= $3",
+        )
+        .bind(assertion_id)
+        .bind(expires_at)
+        .bind(now)
+        .execute(&self.db)
+        .await
+        .map_err(|e| SamlError::Verification(format!("saml replay store: {e}")))?
+        .rows_affected();
+
+        Ok(inserted > 0)
+    }
+
+    fn is_distributed(&self) -> bool {
+        true
     }
 }

--- a/crates/fraiseql-auth/src/saml/tests.rs
+++ b/crates/fraiseql-auth/src/saml/tests.rs
@@ -23,6 +23,7 @@ use samael::{
 use super::{
     SamlError, SamlIdpConfig, SamlReplayCache, effective_saml_email_verified,
     handler::{AcsForm, LoginQuery, SamlAuthState, saml_acs, saml_login, saml_routes},
+    replay::SamlReplayStore as _,
     saml_provider_key,
     verify::{reject_doctype, verify_saml_response},
 };
@@ -135,8 +136,8 @@ fn encode(xml: &str) -> String {
 
 // ─── Happy path ──────────────────────────────────────────────────────────────
 
-#[test]
-fn valid_response_verifies_and_extracts_identity() {
+#[tokio::test]
+async fn valid_response_verifies_and_extracts_identity() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -148,16 +149,17 @@ fn valid_response_verifies_and_extracts_identity() {
     assert!(xml.contains("<saml2:Assertion"), "expected saml2-prefixed Assertion: {xml}");
     assert!(xml.contains("Signature"), "expected an XML signature: {xml}");
 
-    let verified =
-        verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).expect("should verify");
+    let verified = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now())
+        .await
+        .expect("should verify");
     assert_eq!(verified.name_id, "nameid-123");
     assert_eq!(verified.email.as_deref(), Some("user@example.com"));
 }
 
 // ─── Signature / trust ───────────────────────────────────────────────────────
 
-#[test]
-fn wrong_idp_certificate_is_rejected() {
+#[tokio::test]
+async fn wrong_idp_certificate_is_rejected() {
     let signer = new_idp();
     // Config trusts a DIFFERENT IdP's certificate than the one that signed.
     let other = new_idp();
@@ -165,12 +167,12 @@ fn wrong_idp_certificate_is_rejected() {
     let replay = SamlReplayCache::new();
     let b64 = signed_response(&signer, "nameid-123", SP_ENTITY, SP_ACS, REQ_ID, &[]);
 
-    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
-#[test]
-fn tampered_attribute_breaks_signature() {
+#[tokio::test]
+async fn tampered_attribute_breaks_signature() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -179,12 +181,13 @@ fn tampered_attribute_breaks_signature() {
 
     // Flip the signed email value — the digest no longer matches.
     let tampered = decode(&b64).replace("user@example.com", "attacker@evil.test");
-    let result = verify_saml_response(&config, &encode(&tampered), &[REQ_ID], &replay, Utc::now());
+    let result =
+        verify_saml_response(&config, &encode(&tampered), &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
-#[test]
-fn unsigned_response_is_rejected() {
+#[tokio::test]
+async fn unsigned_response_is_rejected() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -201,12 +204,12 @@ fn unsigned_response_is_rejected() {
     );
     let b64 = encode(&unsigned.to_string().unwrap());
 
-    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
-#[test]
-fn strict_algorithm_allowlist_rejects_weak_digest() {
+#[tokio::test]
+async fn strict_algorithm_allowlist_rejects_weak_digest() {
     let test_idp = new_idp();
     let replay = SamlReplayCache::new();
     // samael signs RSA-SHA256 but with a SHA-1 reference digest.
@@ -218,7 +221,7 @@ fn strict_algorithm_allowlist_rejects_weak_digest() {
         .unwrap()
         .build()
         .unwrap();
-    let strict_result = verify_saml_response(&strict, &b64, &[REQ_ID], &replay, Utc::now());
+    let strict_result = verify_saml_response(&strict, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(
         matches!(strict_result, Err(SamlError::Verification(_))),
         "strict allow-list must reject the weak SHA-1 digest: {strict_result:?}"
@@ -229,26 +232,28 @@ fn strict_algorithm_allowlist_rejects_weak_digest() {
     let lenient = config_with_cert(&test_idp.cert);
     let replay2 = SamlReplayCache::new();
     assert!(
-        verify_saml_response(&lenient, &b64, &[REQ_ID], &replay2, Utc::now()).is_ok(),
+        verify_saml_response(&lenient, &b64, &[REQ_ID], &replay2, Utc::now())
+            .await
+            .is_ok(),
         "relaxed allow-list should accept the same fixture"
     );
 }
 
 // ─── Audience / recipient / request binding ──────────────────────────────────
 
-#[test]
-fn wrong_audience_is_rejected() {
+#[tokio::test]
+async fn wrong_audience_is_rejected() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
     let b64 = signed_response(&test_idp, "nameid-123", "https://evil.example", SP_ACS, REQ_ID, &[]);
 
-    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
-#[test]
-fn wrong_recipient_is_rejected() {
+#[tokio::test]
+async fn wrong_recipient_is_rejected() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -262,24 +267,24 @@ fn wrong_recipient_is_rejected() {
         &[],
     );
 
-    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
-#[test]
-fn unsolicited_in_response_to_is_rejected() {
+#[tokio::test]
+async fn unsolicited_in_response_to_is_rejected() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
     // Assertion is bound to a request ID we never issued.
     let b64 = signed_response(&test_idp, "nameid-123", SP_ENTITY, SP_ACS, "id-attacker", &[]);
 
-    let result = verify_saml_response(&config, &b64, &["id-legit"], &replay, Utc::now());
+    let result = verify_saml_response(&config, &b64, &["id-legit"], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
-#[test]
-fn expired_response_is_rejected() {
+#[tokio::test]
+async fn expired_response_is_rejected() {
     let test_idp = new_idp();
     let mut config = config_with_cert(&test_idp.cert);
     // Make the SP intolerant: a just-issued response is past max_issue_delay.
@@ -287,46 +292,46 @@ fn expired_response_is_rejected() {
     let replay = SamlReplayCache::new();
     let b64 = signed_response(&test_idp, "nameid-123", SP_ENTITY, SP_ACS, REQ_ID, &[]);
 
-    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::Verification(_))), "got {result:?}");
 }
 
 // ─── Replay ──────────────────────────────────────────────────────────────────
 
-#[test]
-fn replayed_assertion_is_rejected() {
+#[tokio::test]
+async fn replayed_assertion_is_rejected() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
     let b64 = signed_response(&test_idp, "nameid-123", SP_ENTITY, SP_ACS, REQ_ID, &[]);
 
-    let first = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let first = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(first.is_ok(), "first presentation should verify: {first:?}");
 
-    let second = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now());
+    let second = verify_saml_response(&config, &b64, &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(second, Err(SamlError::Replay)), "replay must be rejected: {second:?}");
 }
 
-#[test]
-fn replay_cache_detects_duplicate_and_prunes_expired() {
+#[tokio::test]
+async fn replay_cache_detects_duplicate_and_prunes_expired() {
     let cache = SamlReplayCache::new();
     let now = Utc::now();
     let exp = now + Duration::minutes(5);
 
-    assert!(cache.check_and_record("a1", exp, now), "first record is fresh");
-    assert!(!cache.check_and_record("a1", exp, now), "duplicate is a replay");
+    assert!(cache.check_and_record("a1", exp, now).await.unwrap(), "first record is fresh");
+    assert!(!cache.check_and_record("a1", exp, now).await.unwrap(), "duplicate is a replay");
     assert_eq!(cache.len(), 1);
 
     // After the window closes the entry is pruned, so the same id is fresh again — by then
     // the signature's own time-check would already reject it.
     let later = exp + Duration::seconds(1);
-    assert!(cache.check_and_record("a1", later + Duration::minutes(5), later));
+    assert!(cache.check_and_record("a1", later + Duration::minutes(5), later).await.unwrap());
 }
 
 // ─── XXE ─────────────────────────────────────────────────────────────────────
 
-#[test]
-fn doctype_entity_is_rejected_before_parsing() {
+#[tokio::test]
+async fn doctype_entity_is_rejected_before_parsing() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -334,7 +339,7 @@ fn doctype_entity_is_rejected_before_parsing() {
     let xxe = r#"<?xml version="1.0"?>
 <!DOCTYPE Response [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
 <Response>&xxe;</Response>"#;
-    let result = verify_saml_response(&config, &encode(xxe), &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &encode(xxe), &[REQ_ID], &replay, Utc::now()).await;
     assert!(matches!(result, Err(SamlError::DocTypeForbidden)), "got {result:?}");
 }
 
@@ -351,8 +356,8 @@ fn reject_doctype_guards_dtd_and_entities() {
 
 // ─── XML Signature Wrapping (seam test) ──────────────────────────────────────
 
-#[test]
-fn signature_wrapping_never_yields_forged_identity() {
+#[tokio::test]
+async fn signature_wrapping_never_yields_forged_identity() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -368,7 +373,8 @@ fn signature_wrapping_never_yields_forged_identity() {
     let idx = xml.find("<saml2:Assertion").expect("assertion marker");
     let wrapped = format!("{}{forged}{}", &xml[..idx], &xml[idx..]);
 
-    let result = verify_saml_response(&config, &encode(&wrapped), &[REQ_ID], &replay, Utc::now());
+    let result =
+        verify_saml_response(&config, &encode(&wrapped), &[REQ_ID], &replay, Utc::now()).await;
     // Either rejected outright, or the *signed* identity is returned — never the attacker's.
     match result {
         Err(_) => {},
@@ -378,8 +384,8 @@ fn signature_wrapping_never_yields_forged_identity() {
 
 // ─── Comment-truncation NameID confusion (seam test) ─────────────────────────
 
-#[test]
-fn comment_truncation_never_truncates_nameid() {
+#[tokio::test]
+async fn comment_truncation_never_truncates_nameid() {
     let test_idp = new_idp();
     let config = config_with_cert(&test_idp.cert);
     let replay = SamlReplayCache::new();
@@ -390,7 +396,7 @@ fn comment_truncation_never_truncates_nameid() {
     // XML comments are excluded from C14N, so injecting one does not break the signature.
     // A vulnerable parser would split the text node and return "victim@example.com".
     let xml = decode(&b64).replace(signed_name_id, "victim@example.com<!---->.attacker.test");
-    let result = verify_saml_response(&config, &encode(&xml), &[REQ_ID], &replay, Utc::now());
+    let result = verify_saml_response(&config, &encode(&xml), &[REQ_ID], &replay, Utc::now()).await;
     match result {
         Err(_) => {},
         Ok(v) => {
@@ -427,8 +433,8 @@ fn effective_email_verified_optin_single_tenant() {
     assert!(effective_saml_email_verified(&config), "opt-in single-tenant is honored");
 }
 
-#[test]
-fn effective_email_verified_optin_multitenant_fails_closed() {
+#[tokio::test]
+async fn effective_email_verified_optin_multitenant_fails_closed() {
     let test_idp = new_idp();
     let config = SamlIdpConfig::builder("test-idp", SP_ENTITY, SP_ACS)
         .idp_parts(IDP_ENTITY, IDP_SSO, test_idp.cert.der_data())

--- a/crates/fraiseql-auth/src/saml/verify.rs
+++ b/crates/fraiseql-auth/src/saml/verify.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 
-use super::{SamlError, SamlIdpConfig, replay::SamlReplayCache};
+use super::{SamlError, SamlIdpConfig, replay::SamlReplayStore};
 
 /// SAML 1.1 email-address `NameID` format URN. When the subject `NameID` uses this format
 /// and no email attribute is present, the `NameID` value itself is the email.
@@ -77,11 +77,11 @@ pub fn reject_doctype(xml: &str) -> Result<(), SamlError> {
 ///   validation failed.
 /// - [`SamlError::Replay`] — the assertion `ID` was already consumed.
 /// - [`SamlError::MissingField`] — a required field (`NameID`) was absent.
-pub fn verify_saml_response(
+pub async fn verify_saml_response(
     idp: &SamlIdpConfig,
     response_b64: &str,
     possible_request_ids: &[&str],
-    replay: &SamlReplayCache,
+    replay: &dyn SamlReplayStore,
     now: DateTime<Utc>,
 ) -> Result<VerifiedAssertion, SamlError> {
     use base64::Engine as _;
@@ -109,7 +109,7 @@ pub fn verify_saml_response(
     let not_on_or_after = assertion.conditions.as_ref().and_then(|c| c.not_on_or_after);
     let replay_expiry = not_on_or_after
         .unwrap_or_else(|| now + chrono::Duration::seconds(FALLBACK_REPLAY_WINDOW_SECS));
-    if !replay.check_and_record(&assertion.id, replay_expiry, now) {
+    if !replay.check_and_record(&assertion.id, replay_expiry, now).await? {
         return Err(SamlError::Replay);
     }
 

--- a/crates/fraiseql-auth/src/totp_mfa/mod.rs
+++ b/crates/fraiseql-auth/src/totp_mfa/mod.rs
@@ -147,6 +147,18 @@ pub trait MfaStore: Send + Sync {
     /// if the code is wrong.
     async fn confirm_enrollment(&self, user_id: &str, totp_code: &str) -> Result<()>;
 
+    /// Delete challenge rows whose expiry has passed. Returns the number removed.
+    ///
+    /// Required rather than defaulted: a store that cannot sweep must say so in its own
+    /// body, because a default no-op would let a new backend inherit unbounded growth
+    /// silently (#950). Every read already checks expiry, so this is about table size,
+    /// not correctness — and it must never touch an unexpired row.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::DatabaseError`] if the store fails.
+    async fn sweep_expired(&self) -> Result<u64>;
+
     /// Issue a `MFA` challenge token for the given user after first-factor auth.
     ///
     /// # Errors
@@ -363,6 +375,13 @@ impl MfaStore for InMemoryMfaStore {
         })
     }
 
+    async fn sweep_expired(&self) -> Result<u64> {
+        let now = unix_now()?;
+        let before = self.challenges.len();
+        self.challenges.retain(|_, c| c.expires > now);
+        Ok((before - self.challenges.len()) as u64)
+    }
+
     async fn confirm_enrollment(&self, user_id: &str, totp_code: &str) -> Result<()> {
         let mut record =
             self.enrollments.get_mut(user_id).ok_or_else(|| AuthError::InvalidToken {
@@ -575,6 +594,15 @@ pub struct MfaVerifyRequest {
     pub code:            String,
 }
 
+/// Request for `POST /auth/v1/mfa/confirm`.
+#[derive(Debug, Deserialize)]
+pub struct MfaConfirmRequest {
+    /// User whose pending enrollment to confirm.
+    pub user_id: String,
+    /// The first `TOTP` code from the authenticator, proving the secret was stored.
+    pub code:    String,
+}
+
 /// Request for `POST /auth/v1/mfa/unenroll`.
 #[derive(Debug, Deserialize)]
 pub struct MfaUnenrollRequest {
@@ -737,6 +765,58 @@ pub async fn mfa_verify(
     );
 
     (StatusCode::OK, Json(tokens)).into_response()
+}
+
+/// `POST /auth/v1/mfa/confirm`
+///
+/// Completes an enrollment begun by `/enroll` by verifying the first `TOTP` code.
+/// Until this succeeds the enrollment stays `confirmed = false` and `create_challenge`
+/// refuses to issue against it, so without this route `MFA` could be enrolled through
+/// the API and never used (#950).
+///
+/// # Errors
+///
+/// Returns 422 if there is no pending enrollment for the user or the code is wrong.
+pub async fn mfa_confirm(
+    State(state): State<Arc<MfaRouteState>>,
+    Json(req): Json<MfaConfirmRequest>,
+) -> Response {
+    let logger = get_audit_logger();
+
+    match state.mfa_store.confirm_enrollment(&req.user_id, &req.code).await {
+        Ok(()) => {
+            logger.log_success(
+                AuditEventType::AuthSuccess,
+                SecretType::SessionToken,
+                Some(req.user_id),
+                "mfa_confirm",
+            );
+            StatusCode::OK.into_response()
+        },
+        Err(e) => {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(req.user_id.clone()),
+                "mfa_confirm",
+                &e.to_string(),
+            );
+            if let Some(resp) = rate_limited_response(&e) {
+                return resp;
+            }
+            // One generic answer for "no pending enrollment" and "wrong code" alike:
+            // distinguishing them would tell an unauthenticated caller whether a given
+            // user has an enrollment in flight.
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(serde_json::json!({
+                    "error":   "invalid_code",
+                    "message": "enrollment confirmation failed"
+                })),
+            )
+                .into_response()
+        },
+    }
 }
 
 /// `POST /auth/v1/mfa/unenroll`

--- a/crates/fraiseql-auth/src/totp_mfa/postgres.rs
+++ b/crates/fraiseql-auth/src/totp_mfa/postgres.rs
@@ -165,6 +165,18 @@ impl PgMfaStore {
 // Reason: async_trait required for dyn-compatibility; remove when RTN + Send is stable
 #[async_trait]
 impl MfaStore for PgMfaStore {
+    #[allow(clippy::cast_possible_wrap)] // Reason: expiry is only ever written from unix_now()
+    async fn sweep_expired(&self) -> Result<u64> {
+        let now = unix_now()? as i64;
+        let removed = sqlx::query("DELETE FROM core.tb_mfa_challenge WHERE expires_at <= $1")
+            .bind(now)
+            .execute(&self.db)
+            .await
+            .map_err(db_err)?
+            .rows_affected();
+        Ok(removed)
+    }
+
     async fn begin_enrollment(
         &self,
         user_id: &str,

--- a/crates/fraiseql-auth/tests/postgres_expiry_sweep.rs
+++ b/crates/fraiseql-auth/tests/postgres_expiry_sweep.rs
@@ -1,0 +1,151 @@
+//! Live-PostgreSQL tests for the MFA/OTP expiry sweeps (#950).
+//!
+//! Every read of these tables checks expiry, so correctness never depended on a sweep —
+//! which is exactly why none existed. What did depend on it is table size: a challenge
+//! that is minted and simply abandoned is never consumed, never observed expired, and
+//! never deleted, so `core.tb_mfa_challenge` and `core.tb_otp_code` grow for the life of
+//! the deployment. `core.tb_otp_send_budget` is worse: one row per address that has ever
+//! requested a code, removed by nothing at all.
+//!
+//! The assertions below are deliberately two-sided. A sweep that deletes everything would
+//! satisfy "the expired row is gone" while destroying live credentials, so each test also
+//! pins that an unexpired row survives.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: postgres` suite.
+//!
+//! **Execution engine:** PostgreSQL · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** truncates the shared `core` tables on setup → run `--test-threads=1`.
+#![allow(clippy::unwrap_used, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use fraiseql_auth::{MfaStore, OtpStore, PgMfaStore, PgOtpStore};
+use fraiseql_test_support::try_database_url;
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+
+/// Connect, apply both stores' DDL, and clear the tables. `None` (skip) when unconfigured.
+async fn fresh() -> Option<(PgOtpStore, PgMfaStore, PgPool)> {
+    let url = try_database_url()?;
+    let db = PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap();
+
+    let otp = PgOtpStore::new(db.clone());
+    otp.init().await.unwrap();
+    let mfa = PgMfaStore::new(db.clone());
+    mfa.init().await.unwrap();
+
+    sqlx::query(
+        "TRUNCATE core.tb_otp_code, core.tb_otp_send_budget,
+                  core.tb_mfa_challenge, core.tb_mfa_enrollment",
+    )
+    .execute(&db)
+    .await
+    .unwrap();
+
+    Some((otp, mfa, db))
+}
+
+fn now() -> i64 {
+    i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    )
+    .unwrap()
+}
+
+async fn count(db: &PgPool, table: &str) -> i64 {
+    sqlx::query(&format!("SELECT count(*) AS n FROM {table}"))
+        .fetch_one(db)
+        .await
+        .unwrap()
+        .get::<i64, _>("n")
+}
+
+#[tokio::test]
+async fn mfa_sweep_removes_abandoned_challenges_and_keeps_live_ones() {
+    let Some((_, mfa, db)) = fresh().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    sqlx::query(
+        "INSERT INTO core.tb_mfa_challenge (token_hash, user_id, expires_at)
+         VALUES ($1, 'abandoned', $2), ($3, 'live', $4)",
+    )
+    .bind(vec![1_u8; 32])
+    .bind(now() - 60)
+    .bind(vec![2_u8; 32])
+    .bind(now() + 3600)
+    .execute(&db)
+    .await
+    .unwrap();
+
+    let removed = mfa.sweep_expired().await.unwrap();
+
+    assert_eq!(removed, 1, "exactly the expired challenge is swept");
+    let survivors: Vec<String> =
+        sqlx::query("SELECT user_id FROM core.tb_mfa_challenge ORDER BY user_id")
+            .fetch_all(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.get::<String, _>("user_id"))
+            .collect();
+    assert_eq!(survivors, vec!["live".to_string()], "a live challenge must survive the sweep");
+}
+
+#[tokio::test]
+async fn otp_sweep_removes_expired_codes_and_stale_budgets() {
+    let Some((otp, _, db)) = fresh().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    sqlx::query(
+        "INSERT INTO core.tb_otp_code (email, code_hash, expires_at)
+         VALUES ('stale@example.com', $1, $2), ('live@example.com', $3, $4)",
+    )
+    .bind(vec![1_u8; 32])
+    .bind(now() - 60)
+    .bind(vec![2_u8; 32])
+    .bind(now() + 3600)
+    .execute(&db)
+    .await
+    .unwrap();
+
+    // The budget window is 15 minutes (`OTP_RATE_WINDOW_SECS`); a row whose window closed
+    // long ago is dead weight — the next request for that address opens a fresh window.
+    sqlx::query(
+        "INSERT INTO core.tb_otp_send_budget (email, count, window_start)
+         VALUES ('ancient@example.com', 3, $1), ('current@example.com', 1, $2)",
+    )
+    .bind(now() - 86_400)
+    .bind(now())
+    .execute(&db)
+    .await
+    .unwrap();
+
+    let removed = otp.sweep_expired().await.unwrap();
+
+    assert_eq!(removed, 2, "one expired code and one ancient budget row");
+    assert_eq!(count(&db, "core.tb_otp_code").await, 1, "the live code survives");
+    assert_eq!(count(&db, "core.tb_otp_send_budget").await, 1, "the current budget survives");
+
+    let live: String = sqlx::query("SELECT email FROM core.tb_otp_code")
+        .fetch_one(&db)
+        .await
+        .unwrap()
+        .get("email");
+    assert_eq!(live, "live@example.com");
+}
+
+#[tokio::test]
+async fn sweeping_an_empty_table_is_a_no_op() {
+    let Some((otp, mfa, _)) = fresh().await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+
+    assert_eq!(mfa.sweep_expired().await.unwrap(), 0);
+    assert_eq!(otp.sweep_expired().await.unwrap(), 0);
+}

--- a/crates/fraiseql-auth/tests/postgres_saml_replay.rs
+++ b/crates/fraiseql-auth/tests/postgres_saml_replay.rs
@@ -1,0 +1,172 @@
+//! Live-PostgreSQL tests for cross-replica SAML replay protection (#949).
+//!
+//! The assertion that matters here is the one a single-process suite structurally cannot
+//! make, which is why the gap survived: **an assertion accepted by one server must be
+//! refused by a second, independently-constructed one over the same database.** With the
+//! in-process `DashMap` the second store had never seen the ID, so it accepted — the
+//! signature is valid, and the replay cache was the only thing that would have stopped it.
+//!
+//! Two `PgSamlReplayStore` values built from two separate pools stand in for two replicas.
+//! They share nothing but the database, which is exactly the property under test; going
+//! through the full HTTP surface would add a signed-assertion fixture and two bound ports
+//! without changing what is being asserted.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: saml` suite — not the
+//! `postgres` one, which builds `fraiseql-auth` with default features and so cannot see
+//! `PgSamlReplayStore` at all. `required-features = ["auth-saml"]` in `Cargo.toml` is what
+//! holds that: cargo refuses the target by name in a leg that forgets the feature, and
+//! `tools/check-suite-coverage.py` reads the same key and reports an ORPHAN unless some
+//! leg enables it.
+//!
+//! **Execution engine:** PostgreSQL · **Infrastructure:** `DATABASE_URL` + `auth-saml` ·
+//! **Parallelism:** truncates `core.tb_saml_replay` on setup → run `--test-threads=1`.
+#![allow(clippy::unwrap_used, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+
+use chrono::{Duration, Utc};
+use fraiseql_auth::{PgSamlReplayStore, SamlReplayCache, SamlReplayStore};
+use fraiseql_test_support::try_database_url;
+use sqlx::postgres::PgPoolOptions;
+
+/// Build `n` stores, each over its **own** pool — two replicas, one database.
+async fn replicas(n: usize) -> Option<Vec<PgSamlReplayStore>> {
+    let url = try_database_url()?;
+    let mut stores = Vec::with_capacity(n);
+    for _ in 0..n {
+        let pool = PgPoolOptions::new().max_connections(2).connect(&url).await.unwrap();
+        let store = PgSamlReplayStore::new(pool);
+        store.init().await.unwrap();
+        stores.push(store);
+    }
+    sqlx::query("TRUNCATE core.tb_saml_replay")
+        .execute(&PgPoolOptions::new().max_connections(1).connect(&url).await.unwrap())
+        .await
+        .unwrap();
+    Some(stores)
+}
+
+#[tokio::test]
+async fn an_assertion_accepted_by_one_replica_is_refused_by_another() {
+    let Some(stores) = replicas(2).await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let (first, second) = (&stores[0], &stores[1]);
+
+    let now = Utc::now();
+    let expires = now + Duration::minutes(5);
+
+    assert!(
+        first.check_and_record("assertion-1", expires, now).await.unwrap(),
+        "the first presentation is fresh"
+    );
+    assert!(
+        !second.check_and_record("assertion-1", expires, now).await.unwrap(),
+        "a second replica must refuse an assertion the first already consumed — this is \
+         the whole of #949, and the in-process cache accepted it"
+    );
+}
+
+#[tokio::test]
+async fn the_in_process_cache_does_not_hold_across_instances() {
+    // The negative control. Without it, the test above could pass for the wrong reason —
+    // e.g. if both "replicas" shared one store — and would no longer be evidence that the
+    // Postgres store is what closes the gap.
+    let one = SamlReplayCache::new();
+    let two = SamlReplayCache::new();
+
+    let now = Utc::now();
+    let expires = now + Duration::minutes(5);
+
+    assert!(one.check_and_record("assertion-1", expires, now).await.unwrap());
+    assert!(
+        two.check_and_record("assertion-1", expires, now).await.unwrap(),
+        "an in-process cache cannot see another instance's consumption — the defect"
+    );
+}
+
+#[tokio::test]
+async fn a_replica_refuses_an_assertion_it_consumed_itself() {
+    let Some(stores) = replicas(1).await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let store = &stores[0];
+
+    let now = Utc::now();
+    let expires = now + Duration::minutes(5);
+
+    assert!(store.check_and_record("assertion-2", expires, now).await.unwrap());
+    assert!(
+        !store.check_and_record("assertion-2", expires, now).await.unwrap(),
+        "single-node replay protection must not regress"
+    );
+}
+
+#[tokio::test]
+async fn an_id_becomes_reusable_once_its_window_has_closed() {
+    let Some(stores) = replicas(1).await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let store = &stores[0];
+
+    let then = Utc::now() - Duration::hours(2);
+    assert!(
+        store
+            .check_and_record("assertion-3", then + Duration::minutes(5), then)
+            .await
+            .unwrap()
+    );
+
+    // Past its `NotOnOrAfter` the assertion is refused by the signature time-check, so
+    // treating the ID as fresh again cannot enable a replay — and it stops a stale row
+    // from rejecting a legitimately new assertion that happens to reuse the ID.
+    let now = Utc::now();
+    assert!(
+        store
+            .check_and_record("assertion-3", now + Duration::minutes(5), now)
+            .await
+            .unwrap(),
+        "an expired entry must not permanently burn its assertion ID"
+    );
+}
+
+#[tokio::test]
+async fn the_sweep_removes_closed_windows_and_keeps_live_ones() {
+    let Some(stores) = replicas(1).await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    let store = &stores[0];
+
+    let then = Utc::now() - Duration::hours(2);
+    assert!(
+        store
+            .check_and_record("stale", then + Duration::minutes(5), then)
+            .await
+            .unwrap()
+    );
+
+    let now = Utc::now();
+    assert!(store.check_and_record("live", now + Duration::minutes(5), now).await.unwrap());
+
+    assert_eq!(store.sweep_expired(now).await.unwrap(), 1, "only the closed window is swept");
+    assert!(
+        !store.check_and_record("live", now + Duration::minutes(5), now).await.unwrap(),
+        "a live entry must survive the sweep and still refuse a replay"
+    );
+}
+
+#[tokio::test]
+async fn distributed_posture_is_reported_honestly() {
+    // The server refuses a multi-replica posture on a single-process store; that check is
+    // only as good as what the stores report about themselves.
+    assert!(!SamlReplayCache::new().is_distributed());
+
+    let Some(stores) = replicas(1).await else {
+        eprintln!("skipping: DATABASE_URL not set");
+        return;
+    };
+    assert!(stores[0].is_distributed());
+}

--- a/crates/fraiseql-server/src/auth_local.rs
+++ b/crates/fraiseql-server/src/auth_local.rs
@@ -297,7 +297,7 @@ pub async fn build_local_auth_states(
     let otp = None;
 
     let mfa = if local.mfa {
-        info!("TOTP MFA enabled (POST /auth/v1/mfa/{{enroll,challenge,verify,unenroll}})");
+        info!("TOTP MFA enabled (POST /auth/v1/mfa/{{enroll,confirm,challenge,verify,unenroll}})");
         Some(Arc::new(fraiseql_auth::MfaRouteState {
             mfa_store:     Arc::new(fraiseql_auth::PgMfaStore::new(pool.clone())),
             session_store: Arc::clone(&session_store),

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -645,6 +645,13 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         #[cfg(feature = "auth")]
         Self::spawn_pkce_cleanup(pkce_store.as_ref(), &mut tasks);
 
+        // Spawn the MFA/OTP expiry sweeps (#950). Every read of those tables already
+        // checks expiry, so this is about table growth: an abandoned challenge is never
+        // consumed and never observed expired, and the OTP send-budget table keeps a row
+        // for every address that has ever asked for a code.
+        #[cfg(feature = "auth")]
+        Self::spawn_local_auth_sweeps(&local_auth, &mut tasks);
+
         // Spawn the session-state eviction sweep (#389) at the configured cadence.
         #[cfg(feature = "auth")]
         Self::spawn_session_state_eviction(
@@ -751,6 +758,57 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                 loop {
                     ticker.tick().await;
                     store_clone.cleanup_expired().await;
+                }
+            });
+        }
+    }
+
+    /// Spawn the `[auth.local]` MFA/OTP expiry sweeps onto the server's
+    /// [`JoinSet`](tokio::task::JoinSet), so graceful shutdown awaits them.
+    ///
+    /// One ticker per configured store, on the same five-minute cadence as the PKCE
+    /// cleanup next door. A sweep that errors is logged and the ticker continues: a
+    /// transient database error must not silently retire the task and let the tables
+    /// resume growing for the life of the process.
+    #[cfg(feature = "auth")]
+    pub(super) fn spawn_local_auth_sweeps(
+        local_auth: &crate::auth_local::LocalAuthStates,
+        tasks: &mut tokio::task::JoinSet<()>,
+    ) {
+        use std::time::Duration;
+
+        use tokio::time::MissedTickBehavior;
+
+        const SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+
+        if let Some(ref mfa) = local_auth.mfa {
+            let store = Arc::clone(&mfa.mfa_store);
+            tasks.spawn(async move {
+                let mut ticker = tokio::time::interval(SWEEP_INTERVAL);
+                ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                loop {
+                    ticker.tick().await;
+                    match store.sweep_expired().await {
+                        Ok(0) => {},
+                        Ok(n) => tracing::debug!(removed = n, "swept expired MFA challenges"),
+                        Err(e) => tracing::warn!(error = %e, "MFA expiry sweep failed"),
+                    }
+                }
+            });
+        }
+
+        if let Some(ref otp) = local_auth.otp {
+            let store = Arc::clone(&otp.otp_store);
+            tasks.spawn(async move {
+                let mut ticker = tokio::time::interval(SWEEP_INTERVAL);
+                ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                loop {
+                    ticker.tick().await;
+                    match store.sweep_expired().await {
+                        Ok(0) => {},
+                        Ok(n) => tracing::debug!(removed = n, "swept expired OTP rows"),
+                        Err(e) => tracing::warn!(error = %e, "OTP expiry sweep failed"),
+                    }
                 }
             });
         }

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -573,10 +573,22 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                         }),
                     ),
                 );
-                let account_store = Arc::new(fraiseql_auth::PostgresAccountStore::new(pool));
+                let account_store =
+                    Arc::new(fraiseql_auth::PostgresAccountStore::new(pool.clone()));
                 let state_store = Arc::new(fraiseql_auth::InMemoryStateStore::new());
+                // Replay protection is shared across replicas (#949). The in-process
+                // default holds only within one server, so a captured assertion replays
+                // against a replica that has never seen its ID — the signature is valid
+                // and nothing else would stop it. Postgres because `[saml]` already
+                // requires this pool, so it adds no infrastructure.
+                let replay_store = Arc::new(fraiseql_auth::PgSamlReplayStore::new(pool));
+                replay_store
+                    .init()
+                    .await
+                    .map_err(|e| ServerError::ConfigError(format!("[saml] replay store: {e}")))?;
                 let mut state = fraiseql_auth::saml::SamlAuthState::new(state_store, session_store)
-                    .with_user_store(account_store);
+                    .with_user_store(account_store)
+                    .with_replay_store(replay_store);
                 for (name, entry) in &saml_cfg.idps {
                     let xml = match (&entry.metadata_xml, &entry.metadata_xml_path) {
                         (Some(xml), _) => xml.clone(),
@@ -639,6 +651,15 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             revocation_in_memory: revocation_manager
                 .as_ref()
                 .is_some_and(|rm| !rm.is_distributed()),
+            // Gated on `auth-saml`, not `auth`: `saml_state` itself only exists on an
+            // `auth-saml` build, so a plain `auth` build has no SAML replay store to
+            // report on. Only reachable for a library embedder anyway — the binary
+            // always passes the pool `[saml]` already requires, so the store is
+            // Postgres-backed (#949).
+            #[cfg(feature = "auth-saml")]
+            saml_replay_in_memory: saml_state.as_ref().is_some_and(|s| !s.replay_is_distributed()),
+            #[cfg(not(feature = "auth-saml"))]
+            saml_replay_in_memory: false,
         })?;
 
         // Spawn background PKCE state cleanup task (every 5 minutes).

--- a/crates/fraiseql-server/src/server/initialization.rs
+++ b/crates/fraiseql-server/src/server/initialization.rs
@@ -73,6 +73,10 @@ pub(super) struct SharedStateBackends {
     pub rate_limiter_in_memory: bool,
     /// The token revocation store is per-process.
     pub revocation_in_memory:   bool,
+    /// The SAML assertion replay store is per-process (#949). Behind more than one
+    /// replica an assertion consumed by one is unknown to the others, so a captured
+    /// `SAMLResponse` replays against a replica that has never seen its ID.
+    pub saml_replay_in_memory:  bool,
 }
 
 impl SharedStateBackends {
@@ -87,6 +91,9 @@ impl SharedStateBackends {
         }
         if self.revocation_in_memory {
             v.push("token revocation ([security.token_revocation])");
+        }
+        if self.saml_replay_in_memory {
+            v.push("SAML assertion replay protection ([saml])");
         }
         v
     }
@@ -149,7 +156,9 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
              each of them a shared backend:\n    [security.pkce]            redis_url = \
              \"redis://…\"\n    [security.rate_limiting]   redis_url = \"redis://…\"\n    \
              [security.token_revocation] backend = \"postgres\" (or redis_url = \"redis://…\")\
-             \n\n  To allow per-process state (single-replica only): unset \
+             \n    [saml]                     uses the configured pool automatically; a \
+             per-process replay store means Server was built programmatically without \
+             one\n\n  To allow per-process state (single-replica only): unset \
              FRAISEQL_REQUIRE_REDIS",
             violations.join(", ")
         )))

--- a/crates/fraiseql-server/src/server/routing/auth.rs
+++ b/crates/fraiseql-server/src/server/routing/auth.rs
@@ -14,7 +14,7 @@ use tracing::info;
 use super::super::{
     AuthMeState, AuthPkceState, Server, auth_callback, auth_me, auth_start, oidc_auth_middleware,
 };
-use crate::auth::{anon_signup, mfa_challenge, mfa_enroll, mfa_unenroll, mfa_verify};
+use crate::auth::{anon_signup, mfa_challenge, mfa_confirm, mfa_enroll, mfa_unenroll, mfa_verify};
 
 impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
     /// Mount all `#[cfg(feature = "auth")]`-gated authentication routes.
@@ -95,13 +95,18 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
         if let Some(ref mfa) = self.mfa_state {
             let mfa_router = Router::new()
                 .route("/auth/v1/mfa/enroll", post(mfa_enroll))
+                // `/confirm` completes what `/enroll` begins. Without it an enrollment
+                // stays unconfirmed forever and `create_challenge` refuses to issue
+                // against it, so MFA was enrollable but unusable through the API (#950).
+                .route("/auth/v1/mfa/confirm", post(mfa_confirm))
                 .route("/auth/v1/mfa/challenge", post(mfa_challenge))
                 .route("/auth/v1/mfa/verify", post(mfa_verify))
                 .route("/auth/v1/mfa/unenroll", post(mfa_unenroll))
                 .with_state(Arc::clone(mfa));
             app = app.merge(mfa_router);
             info!(
-                "TOTP MFA routes mounted: POST /auth/v1/mfa/{{enroll,challenge,verify,unenroll}}"
+                "TOTP MFA routes mounted: POST \
+                 /auth/v1/mfa/{{enroll,confirm,challenge,verify,unenroll}}"
             );
         }
 
@@ -241,6 +246,7 @@ mod router_construction {
     async fn mfa_router_constructs() {
         let _router: Router = Router::new()
             .route("/auth/v1/mfa/enroll", post(mfa_enroll))
+            .route("/auth/v1/mfa/confirm", post(mfa_confirm))
             .route("/auth/v1/mfa/challenge", post(mfa_challenge))
             .route("/auth/v1/mfa/verify", post(mfa_verify))
             .route("/auth/v1/mfa/unenroll", post(mfa_unenroll))

--- a/crates/fraiseql-server/src/server/tests.rs
+++ b/crates/fraiseql-server/src/server/tests.rs
@@ -979,6 +979,7 @@ mod rate_limit_boot_guard_tests {
             pkce_in_memory:         false,
             rate_limiter_in_memory: !limiter.is_distributed(),
             revocation_in_memory:   false,
+            saml_replay_in_memory:  false,
         }
         .per_process_subsystems();
         assert!(
@@ -1180,6 +1181,7 @@ mod require_redis_874 {
             pkce_in_memory:         false,
             rate_limiter_in_memory: true,
             revocation_in_memory:   true,
+            saml_replay_in_memory:  false,
         };
         let v = b.per_process_subsystems();
         assert!(
@@ -1198,6 +1200,7 @@ mod require_redis_874 {
             pkce_in_memory:         false,
             rate_limiter_in_memory: false,
             revocation_in_memory:   false,
+            saml_replay_in_memory:  false,
         };
         assert!(
             b.per_process_subsystems().is_empty(),

--- a/crates/fraiseql-server/tests/local_auth_e2e_pg.rs
+++ b/crates/fraiseql-server/tests/local_auth_e2e_pg.rs
@@ -31,7 +31,6 @@ use std::sync::Arc;
 
 #[cfg(feature = "inbound-email")]
 use fraiseql_auth::AccountStore as _;
-use fraiseql_auth::MfaStore as _;
 use fraiseql_core::{
     db::postgres::PostgresAdapter,
     schema::{AuthClientConfig, CompiledSchema, LocalAuthConfig},
@@ -496,8 +495,11 @@ async fn mfa_enrollment_survives_a_restart() {
             .expect("enrollment row");
     assert!(!confirmed.0, "a fresh enrollment is unconfirmed until the first code verifies");
 
-    // Confirm it directly through the store (the confirm endpoint is not
-    // mounted; this exercises the Postgres store's own confirm path).
+    // Confirm through the HTTP route. This used to reach past the surface an operator
+    // has and call `PgMfaStore::confirm_enrollment` directly, because no route was
+    // mounted — which meant MFA could be enrolled but never used through the API alone
+    // (#950). Reaching past the surface is exactly how the gap survived: the test still
+    // passed. Confirming through the route is the operator's path.
     let secret = uri
         .split("secret=")
         .nth(1)
@@ -515,8 +517,21 @@ async fn mfa_enrollment_survives_a_restart() {
     )
     .expect("totp");
     let code = totp.generate_current().expect("generate code");
-    let store = fraiseql_auth::PgMfaStore::new(pool.clone());
-    store.confirm_enrollment("user-1", &code).await.expect("confirm enrollment");
+    let (status, body) = post_json(
+        &server.base,
+        "/auth/v1/mfa/confirm",
+        serde_json::json!({ "user_id": "user-1", "code": code }),
+    )
+    .await;
+    assert_eq!(status, 200, "confirm through the route: {body}");
+
+    let confirmed: (bool,) =
+        sqlx::query_as("SELECT confirmed FROM core.tb_mfa_enrollment WHERE user_id = $1")
+            .bind("user-1")
+            .fetch_one(&pool)
+            .await
+            .expect("enrollment row");
+    assert!(confirmed.0, "the route must confirm the enrollment, not just answer 200");
 
     // Restart the server: an in-memory store would lose the enrollment here,
     // which is exactly why `[auth.local] mfa` is backed by Postgres.


### PR DESCRIPTION
Wave 5's first phase. Two `[auth.local]`/SAML gaps that are correctness- and
security-shaped rather than new features. One commit per issue.

## #950 — MFA could be enrolled but never used, and three tables grew forever

`MfaStore::confirm_enrollment` existed and both stores implemented it; no route called it.
An operator could begin an enrollment over HTTP and never finish it — the row stays
`confirmed = false`, and `create_challenge` refuses to issue against an unconfirmed
enrollment. The e2e passed anyway because it called `PgMfaStore::confirm_enrollment`
directly, with a comment saying the endpoint was not mounted. That comment was the tell;
the test now confirms through the route, and the `MfaStore as _` import the workaround
needed is gone with it.

Separately, `core.tb_mfa_challenge`, `core.tb_otp_code` and `core.tb_otp_send_budget` were
never pruned. Correctness was never at stake — every read checks expiry — but an abandoned
challenge is never consumed and never observed expired, and the send-budget table kept one
row for every address that had ever asked for a code. `sweep_expired` is a **required**
trait method on both stores (a defaulted no-op would let a new backend inherit unbounded
growth in silence), spawned per configured store on a five-minute ticker into the server's
`JoinSet` so graceful shutdown awaits it.

## #949 — a captured SAML assertion replayed against a second replica

`SamlReplayCache` was an in-process `DashMap` whose own module doc admitted "replay
protection therefore holds within a single process". Behind more than one replica an
attacker who captures a signed `SAMLResponse` replays it against a different replica,
which has never seen that assertion ID and accepts it. The signature is valid; only the
replay cache would have stopped it.

`SamlReplayStore` is now a trait. The `DashMap` stays as the single-node implementation;
the server builds `PgSamlReplayStore` over the pool `[saml]` already requires, so no new
infrastructure. The check is one `INSERT … ON CONFLICT` — atomic in Postgres rather than a
read-then-write two replicas could interleave — and a row past its window is reclaimable,
so a stale entry cannot permanently burn an assertion ID. Fail-closed, deliberately unlike
the JWT `jti` cache's fail-open default; the module says why. `FRAISEQL_REQUIRE_REDIS` now
covers the replay store, so an operator asserting distributed state cannot silently get
per-process replay protection.

## Verification

Every fix RED first. The replay guard is red-proven by dropping the `ON CONFLICT … WHERE`
clause: 3 of 6 fail, including the cross-replica refusal. The MFA route is red-proven by
the e2e's 404. The sweep tests are two-sided — the expired row goes, the live one stays —
so a sweep that deleted everything would fail them.

**The assertion that matters** is two `PgSamlReplayStore`s over two pools: an assertion
accepted by one is refused by the other. A single-process suite structurally cannot make
it, which is why the gap survived. A negative control pins that two in-process caches do
*not* see each other, so the cross-replica test cannot pass for the wrong reason.

`tools/check-suite-coverage.py` caught both new suites as orphans before they were wired
into the Dagger postgres leg — the P01 gate doing its job.

`make preflight` · `cargo test -p fraiseql-auth --all-features` green · clippy
`--all-targets --all-features -D warnings` on both touched crates.

Closes #950
Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)