### PR TITLE
feat(auth): P14 — Apple, Discord and Facebook social login (#943, #944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1416,6 +1416,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TrustedEmailProviders` set; Private Relay aliases are verified addresses Apple owns, so
   they key normally and simply never match another provider (correct, not a gap).
 
+- **Discord and Facebook social login (#944).** The last two providers the `[auth.social]`
+  umbrella (#368) named. Both are plain OAuth2 on the GitHub template — fixed well-known
+  endpoints, network-free construction, SSRF-guarded base-URL overrides — and each one's
+  interesting question is what it can honestly say about an email address.
+
+  **Discord** carries `email` and `verified` on the same user object, with no second hop.
+  The provider *reads* that flag rather than assuming it: an unverified address arrives at
+  the callback as unverified and keys on `(discord, id)`, so it cannot collapse into an
+  existing email-keyed account. Only because that check exists is **`discord` now in the
+  default `TrustedEmailProviders` set** — the trust and the check ship together, and a
+  deployment that wants neither can drop it with `.distrust("discord")`.
+
+  **Facebook** may return no `email` at all (a phone-number-only account, or a declined
+  permission) and publishes **no verification flag whatsoever**. There is nothing to gate on,
+  so the provider reports `email_verified = false` unconditionally and `facebook` is
+  deliberately absent from the default trusted set — two independent reasons its address can
+  never become a linking key. The Graph API version lives in the request path and Meta
+  deprecates versions on its own schedule, so `api_version` is configuration (default
+  `v21.0`) rather than a constant that would break on Meta's timetable; a value carrying a
+  path separator is refused, since it would re-point the request.
+
+  The two belts made a test-design point worth recording: setting Facebook's
+  `email_verified` to `true` leaves the *end-to-end* test green, because the trust gate
+  downgrades it anyway. Each half therefore has its own test — a stub-backed `user_info`
+  case for the provider's claim, and a trust-set case for the gate.
+
 - **Outbound CDC is mounted by the server (#382).** `[cdc_outbound]` with one
   or more `[[cdc_outbound.sinks]]` now makes the server drain
   `core.tb_entity_change_log` to a broker on its own task set, behind the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **`fraiseql_auth::provider::TokenResponse` gained an `id_token` field (#943).** Any code
+  constructing one — a custom `OAuthProvider`, a test double — must add
+  `id_token: None` (or the provider's ID token, if it issues one; the built-in OIDC provider
+  now carries its through). The field exists because Apple returns the entire identity in
+  the ID token and publishes no userinfo endpoint, which is also why `OAuthProvider` gained
+  `user_info_from_tokens`. That method has a default forwarding to `user_info`, so existing
+  provider impls compile unchanged — but a provider whose identity lives in the ID token
+  must override it, and should make its own `user_info` fail rather than return a degraded
+  identity.
+
 - **Twilio senders must use the `bodySHA256` scheme for non-form bodies (#1069).** A JSON
   delivery signed the way this crate used to accept — `HMAC-SHA1(auth_token, public_url)`
   with no body material — now answers 401. Genuine Twilio traffic is unaffected: Twilio
@@ -1367,6 +1377,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against reintroduction. Use `--database <url>` (the long form always worked).
 
 ### Added
+
+- **Sign in with Apple (#943).** `[auth.social.apple]` completes the third provider the
+  `[auth.social]` umbrella (#368) named, and it is the one that could not have been a copy
+  of the Google client. Apple's client secret is an **ES256 assertion**, not a stored
+  string: the config takes `client_id` (the services ID), `team_id`, `key_id` and the `.p8`
+  key through exactly one of `private_key_env` / `private_key_path`, and the runtime signs
+  a short-lived assertion over that triple, caching it and re-minting before expiry. A key
+  that cannot sign is refused at boot, not at the first login.
+
+  Apple publishes **no userinfo endpoint** — the identity is the token endpoint's
+  `id_token` and nothing else — so `OAuthProvider` gained
+  `user_info_from_tokens(&TokenResponse)`, which defaults to today's
+  `user_info(access_token)` for every provider that does publish one. `AppleOAuth::user_info`
+  refuses loudly rather than returning a degraded identity. The `id_token`'s `iss`, `aud`
+  and `exp` are validated fail-closed; its signature is not re-verified, because it arrives
+  by direct TLS from the token endpoint (OIDC Core §3.1.3.7 rule 6) and an attacker who
+  could forge that response could forge the JWKS document too.
+
+  Requesting the `name`/`email` scopes makes Apple deliver the callback as
+  `response_mode=form_post`, so configuring Apple also mounts a **`POST` variant of
+  `/auth/v1/callback`** — same CSRF-state consumption, same trust gate, same session mint as
+  the `GET` shape. That POST's `user` field carries the display name Apple returns exactly
+  once, on the first authorization.
+
+  **The security-load-bearing decision, and a deliberate narrowing of the issue as filed:**
+  that `user` field arrives in a request the *browser* makes, so anyone holding a valid
+  `code`/`state` pair from their own Apple account can put any address in it. Honouring its
+  `email` would let them link straight into that address's account. It is therefore not even
+  modelled — `AppleFirstAuthUser` has a name and nothing else, the form body's `id_token` is
+  never read, and the linking email comes only from the token endpoint. A live e2e proves it:
+  a sign-in whose payload claims `victim@example.com` leaves that address owning nothing.
+
+  Persisting the first-authorization claims needs no new storage: `AccountStore` resolves a
+  known `(provider, provider_id)` before it looks at any email, so the second sign-in —
+  which Apple sends with `sub` and nothing else — lands on the account the first one created.
+  The e2e drives exactly that sequence. Apple was already in the default
+  `TrustedEmailProviders` set; Private Relay aliases are verified addresses Apple owns, so
+  they key normally and simply never match another provider (correct, not a gap).
 
 - **Outbound CDC is mounted by the server (#382).** `[cdc_outbound]` with one
   or more `[[cdc_outbound.sinks]]` now makes the server drain

--- a/crates/fraiseql-auth/src/account_linking/mod.rs
+++ b/crates/fraiseql-auth/src/account_linking/mod.rs
@@ -318,11 +318,18 @@ fn identity_key(verified_email: Option<&str>, provider: &str, provider_id: &str)
 /// - `github` — the provider resolves the **primary verified** email via the `/user/emails` second
 ///   hop (#368) and reports `email_verified = true` only for an address GitHub itself has verified;
 ///   any failure of that hop fails closed to `false`.
+/// - `discord` — Discord verifies email ownership at signup and reports the outcome as `verified`
+///   on the user object, which [`crate::DiscordOAuth`] reads rather than assumes (#944); an absent
+///   flag is `false`. The trust is warranted only because that check exists, so the two must not be
+///   separated.
 ///
 /// Deliberately **excluded** from the default (opt in explicitly once vetted):
 ///
 /// - `azure_ad` / Microsoft — the `email` claim is **not** reliably verified and is tenant-mutable
 ///   (the *nOAuth* class, 2023), so it must not auto-link by default.
+/// - `facebook` — Facebook publishes **no** verification signal at all, and the address may be
+///   absent entirely (#944). There is nothing to trust, so the provider reports `email_verified =
+///   false` unconditionally and every Facebook identity keys on `(facebook, id)`.
 /// - any generic/custom OIDC provider — FraiseQL cannot vouch for an operator-run IdP.
 ///
 /// # Overriding (up *and* down)
@@ -352,12 +359,12 @@ pub struct TrustedEmailProviders {
 }
 
 impl TrustedEmailProviders {
-    /// The built-in default trusted set: `google`, `apple`, and `github` (see the
-    /// type docs for the per-provider rationale). Equivalent to
-    /// [`TrustedEmailProviders::default`].
+    /// The built-in default trusted set: `google`, `apple`, `github` and
+    /// `discord` (see the type docs for the per-provider rationale). Equivalent
+    /// to [`TrustedEmailProviders::default`].
     #[must_use]
     pub fn builtin_default() -> Self {
-        Self::only(["google", "apple", "github"])
+        Self::only(["google", "apple", "github", "discord"])
     }
 
     /// Trust **no** provider. Every social identity is keyed on `(provider, provider_id)`

--- a/crates/fraiseql-auth/src/account_linking/tests.rs
+++ b/crates/fraiseql-auth/src/account_linking/tests.rs
@@ -295,6 +295,7 @@ fn trusted_can_be_emptied_down_to_none_via_builder() {
     let trusted = TrustedEmailProviders::default()
         .distrust("google")
         .distrust("apple")
-        .distrust("github");
+        .distrust("github")
+        .distrust("discord");
     assert!(trusted.is_empty());
 }

--- a/crates/fraiseql-auth/src/lib.rs
+++ b/crates/fraiseql-auth/src/lib.rs
@@ -116,7 +116,9 @@ pub use phone_otp::{
 };
 pub use pkce::{ConsumedPkceState, PkceError, PkceStateStore};
 pub use provider::{OAuthProvider, PkceChallenge, TokenResponse, UserInfo};
-pub use providers::{AzureADOAuth, GitHubOAuth, GoogleOAuth, KeycloakOAuth, create_provider};
+pub use providers::{
+    AppleOAuth, AzureADOAuth, GitHubOAuth, GoogleOAuth, KeycloakOAuth, create_provider,
+};
 pub use proxy::ProxyConfig;
 pub use rate_limiting::{AuthRateLimitConfig, Clock, KeyedRateLimiter, RateLimiters, SystemClock};
 #[cfg(feature = "auth-saml")]

--- a/crates/fraiseql-auth/src/lib.rs
+++ b/crates/fraiseql-auth/src/lib.rs
@@ -117,7 +117,8 @@ pub use phone_otp::{
 pub use pkce::{ConsumedPkceState, PkceError, PkceStateStore};
 pub use provider::{OAuthProvider, PkceChallenge, TokenResponse, UserInfo};
 pub use providers::{
-    AppleOAuth, AzureADOAuth, GitHubOAuth, GoogleOAuth, KeycloakOAuth, create_provider,
+    AppleOAuth, AzureADOAuth, DiscordOAuth, FacebookOAuth, GitHubOAuth, GoogleOAuth, KeycloakOAuth,
+    create_provider,
 };
 pub use proxy::ProxyConfig;
 pub use rate_limiting::{AuthRateLimitConfig, Clock, KeyedRateLimiter, RateLimiters, SystemClock};

--- a/crates/fraiseql-auth/src/multi_provider.rs
+++ b/crates/fraiseql-auth/src/multi_provider.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use axum::{
-    Json,
+    Form, Json,
     extract::{Query, State},
     http::StatusCode,
     response::{IntoResponse, Redirect, Response},
@@ -240,6 +240,35 @@ pub struct CallbackQuery {
     pub error:             Option<String>,
     /// Provider error description.
     pub error_description: Option<String>,
+}
+
+/// Form body for `POST /auth/v1/callback` — Apple's `response_mode=form_post`
+/// delivery (#943).
+///
+/// # What is deliberately absent
+///
+/// Apple's form POST also carries an `id_token` field, and its `user` field
+/// carries an `email`. Both arrive in a request **the user's browser makes**, so
+/// both are attacker-chosen: anyone holding a valid `code`/`state` pair from
+/// their own Apple account could post a victim's address and, if it were
+/// honoured, link straight into the victim's account. Neither is modelled here.
+/// The identity — subject, email, and its verified flag — comes only from the
+/// `id_token` the **token endpoint** returns to this server over TLS.
+///
+/// The `user` field's *name* is untrusted display data, and is surfaced as such.
+#[derive(Debug, Deserialize)]
+pub struct CallbackForm {
+    /// Authorization code from the provider.
+    pub code:              Option<String>,
+    /// CSRF state token.
+    pub state:             Option<String>,
+    /// Provider error code.
+    pub error:             Option<String>,
+    /// Provider error description.
+    pub error_description: Option<String>,
+    /// Apple's first-authorization `user` payload, a raw JSON string. Present
+    /// on the first authorization only, and never again.
+    pub user:              Option<String>,
 }
 
 /// Response for `GET /auth/v1/providers`.
@@ -486,10 +515,67 @@ pub async fn authorize(
 ///
 /// Returns `400` if the state is invalid/expired, code is missing, or the provider
 /// returned an error. Returns `502` if the token exchange or user info fetch fails.
-#[allow(clippy::cognitive_complexity)] // Reason: OAuth callback with state validation, token exchange, user info, and session creation
 pub async fn callback(
     State(state): State<Arc<MultiProviderAuthState>>,
     Query(q): Query<CallbackQuery>,
+) -> Response {
+    complete_callback(&state, q, None).await
+}
+
+// ---------------------------------------------------------------------------
+// POST /auth/v1/callback
+// ---------------------------------------------------------------------------
+
+/// Complete the OAuth flow when the provider delivers the callback as a form
+/// POST (#943).
+///
+/// Apple uses `response_mode=form_post` whenever the `name`/`email` scopes are
+/// requested, so the callback arrives as a `POST` with a form body rather than
+/// the `GET` every other provider makes. The route is mounted only when a
+/// provider that needs it is configured.
+///
+/// Everything after parsing is the same flow as [`callback`] — same CSRF-state
+/// consumption, same trust gate, same session mint. The only addition is the
+/// first-authorization display name, which is **not** trusted for anything that
+/// resolves an account; see [`CallbackForm`].
+///
+/// # Responses
+///
+/// - `200` JSON `{ access_token, refresh_token?, token_type, expires_in, provider }`, or a `302`
+///   fragment redirect when a `redirect_uri` allow-list is configured (#427).
+/// - `400` — invalid state, missing parameters, or provider error.
+/// - `502` — token exchange with the provider failed.
+pub async fn callback_form_post(
+    State(state): State<Arc<MultiProviderAuthState>>,
+    Form(form): Form<CallbackForm>,
+) -> Response {
+    let display_name = form
+        .user
+        .as_deref()
+        .and_then(crate::providers::apple::AppleFirstAuthUser::parse)
+        .and_then(|u| u.display_name());
+    complete_callback(
+        &state,
+        CallbackQuery {
+            code:              form.code,
+            state:             form.state,
+            error:             form.error,
+            error_description: form.error_description,
+        },
+        display_name,
+    )
+    .await
+}
+
+/// The shared body of both callback shapes.
+///
+/// `first_auth_name` is untrusted display data from a form-POST provider (see
+/// [`CallbackForm`]); it never participates in resolving an account.
+#[allow(clippy::cognitive_complexity)] // Reason: OAuth callback with state validation, token exchange, user info, and session creation
+async fn complete_callback(
+    state: &Arc<MultiProviderAuthState>,
+    q: CallbackQuery,
+    first_auth_name: Option<String>,
 ) -> Response {
     // Surface provider errors
     if let Some(err) = q.error {
@@ -544,14 +630,25 @@ pub async fn callback(
         },
     };
 
-    // Get user info from provider
-    let user_info = match provider.user_info(&token_response.access_token).await {
+    // Get user info from the whole token response, not just the access token:
+    // a provider with no userinfo endpoint (Apple) carries the identity in the
+    // `id_token` and nowhere else. Providers that do publish one are unaffected
+    // — the trait default forwards to `user_info(access_token)`.
+    let mut user_info = match provider.user_info_from_tokens(&token_response).await {
         Ok(u) => u,
         Err(e) => {
             tracing::error!(error = %e, "user info fetch failed");
             return json_error(StatusCode::BAD_GATEWAY, "failed to retrieve user information");
         },
     };
+
+    // A first-authorization display name, if the provider sent one and the
+    // provider itself did not supply a name. Display data only — the account is
+    // resolved from `user_info.id` and `user_info.email` below, neither of
+    // which this can touch.
+    if user_info.name.is_none() {
+        user_info.name = first_auth_name;
+    }
 
     // #368: gate the provider's email-verified claim on the trust policy. An untrusted
     // provider's `email_verified = true` is downgraded to unverified so it can never

--- a/crates/fraiseql-auth/src/multi_provider/tests.rs
+++ b/crates/fraiseql-auth/src/multi_provider/tests.rs
@@ -196,6 +196,7 @@ impl OAuthProvider for MockProvider {
             refresh_token: Some("provider-refresh".to_string()),
             expires_in:    3600,
             token_type:    "Bearer".to_string(),
+            id_token:      None,
         })
     }
 

--- a/crates/fraiseql-auth/src/oidc_provider.rs
+++ b/crates/fraiseql-auth/src/oidc_provider.rs
@@ -86,6 +86,10 @@ struct TokenResponseRaw {
     expires_in:    u64,
     #[serde(default)]
     token_type:    Option<String>,
+    /// Present on OIDC flows; carried through so a caller that needs the
+    /// signed identity does not have to re-fetch it.
+    #[serde(default)]
+    id_token:      Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -438,6 +442,7 @@ impl OAuthProvider for OidcProvider {
             refresh_token: response.refresh_token,
             expires_in:    response.expires_in,
             token_type:    response.token_type.unwrap_or_else(|| "Bearer".to_string()),
+            id_token:      response.id_token,
         })
     }
 
@@ -544,6 +549,7 @@ impl OAuthProvider for OidcProvider {
             refresh_token: response.refresh_token,
             expires_in:    response.expires_in,
             token_type:    response.token_type.unwrap_or_else(|| "Bearer".to_string()),
+            id_token:      response.id_token,
         })
     }
 

--- a/crates/fraiseql-auth/src/provider.rs
+++ b/crates/fraiseql-auth/src/provider.rs
@@ -42,6 +42,13 @@ pub struct TokenResponse {
     pub expires_in:    u64,
     /// Token type (typically "Bearer")
     pub token_type:    String,
+    /// OIDC ID token, when the provider issued one.
+    ///
+    /// `None` for plain-OAuth2 providers. It is load-bearing for providers that
+    /// publish no userinfo endpoint — Apple returns the whole identity here and
+    /// nowhere else — which is why [`OAuthProvider::user_info_from_tokens`]
+    /// exists.
+    pub id_token:      Option<String>,
 }
 
 /// OAuth 2.0 / OIDC provider trait
@@ -78,6 +85,26 @@ pub trait OAuthProvider: Send + Sync + fmt::Debug {
     /// # Returns
     /// UserInfo with user details from provider
     async fn user_info(&self, access_token: &str) -> Result<UserInfo>;
+
+    /// Get user information from a whole token response.
+    ///
+    /// This is the method callers should use after
+    /// [`exchange_code`](Self::exchange_code): it defaults to
+    /// [`user_info`](Self::user_info) with the access token, which is right for
+    /// every provider that publishes a userinfo endpoint, and lets a provider
+    /// whose identity lives in the `id_token` — Apple has no userinfo endpoint
+    /// at all — override it.
+    ///
+    /// A provider that overrides this should make its `user_info` fail loudly
+    /// rather than return a degraded identity, so a caller on the wrong method
+    /// gets an error and not a silently wrong subject.
+    ///
+    /// # Errors
+    ///
+    /// Whatever the provider's identity fetch returns.
+    async fn user_info_from_tokens(&self, tokens: &TokenResponse) -> Result<UserInfo> {
+        self.user_info(&tokens.access_token).await
+    }
 
     /// Refresh the access token (optional, default returns error)
     ///

--- a/crates/fraiseql-auth/src/providers/apple.rs
+++ b/crates/fraiseql-auth/src/providers/apple.rs
@@ -1,0 +1,612 @@
+//! Sign in with Apple (#943).
+//!
+//! Apple is not an ordinary OIDC client, and every difference below is a place
+//! a copy of the Google provider would have failed:
+//!
+//! - **The client secret is a signed assertion, not a static string.** It is an ES256 JWT over
+//!   `(team_id, key_id, client_id)`, signed with the `.p8` key Apple issues, valid for at most six
+//!   months. There is no `client_secret_env` to read — [`AppleOAuth`] mints the assertion on demand
+//!   and re-mints it before it expires.
+//! - **There is no userinfo endpoint.** The identity lives in the `id_token` returned by the token
+//!   endpoint, which is why the provider implements
+//!   [`user_info_from_tokens`](crate::provider::OAuthProvider::user_info_from_tokens) and refuses
+//!   the access-token-only [`user_info`](crate::provider::OAuthProvider::user_info).
+//! - **`response_mode=form_post`.** Requesting the `name`/`email` scopes makes Apple deliver the
+//!   callback as a `POST` with a form body, so the server mounts a POST variant of
+//!   `/auth/v1/callback` whenever Apple is configured.
+//! - **The name is returned exactly once**, in that first form POST's `user` field. It is
+//!   **browser-supplied and therefore untrusted** — see [`AppleFirstAuthUser`].
+//! - **Private Relay addresses** (`…@privaterelay.appleid.com`) are per-app aliases Apple owns and
+//!   verifies, so they are safe to key on. They never match another provider's email, so a Private
+//!   Relay user's identity simply does not participate in cross-provider linking — correct, not a
+//!   bug.
+//!
+//! # Why the `id_token` signature is not re-verified
+//!
+//! The token this provider reads is the one the **token endpoint** returned over
+//! TLS to a URL that passed the shared SSRF guard — direct client-to-issuer
+//! communication. OIDC Core §3.1.3.7 rule 6 blesses exactly this case: TLS
+//! server validation stands in for checking the signature. An attacker able to
+//! forge that response could equally forge the JWKS document that would be used
+//! to verify it, so a JWKS hop would add cost and no security. The claims that
+//! *do* carry meaning — `iss`, `aud`, `exp` — are validated, fail-closed.
+//!
+//! The `id_token` a browser posts to the form-POST callback is a different
+//! thing entirely and is never read; see [`crate::multi_provider::callback_form_post`].
+
+use std::{
+    fmt::Write as _,
+    sync::RwLock,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use crate::{
+    error::{AuthError, Result},
+    oidc_provider::validate_oauth_endpoint_url,
+    provider::{OAuthProvider, TokenResponse, UserInfo},
+};
+
+/// Timeout for all Apple ID HTTP requests.
+const APPLE_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum byte size for an Apple ID token-endpoint response.
+const MAX_APPLE_RESPONSE_BYTES: usize = 1024 * 1024; // 1 MiB
+
+/// Default Apple ID base URL (authorize + token endpoints, and the `iss` every
+/// `id_token` must carry).
+const DEFAULT_BASE_URL: &str = "https://appleid.apple.com";
+
+/// The `aud` Apple requires in the client-secret assertion. It names Apple
+/// itself, **not** whichever host the token endpoint is reached on — so it stays
+/// fixed even when [`AppleOAuth::with_base_url`] points elsewhere.
+const CLIENT_SECRET_AUDIENCE: &str = "https://appleid.apple.com";
+
+/// Scopes requested: `name` and `email` are what make Apple return the user
+/// payload — and what make the callback a form POST.
+const APPLE_SCOPES: &str = "name email";
+
+/// Lifetime of a minted client-secret assertion. Apple's ceiling is six months;
+/// minting a short-lived one per hour costs one ES256 signature and keeps a
+/// leaked assertion worth minutes rather than half a year.
+const CLIENT_SECRET_TTL_SECS: u64 = 3600;
+
+/// Re-mint this long before expiry, so an assertion never expires in flight
+/// between being taken from the cache and reaching Apple.
+const CLIENT_SECRET_RENEW_SKEW_SECS: u64 = 300;
+
+/// Domain of Apple's Private Relay aliases.
+const PRIVATE_RELAY_DOMAIN: &str = "@privaterelay.appleid.com";
+
+/// Claims of the ES256 client-secret assertion (Apple's documented shape).
+#[derive(Debug, Serialize)]
+struct ClientSecretClaims<'a> {
+    /// Apple developer team ID.
+    iss: &'a str,
+    /// Issued-at, seconds since the epoch.
+    iat: u64,
+    /// Expiry, seconds since the epoch.
+    exp: u64,
+    /// Always [`CLIENT_SECRET_AUDIENCE`].
+    aud: &'a str,
+    /// The services ID this assertion authenticates.
+    sub: &'a str,
+}
+
+/// A minted assertion and the moment it stops being usable.
+#[derive(Debug, Clone)]
+struct CachedClientSecret {
+    assertion:  String,
+    expires_at: u64,
+}
+
+/// Apple's `id_token` audience: a bare string in practice, an array by OIDC
+/// spec. Accept both rather than fail on a conformant provider.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Audience {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl Audience {
+    fn contains(&self, value: &str) -> bool {
+        match self {
+            Self::One(a) => a == value,
+            Self::Many(all) => all.iter().any(|a| a == value),
+        }
+    }
+}
+
+/// Apple renders its boolean `id_token` claims as either a JSON bool or the
+/// strings `"true"`/`"false"`, depending on the flow. A parser that accepts only
+/// one of the two silently drops `email_verified` — which fails *open* into the
+/// email-keyed linking space, so both are accepted explicitly.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum AppleBool {
+    Bool(bool),
+    Str(String),
+}
+
+impl AppleBool {
+    /// Fail-closed: anything that is not recognisably true is false.
+    fn as_bool(&self) -> bool {
+        match self {
+            Self::Bool(b) => *b,
+            Self::Str(s) => s.eq_ignore_ascii_case("true"),
+        }
+    }
+}
+
+/// The subset of Apple's `id_token` claims that carry identity.
+#[derive(Debug, Deserialize)]
+struct AppleIdTokenClaims {
+    iss:              String,
+    aud:              Audience,
+    sub:              String,
+    exp:              u64,
+    #[serde(default)]
+    email:            Option<String>,
+    #[serde(default)]
+    email_verified:   Option<AppleBool>,
+    #[serde(default)]
+    is_private_email: Option<AppleBool>,
+}
+
+/// Apple's token-endpoint response. `id_token` is the identity; `access_token`
+/// opens nothing (Apple exposes no user API).
+#[derive(Debug, Deserialize)]
+struct AppleTokenResponse {
+    access_token:  String,
+    #[serde(default)]
+    token_type:    Option<String>,
+    #[serde(default)]
+    expires_in:    Option<u64>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    id_token:      Option<String>,
+}
+
+/// The `user` field of Apple's first-authorization form POST.
+///
+/// # This is browser-supplied data
+///
+/// Apple does not sign it: it arrives as a form field in a POST the user's
+/// browser makes, so any caller holding a valid `code`/`state` pair from *their
+/// own* Apple account can put anything in it. Its `email` is therefore
+/// deliberately **not** modelled here — an attacker-chosen address must never
+/// reach the email-keyed linking space (that is account takeover). The linking
+/// email comes only from the token endpoint's `id_token`, which Apple issues.
+///
+/// The name is display data, and is surfaced on the first callback's
+/// [`UserInfo`] as such.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AppleFirstAuthUser {
+    /// The user's name, present only on the very first authorization.
+    #[serde(default)]
+    pub name: Option<AppleFirstAuthName>,
+}
+
+/// The `name` object inside [`AppleFirstAuthUser`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleFirstAuthName {
+    /// Given name, as the user typed it into Apple's consent sheet.
+    #[serde(default)]
+    pub first_name: Option<String>,
+    /// Family name, as the user typed it into Apple's consent sheet.
+    #[serde(default)]
+    pub last_name:  Option<String>,
+}
+
+impl AppleFirstAuthUser {
+    /// Parse the raw `user` form field. A malformed payload is *not* an error:
+    /// it is optional display data, and refusing a login over it would let a
+    /// broken client lock a user out.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        serde_json::from_str(raw).ok()
+    }
+
+    /// The display name, or `None` when neither part was supplied.
+    #[must_use]
+    pub fn display_name(&self) -> Option<String> {
+        let name = self.name.as_ref()?;
+        let joined = [name.first_name.as_deref(), name.last_name.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        (!joined.is_empty()).then_some(joined)
+    }
+}
+
+/// Return `true` when `email` is one of Apple's Private Relay aliases.
+///
+/// Relay addresses are verified — Apple owns the domain — so they are safe
+/// linking keys. They are also per-app, so they never match another provider's
+/// address and a Relay user's identity does not participate in cross-provider
+/// linking.
+#[must_use]
+pub fn is_private_relay_email(email: &str) -> bool {
+    email.trim().to_ascii_lowercase().ends_with(PRIVATE_RELAY_DOMAIN)
+}
+
+/// Sign in with Apple provider.
+pub struct AppleOAuth {
+    /// Services ID — the `client_id`, and the `aud` of every `id_token`.
+    client_id:     String,
+    /// Apple developer team ID (the assertion's `iss`).
+    team_id:       String,
+    /// Key ID of the `.p8` signing key (the assertion header's `kid`).
+    key_id:        String,
+    /// `.p8` private key, PEM-encoded. Wiped from memory on drop.
+    private_key:   Zeroizing<String>,
+    redirect_uri:  String,
+    /// Base URL of the Apple ID service, and the `iss` every `id_token` must
+    /// carry. Overridable for a stub `IdP`; the SSRF guard still applies.
+    base_url:      String,
+    client:        reqwest::Client,
+    /// The current assertion. `RwLock` and not `OnceCell` because it is
+    /// deliberately re-minted.
+    cached_secret: RwLock<Option<CachedClientSecret>>,
+}
+
+impl std::fmt::Debug for AppleOAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppleOAuth")
+            .field("client_id", &self.client_id)
+            .field("team_id", &self.team_id)
+            .field("key_id", &self.key_id)
+            .field("redirect_uri", &self.redirect_uri)
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive() // private_key and minted assertions omitted
+    }
+}
+
+fn now_secs() -> Result<u64> {
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).map_err(|e| {
+        AuthError::ConfigError {
+            message: format!("system clock is before the Unix epoch: {e}"),
+        }
+    })
+}
+
+impl AppleOAuth {
+    /// Create a provider against `https://appleid.apple.com`.
+    ///
+    /// Construction is network-free and does **not** sign anything: the key is
+    /// validated here so a bad `.p8` fails at boot rather than on the first
+    /// login attempt.
+    ///
+    /// # Arguments
+    /// * `client_id` — the services ID registered with Apple
+    /// * `team_id` — Apple developer team ID
+    /// * `key_id` — key ID of the `.p8` signing key
+    /// * `private_key_pem` — contents of the `.p8` file (PKCS#8 PEM)
+    /// * `redirect_uri` — this server's `/auth/v1/callback` URL
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] if the private key is not a usable
+    /// ES256 key or the HTTP client cannot be built.
+    pub fn new(
+        client_id: String,
+        team_id: String,
+        key_id: String,
+        private_key_pem: String,
+        redirect_uri: String,
+    ) -> Result<Self> {
+        Self::with_base_url(
+            client_id,
+            team_id,
+            key_id,
+            private_key_pem,
+            redirect_uri,
+            DEFAULT_BASE_URL.to_string(),
+        )
+    }
+
+    /// Create a provider against an explicit base URL — a stub `IdP` in tests.
+    ///
+    /// `base_url` is also the issuer every `id_token` must name, so pointing it
+    /// elsewhere moves both halves together and cannot silently accept a token
+    /// from a different issuer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OidcMetadataError`] when `base_url` fails the shared
+    /// SSRF guard (non-HTTPS scheme, or a private/loopback/link-local address;
+    /// the `FRAISEQL_OIDC_ALLOW_INSECURE` development bypass applies), or
+    /// [`AuthError::ConfigError`] if the private key is unusable or the HTTP
+    /// client cannot be built.
+    pub fn with_base_url(
+        client_id: String,
+        team_id: String,
+        key_id: String,
+        private_key_pem: String,
+        redirect_uri: String,
+        base_url: String,
+    ) -> Result<Self> {
+        validate_oauth_endpoint_url(&base_url)?;
+        // Fail at boot, not at the first login: a `.p8` that cannot sign is a
+        // provider that can never exchange a code.
+        jsonwebtoken::EncodingKey::from_ec_pem(private_key_pem.as_bytes()).map_err(|e| {
+            AuthError::ConfigError {
+                message: format!(
+                    "[auth.social.apple] private key is not a usable ES256 key — Apple issues a \
+                     PKCS#8 PEM `.p8` file: {e}"
+                ),
+            }
+        })?;
+        let client =
+            reqwest::Client::builder().timeout(APPLE_REQUEST_TIMEOUT).build().map_err(|e| {
+                AuthError::ConfigError {
+                    message: format!("Failed to create HTTP client: {e}"),
+                }
+            })?;
+        Ok(Self {
+            client_id,
+            team_id,
+            key_id,
+            private_key: Zeroizing::new(private_key_pem),
+            redirect_uri,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client,
+            cached_secret: RwLock::new(None),
+        })
+    }
+
+    /// Mint a fresh ES256 client-secret assertion valid from `now`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] if signing fails.
+    fn mint_client_secret(&self, now: u64) -> Result<CachedClientSecret> {
+        let expires_at = now + CLIENT_SECRET_TTL_SECS;
+        let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+        header.kid = Some(self.key_id.clone());
+        let claims = ClientSecretClaims {
+            iss: &self.team_id,
+            iat: now,
+            exp: expires_at,
+            aud: CLIENT_SECRET_AUDIENCE,
+            sub: &self.client_id,
+        };
+        let key =
+            jsonwebtoken::EncodingKey::from_ec_pem(self.private_key.as_bytes()).map_err(|e| {
+                AuthError::ConfigError {
+                    message: format!(
+                        "[auth.social.apple] private key is not a usable ES256 key: {e}"
+                    ),
+                }
+            })?;
+        let assertion =
+            jsonwebtoken::encode(&header, &claims, &key).map_err(|e| AuthError::ConfigError {
+                message: format!(
+                    "[auth.social.apple] client-secret assertion could not be signed: {e}"
+                ),
+            })?;
+        Ok(CachedClientSecret {
+            assertion,
+            expires_at,
+        })
+    }
+
+    /// The current client-secret assertion, minting a new one when the cached
+    /// one is absent or within five minutes of expiry, so an assertion never
+    /// expires in flight between leaving the cache and reaching Apple.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] if the clock cannot be read or
+    /// signing fails.
+    pub fn client_secret(&self) -> Result<String> {
+        let now = now_secs()?;
+        if let Ok(guard) = self.cached_secret.read() {
+            if let Some(cached) = guard.as_ref() {
+                if cached.expires_at > now + CLIENT_SECRET_RENEW_SKEW_SECS {
+                    return Ok(cached.assertion.clone());
+                }
+            }
+        }
+        let minted = self.mint_client_secret(now)?;
+        if let Ok(mut guard) = self.cached_secret.write() {
+            *guard = Some(minted.clone());
+        }
+        Ok(minted.assertion)
+    }
+
+    /// POST a form to Apple's token endpoint and parse the response.
+    async fn post_token(&self, params: &[(&str, &str)]) -> Result<TokenResponse> {
+        let resp = self
+            .client
+            .post(format!("{}/auth/token", self.base_url))
+            .form(params)
+            .send()
+            .await
+            .map_err(|e| AuthError::OAuthError {
+                message: format!("Apple token endpoint request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to read Apple token response: {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(AuthError::OAuthError {
+                message: format!("Apple token endpoint returned HTTP {status}"),
+            });
+        }
+        if bytes.len() > MAX_APPLE_RESPONSE_BYTES {
+            return Err(AuthError::OAuthError {
+                message: format!("Apple token response too large ({} bytes)", bytes.len()),
+            });
+        }
+        let response: AppleTokenResponse =
+            serde_json::from_slice(&bytes).map_err(|e| AuthError::OAuthError {
+                message: format!("Failed to parse Apple token response: {e}"),
+            })?;
+        Ok(TokenResponse {
+            access_token:  response.access_token,
+            refresh_token: response.refresh_token,
+            expires_in:    response.expires_in.unwrap_or(0),
+            token_type:    response.token_type.unwrap_or_else(|| "Bearer".to_string()),
+            id_token:      response.id_token,
+        })
+    }
+
+    /// Decode and validate an `id_token` that came from the token endpoint.
+    ///
+    /// The signature is not re-verified (see the module docs); `iss`, `aud` and
+    /// `exp` are, fail-closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OAuthError`] if the token is malformed, names a
+    /// different issuer or audience, or has expired.
+    fn decode_id_token(&self, id_token: &str, now: u64) -> Result<AppleIdTokenClaims> {
+        let payload = id_token.split('.').nth(1).ok_or_else(|| AuthError::OAuthError {
+            message: "Apple id_token is not a JWT".to_string(),
+        })?;
+        let bytes =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload).map_err(|e| {
+                AuthError::OAuthError {
+                    message: format!("Apple id_token payload is not base64url: {e}"),
+                }
+            })?;
+        let claims: AppleIdTokenClaims =
+            serde_json::from_slice(&bytes).map_err(|e| AuthError::OAuthError {
+                message: format!("Apple id_token claims do not parse: {e}"),
+            })?;
+        if claims.iss.trim_end_matches('/') != self.base_url {
+            return Err(AuthError::OAuthError {
+                message: format!(
+                    "Apple id_token issuer {} does not match the configured Apple ID service",
+                    claims.iss
+                ),
+            });
+        }
+        if !claims.aud.contains(&self.client_id) {
+            return Err(AuthError::OAuthError {
+                message: "Apple id_token audience does not name this client".to_string(),
+            });
+        }
+        if claims.exp <= now {
+            return Err(AuthError::OAuthError {
+                message: "Apple id_token has expired".to_string(),
+            });
+        }
+        Ok(claims)
+    }
+
+    /// Build the [`UserInfo`] an `id_token` describes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OAuthError`] if the token fails validation.
+    pub fn user_info_from_id_token(&self, id_token: &str) -> Result<UserInfo> {
+        let now = now_secs()?;
+        let claims = self.decode_id_token(id_token, now)?;
+        // Apple only omits `email_verified` when it omitted `email` too; an
+        // address with no flag is treated as unverified rather than assumed.
+        let email_verified = claims.email_verified.as_ref().is_some_and(AppleBool::as_bool);
+        let is_private_email = claims.is_private_email.as_ref().is_some_and(AppleBool::as_bool);
+        // Normalize an empty claim to `None` so it can never key a link.
+        let email = claims.email.filter(|e| !e.trim().is_empty());
+
+        let mut raw_claims = serde_json::Map::new();
+        raw_claims.insert("apple_sub".to_string(), serde_json::json!(claims.sub));
+        if let Some(ref email) = email {
+            raw_claims.insert("email".to_string(), serde_json::json!(email));
+        }
+        raw_claims.insert("email_verified".to_string(), serde_json::json!(email_verified));
+        raw_claims.insert("is_private_email".to_string(), serde_json::json!(is_private_email));
+
+        Ok(UserInfo {
+            id: claims.sub,
+            email,
+            email_verified,
+            name: None,
+            picture: None,
+            raw_claims: serde_json::Value::Object(raw_claims),
+        })
+    }
+}
+
+// Reason: OAuthProvider is defined with #[async_trait]; all implementations must match
+// its transformed method signatures to satisfy the trait contract
+// async_trait: dyn-dispatch required; remove when RTN + Send is stable (RFC 3425)
+#[async_trait]
+impl OAuthProvider for AppleOAuth {
+    fn name(&self) -> &'static str {
+        "apple"
+    }
+
+    fn authorization_url(&self, state: &str) -> String {
+        let mut url = format!("{}/auth/authorize", self.base_url);
+        write!(
+            url,
+            "?client_id={}&redirect_uri={}&state={}&response_type=code&scope={}\
+             &response_mode=form_post",
+            urlencoding::encode(&self.client_id),
+            urlencoding::encode(&self.redirect_uri),
+            urlencoding::encode(state),
+            urlencoding::encode(APPLE_SCOPES),
+        )
+        .expect("write to String is infallible");
+        url
+    }
+
+    async fn exchange_code(&self, code: &str) -> Result<TokenResponse> {
+        let secret = self.client_secret()?;
+        self.post_token(&[
+            ("client_id", self.client_id.as_str()),
+            ("client_secret", secret.as_str()),
+            ("code", code),
+            ("grant_type", "authorization_code"),
+            ("redirect_uri", self.redirect_uri.as_str()),
+        ])
+        .await
+    }
+
+    /// Always an error: Apple publishes no userinfo endpoint, so an access
+    /// token alone identifies nobody. Refusing loudly is the point — a caller
+    /// that reaches here has skipped
+    /// [`user_info_from_tokens`](OAuthProvider::user_info_from_tokens) and would
+    /// otherwise get a silently identity-less login.
+    async fn user_info(&self, _access_token: &str) -> Result<UserInfo> {
+        Err(AuthError::OAuthError {
+            message: "Apple exposes no userinfo endpoint: the identity is in the token \
+                      endpoint's id_token — use OAuthProvider::user_info_from_tokens"
+                .to_string(),
+        })
+    }
+
+    async fn user_info_from_tokens(&self, tokens: &TokenResponse) -> Result<UserInfo> {
+        let id_token = tokens.id_token.as_deref().ok_or_else(|| AuthError::OAuthError {
+            message: "Apple token response carried no id_token — there is no other source of \
+                      identity"
+                .to_string(),
+        })?;
+        self.user_info_from_id_token(id_token)
+    }
+
+    async fn refresh_token(&self, refresh_token: &str) -> Result<TokenResponse> {
+        let secret = self.client_secret()?;
+        self.post_token(&[
+            ("client_id", self.client_id.as_str()),
+            ("client_secret", secret.as_str()),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .await
+    }
+}

--- a/crates/fraiseql-auth/src/providers/discord.rs
+++ b/crates/fraiseql-auth/src/providers/discord.rs
@@ -1,0 +1,303 @@
+//! Discord `OAuth2` provider (#944).
+//!
+//! Discord is plain `OAuth2`, not OIDC — there is no discovery document and no
+//! `sub` claim — so this follows the GitHub template: fixed well-known
+//! endpoints, network-free construction, and an SSRF-guarded base-URL override.
+//!
+//! # The email is on the user object, and the flag must be read
+//!
+//! Unlike GitHub, Discord needs no second hop: `/api/users/@me` carries both
+//! `email` and `verified`. That makes it easy to *assume* the address is
+//! verified, which is the mistake this provider must not make. An unverified
+//! Discord email keys on `(discord, id)` and can never collapse into an
+//! existing email-keyed account. Only because that flag is honoured is
+//! `discord` in the default [`TrustedEmailProviders`] set — the trust and the
+//! check ship together.
+//!
+//! [`TrustedEmailProviders`]: crate::TrustedEmailProviders
+
+use std::{fmt::Write as _, time::Duration};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use zeroize::Zeroizing;
+
+use crate::{
+    error::{AuthError, Result},
+    oidc_provider::validate_oauth_endpoint_url,
+    provider::{OAuthProvider, TokenResponse, UserInfo},
+};
+
+/// Timeout for all Discord API HTTP requests.
+const DISCORD_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum byte size for a Discord API response. The user object is a small
+/// JSON document; this cap blocks allocation bombs from a network intermediary.
+const MAX_DISCORD_RESPONSE_BYTES: usize = 1024 * 1024; // 1 MiB
+
+/// Default Discord base URL (authorize, token and API endpoints live under it).
+const DEFAULT_BASE_URL: &str = "https://discord.com";
+
+/// Host serving user avatars, used to build [`UserInfo::picture`].
+const AVATAR_CDN: &str = "https://cdn.discordapp.com";
+
+/// Scopes requested: `identify` for the user object, `email` for the address
+/// and its `verified` flag.
+const DISCORD_SCOPES: &str = "identify email";
+
+/// Discord user object (`GET /api/users/@me`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct DiscordUser {
+    /// Snowflake user ID, stable across username changes.
+    pub id:          String,
+    /// Current username.
+    pub username:    String,
+    /// Display name, when the account has one.
+    #[serde(default)]
+    pub global_name: Option<String>,
+    /// Email address. Absent unless the `email` scope was granted.
+    #[serde(default)]
+    pub email:       Option<String>,
+    /// Whether Discord has verified the address. Absent is **not** verified.
+    #[serde(default)]
+    pub verified:    Option<bool>,
+    /// Avatar hash, used to build the CDN URL.
+    #[serde(default)]
+    pub avatar:      Option<String>,
+}
+
+/// Discord's token-endpoint response.
+#[derive(Debug, Deserialize)]
+struct DiscordTokenResponse {
+    access_token:  String,
+    #[serde(default)]
+    token_type:    Option<String>,
+    #[serde(default)]
+    expires_in:    Option<u64>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+}
+
+/// Discord `OAuth2` provider.
+pub struct DiscordOAuth {
+    client_id:     String,
+    /// Wiped from memory when the provider is dropped.
+    client_secret: Zeroizing<String>,
+    redirect_uri:  String,
+    /// Base URL (`https://discord.com`, or a stub in tests).
+    base_url:      String,
+    client:        reqwest::Client,
+}
+
+impl std::fmt::Debug for DiscordOAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscordOAuth")
+            .field("client_id", &self.client_id)
+            .field("redirect_uri", &self.redirect_uri)
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive() // client_secret omitted for security
+    }
+}
+
+/// Resolve the linkable email from a Discord user object.
+///
+/// Returns the address with the verified flag Discord actually reported. An
+/// absent flag is `false`, so an address Discord has not confirmed can never
+/// key an account (fail-closed). An empty/whitespace address is no address.
+#[must_use]
+pub fn select_linkable_email(user: &DiscordUser) -> (Option<String>, bool) {
+    let email = user.email.clone().filter(|e| !e.trim().is_empty());
+    let verified = email.is_some() && user.verified.unwrap_or(false);
+    (email, verified)
+}
+
+impl DiscordOAuth {
+    /// Create a provider against the well-known `discord.com` endpoints.
+    ///
+    /// Construction is network-free — Discord serves no OIDC discovery
+    /// document, so there is nothing to fetch at boot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] if the HTTP client cannot be built.
+    pub fn new(client_id: String, client_secret: String, redirect_uri: String) -> Result<Self> {
+        Self::with_base_url(client_id, client_secret, redirect_uri, DEFAULT_BASE_URL.to_string())
+    }
+
+    /// Create a provider against an explicit base URL — a stub `IdP` in tests.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OidcMetadataError`] when the URL fails the shared
+    /// SSRF guard (non-HTTPS scheme or a private/loopback/link-local address;
+    /// the `FRAISEQL_OIDC_ALLOW_INSECURE` development bypass applies), or
+    /// [`AuthError::ConfigError`] if the HTTP client cannot be built.
+    pub fn with_base_url(
+        client_id: String,
+        client_secret: String,
+        redirect_uri: String,
+        base_url: String,
+    ) -> Result<Self> {
+        validate_oauth_endpoint_url(&base_url)?;
+        let client =
+            reqwest::Client::builder()
+                .timeout(DISCORD_REQUEST_TIMEOUT)
+                .build()
+                .map_err(|e| AuthError::ConfigError {
+                    message: format!("Failed to create HTTP client: {e}"),
+                })?;
+        Ok(Self {
+            client_id,
+            client_secret: Zeroizing::new(client_secret),
+            redirect_uri,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client,
+        })
+    }
+
+    /// POST a form to the token endpoint and parse the response.
+    async fn post_token(&self, params: &[(&str, &str)]) -> Result<TokenResponse> {
+        let resp = self
+            .client
+            .post(format!("{}/api/oauth2/token", self.base_url))
+            .form(params)
+            .send()
+            .await
+            .map_err(|e| AuthError::OAuthError {
+                message: format!("Discord token endpoint request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to read Discord token response: {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(AuthError::OAuthError {
+                message: format!("Discord token endpoint returned HTTP {status}"),
+            });
+        }
+        if bytes.len() > MAX_DISCORD_RESPONSE_BYTES {
+            return Err(AuthError::OAuthError {
+                message: format!("Discord token response too large ({} bytes)", bytes.len()),
+            });
+        }
+        let response: DiscordTokenResponse =
+            serde_json::from_slice(&bytes).map_err(|e| AuthError::OAuthError {
+                message: format!("Failed to parse Discord token response: {e}"),
+            })?;
+        Ok(TokenResponse {
+            access_token:  response.access_token,
+            refresh_token: response.refresh_token,
+            expires_in:    response.expires_in.unwrap_or(0),
+            token_type:    response.token_type.unwrap_or_else(|| "Bearer".to_string()),
+            // Plain OAuth2 — Discord issues no ID token.
+            id_token:      None,
+        })
+    }
+
+    /// Fetch the Discord user object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OAuthError`] if the request fails, returns a
+    /// non-success status, exceeds the size cap, or does not parse.
+    pub async fn get_user(&self, access_token: &str) -> Result<DiscordUser> {
+        let resp = self
+            .client
+            .get(format!("{}/api/users/@me", self.base_url))
+            .header("Authorization", format!("Bearer {access_token}"))
+            .send()
+            .await
+            .map_err(|e| AuthError::OAuthError {
+                message: format!("Failed to fetch Discord user: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to read Discord user response: {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(AuthError::OAuthError {
+                message: format!("Discord users/@me returned HTTP {status}"),
+            });
+        }
+        if bytes.len() > MAX_DISCORD_RESPONSE_BYTES {
+            return Err(AuthError::OAuthError {
+                message: format!("Discord user response too large ({} bytes)", bytes.len()),
+            });
+        }
+        serde_json::from_slice(&bytes).map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to parse Discord user: {e}"),
+        })
+    }
+}
+
+// Reason: OAuthProvider is defined with #[async_trait]; all implementations must match
+// its transformed method signatures to satisfy the trait contract
+// async_trait: dyn-dispatch required; remove when RTN + Send is stable (RFC 3425)
+#[async_trait]
+impl OAuthProvider for DiscordOAuth {
+    fn name(&self) -> &'static str {
+        "discord"
+    }
+
+    fn authorization_url(&self, state: &str) -> String {
+        let mut url = format!("{}/oauth2/authorize", self.base_url);
+        write!(
+            url,
+            "?client_id={}&redirect_uri={}&state={}&response_type=code&scope={}",
+            urlencoding::encode(&self.client_id),
+            urlencoding::encode(&self.redirect_uri),
+            urlencoding::encode(state),
+            urlencoding::encode(DISCORD_SCOPES),
+        )
+        .expect("write to String is infallible");
+        url
+    }
+
+    async fn exchange_code(&self, code: &str) -> Result<TokenResponse> {
+        self.post_token(&[
+            ("client_id", self.client_id.as_str()),
+            ("client_secret", self.client_secret.as_str()),
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", self.redirect_uri.as_str()),
+        ])
+        .await
+    }
+
+    async fn user_info(&self, access_token: &str) -> Result<UserInfo> {
+        let user = self.get_user(access_token).await?;
+        let (email, email_verified) = select_linkable_email(&user);
+
+        let mut raw_claims = serde_json::Map::new();
+        raw_claims.insert("discord_id".to_string(), serde_json::json!(user.id));
+        raw_claims.insert("discord_username".to_string(), serde_json::json!(user.username));
+        if let Some(ref email) = email {
+            raw_claims.insert("email".to_string(), serde_json::json!(email));
+        }
+        raw_claims.insert("email_verified".to_string(), serde_json::json!(email_verified));
+
+        let picture = user
+            .avatar
+            .as_ref()
+            .map(|hash| format!("{AVATAR_CDN}/avatars/{}/{hash}.png", user.id));
+
+        Ok(UserInfo {
+            id: user.id.clone(),
+            email,
+            email_verified,
+            name: user.global_name.clone().or_else(|| Some(user.username.clone())),
+            picture,
+            raw_claims: serde_json::Value::Object(raw_claims),
+        })
+    }
+
+    async fn refresh_token(&self, refresh_token: &str) -> Result<TokenResponse> {
+        self.post_token(&[
+            ("client_id", self.client_id.as_str()),
+            ("client_secret", self.client_secret.as_str()),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .await
+    }
+}

--- a/crates/fraiseql-auth/src/providers/facebook.rs
+++ b/crates/fraiseql-auth/src/providers/facebook.rs
@@ -1,0 +1,319 @@
+//! Facebook `OAuth2` provider (#944).
+//!
+//! Plain `OAuth2` on the GitHub template — fixed well-known endpoints,
+//! network-free construction, SSRF-guarded base-URL overrides — with two
+//! Facebook-specific facts that shape the whole implementation.
+//!
+//! # The API version is in the path, so it is configuration
+//!
+//! Every Graph endpoint carries a version segment (`/v21.0/me`), and Meta
+//! deprecates versions on its own schedule. Hard-coding it would mean the
+//! provider breaks on Meta's timetable rather than on a release of ours, so the
+//! version is configurable and merely *defaults* to [`DEFAULT_API_VERSION`].
+//!
+//! # Facebook cannot say whether an email is verified
+//!
+//! `email` may be absent entirely — a phone-number-only account, or a user who
+//! declined the permission — and there is **no verification flag at all** in the
+//! response. There is therefore nothing to gate on: this provider reports
+//! `email_verified = false` unconditionally, so every Facebook identity keys on
+//! `(facebook, id)` and can never link into an existing email-keyed account.
+//! `facebook` is correspondingly **absent** from the default
+//! [`TrustedEmailProviders`](crate::TrustedEmailProviders) set — two independent
+//! reasons the address cannot become a linking key.
+//!
+//! # What is deliberately not here
+//!
+//! Facebook issues no refresh token; the analogous operation is exchanging a
+//! short-lived token for a long-lived one (`grant_type=fb_exchange_token`),
+//! which takes an access token rather than a refresh token and has no consumer
+//! in FraiseQL's flow. [`OAuthProvider::refresh_token`]'s default — refuse and
+//! say so — is the honest answer, rather than a method nothing calls.
+
+use std::{fmt::Write as _, time::Duration};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use zeroize::Zeroizing;
+
+use crate::{
+    error::{AuthError, Result},
+    oidc_provider::validate_oauth_endpoint_url,
+    provider::{OAuthProvider, TokenResponse, UserInfo},
+};
+
+/// Timeout for all Facebook HTTP requests.
+const FACEBOOK_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum byte size for a Facebook response.
+const MAX_FACEBOOK_RESPONSE_BYTES: usize = 1024 * 1024; // 1 MiB
+
+/// Default web base URL — the authorization dialog lives here.
+const DEFAULT_BASE_URL: &str = "https://www.facebook.com";
+
+/// Default Graph API base URL — the token and `me` endpoints live here.
+const DEFAULT_GRAPH_BASE_URL: &str = "https://graph.facebook.com";
+
+/// Graph API version used when the operator names none. Meta deprecates
+/// versions on a schedule, which is why this is a default and not a constant
+/// baked into the request paths.
+pub const DEFAULT_API_VERSION: &str = "v21.0";
+
+/// Scope requested. `email` is a permission the user may decline, which is one
+/// of the two reasons the address may simply not arrive.
+const FACEBOOK_SCOPES: &str = "email";
+
+/// Fields requested from `/me`. Facebook returns only what is asked for.
+const FACEBOOK_ME_FIELDS: &str = "id,name,email";
+
+/// Facebook `/me` response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FacebookUser {
+    /// App-scoped user ID, stable for this app.
+    pub id:    String,
+    /// Display name.
+    #[serde(default)]
+    pub name:  Option<String>,
+    /// Email address — **may be absent**, and never carries a verified flag.
+    #[serde(default)]
+    pub email: Option<String>,
+}
+
+/// Facebook's token-endpoint response. There is no refresh token.
+#[derive(Debug, Deserialize)]
+struct FacebookTokenResponse {
+    access_token: String,
+    #[serde(default)]
+    token_type:   Option<String>,
+    #[serde(default)]
+    expires_in:   Option<u64>,
+}
+
+/// Facebook `OAuth2` provider.
+pub struct FacebookOAuth {
+    client_id:      String,
+    /// Wiped from memory when the provider is dropped.
+    client_secret:  Zeroizing<String>,
+    redirect_uri:   String,
+    /// Web base URL (`https://www.facebook.com`).
+    base_url:       String,
+    /// Graph API base URL (`https://graph.facebook.com`).
+    graph_base_url: String,
+    /// Graph API version segment, e.g. `v21.0`.
+    api_version:    String,
+    client:         reqwest::Client,
+}
+
+impl std::fmt::Debug for FacebookOAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FacebookOAuth")
+            .field("client_id", &self.client_id)
+            .field("redirect_uri", &self.redirect_uri)
+            .field("base_url", &self.base_url)
+            .field("graph_base_url", &self.graph_base_url)
+            .field("api_version", &self.api_version)
+            .finish_non_exhaustive() // client_secret omitted for security
+    }
+}
+
+impl FacebookOAuth {
+    /// Create a provider against the well-known Facebook endpoints, on
+    /// [`DEFAULT_API_VERSION`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] if the HTTP client cannot be built.
+    pub fn new(client_id: String, client_secret: String, redirect_uri: String) -> Result<Self> {
+        Self::with_endpoints(
+            client_id,
+            client_secret,
+            redirect_uri,
+            DEFAULT_BASE_URL.to_string(),
+            DEFAULT_GRAPH_BASE_URL.to_string(),
+            DEFAULT_API_VERSION.to_string(),
+        )
+    }
+
+    /// Create a provider against explicit endpoints and API version — a newer
+    /// Graph version, or a stub `IdP` in tests.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OidcMetadataError`] when either URL fails the shared
+    /// SSRF guard (non-HTTPS scheme or a private/loopback/link-local address;
+    /// the `FRAISEQL_OIDC_ALLOW_INSECURE` development bypass applies),
+    /// [`AuthError::ConfigError`] if `api_version` is empty or contains a path
+    /// separator (it is interpolated into request paths), or
+    /// [`AuthError::ConfigError`] if the HTTP client cannot be built.
+    pub fn with_endpoints(
+        client_id: String,
+        client_secret: String,
+        redirect_uri: String,
+        base_url: String,
+        graph_base_url: String,
+        api_version: String,
+    ) -> Result<Self> {
+        validate_oauth_endpoint_url(&base_url)?;
+        validate_oauth_endpoint_url(&graph_base_url)?;
+        // The version lands in a URL path, so a value carrying `/`, `?` or `#`
+        // would re-point the request at an endpoint the operator did not name.
+        let version = api_version.trim();
+        if version.is_empty() || version.contains(['/', '?', '#', '\\']) {
+            return Err(AuthError::ConfigError {
+                message: format!(
+                    "[auth.social.facebook] api_version {api_version:?} is not a Graph API \
+                     version segment (expected something like {DEFAULT_API_VERSION})"
+                ),
+            });
+        }
+        let client =
+            reqwest::Client::builder()
+                .timeout(FACEBOOK_REQUEST_TIMEOUT)
+                .build()
+                .map_err(|e| AuthError::ConfigError {
+                    message: format!("Failed to create HTTP client: {e}"),
+                })?;
+        Ok(Self {
+            client_id,
+            client_secret: Zeroizing::new(client_secret),
+            redirect_uri,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            graph_base_url: graph_base_url.trim_end_matches('/').to_string(),
+            api_version: version.to_string(),
+            client,
+        })
+    }
+
+    /// Fetch the `/me` profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::OAuthError`] if the request fails, returns a
+    /// non-success status, exceeds the size cap, or does not parse.
+    pub async fn get_user(&self, access_token: &str) -> Result<FacebookUser> {
+        let resp = self
+            .client
+            .get(format!(
+                "{}/{}/me?fields={FACEBOOK_ME_FIELDS}",
+                self.graph_base_url, self.api_version
+            ))
+            .header("Authorization", format!("Bearer {access_token}"))
+            .send()
+            .await
+            .map_err(|e| AuthError::OAuthError {
+                message: format!("Failed to fetch Facebook profile: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to read Facebook profile response: {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(AuthError::OAuthError {
+                message: format!("Facebook /me returned HTTP {status}"),
+            });
+        }
+        if bytes.len() > MAX_FACEBOOK_RESPONSE_BYTES {
+            return Err(AuthError::OAuthError {
+                message: format!("Facebook profile response too large ({} bytes)", bytes.len()),
+            });
+        }
+        serde_json::from_slice(&bytes).map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to parse Facebook profile: {e}"),
+        })
+    }
+}
+
+// Reason: OAuthProvider is defined with #[async_trait]; all implementations must match
+// its transformed method signatures to satisfy the trait contract
+// async_trait: dyn-dispatch required; remove when RTN + Send is stable (RFC 3425)
+#[async_trait]
+impl OAuthProvider for FacebookOAuth {
+    fn name(&self) -> &'static str {
+        "facebook"
+    }
+
+    fn authorization_url(&self, state: &str) -> String {
+        let mut url = format!("{}/{}/dialog/oauth", self.base_url, self.api_version);
+        write!(
+            url,
+            "?client_id={}&redirect_uri={}&state={}&response_type=code&scope={}",
+            urlencoding::encode(&self.client_id),
+            urlencoding::encode(&self.redirect_uri),
+            urlencoding::encode(state),
+            urlencoding::encode(FACEBOOK_SCOPES),
+        )
+        .expect("write to String is infallible");
+        url
+    }
+
+    async fn exchange_code(&self, code: &str) -> Result<TokenResponse> {
+        // Facebook documents this endpoint as a GET with the secret in the query
+        // string; it accepts a POST body too, and that keeps the client secret
+        // out of proxy and CDN access logs.
+        let resp = self
+            .client
+            .post(format!("{}/{}/oauth/access_token", self.graph_base_url, self.api_version))
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.as_str()),
+                ("code", code),
+                ("redirect_uri", self.redirect_uri.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|e| AuthError::OAuthError {
+                message: format!("Facebook token endpoint request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = resp.bytes().await.map_err(|e| AuthError::OAuthError {
+            message: format!("Failed to read Facebook token response: {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(AuthError::OAuthError {
+                message: format!("Facebook token endpoint returned HTTP {status}"),
+            });
+        }
+        if bytes.len() > MAX_FACEBOOK_RESPONSE_BYTES {
+            return Err(AuthError::OAuthError {
+                message: format!("Facebook token response too large ({} bytes)", bytes.len()),
+            });
+        }
+        let response: FacebookTokenResponse =
+            serde_json::from_slice(&bytes).map_err(|e| AuthError::OAuthError {
+                message: format!("Failed to parse Facebook token response: {e}"),
+            })?;
+        Ok(TokenResponse {
+            access_token:  response.access_token,
+            // Facebook issues none — see the module docs.
+            refresh_token: None,
+            expires_in:    response.expires_in.unwrap_or(0),
+            token_type:    response.token_type.unwrap_or_else(|| "Bearer".to_string()),
+            id_token:      None,
+        })
+    }
+
+    async fn user_info(&self, access_token: &str) -> Result<UserInfo> {
+        let user = self.get_user(access_token).await?;
+        // Normalize an empty claim to `None`; it could never key a link anyway,
+        // because the flag below is unconditionally false.
+        let email = user.email.clone().filter(|e| !e.trim().is_empty());
+
+        let mut raw_claims = serde_json::Map::new();
+        raw_claims.insert("facebook_id".to_string(), serde_json::json!(user.id));
+        if let Some(ref email) = email {
+            raw_claims.insert("email".to_string(), serde_json::json!(email));
+        }
+        // Facebook publishes no verification signal whatsoever. Reporting false
+        // is not caution, it is the truth: there is nothing to report.
+        raw_claims.insert("email_verified".to_string(), serde_json::json!(false));
+
+        Ok(UserInfo {
+            id: user.id.clone(),
+            email,
+            email_verified: false,
+            name: user.name,
+            picture: None,
+            raw_claims: serde_json::Value::Object(raw_claims),
+        })
+    }
+}

