### PR TITLE
P15: email verification (#945) — promote on a proved mailbox, refuse the merge

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -779,6 +779,11 @@ func (m *FraiseqlCi) integrationPostgres(ctx context.Context, source *dagger.Dir
 		"cargo test -p fraiseql-auth --test local_password -- --test-threads=1",
 		// #367 password reset (selector+verifier tokens, single-use, expiry, RLS).
 		"cargo test -p fraiseql-auth --test password_reset -- --test-threads=1",
+		// #945 email verification: the token discipline, the session binding that makes a
+		// token alone insufficient, and the BIDIRECTIONAL pre-hijack invariant — neither a
+		// pre-seeded unverified local account nor a later-verified one may absorb a trusted
+		// account holding the same address.
+		"cargo test -p fraiseql-auth --test email_verification -- --test-threads=1",
 		// #368 social auto-link trust policy ∘ PostgresAccountStore (trusted vs untrusted → merge vs distinct).
 		"cargo test -p fraiseql-auth --test social_linking -- --test-threads=1",
 		// #984 single-use consume of OTP codes / MFA challenge tokens: a BEFORE DELETE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1378,6 +1378,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Email verification for local-password accounts (#945).** FraiseQL could only *consume*
+  a verification claim someone else asserted — a trusted provider's `email_verified`, or a
+  completed email OTP. A local password signup passes `email_verified = false` (deliberately
+  fail-closed, so it keys on `(local, email)` and can never auto-merge), which meant
+  `core.tb_user.email` stayed `NULL` forever: the account could never *become* verified, and
+  the same person's password and Google sign-ins were two accounts with no way to join them.
+
+  `[auth.local] email_verification = true` mounts `POST /auth/v1/email/verify/start` and
+  `.../confirm`, backed by `core.tb_email_verification_token` on the selector + verifier
+  discipline password reset already uses (plaintext selector indexed, `sha256(verifier)`
+  stored, single-use under an atomic guard, one-hour TTL) plus one column reset does not
+  have: the address the link was mailed to, so confirmation promotes exactly the mailbox
+  that was proved. Delivery goes through the `[auth.local] email_from` mailbox; the link is
+  built from a new required `verification_url_template` (`{token}`), and a config that
+  enables verification without `password = true`, without `email_from`, or without the
+  template is refused by the compiler and again at boot.
+
+  **Both halves are required to confirm.** The routes are the only ones in this group that
+  need an authenticated caller: the token proves control of the mailbox, the session proves
+  ownership of the account, and the token's subject must equal the caller's `user_id`. That
+  is what closes the confused-deputy shape — signup for an arbitrary address is open by
+  design, so an attacker can seed a local account under `victim@example.com` and cause a
+  verification mail to land in the victim's inbox; a victim who clicks it is not
+  authenticated as the attacker, so nothing happens. A token presented by any other account
+  is rejected exactly like a forged one.
+
+  **Confirmation promotes; it never merges.** The proved address is written to the caller's
+  own user row, which is what puts the account in the cross-provider `email:<normalized>`
+  key space — so a later trusted social sign-in for the same address links into it through
+  the ordinary `link_or_create_user` path, one account, no new merge machinery. If another
+  account already holds that verified address, confirmation refuses with the new
+  `AuthError::EmailClaimedByAnotherAccount` (`409`) and changes nothing. The issue asked for
+  a merge there; a merge would move this account's password credential onto an account it
+  could not previously reach, which combined with open signup completes an account-takeover
+  chain needing the mailed code only once. The `TrustedEmailProviders` pre-hijack invariant
+  is re-proved for the new path in **both** directions against real PostgreSQL, and each
+  guard was verified by reverting it alone and watching the matching assertion fail.
+
 - **Sign in with Apple (#943).** `[auth.social.apple]` completes the third provider the
   `[auth.social]` umbrella (#368) named, and it is the one that could not have been a copy
   of the Google client. Apple's client secret is an **ES256 assertion**, not a stored

--- a/crates/fraiseql-auth/src/error.rs
+++ b/crates/fraiseql-auth/src/error.rs
@@ -256,6 +256,20 @@ pub enum AuthError {
     #[error("An account already exists for this email")]
     EmailAlreadyRegistered,
 
+    /// An email-verification confirmation proved a mailbox, but the address is already
+    /// the verified email of a **different** account (or this account already has a
+    /// different verified address), so writing it would collapse two accounts onto one
+    /// cross-provider linking key.
+    ///
+    /// The refusal is deliberate and permanent: resolving the collision would mean
+    /// merging, which would carry this account's password credential onto an account it
+    /// could not previously reach. See `local_password::verification`.
+    ///
+    /// Safe to report to the caller: reaching it requires having already proved control
+    /// of the address, so it discloses nothing the caller had not established.
+    #[error("That email address is already verified on another account")]
+    EmailClaimedByAnotherAccount,
+
     /// A local signup was rejected by input validation (malformed email or a password
     /// that violates the length policy).
     ///

--- a/crates/fraiseql-auth/src/lib.rs
+++ b/crates/fraiseql-auth/src/lib.rs
@@ -35,6 +35,7 @@ pub mod saml;
 pub mod security_config;
 pub mod security_init;
 pub mod session;
+pub mod session_bearer;
 pub mod session_postgres;
 pub mod session_state;
 pub mod state_encryption;
@@ -49,6 +50,10 @@ mod error_sanitization_tests;
 
 #[cfg(test)]
 mod constant_time_tests;
+
+#[allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#[cfg(test)]
+mod session_bearer_tests;
 
 #[cfg(test)]
 mod state_encryption_tests;
@@ -86,9 +91,13 @@ pub use handlers::{
 pub use jwks::{JwksCache, JwksError};
 pub use jwt::{Claims, JwtValidator, generate_hs256_token, generate_rs256_token};
 pub use local_password::{
-    LocalPasswordAuthenticator, PASSWORD_RESET_SCHEMA_SQL, PASSWORD_SCHEMA_SQL,
-    RESET_TOKEN_TTL_SECS, ResetEmailSender,
-    routes::{LocalPasswordRouteState, local_password_routes},
+    EMAIL_VERIFICATION_SCHEMA_SQL, EMAIL_VERIFICATION_TOKEN_TTL_SECS, EmailVerified,
+    LocalPasswordAuthenticator, PASSWORD_RESET_SCHEMA_SQL, PASSWORD_SCHEMA_SQL, PromotionDecision,
+    RESET_TOKEN_TTL_SECS, ResetEmailSender, VerificationEmailSender, decide_promotion,
+    routes::{
+        EmailVerificationRouteState, LocalPasswordRouteState, email_verification_routes,
+        local_password_routes,
+    },
 };
 pub use middleware::{AuthMiddleware, AuthenticatedUser};
 pub use monitoring::{AuthEvent, AuthMetrics, OperationTimer};
@@ -138,6 +147,7 @@ pub use security_init::{
     validate_security_config,
 };
 pub use session::{SessionData, SessionStore, TokenPair, unix_now};
+pub use session_bearer::SessionBearerAuthenticator;
 pub use session_postgres::PostgresSessionStore;
 pub use state_encryption::{
     DecryptionError, EncryptedState, EncryptionAlgorithm, KeyError, StateEncryption,

--- a/crates/fraiseql-auth/src/local_password.rs
+++ b/crates/fraiseql-auth/src/local_password.rs
@@ -16,7 +16,8 @@
 //! - **Signup is fail-closed.** It links with `email_verified = false`, so a local signup keys its
 //!   own `(local, email)` account and can never auto-merge into an existing verified-email account
 //!   (the H26 protection against takeover via an unverified signup). `core.tb_user.email` therefore
-//!   stays `NULL` until a future verification flow promotes it.
+//!   stays `NULL` until [`verification`] promotes it on a proved mailbox (#945) — the one path that
+//!   writes it, and one that never moves a row between accounts.
 //! - **Login is non-enumerable.** An unknown user and a wrong password are indistinguishable: both
 //!   return [`AuthError::InvalidCredentials`] with the same body, and both pay the full Argon2 cost
 //!   — an unknown user is verified against a pre-computed dummy hash built from the *same*
@@ -41,7 +42,10 @@
 //!   same disclosure trade-off as above).
 //! - **Non-enumerable signup.** [`AuthError::EmailAlreadyRegistered`] is a signup existence oracle;
 //!   the standard "we emailed you" mitigation needs the email-action path (#349), not yet shipped.
-//! - **Password reset / email verification** — #367, reusing the #349 email path.
+//! - **Adding a password to an account that already exists under another provider.** The safe
+//!   direction for that ordering is a set-password call from inside an authenticated session;
+//!   [`verification`] deliberately refuses to pull an existing account toward an outside credential
+//!   (#945).
 
 use std::sync::Arc;
 
@@ -58,10 +62,16 @@ use crate::{
     session::SessionStore,
 };
 
+mod opaque_token;
 mod reset;
 pub mod routes;
+pub mod verification;
 
 pub use reset::{PASSWORD_RESET_SCHEMA_SQL, RESET_TOKEN_TTL_SECS, ResetEmailSender};
+pub use verification::{
+    EMAIL_VERIFICATION_SCHEMA_SQL, EMAIL_VERIFICATION_TOKEN_TTL_SECS, EmailVerified,
+    PromotionDecision, VerificationEmailSender, decide_promotion,
+};
 
 /// Provider name recorded for local-password identities in `core.tb_auth_identity`.
 const LOCAL_PROVIDER: &str = "local";
@@ -127,24 +137,29 @@ REVOKE ALL ON core.tb_password_credential FROM PUBLIC;
 /// `PgPool` role must own (or `BYPASSRLS`) the `core` tables — calling `init` creates
 /// them, so the connecting role owns them by construction.
 pub struct LocalPasswordAuthenticator {
-    db:            PgPool,
+    db:                  PgPool,
     /// Resolves/creates users at signup (provider `"local"`). Any [`AccountStore`] that
     /// persists into `core.tb_auth_identity` works; in practice this is
     /// [`PostgresAccountStore`](crate::PostgresAccountStore), since login resolves
     /// email → `user_id` through that table.
-    accounts:      Arc<dyn AccountStore>,
-    argon2:        Argon2<'static>,
+    accounts:            Arc<dyn AccountStore>,
+    argon2:              Argon2<'static>,
     /// A real Argon2id hash, built from `argon2`'s parameters, used to equalize the
     /// verification cost of an unknown-user login with a real one.
-    dummy_hash:    String,
+    dummy_hash:          String,
     /// Delivers reset links for [`start_password_reset`](Self::start_password_reset).
     /// Wired via [`with_email_sender`](Self::with_email_sender); `None` issues tokens
     /// without delivering them (a warning is logged).
-    email_sender:  Option<Arc<dyn reset::ResetEmailSender>>,
+    email_sender:        Option<Arc<dyn reset::ResetEmailSender>>,
     /// Revoked on a successful [`confirm_password_reset`](Self::confirm_password_reset).
     /// Wired via [`with_session_store`](Self::with_session_store); `None` skips revocation
     /// (a warning is logged).
-    session_store: Option<Arc<dyn SessionStore>>,
+    session_store:       Option<Arc<dyn SessionStore>>,
+    /// Delivers verification links for
+    /// [`start_email_verification`](Self::start_email_verification). Wired via
+    /// [`with_verification_email_sender`](Self::with_verification_email_sender); `None`
+    /// issues tokens without delivering them (a warning is logged).
+    verification_sender: Option<Arc<dyn verification::VerificationEmailSender>>,
 }
 
 impl LocalPasswordAuthenticator {
@@ -191,6 +206,7 @@ impl LocalPasswordAuthenticator {
             dummy_hash,
             email_sender: None,
             session_store: None,
+            verification_sender: None,
         }
     }
 
@@ -217,6 +233,10 @@ impl LocalPasswordAuthenticator {
             .execute(&self.db)
             .await
             .map_err(|e| db_error("initialize password reset token store", &e))?;
+        sqlx::raw_sql(verification::EMAIL_VERIFICATION_SCHEMA_SQL)
+            .execute(&self.db)
+            .await
+            .map_err(|e| db_error("initialize email verification token store", &e))?;
         Ok(())
     }
 

--- a/crates/fraiseql-auth/src/local_password/opaque_token.rs
+++ b/crates/fraiseql-auth/src/local_password/opaque_token.rs
@@ -1,0 +1,107 @@
+//! The selector + verifier opaque-token codec shared by the local-password flows.
+//!
+//! Both password reset (#367) and email verification (#945) hand the user a
+//! `b64url(16B selector) "." b64url(32B verifier)` string and persist only the
+//! selector (non-secret, indexed) plus `sha256(verifier)`. The security argument is
+//! identical for both, so the codec lives here once rather than being reimplemented
+//! per flow:
+//!
+//! - Redemption fetches the row `WHERE selector = $1` — no secret in the `WHERE`, so the lookup is
+//!   not an existence oracle — then compares `sha256(presented verifier)` against the stored hash
+//!   in constant time.
+//! - A full database read cannot forge a usable token: that needs a SHA-256 preimage of a 256-bit
+//!   CSPRNG verifier. SHA-256 rather than Argon2 is sufficient precisely because the verifier is
+//!   high-entropy — there is no brute-force surface a KDF's cost would defend.
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use sha2::{Digest, Sha256};
+
+use crate::error::{AuthError, Result};
+
+/// Selector length in bytes (the non-secret, indexed lookup key).
+const SELECTOR_LEN: usize = 16;
+/// Verifier length in bytes (the secret; only its SHA-256 is stored).
+const VERIFIER_LEN: usize = 32;
+
+/// A freshly generated opaque token: a non-secret selector plus a secret verifier.
+pub(super) struct OpaqueToken {
+    selector: [u8; SELECTOR_LEN],
+    verifier: [u8; VERIFIER_LEN],
+}
+
+/// The redemption-relevant parts of a presented token: the selector (for lookup) and
+/// the SHA-256 of the verifier (for constant-time comparison against the stored hash).
+pub(super) struct ParsedToken {
+    pub(super) selector:      String,
+    pub(super) verifier_hash: Vec<u8>,
+}
+
+impl OpaqueToken {
+    /// Generate a token from the OS-seeded CSPRNG ([`rand::rng`], as used for refresh
+    /// tokens).
+    pub(super) fn generate() -> Self {
+        use rand::RngCore as _;
+        let mut selector = [0u8; SELECTOR_LEN];
+        let mut verifier = [0u8; VERIFIER_LEN];
+        rand::rng().fill_bytes(&mut selector);
+        rand::rng().fill_bytes(&mut verifier);
+        Self { selector, verifier }
+    }
+
+    /// The base64url selector, stored as the indexed lookup key.
+    pub(super) fn selector_b64(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.selector)
+    }
+
+    /// SHA-256 of the verifier, the only verifier-derived value persisted.
+    pub(super) fn verifier_hash(&self) -> Vec<u8> {
+        Sha256::digest(self.verifier).to_vec()
+    }
+
+    /// The opaque token string handed to the user: `selector "." verifier`.
+    pub(super) fn to_token_string(&self) -> String {
+        format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(self.selector),
+            URL_SAFE_NO_PAD.encode(self.verifier)
+        )
+    }
+
+    /// Parse a presented token into its lookup selector and verifier hash.
+    ///
+    /// `kind` names the flow (`"reset"`, `"email verification"`) so the diagnostic
+    /// reason reads correctly; callers map every failure to one generic client-facing
+    /// error regardless.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::InvalidToken`] if the token is not `selector.verifier`,
+    /// either half is not valid base64url, or either decodes to the wrong length.
+    pub(super) fn parse(kind: &str, token: &str) -> Result<ParsedToken> {
+        let (selector_b64, verifier_b64) =
+            token.split_once('.').ok_or_else(|| AuthError::InvalidToken {
+                reason: format!("{kind} token is not in selector.verifier form"),
+            })?;
+        let selector =
+            URL_SAFE_NO_PAD.decode(selector_b64).map_err(|_| AuthError::InvalidToken {
+                reason: format!("{kind} token selector is not valid base64url"),
+            })?;
+        let verifier =
+            URL_SAFE_NO_PAD.decode(verifier_b64).map_err(|_| AuthError::InvalidToken {
+                reason: format!("{kind} token verifier is not valid base64url"),
+            })?;
+        if selector.len() != SELECTOR_LEN || verifier.len() != VERIFIER_LEN {
+            return Err(AuthError::InvalidToken {
+                reason: format!("{kind} token has an unexpected length"),
+            });
+        }
+        Ok(ParsedToken {
+            selector:      selector_b64.to_string(),
+            verifier_hash: Sha256::digest(&verifier).to_vec(),
+        })
+    }
+}
+
+#[allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-auth/src/local_password/opaque_token/tests.rs
+++ b/crates/fraiseql-auth/src/local_password/opaque_token/tests.rs
@@ -1,12 +1,18 @@
-//! Unit tests for the reset-token primitives (no database).
+//! Unit tests for the selector + verifier opaque-token codec (no database).
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 
 use super::*;
+use crate::error::AuthError;
+
+/// Flow label; the codec is flow-agnostic, so any label exercises the same paths.
+const KIND: &str = "test";
 
 #[test]
 fn generate_then_parse_round_trips_selector_and_verifier_hash() {
-    let token = ResetToken::generate();
+    let token = OpaqueToken::generate();
     let parsed =
-        ResetToken::parse(&token.to_token_string()).expect("freshly generated token parses");
+        OpaqueToken::parse(KIND, &token.to_token_string()).expect("freshly generated token parses");
 
     assert_eq!(parsed.selector, token.selector_b64(), "selector survives the round-trip");
     assert_eq!(
@@ -18,7 +24,7 @@ fn generate_then_parse_round_trips_selector_and_verifier_hash() {
 
 #[test]
 fn token_string_has_two_base64url_halves() {
-    let token = ResetToken::generate();
+    let token = OpaqueToken::generate();
     let s = token.to_token_string();
     assert_eq!(s.split('.').count(), 2, "token is exactly selector.verifier");
     // URL-safe base64 with no padding: no '+', '/', or '='.
@@ -27,21 +33,21 @@ fn token_string_has_two_base64url_halves() {
 
 #[test]
 fn distinct_generations_are_unique() {
-    let a = ResetToken::generate();
-    let b = ResetToken::generate();
+    let a = OpaqueToken::generate();
+    let b = OpaqueToken::generate();
     assert_ne!(a.to_token_string(), b.to_token_string(), "CSPRNG yields unique tokens");
     assert_ne!(a.verifier_hash(), b.verifier_hash(), "verifier hashes differ");
 }
 
 #[test]
 fn verifier_hash_is_sha256_width() {
-    let token = ResetToken::generate();
+    let token = OpaqueToken::generate();
     assert_eq!(token.verifier_hash().len(), 32, "SHA-256 digest is 32 bytes");
 }
 
 #[test]
 fn parse_rejects_missing_dot() {
-    let err = ResetToken::parse("no-separator-here");
+    let err = OpaqueToken::parse(KIND, "no-separator-here");
     assert!(matches!(err, Err(AuthError::InvalidToken { .. })), "missing dot is rejected");
 }
 
@@ -49,15 +55,15 @@ fn parse_rejects_missing_dot() {
 fn parse_rejects_too_many_dots() {
     // split_once keeps everything after the first '.', so a second dot makes the verifier
     // half undecodable as base64url.
-    let token = ResetToken::generate();
+    let token = OpaqueToken::generate();
     let bad = format!("{}.extra", token.to_token_string());
-    assert!(matches!(ResetToken::parse(&bad), Err(AuthError::InvalidToken { .. })));
+    assert!(matches!(OpaqueToken::parse(KIND, &bad), Err(AuthError::InvalidToken { .. })));
 }
 
 #[test]
 fn parse_rejects_non_base64() {
     let bad = "!!!not-base64!!!.****also-not****";
-    assert!(matches!(ResetToken::parse(bad), Err(AuthError::InvalidToken { .. })));
+    assert!(matches!(OpaqueToken::parse(KIND, bad), Err(AuthError::InvalidToken { .. })));
 }
 
 #[test]
@@ -65,11 +71,11 @@ fn parse_rejects_wrong_length_halves() {
     // Valid base64url but decoding to the wrong byte lengths (4 bytes each).
     let short = URL_SAFE_NO_PAD.encode([1u8, 2, 3, 4]);
     let bad = format!("{short}.{short}");
-    assert!(matches!(ResetToken::parse(&bad), Err(AuthError::InvalidToken { .. })));
+    assert!(matches!(OpaqueToken::parse(KIND, &bad), Err(AuthError::InvalidToken { .. })));
 }
 
 #[test]
 fn parse_accepts_a_real_token() {
-    let token = ResetToken::generate();
-    assert!(ResetToken::parse(&token.to_token_string()).is_ok());
+    let token = OpaqueToken::generate();
+    assert!(OpaqueToken::parse(KIND, &token.to_token_string()).is_ok());
 }

--- a/crates/fraiseql-auth/src/local_password/reset.rs
+++ b/crates/fraiseql-auth/src/local_password/reset.rs
@@ -11,14 +11,11 @@
 //!
 //! # Token security model
 //!
-//! - **Selector + verifier.** The token is `b64url(16B selector) "." b64url(32B verifier)`. The
-//!   store keeps the `selector` (non-secret, indexed) and `verifier_hash = sha256(verifier)`.
-//!   Redemption fetches the row `WHERE selector = $1` — no secret in the `WHERE`, so the lookup is
-//!   not an existence oracle — then compares the SHA-256 of the presented verifier against the
-//!   stored hash in **constant time** ([`ConstantTimeOps::compare`]). A full database read cannot
-//!   forge a usable token: it would require a SHA-256 preimage of a 256-bit CSPRNG verifier.
-//!   SHA-256 (not Argon2) is sufficient precisely because the verifier is high-entropy — there is
-//!   no brute-force surface that Argon2's cost would defend.
+//! - **Selector + verifier** ([`super::opaque_token`]). The token is `b64url(16B selector) "."
+//!   b64url(32B verifier)`. The store keeps the `selector` (non-secret, indexed) and `verifier_hash
+//!   = sha256(verifier)`. Redemption fetches the row `WHERE selector = $1` — no secret in the
+//!   `WHERE`, so the lookup is not an existence oracle — then compares the SHA-256 of the presented
+//!   verifier against the stored hash in **constant time** ([`ConstantTimeOps::compare`]).
 //! - **Single-use.** A `used_at` column is stamped atomically on redemption (`UPDATE … WHERE
 //!   used_at IS NULL AND expires_at > now()`); a concurrent second redemption sees zero affected
 //!   rows and is rejected. On success the user's *other* outstanding tokens are invalidated too.
@@ -46,12 +43,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Duration, Utc};
-use sha2::{Digest, Sha256};
 use sqlx::Row;
 
-use super::{LOCAL_PROVIDER, LocalPasswordAuthenticator, db_error, validate_password};
+use super::{
+    LOCAL_PROVIDER, LocalPasswordAuthenticator, db_error, opaque_token::OpaqueToken,
+    validate_password,
+};
 use crate::{
     account_linking::normalize_email,
     audit::logger::{AuditEventType, SecretType, get_audit_logger},
@@ -63,10 +61,8 @@ use crate::{
 /// Reset-token lifetime in seconds (1 hour, per #367).
 pub const RESET_TOKEN_TTL_SECS: i64 = 3600;
 
-/// Selector length in bytes (the non-secret, indexed lookup key).
-const SELECTOR_LEN: usize = 16;
-/// Verifier length in bytes (the secret; only its SHA-256 is stored).
-const VERIFIER_LEN: usize = 32;
+/// Flow label carried into [`OpaqueToken::parse`]'s diagnostic reasons.
+const TOKEN_KIND: &str = "reset";
 
 /// Idempotent DDL for the password-reset token store.
 ///
@@ -127,81 +123,6 @@ pub trait ResetEmailSender: Send + Sync {
     /// spawned task and only logs failures, so an error never leaks account existence to
     /// the requester.
     async fn send_reset_link(&self, to: &str, token: &str) -> Result<()>;
-}
-
-/// A freshly generated reset token: a non-secret selector plus a secret verifier.
-struct ResetToken {
-    selector: [u8; SELECTOR_LEN],
-    verifier: [u8; VERIFIER_LEN],
-}
-
-/// The redemption-relevant parts of a presented token: the selector (for lookup) and the
-/// SHA-256 of the verifier (for constant-time comparison against the stored hash).
-struct ParsedToken {
-    selector:      String,
-    verifier_hash: Vec<u8>,
-}
-
-impl ResetToken {
-    /// Generate a token from the OS-seeded CSPRNG ([`rand::rng`], as used for refresh
-    /// tokens).
-    fn generate() -> Self {
-        use rand::RngCore as _;
-        let mut selector = [0u8; SELECTOR_LEN];
-        let mut verifier = [0u8; VERIFIER_LEN];
-        rand::rng().fill_bytes(&mut selector);
-        rand::rng().fill_bytes(&mut verifier);
-        Self { selector, verifier }
-    }
-
-    /// The base64url selector, stored as the indexed lookup key.
-    fn selector_b64(&self) -> String {
-        URL_SAFE_NO_PAD.encode(self.selector)
-    }
-
-    /// SHA-256 of the verifier, the only verifier-derived value persisted.
-    fn verifier_hash(&self) -> Vec<u8> {
-        Sha256::digest(self.verifier).to_vec()
-    }
-
-    /// The opaque token string handed to the user: `selector "." verifier`.
-    fn to_token_string(&self) -> String {
-        format!(
-            "{}.{}",
-            URL_SAFE_NO_PAD.encode(self.selector),
-            URL_SAFE_NO_PAD.encode(self.verifier)
-        )
-    }
-
-    /// Parse a presented token into its lookup selector and verifier hash.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AuthError::InvalidToken`] if the token is not `selector.verifier`, either
-    /// half is not valid base64url, or either decodes to the wrong length.
-    fn parse(token: &str) -> Result<ParsedToken> {
-        let (selector_b64, verifier_b64) =
-            token.split_once('.').ok_or_else(|| AuthError::InvalidToken {
-                reason: "reset token is not in selector.verifier form".to_string(),
-            })?;
-        let selector =
-            URL_SAFE_NO_PAD.decode(selector_b64).map_err(|_| AuthError::InvalidToken {
-                reason: "reset token selector is not valid base64url".to_string(),
-            })?;
-        let verifier =
-            URL_SAFE_NO_PAD.decode(verifier_b64).map_err(|_| AuthError::InvalidToken {
-                reason: "reset token verifier is not valid base64url".to_string(),
-            })?;
-        if selector.len() != SELECTOR_LEN || verifier.len() != VERIFIER_LEN {
-            return Err(AuthError::InvalidToken {
-                reason: "reset token has an unexpected length".to_string(),
-            });
-        }
-        Ok(ParsedToken {
-            selector:      selector_b64.to_string(),
-            verifier_hash: Sha256::digest(&verifier).to_vec(),
-        })
-    }
 }
 
 /// The generic error returned to the caller for any unredeemable token. The precise
@@ -277,7 +198,7 @@ impl LocalPasswordAuthenticator {
         let fk_user: i64 = row.get("fk_user");
         let user_id: String = row.get("user_id");
 
-        let token = ResetToken::generate();
+        let token = OpaqueToken::generate();
         let expires_at = Utc::now() + Duration::seconds(RESET_TOKEN_TTL_SECS);
 
         sqlx::query(
@@ -338,7 +259,7 @@ impl LocalPasswordAuthenticator {
         validate_password(new_password)?;
         let logger = get_audit_logger();
 
-        let Ok(parsed) = ResetToken::parse(token) else {
+        let Ok(parsed) = OpaqueToken::parse(TOKEN_KIND, token) else {
             logger.log_failure(
                 AuditEventType::AuthFailure,
                 SecretType::SessionToken,
@@ -492,7 +413,3 @@ impl LocalPasswordAuthenticator {
         Ok(())
     }
 }
-
-#[allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
-#[cfg(test)]
-mod tests;

--- a/crates/fraiseql-auth/src/local_password/routes/mod.rs
+++ b/crates/fraiseql-auth/src/local_password/routes/mod.rs
@@ -11,6 +11,14 @@
 //! - `POST /auth/v1/password/login` — verify credentials, return session tokens.
 //! - `POST /auth/v1/password/reset` — start a reset. Always 202, never enumerable.
 //! - `POST /auth/v1/password/reset/confirm` — redeem the token and set a new password.
+//! - `POST /auth/v1/email/verify/start` — mail a verification link to the caller's own address.
+//! - `POST /auth/v1/email/verify/confirm` — redeem it, promoting the account to verified (#945).
+//!
+//! The two verification routes form their own group
+//! ([`email_verification_routes`]) mounted by `[auth.local] email_verification`, and
+//! are the only routes here that require an authenticated caller: both act on the
+//! account the bearer token was minted for, resolved through
+//! [`SessionBearerAuthenticator`] rather than read from the request body.
 //!
 //! # Security
 //!
@@ -26,7 +34,7 @@ use std::{net::SocketAddr, sync::Arc};
 use axum::{
     Json, Router,
     extract::{ConnectInfo, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::post,
 };
@@ -38,6 +46,7 @@ use crate::{
     error::AuthError,
     rate_limiting::RateLimiters,
     session::{SessionStore, unix_now},
+    session_bearer::SessionBearerAuthenticator,
 };
 
 /// Session lifetime granted by a successful password signup/login (1 hour), matching
@@ -279,6 +288,195 @@ pub async fn password_reset_confirm(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "invalid_token",
                 "invalid, expired, or already-used reset token",
+            )
+        },
+    }
+}
+
+// ─── Email verification (#945) ────────────────────────────────────────────────
+
+/// Axum state for the email-verification routes.
+///
+/// Separate from [`LocalPasswordRouteState`] because the group mounts on its own
+/// `[auth.local] email_verification` switch and needs one thing the password routes
+/// do not: a way to learn *who* is calling.
+#[derive(Clone)]
+pub struct EmailVerificationRouteState {
+    /// The authenticator (owns the verification token store and the promotion gate).
+    pub authenticator:  Arc<LocalPasswordAuthenticator>,
+    /// Resolves the caller's `user_id` from the request's bearer session token.
+    pub session_bearer: Arc<SessionBearerAuthenticator>,
+    /// Per-IP limiters; the `auth_start` bucket governs both routes.
+    pub rate_limiters:  Arc<RateLimiters>,
+}
+
+/// Body of `POST /auth/v1/email/verify/confirm`.
+#[derive(Debug, Deserialize)]
+pub struct EmailVerifyConfirmRequest {
+    /// The opaque token from the verification link.
+    pub token: String,
+}
+
+/// Build the email-verification route group.
+#[allow(clippy::missing_panics_doc)] // Reason: infallible — no path capture syntax to reject
+pub fn email_verification_routes(state: Arc<EmailVerificationRouteState>) -> Router {
+    Router::new()
+        .route("/auth/v1/email/verify/start", post(email_verify_start))
+        .route("/auth/v1/email/verify/confirm", post(email_verify_confirm))
+        .with_state(state)
+}
+
+/// Enforce the per-IP `auth_start` budget for the verification group.
+fn verify_rate_limit(
+    state: &EmailVerificationRouteState,
+    addr: SocketAddr,
+    op: &str,
+) -> Option<Response> {
+    let client_ip = addr.ip().to_string();
+    if state.rate_limiters.auth_start.check(&client_ip).is_ok() {
+        return None;
+    }
+    let retry_after = state.rate_limiters.auth_start.clone_config().window_secs;
+    get_audit_logger().log_failure(
+        AuditEventType::AuthFailure,
+        SecretType::SessionToken,
+        None,
+        op,
+        "rate limited",
+    );
+    Some(
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(axum::http::header::RETRY_AFTER, retry_after.to_string())],
+            Json(serde_json::json!({
+                "error":   "rate_limited",
+                "message": "Too many attempts; please retry later"
+            })),
+        )
+            .into_response(),
+    )
+}
+
+/// Resolve the caller, or render the `401`.
+// Reason: the boxed `Response` keeps the Err variant small (clippy::result_large_err).
+fn caller(
+    state: &EmailVerificationRouteState,
+    headers: &HeaderMap,
+    op: &str,
+) -> Result<String, Box<Response>> {
+    state.session_bearer.subject(headers).map_err(|e| {
+        get_audit_logger().log_failure(
+            AuditEventType::AuthFailure,
+            SecretType::SessionToken,
+            None,
+            op,
+            &e.to_string(),
+        );
+        Box::new(
+            (
+                StatusCode::UNAUTHORIZED,
+                [(axum::http::header::WWW_AUTHENTICATE, "Bearer")],
+                Json(serde_json::json!({
+                    "error":   "unauthenticated",
+                    "message": "a valid session is required"
+                })),
+            )
+                .into_response(),
+        )
+    })
+}
+
+/// `POST /auth/v1/email/verify/start`
+///
+/// Mails a verification link to the address the caller's own local identity claims.
+/// The address is never taken from the request, so this cannot aim a mail at an
+/// address the account does not already claim.
+///
+/// **Always** `202 Accepted` for an authenticated caller: an account with no local
+/// identity, one already verified, and one that was just sent a link are
+/// indistinguishable.
+///
+/// # Errors
+///
+/// `401` without a valid session, `429` when rate-limited. Infrastructure failures
+/// are logged and still return `202`.
+pub async fn email_verify_start(
+    State(state): State<Arc<EmailVerificationRouteState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Response {
+    if let Some(limited) = verify_rate_limit(&state, addr, "email_verify_start") {
+        return limited;
+    }
+    let user_id = match caller(&state, &headers, "email_verify_start") {
+        Ok(user_id) => user_id,
+        Err(unauthorized) => return *unauthorized,
+    };
+    if let Err(e) = state.authenticator.start_email_verification(&user_id).await {
+        tracing::error!(error = %e, "email verification start failed");
+    }
+    (
+        StatusCode::ACCEPTED,
+        Json(serde_json::json!({
+            "message": "If this account has an unverified address, a verification link has been \
+                        sent to it."
+        })),
+    )
+        .into_response()
+}
+
+/// `POST /auth/v1/email/verify/confirm`
+///
+/// Redeems a verification token **for the calling account**. Both halves are
+/// required: the token proves control of the mailbox, the session proves ownership
+/// of the account. A token issued to a different account is rejected exactly like a
+/// forged one.
+///
+/// # Errors
+///
+/// `401` without a valid session; `409` when the address is already verified on
+/// another account (the merge refusal, #945); `422` for an invalid, expired or
+/// already-used token; `429` when rate-limited.
+pub async fn email_verify_confirm(
+    State(state): State<Arc<EmailVerificationRouteState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(req): Json<EmailVerifyConfirmRequest>,
+) -> Response {
+    if let Some(limited) = verify_rate_limit(&state, addr, "email_verify_confirm") {
+        return limited;
+    }
+    let user_id = match caller(&state, &headers, "email_verify_confirm") {
+        Ok(user_id) => user_id,
+        Err(unauthorized) => return *unauthorized,
+    };
+    match state.authenticator.confirm_email_verification(&user_id, &req.token).await {
+        Ok(verified) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "verified": true,
+                "email":    verified.email,
+                "user_id":  verified.user_id,
+            })),
+        )
+            .into_response(),
+        // Reporting this plainly is safe: reaching it required proving control of the
+        // address, so it discloses nothing the caller had not already established.
+        Err(e @ AuthError::EmailClaimedByAnotherAccount) => {
+            json_error(StatusCode::CONFLICT, "email_claimed_by_another_account", &e.to_string())
+        },
+        Err(e) => {
+            get_audit_logger().log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::CsrfToken,
+                Some(user_id),
+                "email_verify_confirm",
+                &e.to_string(),
+            );
+            json_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "invalid_token",
+                "invalid, expired, or already-used verification token",
             )
         },
     }

--- a/crates/fraiseql-auth/src/local_password/verification.rs
+++ b/crates/fraiseql-auth/src/local_password/verification.rs
@@ -1,0 +1,556 @@
+//! Email verification for local email + password accounts (#945).
+//!
+//! Before this, `FraiseQL` could only *consume* a verification claim someone else
+//! asserted — a social provider's `email_verified`, gated by
+//! [`TrustedEmailProviders`](crate::TrustedEmailProviders), or a completed email `OTP`.
+//! A local-password signup passes `email_verified = false` (deliberately fail-closed),
+//! which keys the identity on `(local, <email>)` and leaves `core.tb_user.email` `NULL`
+//! forever: the account could never *become* verified, so the same person's password and
+//! Google sign-ins stayed two accounts with no way to join them.
+//!
+//! This module issues the claim. A token is mailed to the address the account claims;
+//! presenting it back proves control of that mailbox, which promotes the account's own
+//! row into the merge-able `email:<normalized>` key space. A later trusted social
+//! sign-in for the same address then links into it through the ordinary
+//! [`AccountStore::link_or_create_user`](crate::AccountStore::link_or_create_user) path
+//! — no new merge machinery, and the one account the user expected.
+//!
+//! # Security model
+//!
+//! - **Token discipline** — the same selector + verifier codec password reset uses: plaintext
+//!   selector indexed, `sha256(verifier)` stored, constant-time comparison, single-use `used_at`
+//!   stamped atomically, one-hour TTL ([`EMAIL_VERIFICATION_TOKEN_TTL_SECS`]). The token row also
+//!   stores the **address it was mailed to**, so confirmation promotes exactly the address whose
+//!   mailbox was proved, never one re-derived at redemption time.
+//! - **Both halves are required.** `confirm` needs the token *and* an authenticated caller, and the
+//!   token's subject must equal the caller's `user_id`
+//!   ([`LocalPasswordAuthenticator::confirm_email_verification`]). The token alone proves mailbox
+//!   control; the session proves account ownership. This is what defeats the confused-deputy shape:
+//!   an attacker who signs up a local account under a victim's address causes a verification mail
+//!   to land in the *victim's* inbox, and a victim who clicks it is not authenticated as the
+//!   attacker, so the confirmation fails closed.
+//! - **Promotion never absorbs another account** — see [`decide_promotion`], which is the gate.
+//!
+//! # Why there is no merge-into-an-existing-account path
+//!
+//! The obvious extension is: on confirm, if some *other* account already holds this
+//! verified email, merge the two. That is refused, permanently and loudly
+//! ([`AuthError::EmailClaimedByAnotherAccount`]), because the merge would move the local
+//! account's password credential — chosen by whoever ran signup — onto an account it did
+//! not previously reach. Signup for an arbitrary address is open by design (it keys on
+//! `(local, email)` and is harmless precisely *because* it can never merge), so the merge
+//! would complete this chain: sign up under `victim@example.com`, obtain the mailed code
+//! once, and inherit the victim's existing Google-keyed account together with everything
+//! on it.
+//!
+//! The promotion this module *does* perform has no such reach: it writes one address onto
+//! the caller's own user row and moves no credential anywhere. The ordering the issue
+//! actually describes — password signup first, social sign-in later — is served by it
+//! exactly. The reverse ordering (social first, password second) is left to the safe
+//! direction, which is to add a password from inside an authenticated session rather than
+//! to pull an account toward an outside credential.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use sqlx::Row;
+
+use super::{LOCAL_PROVIDER, LocalPasswordAuthenticator, db_error, opaque_token::OpaqueToken};
+use crate::{
+    audit::logger::{AuditEventType, SecretType, get_audit_logger},
+    constant_time::ConstantTimeOps,
+    error::{AuthError, Result},
+};
+
+/// Verification-token lifetime in seconds (1 hour).
+///
+/// The same bound as [`RESET_TOKEN_TTL_SECS`](super::RESET_TOKEN_TTL_SECS), and for the
+/// same reason: redemption performs an account-state change, so the window in which a
+/// leaked mail is actionable stays short. Re-issuing is a single authenticated call, so
+/// the strict bound costs a user nothing but a second click.
+pub const EMAIL_VERIFICATION_TOKEN_TTL_SECS: i64 = 3600;
+
+/// Flow label carried into [`OpaqueToken::parse`]'s diagnostic reasons.
+const TOKEN_KIND: &str = "email verification";
+
+/// Idempotent DDL for the email-verification token store.
+///
+/// Exposed so a migration runner can apply it explicitly;
+/// [`LocalPasswordAuthenticator::init`](super::LocalPasswordAuthenticator::init) runs it
+/// after the #411 identity DDL (the table FK-references `core.tb_user`). Mirrors
+/// `core.tb_password_reset_token`: Trinity `pk_`/`id` columns, deny-by-default RLS
+/// (`ENABLE`, not `FORCE`, so the owning store bypasses while any other role reads zero
+/// rows without the `fraiseql.tenant_id` GUC), and `REVOKE ALL … FROM PUBLIC`.
+///
+/// The one column the reset table does not have is `email`: the address the token was
+/// mailed to. Storing it binds the proof to a specific mailbox rather than to whatever
+/// the identity happens to say at redemption time.
+pub const EMAIL_VERIFICATION_SCHEMA_SQL: &str = r"
+CREATE SCHEMA IF NOT EXISTS core;
+
+CREATE TABLE IF NOT EXISTS core.tb_email_verification_token (
+    pk_email_verification_token BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id            UUID NOT NULL DEFAULT gen_random_uuid(),
+    fk_user       BIGINT NOT NULL REFERENCES core.tb_user (pk_user) ON DELETE CASCADE,
+    user_id       TEXT NOT NULL,
+    email         TEXT NOT NULL,
+    selector      TEXT NOT NULL,
+    verifier_hash BYTEA NOT NULL,
+    expires_at    TIMESTAMPTZ NOT NULL,
+    used_at       TIMESTAMPTZ,
+    tenant_id     UUID,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (selector)
+);
+CREATE INDEX IF NOT EXISTS idx_email_verification_token_fk_user
+    ON core.tb_email_verification_token (fk_user);
+
+-- RLS deny-by-default (mirrors core.tb_user / core.tb_auth_identity / tb_password_reset_token).
+ALTER TABLE core.tb_email_verification_token ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS p_email_verification_token_tenant_read ON core.tb_email_verification_token;
+CREATE POLICY p_email_verification_token_tenant_read ON core.tb_email_verification_token
+    FOR SELECT USING (tenant_id = NULLIF(current_setting('fraiseql.tenant_id', true), '')::uuid);
+DROP POLICY IF EXISTS p_email_verification_token_insert ON core.tb_email_verification_token;
+CREATE POLICY p_email_verification_token_insert ON core.tb_email_verification_token
+    FOR INSERT WITH CHECK (true);
+
+-- Least-privilege baseline: never world-readable. RLS is defence-in-depth on top.
+REVOKE ALL ON core.tb_email_verification_token FROM PUBLIC;
+";
+
+/// Delivers an email-verification link to the address being verified.
+///
+/// Defined in `fraiseql-auth` so the flow stays transport-agnostic and fully
+/// unit-testable; the server provides the concrete implementation over the
+/// `[auth.local] email_from` mailbox. The `token` is the full opaque token to embed in
+/// the link — it is never persisted (only its selector and verifier hash are).
+// async_trait: dyn-dispatch required (Arc<dyn VerificationEmailSender>); remove when
+// RTN + Send is stable (RFC 3425)
+#[async_trait]
+pub trait VerificationEmailSender: Send + Sync {
+    /// Send the verification link carrying `token` to `to`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AuthError`] if delivery fails. The flow dispatches this in a spawned
+    /// task and only logs failures, so a bad relay never turns into a caller-visible
+    /// signal about account state.
+    async fn send_verification_link(&self, to: &str, token: &str) -> Result<()>;
+}
+
+/// What [`LocalPasswordAuthenticator::confirm_email_verification`] settled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmailVerified {
+    /// The account whose row now carries the verified address. Always the caller's own
+    /// `user_id` — this flow never returns a different account than the one that asked.
+    pub user_id: String,
+    /// The normalized address that is now verified.
+    pub email:   String,
+}
+
+/// The outcome of the promotion gate — what confirming a proved mailbox may do to the
+/// account's `core.tb_user.email`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromotionDecision {
+    /// The address is unclaimed and the account has no verified address yet: write it.
+    /// The account enters the merge-able `email:<normalized>` key space, where a later
+    /// trusted social sign-in for the same address links into it.
+    Promote,
+    /// The account already carries exactly this address. Confirming again is a no-op
+    /// success, so a double-clicked link does not read as a failure.
+    AlreadyVerified,
+    /// **The security refusal.** Another account already holds this verified address, so
+    /// promoting would put two accounts in one key slot — and the only way to resolve
+    /// that is a merge, which would carry this account's password credential onto the
+    /// other one. See the module docs for why that chain is refused rather than gated.
+    RefuseClaimedByAnotherAccount,
+    /// The account already has a *different* verified address. A verified address is the
+    /// account's linking key, and this flow does not re-key an account: doing so would
+    /// silently move it out of the key space a previous trusted sign-in placed it in.
+    RefuseAccountHasDifferentEmail,
+}
+
+/// The promotion gate: given the account's current verified address, the address whose
+/// mailbox was just proved, and whether any *other* account already holds that address,
+/// decide what may be written.
+///
+/// This is a pure function on purpose — it is the security-relevant decision of the whole
+/// flow, so it is stated once, unit-tested exhaustively, and consulted by the one caller
+/// rather than being spread across SQL branches. It mirrors
+/// [`effective_saml_email_verified`](crate::saml::effective_saml_email_verified), which
+/// does the same job for the SAML path.
+///
+/// The refusal is checked **first**: a claimed address is refused whatever state the
+/// caller's own account is in.
+#[must_use]
+pub fn decide_promotion(
+    account_email: Option<&str>,
+    proved_email: &str,
+    claimed_by_other_account: bool,
+) -> PromotionDecision {
+    if claimed_by_other_account {
+        return PromotionDecision::RefuseClaimedByAnotherAccount;
+    }
+    match account_email {
+        None => PromotionDecision::Promote,
+        Some(existing) if existing == proved_email => PromotionDecision::AlreadyVerified,
+        Some(_) => PromotionDecision::RefuseAccountHasDifferentEmail,
+    }
+}
+
+/// The generic error returned to the caller for any unredeemable token. The precise
+/// reason is recorded in the audit log, never disclosed to the caller.
+fn invalid_verification_token() -> AuthError {
+    AuthError::InvalidToken {
+        reason: "invalid, expired, or already-used email verification token".to_string(),
+    }
+}
+
+impl LocalPasswordAuthenticator {
+    /// Attach the [`VerificationEmailSender`] used to deliver verification links.
+    ///
+    /// Without it, [`start_email_verification`](Self::start_email_verification) still
+    /// issues and persists a token but logs a warning instead of delivering it.
+    #[must_use]
+    pub fn with_verification_email_sender(
+        mut self,
+        sender: Arc<dyn VerificationEmailSender>,
+    ) -> Self {
+        self.verification_sender = Some(sender);
+        self
+    }
+
+    /// Begin email verification for the authenticated account `user_id`.
+    ///
+    /// The address is taken from the account's **own local identity**, never from the
+    /// request: a caller cannot aim a verification mail at an address their account does
+    /// not already claim. An account with no local identity, or one already verified for
+    /// that address, is a silent no-op — the caller cannot tell the three apart, so this
+    /// is not a probe for another account's state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::DatabaseError`] only on infrastructure failure — never
+    /// "no such account".
+    pub async fn start_email_verification(&self, user_id: &str) -> Result<()> {
+        let logger = get_audit_logger();
+
+        let row = sqlx::query(
+            "SELECT u.pk_user, u.email AS verified_email, i.provider_id AS claimed_email \
+             FROM core.tb_user u \
+             JOIN core.tb_auth_identity i ON i.fk_user = u.pk_user \
+             WHERE u.user_id = $1 AND i.provider = $2",
+        )
+        .bind(user_id)
+        .bind(LOCAL_PROVIDER)
+        .fetch_optional(&self.db)
+        .await
+        .map_err(|e| db_error("lookup local identity for verification", &e))?;
+
+        let Some(row) = row else {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_start",
+                "no_local_identity",
+            );
+            return Ok(());
+        };
+
+        let fk_user: i64 = row.get("pk_user");
+        let verified_email: Option<String> = row.get("verified_email");
+        let claimed_email: String = row.get("claimed_email");
+
+        if verified_email.as_deref() == Some(claimed_email.as_str()) {
+            logger.log_success(
+                AuditEventType::AuthSuccess,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_start:already_verified",
+            );
+            return Ok(());
+        }
+
+        let token = OpaqueToken::generate();
+        let expires_at = Utc::now() + Duration::seconds(EMAIL_VERIFICATION_TOKEN_TTL_SECS);
+
+        sqlx::query(
+            "INSERT INTO core.tb_email_verification_token \
+             (fk_user, user_id, email, selector, verifier_hash, expires_at) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(fk_user)
+        .bind(user_id)
+        .bind(&claimed_email)
+        .bind(token.selector_b64())
+        .bind(token.verifier_hash())
+        .bind(expires_at)
+        .execute(&self.db)
+        .await
+        .map_err(|e| db_error("insert verification token", &e))?;
+
+        // Dispatch in a spawned task: a slow or failing relay must not become a
+        // caller-visible signal, and delivery failure is logged rather than surfaced.
+        if let Some(sender) = self.verification_sender.clone() {
+            let to = claimed_email;
+            let token_str = token.to_token_string();
+            tokio::spawn(async move {
+                if let Err(e) = sender.send_verification_link(&to, &token_str).await {
+                    tracing::warn!(
+                        "email_verification_start: verification email dispatch failed: {e}"
+                    );
+                }
+            });
+        } else {
+            tracing::warn!(
+                "email_verification_start: token issued but no VerificationEmailSender is \
+                 configured; the verification link was not delivered"
+            );
+        }
+
+        logger.log_success(
+            AuditEventType::AuthSuccess,
+            SecretType::SessionToken,
+            Some(user_id.to_string()),
+            "email_verification_start",
+        );
+        Ok(())
+    }
+
+    /// Redeem a verification `token` on behalf of the authenticated account `user_id`.
+    ///
+    /// Both halves are required and must agree: the token proves control of the mailbox,
+    /// `user_id` proves the caller owns the account the token was issued for. A token
+    /// presented by anyone else is rejected exactly like a forged one.
+    ///
+    /// On success the proved address is written to the account's `core.tb_user.email`,
+    /// which is what places it in the cross-provider linking key space. No rows move
+    /// between accounts — see [`decide_promotion`] and the module docs.
+    ///
+    /// The token is consumed on **every** decided outcome, refusals included: the refusal
+    /// is deterministic, so leaving the token live would only offer a replay surface.
+    ///
+    /// # Errors
+    ///
+    /// - [`AuthError::InvalidToken`] for any unredeemable token (unknown / malformed / expired /
+    ///   used / wrong verifier / issued to a different account) — one generic error; the audit log
+    ///   records which.
+    /// - [`AuthError::EmailClaimedByAnotherAccount`] when another account already holds the proved
+    ///   address, or when this account already has a different verified address.
+    /// - [`AuthError::DatabaseError`] / [`AuthError::Internal`] on a storage failure.
+    pub async fn confirm_email_verification(
+        &self,
+        user_id: &str,
+        token: &str,
+    ) -> Result<EmailVerified> {
+        let logger = get_audit_logger();
+
+        let Ok(parsed) = OpaqueToken::parse(TOKEN_KIND, token) else {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "malformed_token",
+            );
+            return Err(invalid_verification_token());
+        };
+
+        let row = sqlx::query(
+            "SELECT pk_email_verification_token AS pk, fk_user, user_id, email, verifier_hash, \
+                    expires_at, used_at \
+             FROM core.tb_email_verification_token WHERE selector = $1",
+        )
+        .bind(&parsed.selector)
+        .fetch_optional(&self.db)
+        .await
+        .map_err(|e| db_error("lookup verification token", &e))?;
+
+        let Some(row) = row else {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "unknown_selector",
+            );
+            return Err(invalid_verification_token());
+        };
+
+        let pk: i64 = row.get("pk");
+        let fk_user: i64 = row.get("fk_user");
+        let token_user_id: String = row.get("user_id");
+        let email: String = row.get("email");
+        let stored_hash: Vec<u8> = row.get("verifier_hash");
+        let expires_at: DateTime<Utc> = row.get("expires_at");
+        let used_at: Option<DateTime<Utc>> = row.get("used_at");
+
+        // Constant-time verifier comparison. The selector is high-entropy and known to
+        // the holder, so an early return on a missing row leaks nothing; the secret check
+        // is the verifier hash, which is always compared in constant time when a row
+        // exists.
+        if !ConstantTimeOps::compare(&stored_hash, &parsed.verifier_hash) {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "bad_verifier",
+            );
+            return Err(invalid_verification_token());
+        }
+
+        // The session half. A valid token presented by an account it was not issued to is
+        // the confused-deputy shape this flow exists to refuse: the mail lands in the
+        // address owner's inbox, and only the account that asked for it may spend it.
+        if token_user_id != user_id {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "wrong_subject",
+            );
+            return Err(invalid_verification_token());
+        }
+
+        if used_at.is_some() {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "used",
+            );
+            return Err(invalid_verification_token());
+        }
+        if expires_at <= Utc::now() {
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "expired",
+            );
+            return Err(invalid_verification_token());
+        }
+
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| db_error("begin verification transaction", &e))?;
+
+        // Atomic single-use guard: mark THIS token used only if still unused and
+        // unexpired. A concurrent redemption that already consumed it affects zero rows.
+        let consumed = sqlx::query(
+            "UPDATE core.tb_email_verification_token SET used_at = now() \
+             WHERE pk_email_verification_token = $1 AND used_at IS NULL AND expires_at > now()",
+        )
+        .bind(pk)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| db_error("consume verification token", &e))?;
+
+        if consumed.rows_affected() == 0 {
+            tx.rollback().await.map_err(|e| db_error("rollback verification", &e))?;
+            logger.log_failure(
+                AuditEventType::AuthFailure,
+                SecretType::SessionToken,
+                Some(user_id.to_string()),
+                "email_verification_confirm",
+                "race",
+            );
+            return Err(invalid_verification_token());
+        }
+
+        // Lock the account row so the gate below decides against state that cannot move
+        // out from under it, then ask whether any *other* account holds the address.
+        let account_email: Option<String> =
+            sqlx::query("SELECT email FROM core.tb_user WHERE pk_user = $1 FOR UPDATE")
+                .bind(fk_user)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| db_error("lock user row", &e))?
+                .ok_or_else(|| AuthError::Internal {
+                    message: "verification token resolved to a missing user row".to_string(),
+                })?
+                .get("email");
+
+        let claimed_by_other =
+            sqlx::query("SELECT 1 AS claimed FROM core.tb_user WHERE email = $1 AND pk_user <> $2")
+                .bind(&email)
+                .bind(fk_user)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| db_error("check email ownership", &e))?
+                .is_some();
+
+        let decision = decide_promotion(account_email.as_deref(), &email, claimed_by_other);
+
+        match decision {
+            PromotionDecision::Promote => {
+                sqlx::query(
+                    "UPDATE core.tb_user SET email = $1, updated_at = now() WHERE pk_user = $2",
+                )
+                .bind(&email)
+                .bind(fk_user)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| db_error("promote verified email", &e))?;
+            },
+            PromotionDecision::AlreadyVerified => {},
+            PromotionDecision::RefuseClaimedByAnotherAccount
+            | PromotionDecision::RefuseAccountHasDifferentEmail => {
+                // Commit so the spent token stays spent, then refuse. Rolling back would
+                // hand the presenter an unlimited-retry token for a decision that cannot
+                // change on its own.
+                tx.commit().await.map_err(|e| db_error("commit verification refusal", &e))?;
+                logger.log_failure(
+                    AuditEventType::AuthFailure,
+                    SecretType::SessionToken,
+                    Some(user_id.to_string()),
+                    "email_verification_confirm",
+                    if decision == PromotionDecision::RefuseClaimedByAnotherAccount {
+                        "email_claimed_by_another_account"
+                    } else {
+                        "account_has_a_different_verified_email"
+                    },
+                );
+                return Err(AuthError::EmailClaimedByAnotherAccount);
+            },
+        }
+
+        // Invalidate the account's other outstanding verification tokens (the consumed
+        // one already has used_at set, so this excludes it).
+        sqlx::query(
+            "UPDATE core.tb_email_verification_token SET used_at = now() \
+             WHERE fk_user = $1 AND used_at IS NULL",
+        )
+        .bind(fk_user)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| db_error("invalidate sibling verification tokens", &e))?;
+
+        tx.commit().await.map_err(|e| db_error("commit verification transaction", &e))?;
+
+        logger.log_success(
+            AuditEventType::AuthSuccess,
+            SecretType::SessionToken,
+            Some(user_id.to_string()),
+            "email_verification_confirm",
+        );
+
+        Ok(EmailVerified {
+            user_id: user_id.to_string(),
+            email,
+        })
+    }
+}
+
+#[allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-auth/src/local_password/verification/tests.rs
+++ b/crates/fraiseql-auth/src/local_password/verification/tests.rs
@@ -1,0 +1,86 @@
+//! Unit tests for the promotion gate (no database).
+//!
+//! [`decide_promotion`] is the security-relevant decision of the whole flow, so its
+//! truth table is exhaustive here rather than sampled through the database path: the
+//! integration suite proves the SQL asks the gate the right question, and this proves
+//! the gate answers it correctly.
+
+use super::*;
+
+const ADDR: &str = "user@example.com";
+const OTHER_ADDR: &str = "someone-else@example.com";
+
+#[test]
+fn unclaimed_address_on_an_unverified_account_promotes() {
+    assert_eq!(decide_promotion(None, ADDR, false), PromotionDecision::Promote);
+}
+
+#[test]
+fn confirming_the_same_address_twice_is_a_no_op_success() {
+    assert_eq!(decide_promotion(Some(ADDR), ADDR, false), PromotionDecision::AlreadyVerified);
+}
+
+#[test]
+fn an_address_another_account_holds_is_refused() {
+    // The takeover refusal. Promoting here would put two accounts in one linking key
+    // slot, and the only resolution — a merge — would carry this account's password
+    // credential onto the other account.
+    assert_eq!(
+        decide_promotion(None, ADDR, true),
+        PromotionDecision::RefuseClaimedByAnotherAccount
+    );
+}
+
+#[test]
+fn the_claimed_refusal_wins_over_every_account_state() {
+    // Checked first, unconditionally: whatever this account already carries, an address
+    // another account holds is never written.
+    for account_email in [None, Some(ADDR), Some(OTHER_ADDR)] {
+        assert_eq!(
+            decide_promotion(account_email, ADDR, true),
+            PromotionDecision::RefuseClaimedByAnotherAccount,
+            "claimed address must refuse with account_email = {account_email:?}"
+        );
+    }
+}
+
+#[test]
+fn an_account_with_a_different_verified_address_is_not_rekeyed() {
+    // A verified address is the account's cross-provider linking key. Re-keying it here
+    // would silently move the account out of the key space a previous trusted sign-in
+    // placed it in.
+    assert_eq!(
+        decide_promotion(Some(OTHER_ADDR), ADDR, false),
+        PromotionDecision::RefuseAccountHasDifferentEmail
+    );
+}
+
+#[test]
+fn only_promote_and_already_verified_are_writeable_outcomes() {
+    // Guards the match in `confirm_email_verification`: every outcome that is not one of
+    // these two must refuse, so a future variant cannot default into writing an address.
+    let writeable = [
+        decide_promotion(None, ADDR, false),
+        decide_promotion(Some(ADDR), ADDR, false),
+    ];
+    for decision in writeable {
+        assert!(
+            matches!(decision, PromotionDecision::Promote | PromotionDecision::AlreadyVerified),
+            "{decision:?} must be a writeable outcome"
+        );
+    }
+    let refusals = [
+        decide_promotion(None, ADDR, true),
+        decide_promotion(Some(OTHER_ADDR), ADDR, false),
+    ];
+    for decision in refusals {
+        assert!(
+            matches!(
+                decision,
+                PromotionDecision::RefuseClaimedByAnotherAccount
+                    | PromotionDecision::RefuseAccountHasDifferentEmail
+            ),
+            "{decision:?} must be a refusal"
+        );
+    }
+}

