### PR TITLE
fix(deps): #1095 — lru 0.18.2, and an advisory that needed no exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "jsonwebtoken",
- "lru 0.18.1",
+ "lru 0.18.2",
  "moka",
  "mutants",
  "parking_lot",
@@ -3834,7 +3834,7 @@ dependencies = [
  "fraiseql-guard",
  "fraiseql-test-utils",
  "futures",
- "lru 0.18.1",
+ "lru 0.18.2",
  "proptest",
  "reqwest 0.12.28",
  "serde",
@@ -5654,9 +5654,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,10 @@ indexmap = {version = "2", features = ["serde"]}
 itertools = "0.14"
 jsonwebtoken = {version = "10", features = ["rust_crypto"]}
 # Caching
+# Lockfile holds 0.18.2 or later: RUSTSEC-2026-0253 (use-after-free when a key's
+# Drop panics in LruCache::pop) affects 0.18.1. The requirement stays at "0.18" —
+# tightening it to "0.18.2" re-resolves the whole graph and drags in unrelated
+# socket2/itertools/windows-sys dedup drift, which a security fix should not carry.
 lru = "0.18"
 moka = {version = "0.12", default-features = false, features = ["sync"]}
 # Parking lot (faster mutexes)


### PR DESCRIPTION
Clears RUSTSEC-2026-0253, which went live 2026-08-11 and reddens the required `security` check on
every branch — including `dev` itself and the in-flight `phase-17-storage`. Merge-blocking for
anything else in the queue, so it lands on its own.

`LruCache::pop()` was not panic-safe: a panicking key `Drop` skipped `detach()`, leaving a
dangling pointer in the LRU list for the next eviction to walk.

## Two premises checked rather than assumed

**No `deny.toml` exception is needed.** The plan going in was to bump the direct dependency *and*
add a dated ignore for `aws-sdk-s3`'s transitive `lru` 0.16.4. cargo-deny flags only 0.18.1 —
0.16.4 predates the affected range — so the bump alone clears it and the ignore list is untouched.

**The requirement stays at `"0.18"`.** Tightening it to a `"0.18.2"` floor re-resolves the entire
graph: 40 changed lockfile lines instead of 8, re-pointing dependents at socket2 0.6.5, itertools
0.14.0 and windows-sys 0.61.2. That drift may be fine, but it is a dependency sweep with its own
verification burden and does not belong in a security fix. The floor would buy nothing regardless
— cargo resolves to the highest compatible version, so 0.18.1 is unreachable now that 0.18.2 is
published. A comment in `Cargo.toml` records this so the next sweep does not pin it "helpfully".

Both call sites (`validation::rate_limiting`, federation's `query_plan_cache`) key on `String`,
whose `Drop` cannot panic, so the trigger was never reachable here. Cleared as hygiene.

## Verification

- `cargo deny check` — red before (`advisories FAILED`, exit 1), all four sections ok after
- Lockfile diff is 8 lines: `lru` version + checksum + its two dependents. No package added,
  removed, or re-versioned.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p fraiseql-federation --all-features` — 416 passed
- `cargo test -p fraiseql-core --all-features --lib` — 2707 passed
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps`
- `cargo +nightly fmt --check`

`cache_rls_isolation_test` fails 2/7 under a parallel local run, before and after this change —
four of its tests share the `tb_rls_probe` fixture table. Reproduces identically on a clean
`origin/dev` worktree and passes 7/7 under `--test-threads=1`, which is how the integration leg
invokes it. Filed as #1096, not touched here.

Closes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)