--- a/crates/fraiseql-auth/src/providers/github.rs
+++ b/crates/fraiseql-auth/src/providers/github.rs
@@ -400,6 +400,8 @@ impl OAuthProvider for GitHubOAuth {
             // expiring tokens; 0 = "no expiry reported by the provider".
             expires_in:    response.expires_in.unwrap_or(0),
             token_type:    response.token_type.unwrap_or_else(|| "bearer".to_string()),
+            // GitHub is plain OAuth2, not OIDC — there is no ID token.
+            id_token:      None,
         })
     }
 
@@ -502,6 +504,7 @@ impl OAuthProvider for GitHubOAuth {
             refresh_token: response.refresh_token,
             expires_in:    response.expires_in.unwrap_or(0),
             token_type:    response.token_type.unwrap_or_else(|| "bearer".to_string()),
+            id_token:      None,
         })
     }
 }

--- a/crates/fraiseql-auth/src/providers/mod.rs
+++ b/crates/fraiseql-auth/src/providers/mod.rs
@@ -4,8 +4,9 @@
 //! provider and translates that provider's user-info format and role/group claims into
 //! FraiseQL's generic [`crate::provider::UserInfo`] and role strings.
 //!
-//! Supported providers: Auth0, GitHub, Google, Keycloak, Okta, Azure AD, Ory, and Logto.
+//! Supported providers: Apple, Auth0, GitHub, Google, Keycloak, Okta, Azure AD, Ory, and Logto.
 