--- a/crates/fraiseql-auth/src/middleware.rs
+++ b/crates/fraiseql-auth/src/middleware.rs
@@ -169,6 +169,13 @@ impl AuthError {
                 "email_already_registered",
                 "An account already exists for this email".to_string(),
             ),
+            // Safe to state plainly: reaching this requires having already proved
+            // control of the address, so it is not an existence oracle (#945).
+            Self::EmailClaimedByAnotherAccount => (
+                StatusCode::CONFLICT,
+                "email_claimed_by_another_account",
+                "That email address is already verified on another account".to_string(),
+            ),
             // The validation reason stays server-side; the client gets a generic message.
             Self::InvalidRegistration { .. } => (
                 StatusCode::BAD_REQUEST,
@@ -229,7 +236,8 @@ impl AuthError {
             | Self::RateLimited { .. }
             | Self::InvalidCredentials
             | Self::AccountDisabled
-            | Self::EmailAlreadyRegistered => {},
+            | Self::EmailAlreadyRegistered
+            | Self::EmailClaimedByAnotherAccount => {},
         }
     }
 }

--- a/crates/fraiseql-auth/src/session_bearer.rs
+++ b/crates/fraiseql-auth/src/session_bearer.rs
@@ -1,0 +1,100 @@
+//! Resolving *who is calling* a first-party auth route from its bearer token (#945).
+//!
+//! Sessions minted by [`PostgresSessionStore`](crate::PostgresSessionStore) carry the
+//! account's `user_id` in the access token's `sub`. Routes that act **on the caller's own
+//! account** — as email verification does — need that subject, and must not accept it
+//! from the request body: a handler that trusts a body-supplied `user_id` is not
+//! authenticated at all, it is a parameter.
+//!
+//! [`SessionBearerAuthenticator`] is that one seam. It validates the `Authorization:
+//! Bearer` header against the same HS256 secret, issuer and audience the session store
+//! signs with, and returns the subject — nothing else. It deliberately does not build a
+//! richer principal: the routes that use it authorize nothing beyond "this is the account
+//! the token was minted for".
+
+use axum::http::{HeaderMap, header};
+use jsonwebtoken::Algorithm;
+use zeroize::Zeroizing;
+
+use crate::{
+    error::{AuthError, Result},
+    jwt::JwtValidator,
+};
+
+/// Validates session access tokens and extracts the account they were minted for.
+///
+/// Construct it with the same `(secret, issuer, audience)` triple handed to
+/// [`PostgresSessionStore::with_hs256_secret`](crate::PostgresSessionStore::with_hs256_secret)
+/// and [`with_token_claims`](crate::PostgresSessionStore::with_token_claims) — a mismatch
+/// means every call fails closed with [`AuthError::InvalidToken`], never opens.
+pub struct SessionBearerAuthenticator {
+    validator: JwtValidator,
+    /// The HS256 signing secret, zeroized on drop.
+    secret:    Zeroizing<Vec<u8>>,
+}
+
+/// Hand-written rather than derived: the struct holds a signing secret, and a derived
+/// `Debug` would print it into any log line that formats the value.
+impl std::fmt::Debug for SessionBearerAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionBearerAuthenticator").finish_non_exhaustive()
+    }
+}
+
+impl SessionBearerAuthenticator {
+    /// Build an authenticator pinned to one issuer and audience.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::ConfigError`] if `issuer` or `audience` is empty — an
+    /// unpinned validator would accept a token minted for any service (the cross-service
+    /// replay shape #359 closed for the server's own validator).
+    pub fn new(secret: Vec<u8>, issuer: &str, audience: &str) -> Result<Self> {
+        if audience.is_empty() {
+            return Err(AuthError::ConfigError {
+                message: "SessionBearerAuthenticator requires a non-empty audience: an unpinned \
+                          validator accepts tokens minted for any service"
+                    .to_string(),
+            });
+        }
+        let validator = JwtValidator::new(issuer, Algorithm::HS256)?.with_audiences(&[audience])?;
+        Ok(Self {
+            validator,
+            secret: Zeroizing::new(secret),
+        })
+    }
+
+    /// Return the `user_id` the request's bearer token was minted for.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthError::InvalidToken`] when the `Authorization` header is absent,
+    /// not a `Bearer` credential, or carries an empty subject; and whatever
+    /// [`JwtValidator::validate_hmac`] returns (expired, bad signature, wrong issuer or
+    /// audience) otherwise.
+    pub fn subject(&self, headers: &HeaderMap) -> Result<String> {
+        let raw =
+            headers
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| AuthError::InvalidToken {
+                    reason: "missing Authorization header".to_string(),
+                })?;
+        // Scheme match is ASCII-case-insensitive per RFC 7235; the credential itself is not.
+        let token = raw
+            .split_once(' ')
+            .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("bearer"))
+            .map(|(_, token)| token.trim())
+            .ok_or_else(|| AuthError::InvalidToken {
+                reason: "Authorization header is not a Bearer credential".to_string(),
+            })?;
+
+        let claims = self.validator.validate_hmac(token, &self.secret)?;
+        if claims.sub.is_empty() {
+            return Err(AuthError::InvalidToken {
+                reason: "session token carries an empty subject".to_string(),
+            });
+        }
+        Ok(claims.sub)
+    }
+}