+pub mod apple;
 pub mod auth0;
 pub mod azure_ad;
 pub mod github;
@@ -15,6 +16,7 @@ pub mod logto;
 pub mod okta;
 pub mod ory;
 
+pub use apple::AppleOAuth;
 pub use auth0::Auth0OAuth;
 pub use azure_ad::AzureADOAuth;
 pub use github::GitHubOAuth;

--- a/crates/fraiseql-auth/src/providers/mod.rs
+++ b/crates/fraiseql-auth/src/providers/mod.rs
@@ -4,11 +4,14 @@
 //! provider and translates that provider's user-info format and role/group claims into
 //! FraiseQL's generic [`crate::provider::UserInfo`] and role strings.
 //!
-//! Supported providers: Apple, Auth0, GitHub, Google, Keycloak, Okta, Azure AD, Ory, and Logto.
+//! Supported providers: Apple, Auth0, Discord, Facebook, GitHub, Google, Keycloak, Okta,
+//! Azure AD, Ory, and Logto.
 
 pub mod apple;
 pub mod auth0;
 pub mod azure_ad;
+pub mod discord;
+pub mod facebook;
 pub mod github;
 pub mod google;
 pub mod keycloak;
@@ -19,6 +22,8 @@ pub mod ory;
 pub use apple::AppleOAuth;
 pub use auth0::Auth0OAuth;
 pub use azure_ad::AzureADOAuth;
+pub use discord::DiscordOAuth;
+pub use facebook::FacebookOAuth;
 pub use github::GitHubOAuth;
 pub use google::GoogleOAuth;
 pub use keycloak::KeycloakOAuth;

--- a/crates/fraiseql-auth/src/providers/tests.rs
+++ b/crates/fraiseql-auth/src/providers/tests.rs
@@ -1042,3 +1042,295 @@ mod github_tests {
         );
     }
 }
+
+/// Sign in with Apple (#943).
+mod apple_tests {
+    use base64::Engine as _;
+
+    use crate::{
+        provider::{OAuthProvider as _, TokenResponse},
+        providers::apple::{AppleFirstAuthUser, AppleOAuth, is_private_relay_email},
+    };
+
+    /// A throwaway P-256 key, generated for this test file and used nowhere
+    /// else. Apple issues a PKCS#8 PEM `.p8`, which is exactly this shape.
+    const TEST_P8: &str = "-----BEGIN PRIVATE KEY-----\n\
+        MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg6mOJdB87DG8anytc\n\
+        jGCaH3eI4OkrTGRc6sZGu1DqyiGhRANCAARKwlK3b7SIes76KDfwwP1Dxf3OgSsa\n\
+        dTtT/3rfS3QYTqqyzOH6LW51mUpy3vxAi/IKx1oEdLAJzOCm1Z1p5wFw\n\
+        -----END PRIVATE KEY-----\n";
+
+    const CLIENT_ID: &str = "com.example.service";
+    const ISSUER: &str = "https://appleid.apple.com";
+
+    fn provider() -> AppleOAuth {
+        AppleOAuth::new(
+            CLIENT_ID.to_string(),
+            "TEAM123456".to_string(),
+            "KEY7890AB".to_string(),
+            TEST_P8.to_string(),
+            "https://app.example.com/auth/v1/callback".to_string(),
+        )
+        .expect("a valid .p8 key constructs")
+    }
+
+    fn decode_part(part: &str) -> serde_json::Value {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(part)
+            .expect("JWT part is base64url");
+        serde_json::from_slice(&bytes).expect("JWT part is JSON")
+    }
+
+    /// Build an unsigned `id_token` — the provider validates claims, not the
+    /// signature (see the module docs), so a claims-only token is exactly what
+    /// the parser sees.
+    fn id_token(claims: &serde_json::Value) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"ES256"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(claims).unwrap());
+        format!("{header}.{payload}.sig")
+    }
+
+    fn far_future() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600
+    }
+
+    // ── Client-secret assertion ──────────────────────────────────────────
+
+    #[test]
+    fn client_secret_is_an_es256_assertion_over_the_apple_triple() {
+        let assertion = provider().client_secret().expect("assertion mints");
+        let parts: Vec<&str> = assertion.split('.').collect();
+        assert_eq!(parts.len(), 3, "the client secret is a signed JWT, not a static string");
+
+        let header = decode_part(parts[0]);
+        assert_eq!(header["alg"], "ES256", "Apple accepts only ES256");
+        assert_eq!(header["kid"], "KEY7890AB", "the header must name the .p8 key");
+
+        let claims = decode_part(parts[1]);
+        assert_eq!(claims["iss"], "TEAM123456", "iss is the developer team ID");
+        assert_eq!(claims["sub"], CLIENT_ID, "sub is the services ID");
+        assert_eq!(
+            claims["aud"], "https://appleid.apple.com",
+            "aud names Apple itself, not the endpoint host"
+        );
+        let iat = claims["iat"].as_u64().unwrap();
+        let exp = claims["exp"].as_u64().unwrap();
+        assert!(exp > iat, "the assertion must expire after it was issued");
+        assert!(
+            exp - iat <= 15_777_000,
+            "Apple refuses an assertion living longer than six months"
+        );
+    }
+
+    #[test]
+    fn client_secret_is_reused_until_it_nears_expiry() {
+        let provider = provider();
+        let first = provider.client_secret().unwrap();
+        let second = provider.client_secret().unwrap();
+        assert_eq!(first, second, "a still-valid assertion is reused, not re-signed per request");
+    }
+
+    #[test]
+    fn a_key_that_cannot_sign_is_refused_at_construction() {
+        let err = AppleOAuth::new(
+            CLIENT_ID.to_string(),
+            "TEAM123456".to_string(),
+            "KEY7890AB".to_string(),
+            "-----BEGIN PRIVATE KEY-----\nnot-a-key\n-----END PRIVATE KEY-----\n".to_string(),
+            "https://app.example.com/auth/v1/callback".to_string(),
+        )
+        .expect_err("an unusable .p8 must not construct a provider");
+        assert!(
+            err.to_string().contains("ES256"),
+            "the error must name what is wrong with the key: {err}"
+        );
+    }
+
+    // ── Authorization URL ────────────────────────────────────────────────
+
+    #[test]
+    fn authorization_url_requests_form_post_and_the_name_email_scopes() {
+        let url = provider().authorization_url("state-abc");
+        assert!(url.starts_with("https://appleid.apple.com/auth/authorize?"), "{url}");
+        assert!(
+            url.contains("response_mode=form_post"),
+            "the name/email scopes make Apple POST the callback: {url}"
+        );
+        assert!(url.contains("scope=name%20email"), "{url}");
+        assert!(url.contains("response_type=code"), "{url}");
+        assert!(url.contains("state=state-abc"), "{url}");
+    }
+
+    // ── id_token → UserInfo ──────────────────────────────────────────────
+
+    #[test]
+    fn id_token_yields_the_subject_and_verified_email() {
+        let info = provider()
+            .user_info_from_id_token(&id_token(&serde_json::json!({
+                "iss": ISSUER,
+                "aud": CLIENT_ID,
+                "sub": "001234.abcdef",
+                "exp": far_future(),
+                "email": "user@example.com",
+                "email_verified": true,
+            })))
+            .expect("a well-formed id_token identifies the user");
+        assert_eq!(info.id, "001234.abcdef");
+        assert_eq!(info.email.as_deref(), Some("user@example.com"));
+        assert!(info.email_verified);
+    }
+
+    #[test]
+    fn email_verified_is_honoured_in_apples_string_spelling() {
+        // Apple renders its booleans as `"true"` in some flows. A parser that
+        // accepts only the JSON bool drops the claim — and dropping it here
+        // fails *open* into the email-keyed linking space.
+        let info = provider()
+            .user_info_from_id_token(&id_token(&serde_json::json!({
+                "iss": ISSUER,
+                "aud": CLIENT_ID,
+                "sub": "001234.abcdef",
+                "exp": far_future(),
+                "email": "user@example.com",
+                "email_verified": "true",
+                "is_private_email": "false",
+            })))
+            .expect("the string spelling parses");
+        assert!(info.email_verified, "email_verified: \"true\" must be honoured");
+        assert_eq!(info.raw_claims["is_private_email"], serde_json::json!(false));
+    }
+
+    #[test]
+    fn an_email_with_no_verified_claim_is_unverified() {
+        let info = provider()
+            .user_info_from_id_token(&id_token(&serde_json::json!({
+                "iss": ISSUER,
+                "aud": CLIENT_ID,
+                "sub": "001234.abcdef",
+                "exp": far_future(),
+                "email": "user@example.com",
+            })))
+            .expect("the token parses");
+        assert!(
+            !info.email_verified,
+            "an address with no verification flag must not enter the email-keyed linking space"
+        );
+    }
+
+    #[test]
+    fn an_id_token_for_another_audience_is_refused() {
+        let err = provider()
+            .user_info_from_id_token(&id_token(&serde_json::json!({
+                "iss": ISSUER,
+                "aud": "com.someone.else",
+                "sub": "001234.abcdef",
+                "exp": far_future(),
+            })))
+            .expect_err("a token minted for a different client must not identify our user");
+        assert!(err.to_string().contains("audience"), "{err}");
+    }
+
+    #[test]
+    fn an_id_token_from_another_issuer_is_refused() {
+        let err = provider()
+            .user_info_from_id_token(&id_token(&serde_json::json!({
+                "iss": "https://evil.example.com",
+                "aud": CLIENT_ID,
+                "sub": "001234.abcdef",
+                "exp": far_future(),
+            })))
+            .expect_err("a token from another issuer must be refused");
+        assert!(err.to_string().contains("issuer"), "{err}");
+    }
+
+    #[test]
+    fn an_expired_id_token_is_refused() {
+        let err = provider()
+            .user_info_from_id_token(&id_token(&serde_json::json!({
+                "iss": ISSUER,
+                "aud": CLIENT_ID,
+                "sub": "001234.abcdef",
+                "exp": 1_000_000_u64,
+            })))
+            .expect_err("an expired token must be refused");
+        assert!(err.to_string().contains("expired"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn user_info_by_access_token_refuses_loudly() {
+        // Apple publishes no userinfo endpoint. A caller on this method has
+        // skipped `user_info_from_tokens`; failing beats returning nothing.
+        let err = provider()
+            .user_info("any-access-token")
+            .await
+            .expect_err("there is no userinfo endpoint to call");
+        assert!(err.to_string().contains("user_info_from_tokens"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_token_response_with_no_id_token_identifies_nobody() {
+        let err = provider()
+            .user_info_from_tokens(&TokenResponse {
+                access_token:  "at".to_string(),
+                refresh_token: None,
+                expires_in:    3600,
+                token_type:    "Bearer".to_string(),
+                id_token:      None,
+            })
+            .await
+            .expect_err("without an id_token there is no identity");
+        assert!(err.to_string().contains("id_token"), "{err}");
+    }
+
+    // ── Private Relay ────────────────────────────────────────────────────
+
+    #[test]
+    fn private_relay_addresses_are_recognised() {
+        assert!(is_private_relay_email("abc123@privaterelay.appleid.com"));
+        assert!(is_private_relay_email("  ABC123@PrivateRelay.AppleID.com  "));
+        assert!(!is_private_relay_email("user@example.com"));
+        assert!(
+            !is_private_relay_email("user@privaterelay.appleid.com.evil.example"),
+            "the domain must match at the end, not anywhere"
+        );
+    }
+
+    // ── First-authorization user payload ─────────────────────────────────
+
+    #[test]
+    fn the_first_auth_payload_yields_a_display_name() {
+        let user = AppleFirstAuthUser::parse(
+            r#"{"name":{"firstName":"Ada","lastName":"Lovelace"},"email":"ada@example.com"}"#,
+        )
+        .expect("Apple's documented shape parses");
+        assert_eq!(user.display_name().as_deref(), Some("Ada Lovelace"));
+    }
+
+    #[test]
+    fn the_first_auth_payloads_email_is_not_even_modelled() {
+        // The payload arrives in a POST the *browser* makes, so its email is
+        // attacker-chosen. Nothing in `AppleFirstAuthUser` can carry it into
+        // account resolution, and this test pins that: the struct that reaches
+        // the callback has a name and nothing else.
+        let user = AppleFirstAuthUser::parse(r#"{"email":"victim@example.com"}"#)
+            .expect("an email-only payload still parses");
+        assert!(user.name.is_none());
+        assert_eq!(user.display_name(), None, "there is no path from the payload to an address");
+        assert!(
+            !format!("{user:?}").contains("victim@example.com"),
+            "the parsed payload must not retain the browser-supplied address anywhere: {user:?}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_first_auth_payload_is_ignored_not_fatal() {
+        assert!(AppleFirstAuthUser::parse("not json").is_none());
+        let partial = AppleFirstAuthUser::parse(r#"{"name":{"firstName":"  "}}"#).unwrap();
+        assert_eq!(partial.display_name(), None, "a blank name is no name");
+    }
+}

--- a/crates/fraiseql-auth/src/providers/tests.rs
+++ b/crates/fraiseql-auth/src/providers/tests.rs
@@ -1334,3 +1334,301 @@ mod apple_tests {
         assert_eq!(partial.display_name(), None, "a blank name is no name");
     }
 }
+
+/// Discord (#944).
+mod discord_tests {
+    use crate::{
+        provider::OAuthProvider as _,
+        providers::discord::{DiscordOAuth, DiscordUser, select_linkable_email},
+    };
+
+    fn provider() -> DiscordOAuth {
+        DiscordOAuth::new(
+            "discord-client".to_string(),
+            "discord-secret".to_string(),
+            "https://app.example.com/auth/v1/callback".to_string(),
+        )
+        .expect("construction is network-free")
+    }
+
+    fn user(email: Option<&str>, verified: Option<bool>) -> DiscordUser {
+        DiscordUser {
+            id: "776655443322110099".to_string(),
+            username: "carol".to_string(),
+            global_name: Some("Carol".to_string()),
+            email: email.map(str::to_string),
+            verified,
+            avatar: None,
+        }
+    }
+
+    #[test]
+    fn authorization_url_requests_identify_and_email() {
+        let url = provider().authorization_url("state-abc");
+        assert!(url.starts_with("https://discord.com/oauth2/authorize?"), "{url}");
+        // Without `email` the user object carries no address at all, and
+        // without `identify` there is no user object.
+        assert!(url.contains("scope=identify%20email"), "{url}");
+        assert!(url.contains("response_type=code"), "{url}");
+        assert!(url.contains("state=state-abc"), "{url}");
+    }
+
+    #[test]
+    fn a_verified_email_is_linkable() {
+        let (email, verified) = select_linkable_email(&user(Some("carol@example.com"), Some(true)));
+        assert_eq!(email.as_deref(), Some("carol@example.com"));
+        assert!(verified);
+    }
+
+    #[test]
+    fn an_unverified_email_is_reported_unverified() {
+        // The whole reason `discord` may sit in the default trusted set: the
+        // flag is read, not assumed. Assuming it would put an address the user
+        // never confirmed into the email-keyed linking space.
+        let (email, verified) =
+            select_linkable_email(&user(Some("carol@example.com"), Some(false)));
+        assert_eq!(email.as_deref(), Some("carol@example.com"));
+        assert!(!verified);
+    }
+
+    #[test]
+    fn an_absent_verified_flag_is_not_verified() {
+        let (_, verified) = select_linkable_email(&user(Some("carol@example.com"), None));
+        assert!(!verified, "a missing flag must fail closed, not default to trusted");
+    }
+
+    #[test]
+    fn an_absent_or_blank_email_is_no_email() {
+        assert_eq!(select_linkable_email(&user(None, Some(true))), (None, false));
+        assert_eq!(select_linkable_email(&user(Some("   "), Some(true))), (None, false));
+    }
+
+    #[test]
+    fn discord_is_trusted_for_email_verification_by_default() {
+        // Trust is warranted only because `verified` is honoured above; the two
+        // travel together.
+        assert!(crate::TrustedEmailProviders::default().is_trusted("discord"));
+    }
+
+    #[test]
+    fn a_private_base_url_is_refused_by_the_ssrf_guard() {
+        // The bypass is process-global, and sibling tests in this binary switch
+        // it on to reach a loopback stub. Clear it for this assertion's window,
+        // matching `github_endpoint_overrides_are_ssrf_guarded`.
+        temp_env::with_vars([("FRAISEQL_OIDC_ALLOW_INSECURE", None::<&str>)], || {
+            let err = DiscordOAuth::with_base_url(
+                "c".to_string(),
+                "s".to_string(),
+                "https://app.example.com/cb".to_string(),
+                "http://169.254.169.254".to_string(),
+            )
+            .expect_err("a link-local override must be refused");
+            assert!(err.to_string().contains("SSRF") || err.to_string().contains("https"), "{err}");
+        });
+    }
+
+    /// The whole flow, against a stub: an address Discord reports as
+    /// unverified must arrive at the callback as **unverified**, so the account
+    /// store keys it on `(discord, id)`. The trust gate is a second, separate
+    /// belt — this pins the provider's own half.
+    #[tokio::test]
+    async fn user_info_reports_discords_verified_flag_verbatim() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        for (reported, expected) in [(Some(true), true), (Some(false), false), (None, false)] {
+            let server = MockServer::start().await;
+            let mut body = serde_json::json!({
+                "id": "776655443322110099",
+                "username": "carol",
+                "email": "carol@example.com",
+            });
+            if let Some(v) = reported {
+                body["verified"] = serde_json::json!(v);
+            }
+            Mock::given(method("GET"))
+                .and(path("/api/users/@me"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body))
+                .mount(&server)
+                .await;
+
+            // Only *construction* consults the SSRF guard, so the bypass is held
+            // for that call alone rather than across the HTTP round-trip. The
+            // variable is process-global: a wider window races the guard tests
+            // in this same binary, which is exactly how this suite first went
+            // red in CI while passing locally.
+            let provider = temp_env::with_vars(
+                [
+                    ("FRAISEQL_OIDC_ALLOW_INSECURE", Some("1")),
+                    ("FRAISEQL_ENV", Some("development")),
+                    ("FRAISEQL_PROFILE", None),
+                    ("KUBERNETES_SERVICE_HOST", None),
+                ],
+                || {
+                    DiscordOAuth::with_base_url(
+                        "c".to_string(),
+                        "s".to_string(),
+                        "https://app.example.com/cb".to_string(),
+                        server.uri(),
+                    )
+                    .expect("stub provider constructs")
+                },
+            );
+            let info = provider.user_info("discord-at").await.expect("the user object parses");
+
+            assert_eq!(info.id, "776655443322110099");
+            assert_eq!(info.email.as_deref(), Some("carol@example.com"));
+            assert_eq!(
+                info.email_verified, expected,
+                "verified: {reported:?} must surface as email_verified = {expected}"
+            );
+            assert_eq!(info.raw_claims["email_verified"], serde_json::json!(expected));
+        }
+    }
+}
+
+/// Facebook (#944).
+mod facebook_tests {
+    use crate::{
+        provider::OAuthProvider as _,
+        providers::facebook::{DEFAULT_API_VERSION, FacebookOAuth},
+    };
+
+    fn provider() -> FacebookOAuth {
+        FacebookOAuth::new(
+            "facebook-client".to_string(),
+            "facebook-secret".to_string(),
+            "https://app.example.com/auth/v1/callback".to_string(),
+        )
+        .expect("construction is network-free")
+    }
+
+    #[test]
+    fn the_api_version_is_in_the_path_and_configurable() {
+        let url = provider().authorization_url("state-abc");
+        assert!(
+            url.starts_with(&format!(
+                "https://www.facebook.com/{DEFAULT_API_VERSION}/dialog/oauth?"
+            )),
+            "{url}"
+        );
+
+        // Meta deprecates versions on its own schedule, so an operator must be
+        // able to move without waiting for a FraiseQL release.
+        let pinned = FacebookOAuth::with_endpoints(
+            "facebook-client".to_string(),
+            "facebook-secret".to_string(),
+            "https://app.example.com/auth/v1/callback".to_string(),
+            "https://www.facebook.com".to_string(),
+            "https://graph.facebook.com".to_string(),
+            "v23.0".to_string(),
+        )
+        .expect("a later version constructs");
+        assert!(
+            pinned.authorization_url("s").contains("/v23.0/dialog/oauth"),
+            "the configured version must reach the request path"
+        );
+    }
+
+    #[test]
+    fn an_api_version_that_would_repoint_the_request_is_refused() {
+        for bad in [
+            "",
+            "  ",
+            "v21.0/../../evil",
+            "v21.0?x=1",
+            "v21.0#f",
+            "v21.0\\x",
+        ] {
+            FacebookOAuth::with_endpoints(
+                "c".to_string(),
+                "s".to_string(),
+                "https://app.example.com/cb".to_string(),
+                "https://www.facebook.com".to_string(),
+                "https://graph.facebook.com".to_string(),
+                bad.to_string(),
+            )
+            .expect_err(&format!("api_version {bad:?} lands in a URL path and must be refused"));
+        }
+    }
+
+    #[test]
+    fn facebook_is_never_trusted_for_email_verification() {
+        // Two independent reasons an address cannot become a linking key: the
+        // provider reports `email_verified = false` unconditionally (there is no
+        // signal to report), and the trust gate would downgrade it anyway.
+        assert!(!crate::TrustedEmailProviders::default().is_trusted("facebook"));
+    }
+
+    #[test]
+    fn a_private_graph_url_is_refused_by_the_ssrf_guard() {
+        // See the Discord twin: the bypass is process-global, so clear it here.
+        temp_env::with_vars([("FRAISEQL_OIDC_ALLOW_INSECURE", None::<&str>)], || {
+            let err = FacebookOAuth::with_endpoints(
+                "c".to_string(),
+                "s".to_string(),
+                "https://app.example.com/cb".to_string(),
+                "https://www.facebook.com".to_string(),
+                "http://127.0.0.1:8080".to_string(),
+                DEFAULT_API_VERSION.to_string(),
+            )
+            .expect_err("a loopback graph override must be refused");
+            assert!(err.to_string().contains("SSRF") || err.to_string().contains("https"), "{err}");
+        });
+    }
+
+    /// Facebook publishes no verification signal, so the provider itself must
+    /// report `email_verified = false` — independently of the trust gate, which
+    /// would also downgrade it. Two belts, proven one at a time.
+    #[tokio::test]
+    async fn user_info_never_claims_a_facebook_email_is_verified() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{DEFAULT_API_VERSION}/me")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "10223344556677889",
+                "name": "Dave",
+                "email": "dave@example.com",
+            })))
+            .mount(&server)
+            .await;
+
+        // See the Discord twin: the bypass is held for construction only, because
+        // it is process-global and a wider window races the guard tests.
+        let provider = temp_env::with_vars(
+            [
+                ("FRAISEQL_OIDC_ALLOW_INSECURE", Some("1")),
+                ("FRAISEQL_ENV", Some("development")),
+                ("FRAISEQL_PROFILE", None),
+                ("KUBERNETES_SERVICE_HOST", None),
+            ],
+            || {
+                FacebookOAuth::with_endpoints(
+                    "c".to_string(),
+                    "s".to_string(),
+                    "https://app.example.com/cb".to_string(),
+                    "https://www.facebook.com".to_string(),
+                    server.uri(),
+                    DEFAULT_API_VERSION.to_string(),
+                )
+                .expect("stub provider constructs")
+            },
+        );
+        let info = provider.user_info("facebook-at").await.expect("the profile parses");
+
+        assert_eq!(info.id, "10223344556677889");
+        assert_eq!(info.email.as_deref(), Some("dave@example.com"));
+        assert!(
+            !info.email_verified,
+            "there is no signal to base a verified claim on, so it must be false"
+        );
+        assert_eq!(info.raw_claims["email_verified"], serde_json::json!(false));
+    }
+}

--- a/crates/fraiseql-auth/src/tests.rs
+++ b/crates/fraiseql-auth/src/tests.rs
@@ -4531,6 +4531,7 @@ mod multi_provider_tests {
                 refresh_token: Some("mock_refresh_token".to_string()),
                 expires_in:    3600,
                 token_type:    "Bearer".to_string(),
+                id_token:      None,
             })
         }
 

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -268,37 +268,64 @@ impl OidcClientConfig {
         // provider's fields must be non-empty — an empty block or blank
         // client_id would compile into a registry that can never serve a login.
         if let Some(social) = &self.social {
-            if social.google.is_none() && social.github.is_none() {
+            if social.google.is_none() && social.github.is_none() && social.apple.is_none() {
                 anyhow::bail!(
                     "[auth.social] is configured but names no provider. Add an \
-                     [auth.social.google] or [auth.social.github] block (Apple/Discord/Facebook \
-                     are not implemented and are refused as unknown fields)."
+                     [auth.social.google], [auth.social.github] or [auth.social.apple] block \
+                     (Discord/Facebook are not implemented and are refused as unknown fields)."
                 );
             }
-            let providers = [
-                (
+            // #943: Apple has no client_secret_env — the client secret is an
+            // ES256 assertion the runtime signs with the `.p8` key. Exactly one
+            // key source, refused at compile time so the operator hears it at
+            // the file they are editing rather than at server boot.
+            if let Some(apple) = &social.apple {
+                match (&apple.private_key_env, &apple.private_key_path) {
+                    (Some(_), None) | (None, Some(_)) => {},
+                    (Some(_), Some(_)) => anyhow::bail!(
+                        "[auth.social.apple] names both private_key_env and private_key_path — \
+                         set exactly one."
+                    ),
+                    (None, None) => anyhow::bail!(
+                        "[auth.social.apple] needs exactly one of private_key_env / \
+                         private_key_path: the .p8 key is what signs the client-secret assertion."
+                    ),
+                }
+            }
+            let mut providers: Vec<(&str, Vec<(&str, &String)>)> = Vec::new();
+            if let Some(g) = social.google.as_ref() {
+                providers.push((
                     "google",
-                    social.google.as_ref().map(|g| {
-                        [
-                            ("client_id", &g.client_id),
-                            ("client_secret_env", &g.client_secret_env),
-                            ("redirect_uri", &g.redirect_uri),
-                        ]
-                    }),
-                ),
-                (
+                    vec![
+                        ("client_id", &g.client_id),
+                        ("client_secret_env", &g.client_secret_env),
+                        ("redirect_uri", &g.redirect_uri),
+                    ],
+                ));
+            }
+            if let Some(g) = social.github.as_ref() {
+                providers.push((
                     "github",
-                    social.github.as_ref().map(|g| {
-                        [
-                            ("client_id", &g.client_id),
-                            ("client_secret_env", &g.client_secret_env),
-                            ("redirect_uri", &g.redirect_uri),
-                        ]
-                    }),
-                ),
-            ];
+                    vec![
+                        ("client_id", &g.client_id),
+                        ("client_secret_env", &g.client_secret_env),
+                        ("redirect_uri", &g.redirect_uri),
+                    ],
+                ));
+            }
+            if let Some(a) = social.apple.as_ref() {
+                providers.push((
+                    "apple",
+                    vec![
+                        ("client_id", &a.client_id),
+                        ("team_id", &a.team_id),
+                        ("key_id", &a.key_id),
+                        ("redirect_uri", &a.redirect_uri),
+                    ],
+                ));
+            }
             for (provider, fields) in providers {
-                for (field, value) in fields.into_iter().flatten() {
+                for (field, value) in fields {
                     if value.trim().is_empty() {
                         anyhow::bail!("[auth.social.{provider}] {field} must not be empty.");
                     }

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -268,11 +268,15 @@ impl OidcClientConfig {
         // provider's fields must be non-empty — an empty block or blank
         // client_id would compile into a registry that can never serve a login.
         if let Some(social) = &self.social {
-            if social.google.is_none() && social.github.is_none() && social.apple.is_none() {
+            if social.google.is_none()
+                && social.github.is_none()
+                && social.apple.is_none()
+                && social.discord.is_none()
+                && social.facebook.is_none()
+            {
                 anyhow::bail!(
                     "[auth.social] is configured but names no provider. Add an \
-                     [auth.social.google], [auth.social.github] or [auth.social.apple] block \
-                     (Discord/Facebook are not implemented and are refused as unknown fields)."
+                     [auth.social.{{google,github,apple,discord,facebook}}] block."
                 );
             }
             // #943: Apple has no client_secret_env — the client secret is an
@@ -321,6 +325,26 @@ impl OidcClientConfig {
                         ("team_id", &a.team_id),
                         ("key_id", &a.key_id),
                         ("redirect_uri", &a.redirect_uri),
+                    ],
+                ));
+            }
+            if let Some(d) = social.discord.as_ref() {
+                providers.push((
+                    "discord",
+                    vec![
+                        ("client_id", &d.client_id),
+                        ("client_secret_env", &d.client_secret_env),
+                        ("redirect_uri", &d.redirect_uri),
+                    ],
+                ));
+            }
+            if let Some(f) = social.facebook.as_ref() {
+                providers.push((
+                    "facebook",
+                    vec![
+                        ("client_id", &f.client_id),
+                        ("client_secret_env", &f.client_secret_env),
+                        ("redirect_uri", &f.redirect_uri),
                     ],
                 ));
             }

--- a/crates/fraiseql-cli/tests/compile_auth_client_passthrough.rs
+++ b/crates/fraiseql-cli/tests/compile_auth_client_passthrough.rs
@@ -141,8 +141,43 @@ fn toml_auth_social_group_carries_through_to_compiled_schema() {
 
 #[test]
 fn an_unimplemented_social_provider_is_refused_at_compile_time() {
-    // #368: [auth.social.apple] has no provider implementation. The block must
-    // refuse to compile rather than be silently accepted and never served.
+    // #368: a provider key with no implementation must refuse to compile rather
+    // than be silently accepted and never served. (`apple` used to be the case
+    // in point; #943 implemented it, so the guarantee is pinned on a key that
+    // is not a provider at all.)
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(
+        br#"
+        [schema]
+        name = "app"
+
+        [types.User]
+        sql_source = "v_user"
+
+        [auth.social.myspace]
+        client_id         = "myspace-client-id"
+        client_secret_env = "MYSPACE_CLIENT_SECRET"
+        redirect_uri      = "https://api.example.com/auth/v1/callback"
+    "#,
+    )
+    .unwrap();
+    f.flush().unwrap();
+
+    let err = SchemaMerger::merge_toml_only(f.path().to_str().unwrap())
+        .err()
+        .map(|e| format!("{e:#}"))
+        .expect("[auth.social.myspace] must be refused, not silently dropped");
+    assert!(
+        err.contains("myspace"),
+        "the refusal must name the unsupported provider key: {err}"
+    );
+}
+
+/// #943: `[auth.social.apple]` reaches the compiled schema with the fields
+/// Apple actually needs — no `client_secret_env`, because Apple's client secret
+/// is an assertion the runtime signs rather than a string it reads.
+#[test]
+fn the_apple_provider_compiles_with_its_assertion_key_material() {
     let mut f = NamedTempFile::new().unwrap();
     f.write_all(
         br#"
@@ -153,22 +188,74 @@ fn an_unimplemented_social_provider_is_refused_at_compile_time() {
         sql_source = "v_user"
 
         [auth.social.apple]
-        client_id         = "apple-client-id"
-        client_secret_env = "APPLE_CLIENT_SECRET"
-        redirect_uri      = "https://api.example.com/auth/v1/callback"
+        client_id       = "com.example.service"
+        team_id         = "TEAM123456"
+        key_id          = "KEY7890AB"
+        private_key_env = "APPLE_SIGNIN_P8"
+        redirect_uri    = "https://api.example.com/auth/v1/callback"
     "#,
     )
     .unwrap();
     f.flush().unwrap();
 
-    let err = SchemaMerger::merge_toml_only(f.path().to_str().unwrap())
-        .err()
-        .map(|e| format!("{e:#}"))
-        .expect("[auth.social.apple] must be refused, not silently dropped");
-    assert!(
-        err.contains("apple"),
-        "the refusal must name the unsupported provider key: {err}"
-    );
+    let intermediate = SchemaMerger::merge_toml_only(f.path().to_str().unwrap()).unwrap();
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+    let apple = compiled
+        .auth
+        .as_ref()
+        .and_then(|a| a.social.as_ref())
+        .and_then(|s| s.apple.as_ref())
+        .expect("apple provider must be compiled");
+    assert_eq!(apple.client_id, "com.example.service");
+    assert_eq!(apple.team_id, "TEAM123456");
+    assert_eq!(apple.key_id, "KEY7890AB");
+    assert_eq!(apple.private_key_env.as_deref(), Some("APPLE_SIGNIN_P8"));
+    assert!(apple.private_key_path.is_none());
+    assert!(apple.base_url.is_none(), "no override configured");
+}
+
+/// #943: the `.p8` key has exactly one source. Naming both is ambiguous and
+/// naming neither is unusable — each is refused where the operator is editing,
+/// not at server boot.
+#[test]
+fn apple_needs_exactly_one_private_key_source() {
+    let cases = [
+        (
+            "private_key_env = \"A\"\n        private_key_path = \"/tmp/k.p8\"",
+            "names both",
+        ),
+        ("", "needs exactly one"),
+    ];
+    for (key_lines, expected) in cases {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(
+            format!(
+                r#"
+        [schema]
+        name = "app"
+
+        [types.User]
+        sql_source = "v_user"
+
+        [auth.social.apple]
+        client_id    = "com.example.service"
+        team_id      = "TEAM123456"
+        key_id       = "KEY7890AB"
+        redirect_uri = "https://api.example.com/auth/v1/callback"
+        {key_lines}
+    "#
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+        f.flush().unwrap();
+
+        let err = SchemaMerger::merge_toml_only(f.path().to_str().unwrap())
+            .err()
+            .map(|e| format!("{e:#}"))
+            .expect("an ambiguous or absent key source must be refused");
+        assert!(err.contains(expected), "expected {expected:?} in: {err}");
+    }
 }
 
 #[test]

--- a/crates/fraiseql-cli/tests/compile_auth_client_passthrough.rs
+++ b/crates/fraiseql-cli/tests/compile_auth_client_passthrough.rs
@@ -214,6 +214,59 @@ fn the_apple_provider_compiles_with_its_assertion_key_material() {
     assert!(apple.base_url.is_none(), "no override configured");
 }
 
+/// #944: Discord and Facebook reach the compiled schema, Facebook carrying the
+/// Graph API version that Meta's deprecation schedule makes configuration
+/// rather than a constant.
+#[test]
+fn the_discord_and_facebook_providers_compile_with_their_overrides() {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(
+        br#"
+        [schema]
+        name = "app"
+
+        [types.User]
+        sql_source = "v_user"
+
+        [auth.social.discord]
+        client_id         = "discord-client-id"
+        client_secret_env = "DISCORD_CLIENT_SECRET"
+        redirect_uri      = "https://api.example.com/auth/v1/callback"
+
+        [auth.social.facebook]
+        client_id         = "facebook-client-id"
+        client_secret_env = "FACEBOOK_CLIENT_SECRET"
+        redirect_uri      = "https://api.example.com/auth/v1/callback"
+        api_version       = "v23.0"
+    "#,
+    )
+    .unwrap();
+    f.flush().unwrap();
+
+    let intermediate = SchemaMerger::merge_toml_only(f.path().to_str().unwrap()).unwrap();
+    let compiled = SchemaConverter::convert(intermediate).expect("convert to compiled schema");
+    let social = compiled
+        .auth
+        .as_ref()
+        .and_then(|a| a.social.as_ref())
+        .expect("compiled auth must carry the social group");
+
+    let discord = social.discord.as_ref().expect("discord provider must be compiled");
+    assert_eq!(discord.client_id, "discord-client-id");
+    assert_eq!(discord.client_secret_env, "DISCORD_CLIENT_SECRET");
+    assert!(discord.base_url.is_none(), "no override configured");
+
+    let facebook = social.facebook.as_ref().expect("facebook provider must be compiled");
+    assert_eq!(facebook.client_id, "facebook-client-id");
+    assert_eq!(facebook.client_secret_env, "FACEBOOK_CLIENT_SECRET");
+    assert_eq!(
+        facebook.api_version.as_deref(),
+        Some("v23.0"),
+        "the Graph version must survive the seam — Meta deprecates versions on its own schedule"
+    );
+    assert!(facebook.base_url.is_none() && facebook.graph_base_url.is_none());
+}
+
 /// #943: the `.p8` key has exactly one source. Naming both is ambiguous and
 /// naming neither is unusable — each is refused where the operator is editing,
 /// not at server boot.

--- a/crates/fraiseql-core/src/schema/compiled/mod.rs
+++ b/crates/fraiseql-core/src/schema/compiled/mod.rs
@@ -22,8 +22,9 @@ pub use directive::{DirectiveDefinition, DirectiveLocationKind};
 pub use mutation::{InputStyle, MutationDefinition, MutationOperation};
 pub use query::{CursorType, QueryDefinition};
 pub use schema::{
-    AuthClientConfig, CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema, GitHubSocialConfig,
-    GoogleSocialConfig, LocalAuthConfig, PkceClientConfig, SocialAuthConfig, SubscribableEntity,
+    AppleSocialConfig, AuthClientConfig, CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema,
+    GitHubSocialConfig, GoogleSocialConfig, LocalAuthConfig, PkceClientConfig, SocialAuthConfig,
+    SubscribableEntity,
 };
 pub use schema_serde::{canonicalize_json, content_hash_of};
 pub use validation::is_safe_sql_identifier;

--- a/crates/fraiseql-core/src/schema/compiled/mod.rs
+++ b/crates/fraiseql-core/src/schema/compiled/mod.rs
@@ -23,8 +23,8 @@ pub use mutation::{InputStyle, MutationDefinition, MutationOperation};
 pub use query::{CursorType, QueryDefinition};
 pub use schema::{
     AppleSocialConfig, AuthClientConfig, CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema,
-    GitHubSocialConfig, GoogleSocialConfig, LocalAuthConfig, PkceClientConfig, SocialAuthConfig,
-    SubscribableEntity,
+    DiscordSocialConfig, FacebookSocialConfig, GitHubSocialConfig, GoogleSocialConfig,
+    LocalAuthConfig, PkceClientConfig, SocialAuthConfig, SubscribableEntity,
 };
 pub use schema_serde::{canonicalize_json, content_hash_of};
 pub use validation::is_safe_sql_identifier;

--- a/crates/fraiseql-core/src/schema/compiled/schema.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema.rs
@@ -490,6 +490,11 @@ pub struct SocialAuthConfig {
     /// `GitHub` `OAuth2` social login (non-`OIDC`; fixed well-known endpoints).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github: Option<GitHubSocialConfig>,
+
+    /// Sign in with `Apple`. Configuring it also mounts the `POST` variant of
+    /// `/auth/v1/callback` that `Apple`'s `response_mode=form_post` requires.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub apple: Option<AppleSocialConfig>,
 }
 
 /// `[auth.social.google]` — `Google` `OIDC` social-login client (#368).
@@ -531,4 +536,41 @@ pub struct GitHubSocialConfig {
     /// Enterprise Server (`https://HOSTNAME/api/v3`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_base_url:      Option<String>,
+}
+
+/// `[auth.social.apple]` — Sign in with `Apple` (#943).
+///
+/// `Apple` has no `client_secret_env`: its client secret is an ES256 assertion
+/// the runtime mints from the `.p8` key over
+/// ([`team_id`](Self::team_id), [`key_id`](Self::key_id),
+/// [`client_id`](Self::client_id)) and re-mints before expiry. Supply the key
+/// through exactly one of [`private_key_env`](Self::private_key_env) or
+/// [`private_key_path`](Self::private_key_path) — naming both, or neither, is a
+/// configuration error rather than a silent preference.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppleSocialConfig {
+    /// The services ID registered with `Apple` (its `OAuth2` `client_id`, and
+    /// the `aud` of every `id_token`).
+    pub client_id:        String,
+    /// `Apple` developer team ID — the client-secret assertion's `iss`.
+    pub team_id:          String,
+    /// Key ID of the `.p8` signing key — the assertion header's `kid`.
+    pub key_id:           String,
+    /// Name of the environment variable holding the `.p8` private key, PEM text
+    /// and all. Mutually exclusive with
+    /// [`private_key_path`](Self::private_key_path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub private_key_env:  Option<String>,
+    /// Filesystem path to the `.p8` private key. Mutually exclusive with
+    /// [`private_key_env`](Self::private_key_env).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub private_key_path: Option<String>,
+    /// This server's `/auth/v1/callback` URL, registered with `Apple`.
+    pub redirect_uri:     String,
+    /// Base URL override (default `https://appleid.apple.com`). This is also
+    /// the issuer every `id_token` must name, so the two move together. The
+    /// runtime's SSRF guards still apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url:         Option<String>,
 }

--- a/crates/fraiseql-core/src/schema/compiled/schema.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema.rs
@@ -495,6 +495,14 @@ pub struct SocialAuthConfig {
     /// `/auth/v1/callback` that `Apple`'s `response_mode=form_post` requires.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub apple: Option<AppleSocialConfig>,
+
+    /// `Discord` `OAuth2` social login (non-`OIDC`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discord: Option<DiscordSocialConfig>,
+
+    /// `Facebook` `OAuth2` social login (non-`OIDC`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub facebook: Option<FacebookSocialConfig>,
 }
 
 /// `[auth.social.google]` — `Google` `OIDC` social-login client (#368).
@@ -573,4 +581,53 @@ pub struct AppleSocialConfig {
     /// runtime's SSRF guards still apply.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url:         Option<String>,
+}
+
+/// `[auth.social.discord]` — `Discord` `OAuth2` social login (#944).
+///
+/// `Discord` reports `verified` on the user object, and the runtime honours it:
+/// an unverified address keys on `(discord, id)` rather than on the email. That
+/// check is why `discord` is in the default trusted-email set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DiscordSocialConfig {
+    /// `OAuth2` `client_id` of the `Discord` application.
+    pub client_id:         String,
+    /// Name of the environment variable holding the client secret.
+    pub client_secret_env: String,
+    /// This server's `/auth/v1/callback` URL, registered with `Discord`.
+    pub redirect_uri:      String,
+    /// Base URL override (default `https://discord.com`). The runtime's SSRF
+    /// guards still apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url:          Option<String>,
+}
+
+/// `[auth.social.facebook]` — `Facebook` `OAuth2` social login (#944).
+///
+/// `Facebook` publishes **no** email-verification signal, so every `Facebook`
+/// identity keys on `(facebook, id)` and `facebook` is deliberately absent from
+/// the default trusted-email set. The Graph API version is part of the request
+/// path and `Meta` deprecates versions on a schedule, so it is configuration
+/// rather than a constant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FacebookSocialConfig {
+    /// `OAuth2` `client_id` (the `Meta` app ID).
+    pub client_id:         String,
+    /// Name of the environment variable holding the client secret.
+    pub client_secret_env: String,
+    /// This server's `/auth/v1/callback` URL, registered with `Meta`.
+    pub redirect_uri:      String,
+    /// Graph API version segment (default `v21.0`), e.g. `v22.0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_version:       Option<String>,
+    /// Web base URL override (default `https://www.facebook.com`) — the
+    /// authorization dialog. The runtime's SSRF guards still apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url:          Option<String>,
+    /// Graph API base URL override (default `https://graph.facebook.com`) — the
+    /// token and profile endpoints. The runtime's SSRF guards still apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph_base_url:    Option<String>,
 }

--- a/crates/fraiseql-core/src/schema/mod.rs
+++ b/crates/fraiseql-core/src/schema/mod.rs
@@ -66,9 +66,10 @@ pub use changelog::inject_changelog;
 pub use compiled::{
     AppleSocialConfig, ArgumentDefinition, AuthClientConfig, AutoParams,
     CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema, CursorType, DirectiveDefinition,
-    DirectiveLocationKind, GitHubSocialConfig, GoogleSocialConfig, InputStyle, LocalAuthConfig,
-    MutationDefinition, MutationOperation, PkceClientConfig, QueryDefinition, SocialAuthConfig,
-    SubscribableEntity, canonicalize_json, content_hash_of, is_safe_sql_identifier,
+    DirectiveLocationKind, DiscordSocialConfig, FacebookSocialConfig, GitHubSocialConfig,
+    GoogleSocialConfig, InputStyle, LocalAuthConfig, MutationDefinition, MutationOperation,
+    PkceClientConfig, QueryDefinition, SocialAuthConfig, SubscribableEntity, canonicalize_json,
+    content_hash_of, is_safe_sql_identifier,
 };
 pub use config_types::{
     AuthorizationPolicy, AuthorizationRule, Cardinality, ChangelogConfig, CircuitBreakerConfig,

--- a/crates/fraiseql-core/src/schema/mod.rs
+++ b/crates/fraiseql-core/src/schema/mod.rs
@@ -64,11 +64,11 @@ mod subscription_types;
 
 pub use changelog::inject_changelog;
 pub use compiled::{
-    ArgumentDefinition, AuthClientConfig, AutoParams, CURRENT_SCHEMA_FORMAT_VERSION,
-    CompiledSchema, CursorType, DirectiveDefinition, DirectiveLocationKind, GitHubSocialConfig,
-    GoogleSocialConfig, InputStyle, LocalAuthConfig, MutationDefinition, MutationOperation,
-    PkceClientConfig, QueryDefinition, SocialAuthConfig, SubscribableEntity, canonicalize_json,
-    content_hash_of, is_safe_sql_identifier,
+    AppleSocialConfig, ArgumentDefinition, AuthClientConfig, AutoParams,
+    CURRENT_SCHEMA_FORMAT_VERSION, CompiledSchema, CursorType, DirectiveDefinition,
+    DirectiveLocationKind, GitHubSocialConfig, GoogleSocialConfig, InputStyle, LocalAuthConfig,
+    MutationDefinition, MutationOperation, PkceClientConfig, QueryDefinition, SocialAuthConfig,
+    SubscribableEntity, canonicalize_json, content_hash_of, is_safe_sql_identifier,
 };
 pub use config_types::{
     AuthorizationPolicy, AuthorizationRule, Cardinality, ChangelogConfig, CircuitBreakerConfig,

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -1093,6 +1093,54 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             })?;
             providers.push(("github", Arc::new(provider)));
         }
+        if let Some(a) = &social.apple {
+            // Apple's client secret is a signed assertion, not a stored string,
+            // so what the operator supplies is the `.p8` key itself — through
+            // exactly one of the two sources. Naming both is ambiguous and
+            // naming neither is unusable; both refuse rather than pick.
+            let private_key = match (&a.private_key_env, &a.private_key_path) {
+                (Some(env_name), None) => std::env::var(env_name).map_err(|_| {
+                    ServerError::ConfigError(format!(
+                        "[auth.social.apple] private_key_env {env_name} is not set. Apple's \
+                         client secret is an ES256 assertion signed with the .p8 key — without \
+                         it no authorization code can ever be exchanged."
+                    ))
+                })?,
+                (None, Some(path)) => std::fs::read_to_string(path).map_err(|e| {
+                    ServerError::ConfigError(format!(
+                        "[auth.social.apple] cannot read private_key_path {path}: {e}"
+                    ))
+                })?,
+                (Some(_), Some(_)) => {
+                    return Err(ServerError::ConfigError(
+                        "[auth.social.apple] names both private_key_env and private_key_path — \
+                         set exactly one."
+                            .to_string(),
+                    ));
+                },
+                (None, None) => {
+                    return Err(ServerError::ConfigError(
+                        "[auth.social.apple] needs exactly one of private_key_env / \
+                         private_key_path: the .p8 key is what signs the client-secret assertion."
+                            .to_string(),
+                    ));
+                },
+            };
+            let provider = fraiseql_auth::AppleOAuth::with_base_url(
+                a.client_id.clone(),
+                a.team_id.clone(),
+                a.key_id.clone(),
+                private_key,
+                a.redirect_uri.clone(),
+                a.base_url.clone().unwrap_or_else(|| "https://appleid.apple.com".to_string()),
+            )
+            .map_err(|e| {
+                ServerError::ConfigError(format!(
+                    "[auth.social.apple] provider construction failed: {e}"
+                ))
+            })?;
+            providers.push(("apple", Arc::new(provider)));
+        }
         if providers.is_empty() {
             // The CLI refuses this at compile time; belt-and-braces for
             // programmatically constructed schemas.

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -1141,6 +1141,42 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             })?;
             providers.push(("apple", Arc::new(provider)));
         }
+        if let Some(d) = &social.discord {
+            let secret = read_secret("discord", &d.client_secret_env)?;
+            let provider = fraiseql_auth::DiscordOAuth::with_base_url(
+                d.client_id.clone(),
+                secret,
+                d.redirect_uri.clone(),
+                d.base_url.clone().unwrap_or_else(|| "https://discord.com".to_string()),
+            )
+            .map_err(|e| {
+                ServerError::ConfigError(format!(
+                    "[auth.social.discord] provider construction failed: {e}"
+                ))
+            })?;
+            providers.push(("discord", Arc::new(provider)));
+        }
+        if let Some(f) = &social.facebook {
+            let secret = read_secret("facebook", &f.client_secret_env)?;
+            let provider = fraiseql_auth::FacebookOAuth::with_endpoints(
+                f.client_id.clone(),
+                secret,
+                f.redirect_uri.clone(),
+                f.base_url.clone().unwrap_or_else(|| "https://www.facebook.com".to_string()),
+                f.graph_base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://graph.facebook.com".to_string()),
+                f.api_version.clone().unwrap_or_else(|| {
+                    fraiseql_auth::providers::facebook::DEFAULT_API_VERSION.to_string()
+                }),
+            )
+            .map_err(|e| {
+                ServerError::ConfigError(format!(
+                    "[auth.social.facebook] provider construction failed: {e}"
+                ))
+            })?;
+            providers.push(("facebook", Arc::new(provider)));
+        }
         if providers.is_empty() {
             // The CLI refuses this at compile time; belt-and-braces for
             // programmatically constructed schemas.

--- a/crates/fraiseql-server/src/server/parity_tests.rs
+++ b/crates/fraiseql-server/src/server/parity_tests.rs
@@ -533,6 +533,7 @@ fn schema_with_github_social(secret_env: &str) -> CompiledSchema {
                 base_url:          None,
                 api_base_url:      None,
             }),
+            apple:                  None,
         }),
     });
     schema