--- a/crates/fraiseql-auth/src/session_bearer_tests.rs
+++ b/crates/fraiseql-auth/src/session_bearer_tests.rs
@@ -1,0 +1,146 @@
+//! Unit tests for [`SessionBearerAuthenticator`] (no database).
+//!
+//! Every case here is a *refusal* except the round-trip: the point of this seam is that
+//! a route learns the caller's identity from a signature it can check, so anything that
+//! is not a valid session token for this issuer/audience must fail closed.
+
+use std::collections::HashMap;
+
+use axum::http::{HeaderMap, HeaderValue, header};
+
+use crate::{
+    error::AuthError,
+    jwt::{Claims, generate_hs256_token},
+    session_bearer::SessionBearerAuthenticator,
+};
+
+const SECRET: &[u8] = b"session-bearer-test-secret-32-bytes!!";
+const ISSUER: &str = "https://fraiseql.test";
+const AUDIENCE: &str = "fraiseql-session";
+const SUBJECT: &str = "user_0123456789abcdef";
+
+fn authenticator() -> SessionBearerAuthenticator {
+    SessionBearerAuthenticator::new(SECRET.to_vec(), ISSUER, AUDIENCE)
+        .expect("valid issuer + audience")
+}
+
+fn claims(sub: &str, issuer: &str, audience: &str) -> Claims {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs();
+    Claims {
+        sub:   sub.to_string(),
+        iat:   now,
+        exp:   now + 600,
+        nbf:   None,
+        iss:   issuer.to_string(),
+        aud:   vec![audience.to_string()],
+        extra: HashMap::new(),
+    }
+}
+
+fn bearer(token: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).expect("header value"),
+    );
+    headers
+}
+
+#[test]
+fn a_valid_session_token_yields_its_subject() {
+    let token = generate_hs256_token(&claims(SUBJECT, ISSUER, AUDIENCE), SECRET).unwrap();
+    assert_eq!(authenticator().subject(&bearer(&token)).unwrap(), SUBJECT);
+}
+
+#[test]
+fn the_bearer_scheme_match_is_case_insensitive() {
+    let token = generate_hs256_token(&claims(SUBJECT, ISSUER, AUDIENCE), SECRET).unwrap();
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("bearer {token}")).unwrap(),
+    );
+    assert_eq!(authenticator().subject(&headers).unwrap(), SUBJECT);
+}
+
+#[test]
+fn a_missing_authorization_header_is_refused() {
+    let err = authenticator().subject(&HeaderMap::new()).expect_err("no header must refuse");
+    assert!(matches!(err, AuthError::InvalidToken { .. }), "got {err:?}");
+}
+
+#[test]
+fn a_non_bearer_scheme_is_refused() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::AUTHORIZATION, HeaderValue::from_static("Basic dXNlcjpwYXNz"));
+    let err = authenticator().subject(&headers).expect_err("Basic must refuse");
+    assert!(matches!(err, AuthError::InvalidToken { .. }), "got {err:?}");
+}
+
+#[test]
+fn a_token_signed_with_another_secret_is_refused() {
+    let token =
+        generate_hs256_token(&claims(SUBJECT, ISSUER, AUDIENCE), b"a-completely-different-secret")
+            .unwrap();
+    assert!(
+        authenticator().subject(&bearer(&token)).is_err(),
+        "foreign signature must refuse"
+    );
+}
+
+#[test]
+fn a_token_for_another_audience_is_refused() {
+    // The cross-service replay shape: a valid, correctly-signed token minted for a
+    // different service must not authenticate here.
+    let token =
+        generate_hs256_token(&claims(SUBJECT, ISSUER, "some-other-service"), SECRET).unwrap();
+    assert!(
+        authenticator().subject(&bearer(&token)).is_err(),
+        "foreign audience must refuse"
+    );
+}
+
+#[test]
+fn a_token_from_another_issuer_is_refused() {
+    let token =
+        generate_hs256_token(&claims(SUBJECT, "https://elsewhere.test", AUDIENCE), SECRET).unwrap();
+    assert!(authenticator().subject(&bearer(&token)).is_err(), "foreign issuer must refuse");
+}
+
+#[test]
+fn an_expired_token_is_refused() {
+    let mut c = claims(SUBJECT, ISSUER, AUDIENCE);
+    c.exp = c.iat.saturating_sub(60);
+    let token = generate_hs256_token(&c, SECRET).unwrap();
+    assert!(authenticator().subject(&bearer(&token)).is_err(), "expired token must refuse");
+}
+
+#[test]
+fn a_token_with_an_empty_subject_is_refused() {
+    let token = generate_hs256_token(&claims("", ISSUER, AUDIENCE), SECRET).unwrap();
+    let err = authenticator().subject(&bearer(&token)).expect_err("empty sub must refuse");
+    assert!(matches!(err, AuthError::InvalidToken { .. }), "got {err:?}");
+}
+
+#[test]
+fn garbage_in_the_bearer_position_is_refused() {
+    assert!(authenticator().subject(&bearer("not-a-jwt")).is_err());
+}
+
+#[test]
+fn construction_refuses_an_empty_audience() {
+    // An unpinned validator accepts any non-empty `aud`, which is the replay shape.
+    let err = SessionBearerAuthenticator::new(SECRET.to_vec(), ISSUER, "")
+        .expect_err("empty audience must refuse");
+    assert!(matches!(err, AuthError::ConfigError { .. }), "got {err:?}");
+}
+
+#[test]
+fn construction_refuses_an_empty_issuer() {
+    let err = SessionBearerAuthenticator::new(SECRET.to_vec(), "", AUDIENCE)
+        .expect_err("empty issuer must refuse");
+    assert!(matches!(err, AuthError::ConfigError { .. }), "got {err:?}");
+}