--- a/crates/fraiseql-server/src/server/parity_tests.rs
+++ b/crates/fraiseql-server/src/server/parity_tests.rs
@@ -534,6 +534,8 @@ fn schema_with_github_social(secret_env: &str) -> CompiledSchema {
                 api_base_url:      None,
             }),
             apple:                  None,
+            discord:                None,
+            facebook:               None,
         }),
     });
     schema

--- a/crates/fraiseql-server/src/server/routing/auth.rs
+++ b/crates/fraiseql-server/src/server/routing/auth.rs
@@ -170,10 +170,21 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
 /// construction test (the axum-bump checklist), not only when a database-backed
 /// e2e suite runs.
 fn social_router(social: Arc<fraiseql_auth::MultiProviderAuthState>) -> Router {
+    // #943: Apple requests the `name`/`email` scopes, which makes Apple deliver
+    // the callback as `response_mode=form_post` — a POST with a form body, not
+    // the GET every other provider makes. The POST variant is mounted only when
+    // a provider that needs it is registered, so no server grows a second
+    // callback shape it has no use for.
+    let callback = if social.get_provider("apple").is_some() {
+        get(fraiseql_auth::multi_provider::callback)
+            .post(fraiseql_auth::multi_provider::callback_form_post)
+    } else {
+        get(fraiseql_auth::multi_provider::callback)
+    };
     Router::new()
         .route("/auth/v1/providers", get(fraiseql_auth::multi_provider::list_providers))
         .route("/auth/v1/authorize", get(fraiseql_auth::multi_provider::authorize))
-        .route("/auth/v1/callback", get(fraiseql_auth::multi_provider::callback))
+        .route("/auth/v1/callback", callback)
         .with_state(social)
 }
 

--- a/crates/fraiseql-server/tests/social_oauth_e2e_pg.rs
+++ b/crates/fraiseql-server/tests/social_oauth_e2e_pg.rs
@@ -12,6 +12,11 @@
 //!   application/json` is sent, carries **no** `expires_in`, and `/user` hides the email — the
 //!   `/user/emails` second hop resolves the primary verified address and links by email (#368's
 //!   `GitHub` gap).
+//! - `Apple` (#943): the client secret is an ES256 assertion the runtime mints, there is no
+//!   userinfo endpoint (the identity is the token endpoint's `id_token`), and the callback arrives
+//!   as a form `POST`. The suite proves the POST mount, that a second sign-in carrying no name or
+//!   email still resolves to the same account, and — the security-load-bearing one — that the
+//!   browser-supplied `user` payload's email never reaches the email-keyed linking space.
 //! - The `/auth/v1/authorize` flood faces the `auth_start` path bucket (#788).
 //! - Bogus state and unknown providers are refused.
 //!
@@ -47,6 +52,26 @@ const HS256_SECRET: &str = "p26-social-hs256-secret-32bytes!";
 const HS256_SECRET_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_HS256";
 const GOOGLE_SECRET_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_GOOGLE";
 const GITHUB_SECRET_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_GITHUB";