--- a/crates/fraiseql-auth/tests/email_verification.rs
+++ b/crates/fraiseql-auth/tests/email_verification.rs
@@ -1,0 +1,644 @@
+//! Live-PostgreSQL integration tests for the #945 email-verification flow.
+//!
+//! Exercises `start_email_verification` / `confirm_email_verification` on
+//! [`LocalPasswordAuthenticator`] against the durable
+//! `core.tb_email_verification_token` schema (FK-linked to #411's `core.tb_user`):
+//! address-from-identity issuance, the token discipline shared with password reset
+//! (single-use, expiry, bad verifier), the **session binding** that makes a token alone
+//! insufficient, the promotion that puts a local account into the cross-provider linking
+//! key space, and — the reason this flow needed a phase of its own — the **bidirectional
+//! pre-hijack invariant** documented on
+//! [`TrustedEmailProviders`](fraiseql_auth::TrustedEmailProviders):
+//!
+//! - an attacker who pre-seeds an unverified local account under a victim's address must not absorb
+//!   the victim's later trusted sign-in, and
+//! - the reverse: a local account that later proves the mailbox must not absorb a trusted account
+//!   that already holds that address.
+//!
+//! The second direction is the new one. Verification moves an identity out of the
+//! `(provider, provider_id)` key space and into the merge-able `email:<normalized>` one,
+//! which is exactly the move the invariant constrains, so it is re-proved here against
+//! the real store rather than argued.
+//!
+//! Self-skips when no `DATABASE_URL` is set (no `#[ignore]`), so it is inert in the
+//! database-free `test` leg and runs in the Dagger `integration: postgres` suite, which
+//! binds Postgres and injects `DATABASE_URL`.
+//!
+//! **Execution engine:** PostgreSQL · **Infrastructure:** `DATABASE_URL` ·
+//! **Parallelism:** truncates the shared `core` tables on setup → run `--test-threads=1`.
+#![allow(clippy::unwrap_used, clippy::print_stderr, clippy::panic)] // Reason: test code — panics and skip diagnostics are acceptable
+#![allow(clippy::doc_markdown)] // Reason: technical terms (PostgreSQL, RLS) throughout the docs
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use fraiseql_auth::{
+    AccountStore, AuthError, LocalPasswordAuthenticator, PostgresAccountStore,
+    VerificationEmailSender,
+};
+use fraiseql_test_support::try_database_url;
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+
+/// The victim's address, and the one every takeover attempt targets.
+const VICTIM_EMAIL: &str = "victim@example.com";
+/// A policy-satisfying password (≥ 12 bytes).
+const PASSWORD: &str = "correct horse battery staple";
+/// Fast Argon2 cost (8 KiB, 1 pass) — correctness is parameter-independent.
+const FAST_M_COST: u32 = 8;
+/// A provider in the built-in trusted set, standing in for the victim's real sign-in.
+const TRUSTED_PROVIDER: &str = "google";
+
+/// Records every verification link it is asked to deliver, so a test can capture the token.
+#[derive(Default)]
+struct RecordingSender {
+    sent: Mutex<Vec<(String, String)>>,
+}
+
+#[async_trait]
+impl VerificationEmailSender for RecordingSender {
+    async fn send_verification_link(&self, to: &str, token: &str) -> Result<(), AuthError> {
+        self.sent.lock().unwrap().push((to.to_string(), token.to_string()));
+        Ok(())
+    }
+}
+
+/// A fully wired authenticator plus its recording sender, the account store the trusted
+/// sign-ins go through, and the admin pool.
+struct Harness {
+    auth:     LocalPasswordAuthenticator,
+    admin:    PgPool,
+    accounts: Arc<dyn AccountStore>,
+    sender:   Arc<RecordingSender>,
+}
+
+impl Harness {
+    /// Sign up a local password account and return its `user_id`.
+    async fn signup(&self, email: &str) -> String {
+        self.auth.signup(email, PASSWORD).await.unwrap()
+    }
+
+    /// Start verification for `user_id` and return the token that was mailed.
+    async fn issue_token(&self, user_id: &str) -> String {
+        let before = self.sender.sent.lock().unwrap().len();
+        self.auth.start_email_verification(user_id).await.unwrap();
+        for _ in 0..1000 {
+            let next = self.sender.sent.lock().unwrap().get(before).cloned();
+            if let Some((_, token)) = next {
+                return token;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("verification email was never dispatched");
+    }
+
+    /// A trusted-provider sign-in asserting a verified email — the path
+    /// `multi_provider::callback` takes for `google`/`apple`/`github`/`discord`.
+    async fn trusted_signin(&self, email: &str, provider_id: &str) -> String {
+        self.accounts
+            .link_or_create_user(Some(email), true, TRUSTED_PROVIDER, provider_id)
+            .await
+            .unwrap()
+            .user_id
+    }
+
+    /// The verified address on an account's `core.tb_user` row, if any.
+    async fn account_email(&self, user_id: &str) -> Option<String> {
+        sqlx::query("SELECT email FROM core.tb_user WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&self.admin)
+            .await
+            .unwrap()
+            .get("email")
+    }
+
+    /// How many accounts exist. The invariant tests care that a refusal leaves *two*.
+    async fn account_count(&self) -> i64 {
+        sqlx::query("SELECT count(*) FROM core.tb_user")
+            .fetch_one(&self.admin)
+            .await
+            .unwrap()
+            .get(0)
+    }
+
+    /// The providers linked to an account, in link order.
+    async fn linked_providers(&self, user_id: &str) -> Vec<String> {
+        sqlx::query(
+            "SELECT provider FROM core.tb_auth_identity WHERE user_id = $1 \
+             ORDER BY pk_auth_identity",
+        )
+        .bind(user_id)
+        .fetch_all(&self.admin)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| r.get::<String, _>("provider"))
+        .collect()
+    }
+}
+
+/// Connect as the superuser `DATABASE_URL`, ensure the schema exists, and truncate the
+/// `core` tables so each test starts clean. Returns `None` (skip) when unconfigured.
+async fn fresh() -> Option<Harness> {
+    let url = try_database_url()?;
+    let admin = PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap();
+    let accounts: Arc<dyn AccountStore> = Arc::new(PostgresAccountStore::new(admin.clone()));
+    let sender = Arc::new(RecordingSender::default());
+    let auth = LocalPasswordAuthenticator::with_params(
+        admin.clone(),
+        Arc::clone(&accounts),
+        FAST_M_COST,
+        1,
+        1,
+    )
+    .unwrap()
+    .with_verification_email_sender(sender.clone());
+    auth.init().await.unwrap();
+    sqlx::query(
+        "TRUNCATE core.tb_email_verification_token, core.tb_password_reset_token, \
+         core.tb_password_credential, core.tb_auth_identity, core.tb_user \
+         RESTART IDENTITY CASCADE",
+    )
+    .execute(&admin)
+    .await
+    .unwrap();
+    Some(Harness {
+        auth,
+        admin,
+        accounts,
+        sender,
+    })
+}
+
+macro_rules! skip_if_no_db {
+    () => {
+        match fresh().await {
+            Some(h) => h,
+            None => {
+                eprintln!("skipping #945 email-verification test: DATABASE_URL not set");
+                return;
+            },
+        }
+    };
+}
+
+async fn token_count(pool: &PgPool) -> i64 {
+    sqlx::query("SELECT count(*) FROM core.tb_email_verification_token")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .get(0)
+}
+
+/// Brief settle so a (non-)dispatch can be asserted absent without racing the spawn.
+async fn settle() {
+    for _ in 0..100 {
+        tokio::task::yield_now().await;
+    }
+}
+
+// ── schema ──────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn init_is_idempotent_and_creates_the_verification_table() {
+    let h = skip_if_no_db!();
+    // fresh() already called init once; a second call must not error.
+    h.auth.init().await.unwrap();
+    assert_eq!(
+        token_count(&h.admin).await,
+        0,
+        "the verification-token table exists and is empty"
+    );
+}
+
+#[tokio::test]
+async fn the_token_table_is_revoked_from_public_and_has_rls_enabled() {
+    let h = skip_if_no_db!();
+    let row = sqlx::query(
+        "SELECT relrowsecurity, has_table_privilege('public', c.oid, 'SELECT') AS public_select \
+         FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace \
+         WHERE n.nspname = 'core' AND c.relname = 'tb_email_verification_token'",
+    )
+    .fetch_one(&h.admin)
+    .await
+    .unwrap();
+    assert!(row.get::<bool, _>("relrowsecurity"), "RLS is enabled on the token table");
+    assert!(!row.get::<bool, _>("public_select"), "the token table is not world-readable");
+}
+
+// ── start ───────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn start_mails_the_address_the_account_itself_claims() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+
+    h.issue_token(&user_id).await;
+
+    let sent = h.sender.sent.lock().unwrap().clone();
+    assert_eq!(sent.len(), 1, "exactly one link was dispatched");
+    assert_eq!(sent[0].0, VICTIM_EMAIL, "delivered to the identity's own address");
+    assert!(sent[0].1.contains('.'), "the delivered token is selector.verifier");
+
+    // Persisted as selector + verifier hash bound to the address, never the raw token.
+    let row = sqlx::query(
+        "SELECT email, selector, verifier_hash, used_at, expires_at > now() AS live \
+         FROM core.tb_email_verification_token",
+    )
+    .fetch_one(&h.admin)
+    .await
+    .unwrap();
+    assert_eq!(
+        row.get::<String, _>("email"),
+        VICTIM_EMAIL,
+        "the token binds the mailed address"
+    );
+    assert!(
+        row.get::<Option<chrono::DateTime<chrono::Utc>>, _>("used_at").is_none(),
+        "unused"
+    );
+    assert!(row.get::<bool, _>("live"), "the token is within its TTL");
+    let (selector, _) = sent[0].1.split_once('.').unwrap();
+    assert_eq!(
+        row.get::<String, _>("selector"),
+        selector,
+        "the selector is stored in plaintext"
+    );
+    assert_ne!(
+        row.get::<Vec<u8>, _>("verifier_hash"),
+        sent[0].1.as_bytes(),
+        "the verifier is stored hashed, never raw"
+    );
+}
+
+#[tokio::test]
+async fn start_for_an_account_with_no_local_identity_is_a_silent_no_op() {
+    let h = skip_if_no_db!();
+    // A social-only account: no `local` identity, so there is no address it claims.
+    let user_id = h.trusted_signin("social-only@example.com", "google-sub-1").await;
+
+    h.auth.start_email_verification(&user_id).await.unwrap();
+    settle().await;
+
+    assert!(
+        h.sender.sent.lock().unwrap().is_empty(),
+        "no mail for an account with no local id"
+    );
+    assert_eq!(token_count(&h.admin).await, 0, "and no token row");
+}
+
+#[tokio::test]
+async fn start_for_an_unknown_user_is_a_silent_no_op() {
+    let h = skip_if_no_db!();
+    h.auth.start_email_verification("user_does_not_exist").await.unwrap();
+    settle().await;
+    assert!(h.sender.sent.lock().unwrap().is_empty(), "no mail");
+    assert_eq!(token_count(&h.admin).await, 0, "no token row");
+}
+
+#[tokio::test]
+async fn start_on_an_already_verified_account_issues_nothing() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+    h.auth.confirm_email_verification(&user_id, &token).await.unwrap();
+
+    h.auth.start_email_verification(&user_id).await.unwrap();
+    settle().await;
+
+    assert_eq!(h.sender.sent.lock().unwrap().len(), 1, "only the original link was ever sent");
+}
+
+// ── confirm: token discipline ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn confirm_promotes_the_account_to_verified() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    assert_eq!(h.account_email(&user_id).await, None, "a local signup starts unverified");
+
+    let token = h.issue_token(&user_id).await;
+    let verified = h.auth.confirm_email_verification(&user_id, &token).await.unwrap();
+
+    assert_eq!(verified.user_id, user_id, "confirmation never returns a different account");
+    assert_eq!(verified.email, VICTIM_EMAIL);
+    assert_eq!(
+        h.account_email(&user_id).await.as_deref(),
+        Some(VICTIM_EMAIL),
+        "the address is now on the account's own row"
+    );
+}
+
+#[tokio::test]
+async fn a_token_is_single_use() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+
+    h.auth.confirm_email_verification(&user_id, &token).await.unwrap();
+    let err = h
+        .auth
+        .confirm_email_verification(&user_id, &token)
+        .await
+        .expect_err("a spent token must not be redeemable twice");
+    assert!(matches!(err, AuthError::InvalidToken { .. }), "got {err:?}");
+}
+
+#[tokio::test]
+async fn an_expired_token_is_refused() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+    sqlx::query("UPDATE core.tb_email_verification_token SET expires_at = now() - interval '1s'")
+        .execute(&h.admin)
+        .await
+        .unwrap();
+
+    let err = h
+        .auth
+        .confirm_email_verification(&user_id, &token)
+        .await
+        .expect_err("an expired token must be refused");
+    assert!(matches!(err, AuthError::InvalidToken { .. }), "got {err:?}");
+    assert_eq!(h.account_email(&user_id).await, None, "and nothing was promoted");
+}
+
+#[tokio::test]
+async fn a_tampered_verifier_is_refused() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+    let (selector, _) = token.split_once('.').unwrap();
+    // Right selector, a verifier from a different token: the constant-time compare fails.
+    let other = h.issue_token(&user_id).await;
+    let forged = format!("{selector}.{}", other.split_once('.').unwrap().1);
+
+    let err = h
+        .auth
+        .confirm_email_verification(&user_id, &forged)
+        .await
+        .expect_err("a wrong verifier must be refused");
+    assert!(matches!(err, AuthError::InvalidToken { .. }), "got {err:?}");
+    assert_eq!(h.account_email(&user_id).await, None, "and nothing was promoted");
+}
+
+#[tokio::test]
+async fn a_malformed_or_unknown_token_is_refused() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    for bad in ["not-a-token", "aaaa.bbbb", ""] {
+        let err = h
+            .auth
+            .confirm_email_verification(&user_id, bad)
+            .await
+            .expect_err("garbage must be refused");
+        assert!(matches!(err, AuthError::InvalidToken { .. }), "{bad:?} → {err:?}");
+    }
+}
+
+#[tokio::test]
+async fn a_successful_confirm_invalidates_the_accounts_other_outstanding_tokens() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let first = h.issue_token(&user_id).await;
+    let second = h.issue_token(&user_id).await;
+
+    h.auth.confirm_email_verification(&user_id, &second).await.unwrap();
+
+    let live: i64 =
+        sqlx::query("SELECT count(*) FROM core.tb_email_verification_token WHERE used_at IS NULL")
+            .fetch_one(&h.admin)
+            .await
+            .unwrap()
+            .get(0);
+    assert_eq!(live, 0, "the sibling token was invalidated too");
+    assert!(
+        h.auth.confirm_email_verification(&user_id, &first).await.is_err(),
+        "the older link is dead"
+    );
+}
+
+// ── confirm: the session binding ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_token_presented_by_another_account_is_refused() {
+    // The confused-deputy refusal, and the reason `confirm` takes an authenticated
+    // caller at all. An attacker signs up a local account under the victim's address;
+    // the verification mail lands in the *victim's* inbox. If the token alone sufficed,
+    // a victim who clicks it would complete the attacker's verification. It does not:
+    // the token is spendable only by the account it was issued to.
+    let h = skip_if_no_db!();
+    let attacker = h.signup(VICTIM_EMAIL).await;
+    let bystander = h.signup("bystander@example.com").await;
+    let attacker_token = h.issue_token(&attacker).await;
+
+    let err = h
+        .auth
+        .confirm_email_verification(&bystander, &attacker_token)
+        .await
+        .expect_err("a token issued to another account must be refused");
+    assert!(
+        matches!(err, AuthError::InvalidToken { .. }),
+        "rejected exactly like a forged token, got {err:?}"
+    );
+    assert_eq!(h.account_email(&bystander).await, None, "the presenter gained nothing");
+    assert_eq!(
+        h.account_email(&attacker).await,
+        None,
+        "and the token's own account gained nothing"
+    );
+}
+
+// ── the bidirectional pre-hijack invariant ──────────────────────────────────────
+
+#[tokio::test]
+async fn direction_a_a_preseeded_unverified_local_account_does_not_absorb_a_later_trusted_signin() {
+    // The original H26 shape, re-proved because this flow adds a way for a local account
+    // to *become* verified: as long as it has not proved the mailbox, it stays in the
+    // `(local, email)` key space and the victim's later Google sign-in is untouched by it.
+    let h = skip_if_no_db!();
+    let attacker = h.signup(VICTIM_EMAIL).await;
+    // The attacker even asks for a link — but the mail goes to the victim's mailbox, and
+    // without the token the account is never promoted.
+    let _unspent = h.issue_token(&attacker).await;
+
+    let victim = h.trusted_signin(VICTIM_EMAIL, "google-sub-victim").await;
+
+    assert_ne!(victim, attacker, "the trusted sign-in did not land on the seeded account");
+    assert_eq!(h.account_count().await, 2, "two distinct accounts");
+    assert_eq!(h.account_email(&attacker).await, None, "the seeded account is still unverified");
+    assert_eq!(
+        h.account_email(&victim).await.as_deref(),
+        Some(VICTIM_EMAIL),
+        "the victim's account holds the verified address"
+    );
+    assert_eq!(h.linked_providers(&attacker).await, vec!["local"], "no google link was added");
+}
+
+#[tokio::test]
+async fn direction_b_verifying_does_not_absorb_a_trusted_account_that_already_holds_the_address() {
+    // The reverse, and the one this flow newly makes reachable. The victim's Google
+    // account already holds `victim@example.com`. An attacker signs up a local account
+    // under the same address and — by whatever means, phished code or a mailbox they
+    // briefly control — presents a valid token for it. Promotion must refuse: writing
+    // the address here would put two accounts in one linking key slot, and resolving
+    // that by merging would carry the attacker's password credential onto the victim's
+    // account.
+    let h = skip_if_no_db!();
+    let victim = h.trusted_signin(VICTIM_EMAIL, "google-sub-victim").await;
+    let attacker = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&attacker).await;
+
+    let err = h
+        .auth
+        .confirm_email_verification(&attacker, &token)
+        .await
+        .expect_err("promotion onto a claimed address must be refused");
+    assert!(matches!(err, AuthError::EmailClaimedByAnotherAccount), "got {err:?}");
+
+    assert_eq!(h.account_count().await, 2, "the two accounts stay two");
+    assert_ne!(victim, attacker);
+    assert_eq!(h.account_email(&attacker).await, None, "the attacker's account is not verified");
+    assert_eq!(
+        h.account_email(&victim).await.as_deref(),
+        Some(VICTIM_EMAIL),
+        "the victim keeps the address"
+    );
+    assert_eq!(
+        h.linked_providers(&victim).await,
+        vec![TRUSTED_PROVIDER],
+        "no local credential was linked onto the victim's account"
+    );
+    // And nothing moved: the victim's account still has no password credential.
+    let creds: i64 =
+        sqlx::query("SELECT count(*) FROM core.tb_password_credential WHERE user_id = $1")
+            .bind(&victim)
+            .fetch_one(&h.admin)
+            .await
+            .unwrap()
+            .get(0);
+    assert_eq!(creds, 0, "the attacker's password did not land on the victim's account");
+}
+
+#[tokio::test]
+async fn a_refused_confirmation_still_spends_the_token() {
+    // The refusal is deterministic, so leaving the token live would only offer a replay
+    // surface for a decision that cannot change on its own.
+    let h = skip_if_no_db!();
+    h.trusted_signin(VICTIM_EMAIL, "google-sub-victim").await;
+    let attacker = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&attacker).await;
+
+    assert!(h.auth.confirm_email_verification(&attacker, &token).await.is_err());
+
+    let spent: bool =
+        sqlx::query("SELECT used_at IS NOT NULL AS spent FROM core.tb_email_verification_token")
+            .fetch_one(&h.admin)
+            .await
+            .unwrap()
+            .get("spent");
+    assert!(spent, "the refused token was consumed");
+}
+
+#[tokio::test]
+async fn an_account_with_a_different_verified_address_is_not_rekeyed() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+    // The account acquires a *different* verified address in the meantime (a trusted
+    // sign-in linking onto it would do this in production; setting it directly is the
+    // same end state and keeps the test about the gate).
+    sqlx::query("UPDATE core.tb_user SET email = $1 WHERE user_id = $2")
+        .bind("other@example.com")
+        .bind(&user_id)
+        .execute(&h.admin)
+        .await
+        .unwrap();
+
+    let err = h
+        .auth
+        .confirm_email_verification(&user_id, &token)
+        .await
+        .expect_err("re-keying a verified account must be refused");
+    assert!(matches!(err, AuthError::EmailClaimedByAnotherAccount), "got {err:?}");
+    assert_eq!(
+        h.account_email(&user_id).await.as_deref(),
+        Some("other@example.com"),
+        "the existing linking key is untouched"
+    );
+}
+
+// ── what verification is for ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn after_verifying_a_later_trusted_signin_links_into_the_same_account() {
+    // The issue's motivating case, end to end: sign up with a password, verify, then
+    // sign in with Google — one account, not two, with no merge machinery involved. The
+    // promotion alone is what makes the ordinary `link_or_create_user` path find it.
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+    h.auth.confirm_email_verification(&user_id, &token).await.unwrap();
+
+    let after_social = h.trusted_signin(VICTIM_EMAIL, "google-sub-1").await;
+
+    assert_eq!(after_social, user_id, "the Google sign-in linked into the password account");
+    assert_eq!(h.account_count().await, 1, "one account, not two");
+    assert_eq!(
+        h.linked_providers(&user_id).await,
+        vec!["local", TRUSTED_PROVIDER],
+        "both credentials hang off the one account"
+    );
+    // And the password still works against that same account.
+    assert_eq!(h.auth.login(VICTIM_EMAIL, PASSWORD).await.unwrap(), user_id);
+}
+
+#[tokio::test]
+async fn an_untrusted_providers_verified_claim_still_cannot_reach_the_promoted_account() {
+    // Promotion enters the merge-able key space, so the #368 trust gate must keep
+    // meaning what it did: an untrusted provider's `email_verified` is downgraded by the
+    // caller, which keys it on `(provider, provider_id)` and away from this account.
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let token = h.issue_token(&user_id).await;
+    h.auth.confirm_email_verification(&user_id, &token).await.unwrap();
+
+    // What `multi_provider::callback` passes for a provider outside the trusted set.
+    let untrusted = h
+        .accounts
+        .link_or_create_user(Some(VICTIM_EMAIL), false, "some_custom_idp", "idp-sub-1")
+        .await
+        .unwrap();
+
+    assert_ne!(
+        untrusted.user_id, user_id,
+        "an untrusted claim did not reach the verified account"
+    );
+    assert_eq!(h.account_count().await, 2, "it got its own account instead");
+}
+
+#[tokio::test]
+async fn confirming_the_same_address_twice_is_idempotent() {
+    let h = skip_if_no_db!();
+    let user_id = h.signup(VICTIM_EMAIL).await;
+    let first = h.issue_token(&user_id).await;
+    h.auth.confirm_email_verification(&user_id, &first).await.unwrap();
+
+    // A fresh link for an account that is already verified is not issued (see
+    // `start_on_an_already_verified_account_issues_nothing`), so drive the idempotent
+    // path with a token minted before the first confirmation would have invalidated it.
+    let h2 = skip_if_no_db!();
+    let user_id = h2.signup(VICTIM_EMAIL).await;
+    let token = h2.issue_token(&user_id).await;
+    sqlx::query("UPDATE core.tb_user SET email = $1 WHERE user_id = $2")
+        .bind(VICTIM_EMAIL)
+        .bind(&user_id)
+        .execute(&h2.admin)
+        .await
+        .unwrap();
+
+    let verified = h2.auth.confirm_email_verification(&user_id, &token).await.unwrap();
+    assert_eq!(
+        verified.email, VICTIM_EMAIL,
+        "already-verified confirms as success, not failure"
+    );
+}