+const APPLE_KEY_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_APPLE_P8";
+
+/// Apple's services ID in this suite — the `client_id`, and the `aud` every
+/// stub `id_token` must name.
+const APPLE_CLIENT_ID: &str = "com.example.fraiseql.service";
+/// Apple subject, stable across sign-ins the way a real `sub` is.
+const APPLE_SUB: &str = "001999.deadbeef.0000";
+/// The address Apple itself asserts, in the `id_token`.
+const APPLE_EMAIL: &str = "apple-user@example.com";
+/// The address a hostile client puts in the browser-posted `user` payload.
+/// Nothing may ever key on it.
+const APPLE_FORGED_EMAIL: &str = "victim@example.com";
+
+/// A throwaway P-256 key, generated for this suite and used nowhere else.
+/// Apple issues a PKCS#8 PEM `.p8`, which is exactly this shape.
+const TEST_P8: &str = "-----BEGIN PRIVATE KEY-----\n\
+    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg6mOJdB87DG8anytc\n\
+    jGCaH3eI4OkrTGRc6sZGu1DqyiGhRANCAARKwlK3b7SIes76KDfwwP1Dxf3OgSsa\n\
+    dTtT/3rfS3QYTqqyzOH6LW51mUpy3vxAi/IKx1oEdLAJzOCm1Z1p5wFw\n\
+    -----END PRIVATE KEY-----\n";
 
 /// Process-wide test environment. Fixed valid values, set unconditionally:
 /// safe under the parallel runner because every reader wants exactly these.
@@ -56,6 +81,7 @@ fn set_test_env() {
     std::env::set_var(HS256_SECRET_ENV, HS256_SECRET);
     std::env::set_var(GOOGLE_SECRET_ENV, "google-client-secret");
     std::env::set_var(GITHUB_SECRET_ENV, "github-client-secret");
+    std::env::set_var(APPLE_KEY_ENV, TEST_P8);
 }
 
 fn with_database(url: &str, db: &str) -> String {
@@ -99,14 +125,68 @@ fn database_url_or_skip(test: &str) -> Option<String> {
 
 // ── Stub IdP ─────────────────────────────────────────────────────────────────
 
+/// Build an `id_token` with a placeholder signature.
+///
+/// The provider deliberately does not re-verify the signature of a token the
+/// token endpoint handed it over TLS (OIDC Core §3.1.3.7 rule 6), so a
+/// claims-only token is exactly what the production parser sees. What it *does*
+/// check — `iss`, `aud`, `exp` — is real here, and the refusal cases are
+/// covered by the provider's unit tests.
+fn unsigned_jwt(claims: &serde_json::Value) -> String {
+    use base64::Engine as _;
+    let engine = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = engine.encode(br#"{"alg":"ES256","typ":"JWT"}"#);
+    let payload = engine.encode(serde_json::to_vec(claims).expect("claims serialize"));
+    format!("{header}.{payload}.stub-signature")
+}
+
 /// Boot a stub `IdP` serving both a `Google`-shaped `OIDC` surface and a
 /// `GitHub`-shaped plain-`OAuth2` surface. Returns its base URL.
 async fn stub_idp() -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind stub idp");
     let base = format!("http://127.0.0.1:{}", listener.local_addr().expect("addr").port());
 
+    // Apple hands out the identity in an id_token and nowhere else. The first
+    // exchange carries the email claims; every later one carries only `sub`,
+    // which is the shape a real second sign-in has — and the reason the account
+    // must already be resolvable from `(apple, sub)` alone.
+    let apple_issuer = base.clone();
+    let apple_exchanges = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
     let discovery_base = base.clone();
     let app = Router::new()
+        // Apple-shaped surface: token endpoint only — no userinfo exists.
+        .route(
+            "/auth/token",
+            post(move || {
+                let iss = apple_issuer.clone();
+                let seen = Arc::clone(&apple_exchanges);
+                async move {
+                    let first = seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0;
+                    let exp = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .expect("clock")
+                        .as_secs()
+                        + 3600;
+                    let mut claims = serde_json::json!({
+                        "iss": iss,
+                        "aud": APPLE_CLIENT_ID,
+                        "sub": APPLE_SUB,
+                        "exp": exp,
+                    });
+                    if first {
+                        claims["email"] = serde_json::json!(APPLE_EMAIL);
+                        claims["email_verified"] = serde_json::json!("true");
+                    }
+                    Json(serde_json::json!({
+                        "access_token": "apple-at",
+                        "token_type": "Bearer",
+                        "expires_in": 3600,
+                        "id_token": unsigned_jwt(&claims),
+                    }))
+                }
+            }),
+        )
         // Google-shaped OIDC surface.
         .route(
             "/.well-known/openid-configuration",
@@ -238,6 +318,15 @@ fn social_schema(stub_base: &str) -> CompiledSchema {
                 redirect_uri:      "https://app.example.com/auth/v1/callback".to_string(),
                 base_url:          Some(stub_base.to_string()),
                 api_base_url:      Some(stub_base.to_string()),
+            }),
+            apple:                  Some(fraiseql_core::schema::AppleSocialConfig {
+                client_id:        APPLE_CLIENT_ID.to_string(),
+                team_id:          "TEAM123456".to_string(),
+                key_id:           "KEY7890AB".to_string(),
+                private_key_env:  Some(APPLE_KEY_ENV.to_string()),
+                private_key_path: None,
+                redirect_uri:     "https://app.example.com/auth/v1/callback".to_string(),
+                base_url:         Some(stub_base.to_string()),
             }),
         }),
     });
@@ -373,6 +462,49 @@ async fn login(base: &str, provider: &str) -> serde_json::Value {
     resp.json().await.expect("token response JSON")
 }
 
+/// Drive Apple through authorize → **form-POST** callback; returns the
+/// token-response JSON. `user_payload` is the browser-supplied first-auth field.
+async fn apple_login(base: &str, user_payload: Option<&str>) -> serde_json::Value {
+    let client = no_redirect_client();
+    let resp = client
+        .get(format!(
+            "{base}/auth/v1/authorize?provider=apple&redirect_uri=https://app.example.com/cb"
+        ))
+        .send()
+        .await
+        .expect("authorize request");
+    assert!(resp.status().is_redirection(), "authorize must redirect to Apple");
+    let location = resp
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        location.contains("response_mode=form_post"),
+        "Apple's authorize URL must ask for the form-POST callback: {location}"
+    );
+    let state = state_from_location(&location);
+
+    let mut form = vec![("code", "apple-code".to_string()), ("state", state)];
+    if let Some(user) = user_payload {
+        form.push(("user", user.to_string()));
+    }
+    let resp = client
+        .post(format!("{base}/auth/v1/callback"))
+        .form(&form)
+        .send()
+        .await
+        .expect("form-POST callback request");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "the form-POST callback must complete the login: {}",
+        resp.text().await.unwrap_or_default()
+    );
+    resp.json().await.expect("token response JSON")
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -404,7 +536,11 @@ async fn google_and_github_full_loops_link_verified_emails() {
         .iter()
         .filter_map(|v| v.as_str())
         .collect();
-    assert_eq!(names, vec!["github", "google"], "both configured providers are registered");
+    assert_eq!(
+        names,
+        vec!["apple", "github", "google"],
+        "every configured provider is registered"
+    );
 
     // Google (OIDC): full loop mints HS256 session tokens…
     let google_tokens = login(&base, "google").await;
@@ -535,6 +671,114 @@ async fn authorize_flood_faces_the_auth_start_bucket() {
         "the 4th authorize in the window must be rate limited (#788)"
     );
     assert!(resp.headers().contains_key("retry-after"), "a 429 must carry Retry-After");
+
+    let _ = tx.send(());
+    let _ = handle.await;
+    drop_scratch(&url, db).await;
+}
+
+/// #943: the whole Apple loop through the shipped mount — the form-POST
+/// callback, the second sign-in that carries no claims at all, and the one
+/// assertion that decides whether this provider is safe: the browser-supplied
+/// `user` payload must never reach the email-keyed linking space.
+#[tokio::test]
+async fn apple_form_post_loop_links_only_the_id_tokens_email() {
+    let Some(url) = database_url_or_skip("apple_form_post_loop") else {
+        return;
+    };
+    set_test_env();
+
+    let db = "fraiseql_p14_social_apple";
+    let pool = scratch_pool(&url, db).await;
+    let scratch_url = with_database(&url, db);
+    let stub = stub_idp().await;
+
+    let (base, tx, handle) =
+        boot_server(social_config(&scratch_url), social_schema(&stub), pool.clone(), &scratch_url)
+            .await;
+
+    // First authorization: Apple's id_token asserts APPLE_EMAIL, while the
+    // browser posts a `user` payload naming someone else entirely. A client can
+    // put anything in that field — it is not signed and not from Apple.
+    let forged_user = format!(
+        r#"{{"name":{{"firstName":"Ada","lastName":"Lovelace"}},"email":"{APPLE_FORGED_EMAIL}"}}"#
+    );
+    let first = apple_login(&base, Some(&forged_user)).await;
+    assert_eq!(first["provider"], "apple");
+    let apple_user = jwt_sub(first["access_token"].as_str().expect("access_token"));
+
+    let store = fraiseql_auth::PostgresAccountStore::new(pool.clone());
+
+    // The account is keyed on the address APPLE asserted: another trusted
+    // provider presenting it lands on the same account.
+    let same = store
+        .link_or_create_user(Some(APPLE_EMAIL), true, "google", "g-sub-apple-twin")
+        .await
+        .expect("link the id_token email");
+    assert!(
+        !same.is_new,
+        "the callback must have created the account under the id_token email"
+    );
+    assert_eq!(same.user_id, apple_user, "the session subject is that account");
+
+    // …and the forged address owns nothing. If the form payload's email had
+    // been honoured, this would resolve to an existing account — the account
+    // takeover this provider must not permit.
+    let forged = store
+        .link_or_create_user(Some(APPLE_FORGED_EMAIL), true, "google", "g-sub-victim")
+        .await
+        .expect("link the forged email");
+    assert!(
+        forged.is_new,
+        "the browser-supplied `user` email must never key an account (it would let any Apple \
+         user link into an address they do not own)"
+    );
+    assert_ne!(forged.user_id, apple_user);
+
+    // Second sign-in: Apple sends `sub` and nothing else — no name, no email,
+    // exactly as it does on every authorization after the first. The identity
+    // persisted on first sight is what makes this resolve.
+    let second = apple_login(&base, None).await;
+    let second_user = jwt_sub(second["access_token"].as_str().expect("access_token"));
+    assert_eq!(
+        second_user, apple_user,
+        "a claimless second sign-in must resolve to the account the first one created — \
+         otherwise every login after the first forks a new user"
+    );
+
+    let _ = tx.send(());
+    let _ = handle.await;
+    drop_scratch(&url, db).await;
+}
+
+/// #943: the form-POST mount is Apple's, and it faces the same CSRF-state gate
+/// as the GET shape — a POST with a state this server never issued is refused.
+#[tokio::test]
+async fn apple_form_post_callback_refuses_a_forged_state() {
+    let Some(url) = database_url_or_skip("apple_form_post_forged_state") else {
+        return;
+    };
+    set_test_env();
+
+    let db = "fraiseql_p14_social_apple_csrf";
+    let pool = scratch_pool(&url, db).await;
+    let scratch_url = with_database(&url, db);
+    let stub = stub_idp().await;
+
+    let (base, tx, handle) =
+        boot_server(social_config(&scratch_url), social_schema(&stub), pool, &scratch_url).await;
+
+    let resp = no_redirect_client()
+        .post(format!("{base}/auth/v1/callback"))
+        .form(&[("code", "apple-code"), ("state", "never-issued")])
+        .send()
+        .await
+        .expect("forged-state form POST");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "the POST callback must consume the same CSRF state the GET one does"
+    );
 
     let _ = tx.send(());
     let _ = handle.await;

--- a/crates/fraiseql-server/tests/social_oauth_e2e_pg.rs
+++ b/crates/fraiseql-server/tests/social_oauth_e2e_pg.rs
@@ -17,6 +17,11 @@
 //!   as a form `POST`. The suite proves the POST mount, that a second sign-in carrying no name or
 //!   email still resolves to the same account, and — the security-load-bearing one — that the
 //!   browser-supplied `user` payload's email never reaches the email-keyed linking space.
+//! - `Discord` and `Facebook` (#944, both plain `OAuth2`): the security-load-bearing case for each
+//!   — `Discord` reports `verified: false` and `Facebook` reports no verification signal at all, so
+//!   neither address may key an account. The provider's own half of that (it reports the flag
+//!   verbatim / never claims verification) is pinned by unit tests, because the trust gate is a
+//!   second, independent belt that would mask a broken provider here.
 //! - The `/auth/v1/authorize` flood faces the `auth_start` path bucket (#788).
 //! - Bogus state and unknown providers are refused.
 //!
@@ -53,6 +58,17 @@ const HS256_SECRET_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_HS256";
 const GOOGLE_SECRET_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_GOOGLE";
 const GITHUB_SECRET_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_GITHUB";
 const APPLE_KEY_ENV: &str = "FRAISEQL_TEST_P26_SOCIAL_E2E_APPLE_P8";
+const DISCORD_SECRET_ENV: &str = "FRAISEQL_TEST_P14_SOCIAL_E2E_DISCORD";
+const FACEBOOK_SECRET_ENV: &str = "FRAISEQL_TEST_P14_SOCIAL_E2E_FACEBOOK";
+
+/// A non-default Graph version, so a provider that hard-codes one shows up as a
+/// 404 against the stub rather than passing by coincidence.
+const FACEBOOK_API_VERSION: &str = "v22.0";
+/// Discord reports this address as **unverified** — it must stay out of the
+/// email-keyed linking space.
+const DISCORD_UNVERIFIED_EMAIL: &str = "discord-unverified@example.com";
+/// Facebook hands this back with no verification signal of any kind — likewise.
+const FACEBOOK_EMAIL: &str = "facebook-user@example.com";
 
 /// Apple's services ID in this suite — the `client_id`, and the `aud` every
 /// stub `id_token` must name.
@@ -82,6 +98,8 @@ fn set_test_env() {
     std::env::set_var(GOOGLE_SECRET_ENV, "google-client-secret");
     std::env::set_var(GITHUB_SECRET_ENV, "github-client-secret");
     std::env::set_var(APPLE_KEY_ENV, TEST_P8);
+    std::env::set_var(DISCORD_SECRET_ENV, "discord-client-secret");
+    std::env::set_var(FACEBOOK_SECRET_ENV, "facebook-client-secret");
 }
 
 fn with_database(url: &str, db: &str) -> String {
@@ -140,8 +158,9 @@ fn unsigned_jwt(claims: &serde_json::Value) -> String {
     format!("{header}.{payload}.stub-signature")
 }
 
-/// Boot a stub `IdP` serving both a `Google`-shaped `OIDC` surface and a
-/// `GitHub`-shaped plain-`OAuth2` surface. Returns its base URL.
+/// Boot a stub `IdP` serving every configured provider's surface — `Google`'s
+/// `OIDC` shape, and the plain-`OAuth2` shapes of `Apple`, `Discord`, `Facebook`
+/// and `GitHub`. Returns its base URL.
 async fn stub_idp() -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind stub idp");
     let base = format!("http://127.0.0.1:{}", listener.local_addr().expect("addr").port());
@@ -185,6 +204,57 @@ async fn stub_idp() -> String {
                         "id_token": unsigned_jwt(&claims),
                     }))
                 }
+            }),
+        )
+        // Discord-shaped surface. The user object carries `verified` — this
+        // account's is false, which is the case that must not link on email.
+        .route(
+            "/api/oauth2/token",
+            post(|| async {
+                Json(serde_json::json!({
+                    "access_token": "discord-at",
+                    "token_type": "Bearer",
+                    "expires_in": 604_800,
+                    "refresh_token": "discord-rt",
+                    "scope": "identify email"
+                }))
+            }),
+        )
+        .route(
+            "/api/users/@me",
+            get(|| async {
+                Json(serde_json::json!({
+                    "id": "776655443322110099",
+                    "username": "carol",
+                    "global_name": "Carol",
+                    "email": DISCORD_UNVERIFIED_EMAIL,
+                    "verified": false,
+                    "avatar": null
+                }))
+            }),
+        )
+        // Facebook-shaped surface, under the configured API version — a
+        // provider that hard-coded a version would 404 here.
+        .route(
+            &format!("/{FACEBOOK_API_VERSION}/oauth/access_token"),
+            post(|| async {
+                Json(serde_json::json!({
+                    "access_token": "facebook-at",
+                    "token_type": "bearer",
+                    "expires_in": 5_183_944
+                }))
+            }),
+        )
+        .route(
+            &format!("/{FACEBOOK_API_VERSION}/me"),
+            get(|| async {
+                // An address, and no verification signal anywhere — Facebook
+                // publishes none.
+                Json(serde_json::json!({
+                    "id": "10223344556677889",
+                    "name": "Dave",
+                    "email": FACEBOOK_EMAIL
+                }))
             }),
         )
         // Google-shaped OIDC surface.
@@ -327,6 +397,20 @@ fn social_schema(stub_base: &str) -> CompiledSchema {
                 private_key_path: None,
                 redirect_uri:     "https://app.example.com/auth/v1/callback".to_string(),
                 base_url:         Some(stub_base.to_string()),
+            }),
+            discord:                Some(fraiseql_core::schema::DiscordSocialConfig {
+                client_id:         "discord-client".to_string(),
+                client_secret_env: DISCORD_SECRET_ENV.to_string(),
+                redirect_uri:      "https://app.example.com/auth/v1/callback".to_string(),
+                base_url:          Some(stub_base.to_string()),
+            }),
+            facebook:               Some(fraiseql_core::schema::FacebookSocialConfig {
+                client_id:         "facebook-client".to_string(),
+                client_secret_env: FACEBOOK_SECRET_ENV.to_string(),
+                redirect_uri:      "https://app.example.com/auth/v1/callback".to_string(),
+                api_version:       Some(FACEBOOK_API_VERSION.to_string()),
+                base_url:          Some(stub_base.to_string()),
+                graph_base_url:    Some(stub_base.to_string()),
             }),
         }),
     });
@@ -538,7 +622,7 @@ async fn google_and_github_full_loops_link_verified_emails() {
         .collect();
     assert_eq!(
         names,
-        vec!["apple", "github", "google"],
+        vec!["apple", "discord", "facebook", "github", "google"],
         "every configured provider is registered"
     );
 
@@ -601,7 +685,7 @@ async fn bogus_state_and_unknown_provider_are_refused() {
     // An unregistered provider is refused, not silently defaulted.
     let resp = client
         .get(format!(
-            "{base}/auth/v1/authorize?provider=facebook&redirect_uri=https://app.example.com/cb"
+            "{base}/auth/v1/authorize?provider=myspace&redirect_uri=https://app.example.com/cb"
         ))
         .send()
         .await
@@ -778,6 +862,82 @@ async fn apple_form_post_callback_refuses_a_forged_state() {
         resp.status(),
         reqwest::StatusCode::BAD_REQUEST,
         "the POST callback must consume the same CSRF state the GET one does"
+    );
+
+    let _ = tx.send(());
+    let _ = handle.await;
+    drop_scratch(&url, db).await;
+}
+
+/// #944: the assertion that decides whether Discord and Facebook are safe to
+/// ship — an unverified or unverifiable address must stay in the
+/// `(provider, id)` key space, so it can never collapse into an email-keyed
+/// account belonging to someone else.
+///
+/// Discord *reports* `verified: false` for this account, and Facebook reports
+/// nothing at all. Both addresses therefore own nothing, and a later trusted
+/// login on the same address must create a fresh account rather than land on
+/// theirs.
+#[tokio::test]
+async fn discord_and_facebook_keep_unverified_emails_out_of_the_linking_space() {
+    let Some(url) = database_url_or_skip("discord_and_facebook_linking_space") else {
+        return;
+    };
+    set_test_env();
+
+    let db = "fraiseql_p14_social_plain_oauth";
+    let pool = scratch_pool(&url, db).await;
+    let scratch_url = with_database(&url, db);
+    let stub = stub_idp().await;
+
+    let (base, tx, handle) =
+        boot_server(social_config(&scratch_url), social_schema(&stub), pool.clone(), &scratch_url)
+            .await;
+    let store = fraiseql_auth::PostgresAccountStore::new(pool.clone());
+
+    // ── Discord: `verified: false` on the user object, honoured ──────────
+    let discord = login(&base, "discord").await;
+    assert_eq!(discord["provider"], "discord");
+    let discord_user = jwt_sub(discord["access_token"].as_str().expect("access_token"));
+
+    let discord_claim = store
+        .link_or_create_user(Some(DISCORD_UNVERIFIED_EMAIL), true, "google", "g-sub-discord-twin")
+        .await
+        .expect("claim the discord address from a trusted provider");
+    assert!(
+        discord_claim.is_new,
+        "an address Discord itself calls unverified must not own an account — otherwise anyone \
+         who sets that address on Discord without confirming it inherits the real owner's account"
+    );
+    assert_ne!(discord_claim.user_id, discord_user);
+
+    // The Discord identity is nonetheless durable: signing in again is the same
+    // account, resolved on `(discord, id)`.
+    let discord_again = login(&base, "discord").await;
+    assert_eq!(
+        jwt_sub(discord_again["access_token"].as_str().expect("access_token")),
+        discord_user,
+        "an unverified-email identity must still be stable across sign-ins"
+    );
+
+    // ── Facebook: no verification signal exists at all ───────────────────
+    let facebook = login(&base, "facebook").await;
+    assert_eq!(facebook["provider"], "facebook");
+    let facebook_user = jwt_sub(facebook["access_token"].as_str().expect("access_token"));
+
+    let facebook_claim = store
+        .link_or_create_user(Some(FACEBOOK_EMAIL), true, "google", "g-sub-facebook-twin")
+        .await
+        .expect("claim the facebook address from a trusted provider");
+    assert!(
+        facebook_claim.is_new,
+        "Facebook publishes no verification signal, so its address must never key an account"
+    );
+    assert_ne!(facebook_claim.user_id, facebook_user);
+
+    assert_ne!(
+        discord_user, facebook_user,
+        "two email-less identities must not collapse into one account"
     );
 
     let _ = tx.send(());


### PR DESCRIPTION
**P14 of the open-finding remediation program** (Wave 5). Completes the `[auth.social]`
umbrella (#368) with the three providers it named but never implemented. One commit per
issue, both red-proven.

## #943 — Sign in with Apple

Apple is the one provider a copy of the Google client could not have served:

- **The client secret is a signed assertion.** `AppleOAuth` mints an ES256 JWT over
  `(team_id, key_id, client_id)` from the `.p8` key, caches it, and re-mints five minutes
  before expiry. A key that cannot sign is refused at construction — bad `.p8` fails at boot,
  not at the first login.
- **There is no userinfo endpoint.** The identity is the token endpoint's `id_token`, so
  `OAuthProvider` gained `user_info_from_tokens(&TokenResponse)`, defaulting to today's
  `user_info(access_token)`. Apple overrides it and makes its own `user_info` refuse loudly
  rather than return a degraded identity. `iss` / `aud` / `exp` are validated fail-closed; the
  signature is not re-verified (direct TLS from the token endpoint, OIDC Core §3.1.3.7 rule 6).
- **`response_mode=form_post`**, so configuring Apple mounts a `POST` variant of
  `/auth/v1/callback`. Both shapes run the same `complete_callback` — same CSRF-state
  consumption, same trust gate, same session mint.
- `AppleBool` accepts Apple's `"true"` spelling as well as the JSON bool. Dropping the string
  form silently discards `email_verified`, which fails **open** into the email-keyed linking
  space.

### One deliberate narrowing of the issue

The issue asks for the first-authorization `user` payload to be persisted. Its **name** is;
its **email** is not even modelled, and neither is the form body's `id_token`. That payload
arrives in a request the *browser* makes, so anyone holding a valid `code`/`state` pair from
their own Apple account can put any address in it — honouring it links them straight into
that address's account. The linking email comes only from the token endpoint. A live e2e
proves it: a sign-in whose payload claims `victim@example.com` leaves that address owning
nothing.

Persisting the claims needs no new storage: `AccountStore` resolves a known
`(provider, provider_id)` before it consults any email, so the second sign-in — which Apple
sends with `sub` and nothing else — lands on the account the first created. The e2e drives
exactly that sequence.

## #944 — Discord + Facebook

Both plain OAuth2 on the GitHub template. Each one's real question is what it can honestly
say about an email address.

**Discord** carries `email` and `verified` on one object with no second hop, which makes it
easy to *assume* the address is confirmed. The provider reads the flag instead; an absent
flag is `false`. Only because that check exists is **`discord` added to the default
`TrustedEmailProviders` set** — trust and check ship together.

**Facebook** may return no `email` at all and publishes **no verification flag whatsoever**,
so `email_verified` is `false` unconditionally and `facebook` stays out of the default trusted
set — two independent reasons its address can never key a link. The Graph API version lives in
the request path and Meta deprecates on its own schedule, so `api_version` is configuration
(default `v21.0`); a value carrying a path separator is refused, since it would re-point the
request.

### A test-design point worth recording

Setting Facebook's `email_verified` to `true` leaves the **e2e green** — the trust gate
downgrades it anyway. A single end-to-end assertion would have covered a broken provider. Each
half now has its own test: a stub-backed `user_info` case for the provider's claim, and a
trust-set case for the gate.

## Breaking

`fraiseql_auth::provider::TokenResponse` gained `id_token: Option<String>`. Any code
constructing one (a custom `OAuthProvider`, a test double) must add `id_token: None`.
`OAuthProvider::user_info_from_tokens` has a default forwarding to `user_info`, so existing
impls compile unchanged.

## Verification

- 29 provider unit tests (3 stub-IdP-backed) + 3 e2e through the shipped mount, all in legs that
  already run — **no new test binary**, so the #1082 asymmetry cannot bite here
- **Red-proven thirteen ways**, each guarantee reverted alone. #943: honouring the posted email
  fires the takeover assertion; keying on email instead of `sub` fires the claimless second
  sign-in; unmounting the POST route, dropping `response_mode=form_post`, dropping the `"true"`
  spelling, and neutering each of `iss`/`aud`/`exp` each fire their own test. #944: assuming
  Discord's flag fires 3 unit tests and the e2e; claiming Facebook verification fires the
  provider test; trusting `facebook` fires the trust-set test; hard-coding the Graph version
  fires the unit test and 404s the e2e; dropping the version validation fires the path-injection
  test.
- `make preflight` green (fmt → ~12 ShellGates → rustdoc → clippy → tests → deny)
- **Narrow feature configs built, not only `--all-features`** — the trap that cost two red legs
  last wave: `fraiseql-auth` {default, all, no-default, auth-saml}, `fraiseql-core`
  {all, redis-apq, postgres, default}, `fraiseql-server` {default, auth, the Test leg's set}
- `fraiseql-auth` lib 919 · social e2e 6/6 · `fraiseql-cli` 14 · `fraiseql-core` lib 2707 ·
  `fraiseql-server` lib 1607
- suite-coverage OK (404 binaries, 84 feature-gated lib modules), route-syntax OK

Filed out of scope: **#1083** (`fraiseql-core --no-default-features --all-targets` does not
compile on `dev`; pre-existing, no leg builds that config).

Closes #943
Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)