--- a/crates/fraiseql-cli/src/config/toml_schema/security.rs
+++ b/crates/fraiseql-cli/src/config/toml_schema/security.rs
@@ -368,12 +368,39 @@ impl OidcClientConfig {
                      password / otp / mfa / anonymous, or remove the block."
                 );
             }
-            if (local.otp || local.password) && local.email_from.is_none() {
+            // #945: verification proves the address a *local* identity claims. Without
+            // password auth there is no local identity, so the routes would mount over
+            // nothing — the accepted-and-unconsumed shape, refused at the file being
+            // edited rather than discovered at runtime.
+            if local.email_verification && !local.password {
                 anyhow::bail!(
-                    "[auth.local] enables {} but sets no email_from. Both flows deliver mail \
-                     (OTP codes, reset links); name the [mailbox.<name>] account whose SMTP \
-                     half should send them.",
-                    if local.otp { "otp" } else { "password" }
+                    "[auth.local] email_verification = true needs password = true: \
+                     verification proves the address a local password identity claims, and \
+                     there is no such identity without it."
+                );
+            }
+            if local.email_verification && local.verification_url_template.is_none() {
+                anyhow::bail!(
+                    "[auth.local] email_verification = true needs verification_url_template \
+                     — the verification link points at your front end, which FraiseQL cannot \
+                     guess. Example: verification_url_template = \
+                     \"https://app.example.com/verify-email?token={{token}}\""
+                );
+            }
+            if (local.otp || local.password || local.email_verification)
+                && local.email_from.is_none()
+            {
+                anyhow::bail!(
+                    "[auth.local] enables {} but sets no email_from. These flows deliver mail \
+                     (OTP codes, reset links, verification links); name the [mailbox.<name>] \
+                     account whose SMTP half should send them.",
+                    if local.otp {
+                        "otp"
+                    } else if local.password {
+                        "password"
+                    } else {
+                        "email_verification"
+                    }
                 );
             }
             if local.password && local.reset_url_template.is_none() {
@@ -386,6 +413,7 @@ impl OidcClientConfig {
             for (field, template, placeholder) in [
                 ("reset_url_template", local.reset_url_template.as_ref(), "{token}"),
                 ("magic_link_template", local.magic_link_template.as_ref(), "{code}"),
+                ("verification_url_template", local.verification_url_template.as_ref(), "{token}"),
             ] {
                 if let Some(t) = template {
                     if !t.contains(placeholder) {

--- a/crates/fraiseql-core/src/schema/compiled/schema.rs
+++ b/crates/fraiseql-core/src/schema/compiled/schema.rs
@@ -421,6 +421,22 @@ pub struct LocalAuthConfig {
     #[serde(default)]
     pub anonymous: bool,
 
+    /// Email verification for local-password accounts (#945): mounts
+    /// `POST /auth/v1/email/verify/{start,confirm}`, both of which require an
+    /// authenticated caller and act only on that caller's own account.
+    ///
+    /// Requires [`password`](Self::password) — verification proves the address a
+    /// *local* identity claims, and an account without one has nothing to verify
+    /// — plus [`email_from`](Self::email_from) and
+    /// [`verification_url_template`](Self::verification_url_template).
+    ///
+    /// Confirming promotes the account's own `core.tb_user.email`, which is what
+    /// lets a later trusted social sign-in for the same address link into it. It
+    /// never merges two accounts: an address already verified elsewhere is
+    /// refused.
+    #[serde(default)]
+    pub email_verification: bool,
+
     /// Service name shown in authenticator apps for `MFA` enrollment
     /// (`otpauth://…?issuer=`). Defaults to `"`FraiseQL`"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -443,6 +459,14 @@ pub struct LocalAuthConfig {
     /// when absent the email carries the bare six-digit code.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub magic_link_template: Option<String>,
+
+    /// Template for the email-verification link, with `{token}` substituted for
+    /// the opaque verification token — e.g.
+    /// `https://app.example.com/verify-email?token={token}`. Required when
+    /// [`email_verification`](Self::email_verification) is enabled: the link
+    /// points at the operator's front end, which `FraiseQL` cannot guess.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verification_url_template: Option<String>,
 }
 
 /// PKCE OAuth-client configuration compiled from the `[auth]` PKCE group (#621).

--- a/crates/fraiseql-server/src/auth_local.rs
+++ b/crates/fraiseql-server/src/auth_local.rs
@@ -33,15 +33,20 @@ const RESET_TOKEN_PLACEHOLDER: &str = "{token}";
 #[cfg(feature = "inbound-email")]
 const MAGIC_CODE_PLACEHOLDER: &str = "{code}";
 
+/// Placeholder the verification-link template substitutes the opaque token for (#945).
+#[cfg(feature = "inbound-email")]
+const VERIFICATION_TOKEN_PLACEHOLDER: &str = "{token}";
+
 /// Default `MFA` issuer shown in authenticator apps.
 const DEFAULT_MFA_ISSUER: &str = "FraiseQL";
 
 /// The states `[auth.local]` produces, each `Some` only when its method is enabled.
 pub struct LocalAuthStates {
-    pub otp:      Option<Arc<fraiseql_auth::OtpRouteState>>,
-    pub mfa:      Option<Arc<fraiseql_auth::MfaRouteState>>,
-    pub password: Option<Arc<fraiseql_auth::LocalPasswordRouteState>>,
-    pub anon:     Option<Arc<fraiseql_auth::AnonSignupState>>,
+    pub otp:                Option<Arc<fraiseql_auth::OtpRouteState>>,
+    pub mfa:                Option<Arc<fraiseql_auth::MfaRouteState>>,
+    pub password:           Option<Arc<fraiseql_auth::LocalPasswordRouteState>>,
+    pub anon:               Option<Arc<fraiseql_auth::AnonSignupState>>,
+    pub email_verification: Option<Arc<fraiseql_auth::EmailVerificationRouteState>>,
 }
 
 /// Delivers `OTP` codes and password-reset links through a configured
@@ -52,13 +57,16 @@ pub struct LocalAuthStates {
 /// configures its outbound mail **once**.
 #[cfg(feature = "inbound-email")]
 pub struct MailboxEmailSender {
-    transport:           Arc<dyn fraiseql_functions::outbound::EmailTransport>,
+    transport: Arc<dyn fraiseql_functions::outbound::EmailTransport>,
     /// The verified sending address; selects the account inside the transport.
-    from:                fraiseql_functions::outbound::SenderIdentity,
+    from: fraiseql_functions::outbound::SenderIdentity,
     /// `{token}`-templated reset link. `None` disables reset delivery.
-    reset_url_template:  Option<String>,
+    reset_url_template: Option<String>,
     /// `{code}`-templated magic link. `None` sends the bare code.
     magic_link_template: Option<String>,
+    /// `{token}`-templated email-verification link. `None` disables verification
+    /// delivery.
+    verification_url_template: Option<String>,
 }
 
 #[cfg(feature = "inbound-email")]
@@ -105,6 +113,36 @@ impl fraiseql_auth::ResetEmailSender for MailboxEmailSender {
                 "Use the link below to choose a new password. It expires in one hour and can \
                  only be used once.\n\n{link}\n\nIf you did not request this, you can ignore \
                  this message."
+            ),
+        )
+        .await
+        .map_err(|e| fraiseql_auth::AuthError::Internal {
+            message: e.to_string(),
+        })
+    }
+}
+
+#[cfg(feature = "inbound-email")]
+#[async_trait::async_trait]
+impl fraiseql_auth::VerificationEmailSender for MailboxEmailSender {
+    async fn send_verification_link(&self, to: &str, token: &str) -> fraiseql_auth::Result<()> {
+        // Required by both the CLI validation and the boot check when
+        // email_verification is on, so `None` here is unreachable through
+        // configuration; refuse rather than mail a bare token.
+        let template = self.verification_url_template.as_ref().ok_or_else(|| {
+            fraiseql_auth::AuthError::ConfigError {
+                message: "[auth.local] verification_url_template is not configured".to_string(),
+            }
+        })?;
+        let link = template.replace(VERIFICATION_TOKEN_PLACEHOLDER, &urlencoding::encode(token));
+        self.send(
+            to,
+            "Verify your email address",
+            format!(
+                "Use the link below to confirm this address. It expires in one hour and can \
+                 only be used once, and it only works while you are signed in to the account \
+                 that asked for it.\n\n{link}\n\nIf you did not request this, you can ignore \
+                 this message — nothing changes until the link is used."
             ),
         )
         .await
@@ -190,6 +228,7 @@ fn build_email_sender(
         },
         reset_url_template: local.reset_url_template.clone(),
         magic_link_template: local.magic_link_template.clone(),
+        verification_url_template: local.verification_url_template.clone(),
     }))
 }
 
@@ -238,29 +277,34 @@ pub async fn build_local_auth_states(
     })?;
     let secret = hs.load_secret().map_err(ServerError::ConfigError)?;
     // Mint the claims the configured validator demands, or every login would
-    // "succeed" and then 401 on the first validated request.
+    // "succeed" and then 401 on the first validated request. The same triple is
+    // handed to the bearer authenticator below, so what this server signs is
+    // exactly what it accepts back (#945) — one binding, not two that can drift.
+    let token_issuer = hs
+        .issuer
+        .clone()
+        .unwrap_or_else(|| fraiseql_auth::session_postgres::DEFAULT_TOKEN_ISSUER.to_string());
+    let token_audience = hs
+        .audience
+        .clone()
+        .unwrap_or_else(|| fraiseql_auth::session_postgres::DEFAULT_TOKEN_AUDIENCE.to_string());
+    let secret_bytes = secret.into_bytes();
     let session_store: Arc<dyn fraiseql_auth::SessionStore> = Arc::new(
-        fraiseql_auth::PostgresSessionStore::with_hs256_secret(pool.clone(), secret.into_bytes())
-            .with_token_claims(
-                hs.issuer.clone().unwrap_or_else(|| {
-                    fraiseql_auth::session_postgres::DEFAULT_TOKEN_ISSUER.to_string()
-                }),
-                hs.audience.clone().unwrap_or_else(|| {
-                    fraiseql_auth::session_postgres::DEFAULT_TOKEN_AUDIENCE.to_string()
-                }),
-            ),
+        fraiseql_auth::PostgresSessionStore::with_hs256_secret(pool.clone(), secret_bytes.clone())
+            .with_token_claims(token_issuer.clone(), token_audience.clone()),
     );
     let account_store = Arc::new(fraiseql_auth::PostgresAccountStore::new(pool.clone()));
 
-    // The mail sender is built once and shared by OTP and password reset.
-    let needs_email = local.otp || local.password;
+    // The mail sender is built once and shared by OTP, password reset and email
+    // verification.
+    let needs_email = local.otp || local.password || local.email_verification;
     #[cfg(feature = "inbound-email")]
     let email_sender = if needs_email {
         let mailbox_name = local.email_from.as_deref().ok_or_else(|| {
             ServerError::ConfigError(
                 "[auth.local] enables a mail-sending method but sets no email_from. Name the \
-                 [mailbox.<name>] account whose SMTP half should deliver OTP codes and reset \
-                 links."
+                 [mailbox.<name>] account whose SMTP half should deliver OTP codes, reset \
+                 links and verification links."
                     .to_string(),
             )
         })?;
@@ -270,7 +314,13 @@ pub async fn build_local_auth_states(
     };
     #[cfg(not(feature = "inbound-email"))]
     if needs_email {
-        return Err(missing_email_feature(if local.otp { "otp" } else { "password" }));
+        return Err(missing_email_feature(if local.otp {
+            "otp"
+        } else if local.password {
+            "password"
+        } else {
+            "email_verification"
+        }));
     }
 
     // `needs_email` already returned above on a build without `inbound-email`,
@@ -310,8 +360,11 @@ pub async fn build_local_auth_states(
         None
     };
 
-    let password = if local.password {
-        // Reason: `mut` is only used by the inbound-email-gated sender attachment below
+    // One authenticator, shared by the password routes and the verification routes:
+    // they operate on the same credential and token stores, and two instances would
+    // be two configurations to keep in step.
+    let authenticator = if local.password {
+        // Reason: `mut` is only used by the inbound-email-gated sender attachments below
         #[cfg_attr(not(feature = "inbound-email"), allow(unused_mut))]
         let mut authenticator = fraiseql_auth::LocalPasswordAuthenticator::new(
             pool,
@@ -323,14 +376,68 @@ pub async fn build_local_auth_states(
             let sender = email_sender.ok_or_else(|| {
                 ServerError::ConfigError("[auth.local] password needs email".into())
             })?;
-            authenticator =
-                authenticator.with_email_sender(sender as Arc<dyn fraiseql_auth::ResetEmailSender>);
+            authenticator = authenticator
+                .with_email_sender(Arc::clone(&sender) as Arc<dyn fraiseql_auth::ResetEmailSender>);
+            if local.email_verification {
+                authenticator = authenticator.with_verification_email_sender(
+                    sender as Arc<dyn fraiseql_auth::VerificationEmailSender>,
+                );
+            }
         }
+        Some(Arc::new(authenticator))
+    } else {
+        None
+    };
+
+    let password = authenticator.as_ref().map(|authenticator| {
         info!("Local password sign-in enabled (POST /auth/v1/password/{{signup,login,reset}})");
-        Some(Arc::new(fraiseql_auth::LocalPasswordRouteState {
-            authenticator: Arc::new(authenticator),
+        Arc::new(fraiseql_auth::LocalPasswordRouteState {
+            authenticator: Arc::clone(authenticator),
             session_store: Arc::clone(&session_store),
             rate_limiters: Arc::new(fraiseql_auth::RateLimiters::default()),
+        })
+    });
+
+    // #945. Refuse rather than mount a flow that dead-ends: verification proves the
+    // address a *local* identity claims, and a link nobody can follow is not a
+    // verification method. The CLI refuses both shapes at compile time; this is the
+    // same check for a server booted from a hand-written or env-overridden config.
+    let email_verification = if local.email_verification {
+        let authenticator = authenticator.as_ref().ok_or_else(|| {
+            ServerError::ConfigError(
+                "[auth.local] email_verification = true requires password = true: \
+                 verification proves the address a local password identity claims, and there \
+                 is no such identity without it."
+                    .to_string(),
+            )
+        })?;
+        if local.verification_url_template.is_none() {
+            return Err(ServerError::ConfigError(
+                "[auth.local] email_verification = true requires verification_url_template — \
+                 the verification link points at your front end, which FraiseQL cannot guess. \
+                 Example: verification_url_template = \
+                 \"https://app.example.com/verify-email?token={token}\""
+                    .to_string(),
+            ));
+        }
+        let session_bearer = fraiseql_auth::SessionBearerAuthenticator::new(
+            secret_bytes,
+            &token_issuer,
+            &token_audience,
+        )
+        .map_err(|e| {
+            ServerError::ConfigError(format!(
+                "[auth.local] email_verification could not build its session validator: {e}"
+            ))
+        })?;
+        info!(
+            "Email verification enabled (POST /auth/v1/email/verify/{{start,confirm}}, \
+             authenticated)"
+        );
+        Some(Arc::new(fraiseql_auth::EmailVerificationRouteState {
+            authenticator:  Arc::clone(authenticator),
+            session_bearer: Arc::new(session_bearer),
+            rate_limiters:  Arc::new(fraiseql_auth::RateLimiters::default()),
         }))
     } else {
         None
@@ -352,5 +459,6 @@ pub async fn build_local_auth_states(
         mfa,
         password,
         anon,
+        email_verification,
     })
 }

--- a/crates/fraiseql-server/src/server/builder.rs
+++ b/crates/fraiseql-server/src/server/builder.rs
@@ -527,10 +527,11 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
                 .await?
             },
             None => crate::auth_local::LocalAuthStates {
-                otp:      None,
-                mfa:      None,
-                password: None,
-                anon:     None,
+                otp:                None,
+                mfa:                None,
+                password:           None,
+                anon:               None,
+                email_verification: None,
             },
         };
 
@@ -712,6 +713,8 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             otp_state: local_auth.otp,
             #[cfg(feature = "auth")]
             local_password_state: local_auth.password,
+            #[cfg(feature = "auth")]
+            email_verification_state: local_auth.email_verification,
             #[cfg(feature = "auth")]
             session_state,
             async_operations,

--- a/crates/fraiseql-server/src/server/mod.rs
+++ b/crates/fraiseql-server/src/server/mod.rs
@@ -152,6 +152,12 @@ pub struct Server<A: DatabaseAdapter> {
     /// When `Some`, mounts `/auth/v1/password/{signup,login,reset,reset/confirm}`.
     #[cfg(feature = "auth")]
     pub(super) local_password_state: Option<Arc<crate::auth::LocalPasswordRouteState>>,
+    /// Email-verification route state (`[auth.local] email_verification = true`, #945).
+    ///
+    /// When `Some`, mounts the authenticated `/auth/v1/email/verify/{start,confirm}`
+    /// pair.
+    #[cfg(feature = "auth")]
+    pub(super) email_verification_state: Option<Arc<crate::auth::EmailVerificationRouteState>>,
     /// Session-state subsystem (#389) — present when `[session_state]` is
     /// configured. The lifecycle spawns its periodic eviction sweep; the MCP
     /// session-continuity binding is its per-request consumer.

--- a/crates/fraiseql-server/src/server/routing/auth.rs
+++ b/crates/fraiseql-server/src/server/routing/auth.rs
@@ -91,6 +91,18 @@ impl<A: DatabaseAdapter + Clone + Send + Sync + 'static> Server<A> {
             );
         }
 
+        // Email verification (#945) — mounted when [auth.local] email_verification = true.
+        // Both routes require an authenticated caller and act only on that caller's own
+        // account; the bearer check lives in the handlers (they need the subject, not
+        // just a pass/refuse), so no route_layer here.
+        if let Some(ref verify) = self.email_verification_state {
+            app = app.merge(fraiseql_auth::email_verification_routes(Arc::clone(verify)));
+            info!(
+                "Email verification routes mounted: POST \
+                 /auth/v1/email/verify/{{start,confirm}}"
+            );
+        }
+
         // TOTP MFA endpoints — mounted when mfa_state is configured.
         if let Some(ref mfa) = self.mfa_state {
             let mfa_router = Router::new()

--- a/crates/fraiseql-server/tests/local_auth_e2e_pg.rs
+++ b/crates/fraiseql-server/tests/local_auth_e2e_pg.rs
@@ -13,6 +13,8 @@
 //! - `MFA`: enroll → confirm → challenge → verify against the **`Postgres`** store, and the
 //!   enrollment survives a full server restart (the whole reason that store exists)
 //! - anonymous: `POST /auth/v1/signup` mints a guest session only when enabled
+//! - email verification (#945): signup → authenticated start → the link this server actually mailed
+//!   → confirm → the account is promoted to verified, plus the 401/422 refusals
 //! - the mounted set matches the enabled set: a disabled method 404s
 //!
 //! Mail delivery is exercised through a capturing `EmailDelivery` in the `OTP` case
@@ -25,7 +27,11 @@
 //! **Parallelism:** creates and drops its own `fraiseql_p26_local_*` databases →
 //! run `--test-threads=1`.
 #![cfg(feature = "auth")]
-#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stderr)] // Reason: test code — panics and skip diagnostics are acceptable
+#![allow(clippy::unwrap_used, clippy::panic, clippy::print_stderr)]
+// Reason: test code — panics and skip diagnostics are acceptable
+// Reason: `{token}` / `{code}` in the URL templates are FraiseQL's own placeholders, which
+// the server substitutes — not Rust format arguments.
+#![allow(clippy::literal_string_with_formatting_args)]
 
 use std::sync::Arc;
 
@@ -641,6 +647,8 @@ async fn only_enabled_methods_are_mounted() {
         "/auth/v1/verify",
         "/auth/v1/mfa/enroll",
         "/auth/v1/mfa/challenge",
+        "/auth/v1/email/verify/start",
+        "/auth/v1/email/verify/confirm",
     ] {
         let (status, _) = post_json(base, path, serde_json::json!({})).await;
         assert_eq!(
@@ -651,5 +659,451 @@ async fn only_enabled_methods_are_mounted() {
     }
 
     server.stop().await;
+    drop_scratch(&url, db).await;
+}
+
+// ── #945: email verification through the shipped mount ───────────────────────
+
+/// A minimal capturing SMTP server: enough of the protocol for `lettre`'s
+/// plaintext relay to complete a send, and nothing more.
+///
+/// The other tests here point the mailbox at a discard port and read what the
+/// server *stored*. Verification cannot work that way — only the token's SHA-256
+/// is persisted, so the sole place the usable token exists is the delivered
+/// message. Capturing it is what makes this an end-to-end proof rather than a
+/// re-assertion of the library test: the link the operator's user clicks is the
+/// link built from `verification_url_template` by the server's own sender.
+#[cfg(feature = "inbound-email")]
+struct CapturingSmtp {
+    port:     u16,
+    captured: Arc<std::sync::Mutex<Vec<String>>>,
+    shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+#[cfg(feature = "inbound-email")]
+impl CapturingSmtp {
+    async fn start() -> Self {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let listener =
+            tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind SMTP sink port");
+        let port = listener.local_addr().expect("sink addr").port();
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            loop {
+                let stream = tokio::select! {
+                    accepted = listener.accept() => match accepted {
+                        Ok((stream, _)) => stream,
+                        Err(_) => break,
+                    },
+                    _ = &mut rx => break,
+                };
+                let sink = Arc::clone(&sink);
+                tokio::spawn(async move {
+                    let (read_half, mut write) = stream.into_split();
+                    let mut reader = BufReader::new(read_half);
+                    let mut line = String::new();
+                    if write.write_all(b"220 localhost ESMTP sink\r\n").await.is_err() {
+                        return;
+                    }
+                    loop {
+                        line.clear();
+                        match reader.read_line(&mut line).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(_) => {},
+                        }
+                        let command = line.trim_end().to_ascii_uppercase();
+                        let reply: &[u8] = if command.starts_with("EHLO")
+                            || command.starts_with("HELO")
+                        {
+                            // AUTH must be advertised: the transport is built with
+                            // credentials, and lettre refuses to send without a
+                            // mechanism it recognizes.
+                            b"250-localhost\r\n250-AUTH PLAIN LOGIN\r\n250 8BITMIME\r\n"
+                        } else if command.starts_with("AUTH") {
+                            b"235 2.7.0 accepted\r\n"
+                        } else if command.starts_with("MAIL FROM")
+                            || command.starts_with("RCPT TO")
+                            || command.starts_with("RSET")
+                        {
+                            b"250 2.1.0 ok\r\n"
+                        } else if command.starts_with("DATA") {
+                            if write.write_all(b"354 end with <CRLF>.<CRLF>\r\n").await.is_err() {
+                                return;
+                            }
+                            let mut body = String::new();
+                            loop {
+                                line.clear();
+                                match reader.read_line(&mut line).await {
+                                    Ok(0) | Err(_) => return,
+                                    Ok(_) => {},
+                                }
+                                if line.trim_end() == "." {
+                                    break;
+                                }
+                                body.push_str(&line);
+                            }
+                            sink.lock().unwrap().push(body);
+                            b"250 2.0.0 queued\r\n"
+                        } else if command.starts_with("QUIT") {
+                            let _ = write.write_all(b"221 2.0.0 bye\r\n").await;
+                            return;
+                        } else {
+                            b"250 2.0.0 ok\r\n"
+                        };
+                        if write.write_all(reply).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+
+        Self {
+            port,
+            captured,
+            shutdown: tx,
+        }
+    }
+
+    /// Wait for one delivered message and return its body.
+    async fn next_message(&self) -> String {
+        for _ in 0..200 {
+            // Bound the guard to a statement: holding it across the match arm would
+            // keep the mutex locked while the sink thread wants it.
+            let delivered = self.captured.lock().unwrap().first().cloned();
+            if let Some(message) = delivered {
+                return message;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        panic!("no message was delivered to the SMTP sink within 5s");
+    }
+
+    fn stop(self) {
+        let _ = self.shutdown.send(());
+    }
+}
+
+/// A `[mailbox.support]` whose SMTP half points at the capturing sink.
+#[cfg(feature = "inbound-email")]
+fn capturing_mailbox(
+    port: u16,
+) -> std::collections::HashMap<String, fraiseql_server::inbound::email::MailboxConfig> {
+    let mut mailbox = unreachable_mailbox();
+    if let Some(entry) = mailbox.get_mut("support") {
+        if let Some(smtp) = entry.smtp.as_mut() {
+            smtp.port = port;
+        }
+    }
+    mailbox
+}
+
+/// Boot with a mailbox that actually delivers, so the mailed link can be read back.
+#[cfg(feature = "inbound-email")]
+async fn boot_with_smtp(
+    local: LocalAuthConfig,
+    pool: PgPool,
+    scratch_url: &str,
+    smtp_port: u16,
+) -> RunningServer {
+    let adapter = Arc::new(PostgresAdapter::new(scratch_url).await.expect("PostgresAdapter::new"));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    let config = ServerConfig {
+        mailbox: capturing_mailbox(smtp_port),
+        ..local_config(scratch_url)
+    };
+    let server = Box::pin(Server::new(config, local_schema(local), adapter, Some(pool)))
+        .await
+        .expect("Server::new with [auth.local] email_verification must succeed");
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = server
+            .serve_on_listener(listener, async {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    RunningServer {
+        base: format!("http://127.0.0.1:{port}"),
+        shutdown: tx,
+        handle,
+    }
+}
+
+/// POST with a bearer session token.
+#[cfg(feature = "inbound-email")]
+async fn post_authed(
+    base: &str,
+    path: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> (reqwest::StatusCode, serde_json::Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("{base}{path}"))
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let json = resp.json().await.unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+/// Decode the quoted-printable body lettre sends.
+///
+/// Not decorative: the link contains `?token=`, and quoted-printable renders that
+/// `=` as `=3D`, so a naive substring search finds the prefix and then reads a
+/// corrupted token. Soft line breaks (`=` at end of line) also split the token
+/// across lines.
+#[cfg(feature = "inbound-email")]
+fn decode_quoted_printable(body: &str) -> String {
+    let bytes = body.replace("=\r\n", "").replace("=\n", "").into_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'=' && i + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+            if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).expect("decoded body is UTF-8")
+}
+
+/// Pull the `{token}` value out of the verification link the server mailed.
+#[cfg(feature = "inbound-email")]
+fn token_from_message(message: &str, template_prefix: &str) -> String {
+    let decoded = decode_quoted_printable(message);
+    let start = decoded
+        .find(template_prefix)
+        .unwrap_or_else(|| panic!("verification link not found in message:\n{decoded}"))
+        + template_prefix.len();
+    let rest = &decoded[start..];
+    let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
+    urlencoding::decode(&rest[..end])
+        .expect("token is percent-decodable")
+        .into_owned()
+}
+
+#[cfg(feature = "inbound-email")]
+#[tokio::test]
+async fn email_verification_start_confirm_promotes_the_account() {
+    let Some(url) = database_url_or_skip("email_verification_start_confirm") else {
+        return;
+    };
+    set_test_env();
+    let db = "fraiseql_p26_local_verify";
+    let pool = scratch_pool(&url, db).await;
+    let scratch_url = with_database(&url, db);
+
+    let smtp = CapturingSmtp::start().await;
+    let server = boot_with_smtp(
+        LocalAuthConfig {
+            password: true,
+            email_verification: true,
+            email_from: Some("support".to_string()),
+            reset_url_template: Some("https://app.example.com/reset?token={token}".to_string()),
+            verification_url_template: Some(
+                "https://app.example.com/verify-email?token={token}".to_string(),
+            ),
+            ..LocalAuthConfig::default()
+        },
+        pool.clone(),
+        &scratch_url,
+        smtp.port,
+    )
+    .await;
+    let base = &server.base;
+
+    // Sign up: a local account starts unverified, by design.
+    let (status, body) = post_json(
+        base,
+        "/auth/v1/password/signup",
+        serde_json::json!({ "email": "dave@example.com", "password": "correct horse battery" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "signup must succeed: {body}");
+    let access = body["access_token"].as_str().expect("access_token").to_string();
+    let user_id = jwt_sub(&access);
+    let verified_email = |pool: PgPool, user_id: String| async move {
+        sqlx::query_scalar::<_, Option<String>>("SELECT email FROM core.tb_user WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&pool)
+            .await
+            .expect("user row")
+    };
+    assert_eq!(
+        verified_email(pool.clone(), user_id.clone()).await,
+        None,
+        "a fresh local signup is unverified"
+    );
+
+    // Unauthenticated start is refused: these routes act on the caller's account,
+    // so there is no caller-less form of them.
+    let (status, _) = post_json(base, "/auth/v1/email/verify/start", serde_json::json!({})).await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED, "start needs a session");
+    let (status, _) = post_json(
+        base,
+        "/auth/v1/email/verify/confirm",
+        serde_json::json!({ "token": "whatever" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED, "confirm needs a session");
+
+    // Authenticated start mails the link.
+    let (status, body) =
+        post_authed(base, "/auth/v1/email/verify/start", &access, serde_json::json!({})).await;
+    assert_eq!(status, reqwest::StatusCode::ACCEPTED, "start must be accepted: {body}");
+
+    let message = smtp.next_message().await;
+    assert!(message.contains("dave@example.com"), "addressed to the account's own address");
+    let token = token_from_message(&message, "https://app.example.com/verify-email?token=");
+    assert!(token.contains('.'), "the mailed token is selector.verifier: {token}");
+
+    // A token issued to this account, presented by a *different* account, is
+    // rejected exactly like a forged one — the confused-deputy refusal, over HTTP.
+    let (status, body) = post_json(
+        base,
+        "/auth/v1/password/signup",
+        serde_json::json!({ "email": "erin@example.com", "password": "correct horse battery" }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "second signup: {body}");
+    let other_access = body["access_token"].as_str().expect("access_token").to_string();
+    let (status, body) = post_authed(
+        base,
+        "/auth/v1/email/verify/confirm",
+        &other_access,
+        serde_json::json!({ "token": token }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+        "another account must not spend this token: {body}"
+    );
+    assert_eq!(
+        verified_email(pool.clone(), user_id.clone()).await,
+        None,
+        "and nothing was promoted"
+    );
+
+    // The owner confirms: the account is promoted to verified.
+    let (status, body) = post_authed(
+        base,
+        "/auth/v1/email/verify/confirm",
+        &access,
+        serde_json::json!({ "token": token }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "confirm must succeed: {body}");
+    assert_eq!(body["verified"], serde_json::json!(true), "{body}");
+    assert_eq!(body["email"], serde_json::json!("dave@example.com"), "{body}");
+    assert_eq!(
+        verified_email(pool.clone(), user_id.clone()).await.as_deref(),
+        Some("dave@example.com"),
+        "the address is now on the account's row, where a later social sign-in finds it"
+    );
+
+    // Single-use, over HTTP.
+    let (status, _) = post_authed(
+        base,
+        "/auth/v1/email/verify/confirm",
+        &access,
+        serde_json::json!({ "token": token }),
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::UNPROCESSABLE_ENTITY, "a spent link is dead");
+
+    server.stop().await;
+    smtp.stop();
+    drop_scratch(&url, db).await;
+}
+
+/// `[auth.local] email_verification = true` without `password` refuses to boot:
+/// verification proves the address a *local* identity claims, and there is none.
+#[cfg(feature = "inbound-email")]
+#[tokio::test]
+async fn email_verification_without_password_refuses_to_boot() {
+    let Some(url) = database_url_or_skip("email_verification_without_password") else {
+        return;
+    };
+    set_test_env();
+    let db = "fraiseql_p26_local_verify_nopw";
+    let pool = scratch_pool(&url, db).await;
+    let scratch_url = with_database(&url, db);
+
+    let adapter = Arc::new(PostgresAdapter::new(&scratch_url).await.expect("PostgresAdapter::new"));
+    let err = Box::pin(Server::new(
+        local_config(&scratch_url),
+        local_schema(LocalAuthConfig {
+            email_verification: true,
+            email_from: Some("support".to_string()),
+            verification_url_template: Some(
+                "https://app.example.com/verify-email?token={token}".to_string(),
+            ),
+            ..LocalAuthConfig::default()
+        }),
+        adapter,
+        Some(pool),
+    ))
+    .await
+    .err()
+    .unwrap_or_else(|| panic!("email_verification without password must refuse to boot"));
+    let message = err.to_string();
+    assert!(
+        message.contains("email_verification") && message.contains("password"),
+        "the refusal must name both keys: {message}"
+    );
+
+    drop_scratch(&url, db).await;
+}
+
+/// A verification-enabled config with no `verification_url_template` refuses to
+/// boot rather than mailing a bare token or a dead link.
+#[cfg(feature = "inbound-email")]
+#[tokio::test]
+async fn email_verification_without_a_link_template_refuses_to_boot() {
+    let Some(url) = database_url_or_skip("email_verification_without_template") else {
+        return;
+    };
+    set_test_env();
+    let db = "fraiseql_p26_local_verify_notpl";
+    let pool = scratch_pool(&url, db).await;
+    let scratch_url = with_database(&url, db);
+
+    let adapter = Arc::new(PostgresAdapter::new(&scratch_url).await.expect("PostgresAdapter::new"));
+    let err = Box::pin(Server::new(
+        local_config(&scratch_url),
+        local_schema(LocalAuthConfig {
+            password: true,
+            email_verification: true,
+            email_from: Some("support".to_string()),
+            reset_url_template: Some("https://app.example.com/reset?token={token}".to_string()),
+            ..LocalAuthConfig::default()
+        }),
+        adapter,
+        Some(pool),
+    ))
+    .await
+    .err()
+    .unwrap_or_else(|| panic!("email_verification without a link template must refuse to boot"));
+    assert!(
+        err.to_string().contains("verification_url_template"),
+        "the refusal must name the missing key: {err}"
+    );
+
     drop_scratch(&url, db).await;
 }

--- a/docs/auth/local-password.md
+++ b/docs/auth/local-password.md
@@ -67,8 +67,9 @@ Signup links with `email_verified = false`. A local signup therefore keys its **
 `(local, email)` account and can never auto-merge into an existing verified-email account
 (e.g. a prior Google sign-in for the same address). This is the H26 protection: an
 attacker cannot sign up locally with a victim's email and reach the victim's account.
-`core.tb_user.email` stays `NULL` for a local account until a verification flow promotes
-it; cross-linking is deferred to that flow (#367).
+`core.tb_user.email` stays `NULL` for a local account until [email
+verification](#email-verification-945) promotes it on a proved mailbox — the one path that
+writes it, and one that refuses to move any row between accounts.
 
 ### Login is non-enumerable
 
@@ -158,6 +159,81 @@ SMTP path) when you wire routes. Without a sender, a token is still issued and p
 a warning is logged rather than delivering it; without a session store, the password changes
 but a warning notes that outstanding sessions were not revoked.
 
+## Email verification (#945)
+
+`start_email_verification` / `confirm_email_verification` let a local account *become*
+verified. Before this, FraiseQL could only **consume** a verification claim someone else
+asserted (a trusted provider's `email_verified`, or a completed email OTP); a local
+password account was verified by nobody and stayed that way forever, so the same person's
+password and Google sign-ins were two accounts with no way to join them.
+
+Enable it with `[auth.local] email_verification = true`. It requires `password = true`
+(verification proves the address a *local* identity claims — without one there is nothing
+to verify), `email_from`, and `verification_url_template`; a config missing any of them is
+refused at compile time by the CLI and again at boot.
+
+```toml
+[auth.local]
+password                  = true
+email_verification        = true
+email_from                = "support"
+reset_url_template        = "https://app.example.com/reset?token={token}"
+verification_url_template = "https://app.example.com/verify-email?token={token}"
+```
+
+Two routes mount, and both require an authenticated caller:
+
+| Route | Behaviour |
+|---|---|
+| `POST /auth/v1/email/verify/start` | Mails a link to the address the **caller's own** local identity claims. Always `202`. |
+| `POST /auth/v1/email/verify/confirm` | Body `{ "token": "…" }`. `200` on success, `409` on the refusal below, `422` for any unredeemable token. |
+
+The token uses the same selector + verifier discipline as password reset — single-use,
+one-hour TTL, constant-time verifier comparison, `sha256(verifier)` the only persisted
+form — in `core.tb_email_verification_token`, which additionally stores the address the
+link was mailed to, so confirmation promotes exactly the mailbox that was proved.
+
+### Both halves are required
+
+`confirm` needs the token **and** a session, and the token's subject must equal the
+caller's `user_id`. The token proves control of the mailbox; the session proves ownership
+of the account. This is what closes the confused-deputy shape:
+
+> Signup for an arbitrary address is open by design. An attacker signs up locally under
+> `victim@example.com` and starts verification — the mail lands in the **victim's** inbox.
+> If the token alone sufficed, a victim who clicked the link would complete the attacker's
+> verification.
+
+Because the victim is not authenticated as the attacker's account, the confirmation fails
+closed, and a token presented by any other account is rejected exactly like a forged one.
+
+### Promotion, not merging
+
+On success the proved address is written to the caller's own `core.tb_user.email`. That is
+what puts the account in the cross-provider `email:<normalized>` key space, so a later
+trusted social sign-in for the same address links into it through the ordinary
+`AccountStore::link_or_create_user` path — one account, no merge machinery.
+
+If **another** account already holds that verified address, confirmation refuses with
+`EmailClaimedByAnotherAccount` (`409`) and changes nothing. The refusal is deliberate and
+permanent, not a gap:
+
+- Merging the two would move this account's password credential — chosen by whoever ran
+  signup — onto an account it could not previously reach. Combined with the open signup
+  above, that completes an account-takeover chain that only needs the mailed code once.
+- Signup under an arbitrary address is harmless *precisely because* it can never merge.
+  The [`TrustedEmailProviders`](identity-store.md) invariant is re-proved for this new
+  path in both directions: a pre-seeded unverified local account cannot absorb a victim's
+  later trusted sign-in, and a later-verified local account cannot absorb a trusted
+  account that already holds the address.
+
+An account that already carries a *different* verified address is likewise not re-keyed —
+a verified address is the account's linking key, and this flow does not move an account
+out of the key space a previous trusted sign-in placed it in.
+
+The refused token is still consumed: the refusal is deterministic, so leaving it live
+would only offer a replay surface.
+
 ## Deferred
 
 Named here so they are tracked, not assumed handled:
@@ -169,11 +245,11 @@ Named here so they are tracked, not assumed handled:
 - **Non-enumerable signup.** `EmailAlreadyRegistered` (409) is a signup existence oracle.
   The standard "we emailed you" mitigation needs the email-action path (#349), not yet
   shipped, so v1 returns the distinct error and documents it.
-- **HTTP endpoints and a concrete `ResetEmailSender`** for the reset flow above — deferred
-  to the step that wires the local-auth routes (login/signup have none yet either). The
-  service primitive and the `ResetEmailSender` trait ship now.
-- **Email verification** — the remaining #367 sub-flow, reusing the same #349 email path;
-  it is what will promote `core.tb_user.email` from `NULL` for a local account.
+- **Adding a password to an account that already exists under another provider.** Signing
+  in with Google first and then wanting a password is the ordering email verification
+  deliberately does *not* serve (see below). The safe direction is a set-password call
+  from inside an authenticated session — proving control of the account being changed
+  rather than pulling it toward an outside credential — which is not yet shipped.
 - **Configurable password policy.** v1 enforces a fixed minimum (12 bytes) and maximum
   (4096 bytes, a DoS guard) length, shared by signup and password reset.
 - **Reset rate limiting.** `start_password_reset` is not yet rate-limited against


### PR DESCRIPTION
Phase 15 of the open-finding remediation program. One issue: **#945**.

## What it does

`[auth.local] email_verification = true` mounts `POST /auth/v1/email/verify/{start,confirm}`. Confirmation writes the proved address to the caller's own `core.tb_user.email`, which is what puts a local-password account in the cross-provider `email:<normalized>` key space — so a later trusted social sign-in for the same address links into it through the ordinary `link_or_create_user` path. One account, no new merge machinery.

## The two design calls

**Confirm requires the session as well as the token.** Signup for an arbitrary address is open by design, so an attacker can seed a local account under a victim's address and cause a verification mail to land in the *victim's* inbox. If the token alone sufficed, a victim clicking that link would complete the attacker's verification. Requiring both halves makes that fail closed. `SessionBearerAuthenticator` is the new seam that resolves the caller — the MFA routes take `user_id` from the request body; these do not.

**The merge the issue asks for is refused, permanently.** Merging into an account that already holds the verified address would move this account's password credential — chosen by whoever ran signup — onto an account it could not previously reach; combined with open signup that is a takeover chain needing the mailed code only once. It would also have to move rows across six tables where missing one silently drops the victim's second factor. The ordering the issue describes (password first, social later) is served by promotion alone; the reverse ordering belongs to a set-password call from inside an authenticated session, now the named deferral. Refusal is `AuthError::EmailClaimedByAnotherAccount` (409).

## Verification

- 20 live-PostgreSQL tests, including the **bidirectional pre-hijack invariant** re-proved for this path: a pre-seeded unverified local account cannot absorb a victim's later trusted sign-in, and a later-verified local account cannot absorb a trusted account already holding the address.
- 6 unit tests over the promotion gate (`decide_promotion`, a pure function), 12 over the bearer authenticator.
- 3 e2e through `serve_on_listener`, one driving a **capturing SMTP sink** so the link under test is the one the server actually mailed — that is what caught the quoted-printable rendering of `?token=`.
- **Red-proven**, each guard alone: neutering the session binding, the claimed-address refusal, the re-key refusal, or promoting without a proved mailbox each fails its own assertion and nothing else's.
- Wired into the Dagger `integration: postgres` leg; suite-coverage gate OK.
- `make preflight`, full `cargo test -p` on auth/core/cli (`--test-threads=1`, as those suites document), doctests, clippy at MSRV 1.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)