### PR TITLE
feat(cdc): outbound CDC sinks for Kafka and Kinesis (#975)

### DIFF
--- a/.dagger/feature-combos.go
+++ b/.dagger/feature-combos.go
@@ -152,6 +152,11 @@ var featureCombos = []featureCombo{
 	// #382: the server-side outbound-CDC mount (its own feature, pulling
 	// fraiseql-cdc-sinks with the NATS sink).
 	{name: "server-cdc-outbound", crate: "fraiseql-server", features: []string{"cdc-outbound"}},
+	// #975: the Kafka sink's server mount. Distinct from server-cdc-outbound
+	// because the delegating ConfiguredSink enum, the kafka arm of build_one and
+	// the feature-on half of validate_kind only compile here — and the
+	// feature-OFF half only compiles in the combo above. Neither covers both.
+	{name: "server-cdc-kafka", crate: "fraiseql-server", features: []string{"cdc-kafka"}},
 	{name: "storage-gcs", crate: "fraiseql-storage", noDefaultFeatures: true, features: []string{"gcs"}},
 	{name: "storage-azure-blob", crate: "fraiseql-storage", noDefaultFeatures: true, features: []string{"azure-blob"}},
 
@@ -172,6 +177,11 @@ var featureCombos = []featureCombo{
 	// e2e test under -D warnings on MSRV; the default (broker-free) drain path is
 	// covered by preflight `--all-features` and the workspace test leg.
 	{name: "cdc-nats-jetstream", crate: "fraiseql-cdc-sinks", clippy: true, features: []string{"cdc-nats-jetstream"}},
+	// #975 the gated Kafka outbound sink. Its endpoint guard and topic charset are
+	// pure and always compiled (covered by the default test leg); this combo is
+	// what compiles KafkaSink itself, its produce-error classification and its
+	// rdkafka-bound tests under -D warnings on MSRV.
+	{name: "cdc-kafka", crate: "fraiseql-cdc-sinks", clippy: true, features: []string{"cdc-kafka"}},
 }
 
 // cargoArgs builds the `cargo check|clippy` invocation for this combo, mirroring the

--- a/.dagger/feature-combos.go
+++ b/.dagger/feature-combos.go
@@ -12,7 +12,7 @@ package main
 // These are `cargo check` (and, for the functions combos, `cargo clippy`) only —
 // no test binaries run, so no backing services are needed. That makes this matrix
 // immune to the Docker Hub anonymous pull rate-limit that gates the integration
-// suites (it only ever pulls the already-cached rust:1.94 base). See parity-notes.md.
+// suites (it only ever pulls the already-cached rust:1.94.1 base). See parity-notes.md.
 
 import (
 	"context"
@@ -285,10 +285,12 @@ func (m *FraiseqlCi) runCombo(
 	cmd := strings.Join(c.cargoArgs(), " ")
 	var setup string
 	if c.clippy {
-		// rustBaseFor pins RUSTUP_TOOLCHAIN=1.94, but rustBase installs clippy on the
-		// base image's *default* toolchain — not the instance RUSTUP_TOOLCHAIN selects
-		// (`1.94-x86_64-unknown-linux-gnu`), which ships only rustc. So ensure clippy
-		// for the active toolchain before running it (idempotent: a no-op once present).
+		// rustBaseFor pins RUSTUP_TOOLCHAIN=1.94.1, which since the patch pin IS the
+		// base image's own default toolchain (`1.94.1-x86_64-unknown-linux-gnu`), so
+		// rustBase's `rustup component add clippy` now lands on it. Kept anyway, and
+		// idempotent: it costs a no-op, and it is the only thing between a future image
+		// whose default diverges from RUSTUP_TOOLCHAIN and a clippy-less combo run. Under
+		// the old floating `1.94` pin the two genuinely differed and this was load-bearing.
 		// Scoped here, not in rustBase: the Phase-02 clippy/fmt gates use rustBase()
 		// directly (no RUSTUP_TOOLCHAIN) and are unaffected; only these clippy combos hit
 		// the gap. Promote to rustBase if a future phase runs clippy under rustBaseFor.

--- a/.dagger/feature-combos.go
+++ b/.dagger/feature-combos.go
@@ -157,6 +157,11 @@ var featureCombos = []featureCombo{
 	// the feature-on half of validate_kind only compile here — and the
 	// feature-OFF half only compiles in the combo above. Neither covers both.
 	{name: "server-cdc-kafka", crate: "fraiseql-server", features: []string{"cdc-kafka"}},
+	// #975: the Kinesis sink's server mount, and the same argument as the kafka
+	// combo above — the Kinesis arm of ConfiguredSink/build_one and the
+	// feature-ON half of validate_kind compile only here, while the feature-OFF
+	// half compiles only where cdc-kinesis is absent.
+	{name: "server-cdc-kinesis", crate: "fraiseql-server", features: []string{"cdc-kinesis"}},
 	{name: "storage-gcs", crate: "fraiseql-storage", noDefaultFeatures: true, features: []string{"gcs"}},
 	{name: "storage-azure-blob", crate: "fraiseql-storage", noDefaultFeatures: true, features: []string{"azure-blob"}},
 
@@ -182,6 +187,12 @@ var featureCombos = []featureCombo{
 	// what compiles KafkaSink itself, its produce-error classification and its
 	// rdkafka-bound tests under -D warnings on MSRV.
 	{name: "cdc-kafka", crate: "fraiseql-cdc-sinks", clippy: true, features: []string{"cdc-kafka"}},
+	// #975 the gated Kinesis outbound sink. Its endpoint/region guard, the
+	// endpoint-URL override guard and the stream charset are pure and always
+	// compiled (covered by the default test leg); this combo is what compiles
+	// KinesisSink itself, its PutRecord-error classification and its aws-sdk-bound
+	// tests under -D warnings on MSRV.
+	{name: "cdc-kinesis", crate: "fraiseql-cdc-sinks", clippy: true, features: []string{"cdc-kinesis"}},
 }
 
 // cargoArgs builds the `cargo check|clippy` invocation for this combo, mirroring the

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -17,7 +17,9 @@ import (
 type FraiseqlCi struct{}
 
 const (
-	// rustImage pins the toolchain to the workspace MSRV (rust-toolchain.toml channel = 1.94).
+	// rustImage pins the toolchain to the workspace MSRV (rust-toolchain.toml channel = 1.94.1).
+// The PATCH is pinned deliberately: docker.io/library/rust:1.94 tracks the newest 1.94.x, so a
+// floating tag silently stops testing the rust-version we declare the day 1.94.2 ships.
 	// The default (non-slim) variant is buildpack-deps-based, so gcc/perl/curl/git are present.
 	// (Later: pin by digest — see parity-notes.md Phase 02.)
 	//
@@ -27,7 +29,7 @@ const (
 	// them anonymously. Every ghcr.io/fraiseql/* tag below MUST have a matching entry in that
 	// workflow's IMAGES list. (mcr.microsoft.com/* and the Apollo router stay as-is — not
 	// Docker Hub, not rate-limited.)
-	rustImage = "ghcr.io/fraiseql/rust:1.94"
+	rustImage = "ghcr.io/fraiseql/rust:1.94.1"
 	// ubuntuImage backs shellBase (the toolchain-free shell-gate container).
 	ubuntuImage = "ghcr.io/fraiseql/ubuntu:24.04"
 	// unwrapAllowLimit: the ShellGates `make lint-unwrap` budget (see Makefile).
@@ -35,7 +37,7 @@ const (
 	// sccacheVersion pins the prebuilt sccache binary fetched into rustBase.
 	sccacheVersion = "v0.8.2"
 	// rustMsrv mirrors Cargo.toml workspace rust-version and rust-toolchain.toml channel.
-	rustMsrv = "1.94"
+	rustMsrv = "1.94.1"
 
 	// SYNC:* feature sets — this file is the single authority since the legacy
 	// ci.yml was retired (#951); the SYNC tags mark every use site in this file.
@@ -362,7 +364,7 @@ func (m *FraiseqlCi) shellBase() *dagger.Container {
 //
 // The workspace test leg: a full `cargo build --all-features`
 // followed by the feature-scoped `cargo test -p …` invocations (the SYNC:* lists)
-// and the doctest pass. Parameterized by toolchain (stable | MSRV 1.94).
+// and the doctest pass. Parameterized by toolchain (stable | MSRV 1.94.1).
 
 // Test runs the workspace test suite for the given toolchain. `rust` is "msrv"
 // (default — the pinned floor, == rust-toolchain.toml) or "stable" (latest stable).
@@ -382,7 +384,7 @@ func (m *FraiseqlCi) Test(
 	rust string,
 ) (string, error) {
 	toolchain := resolveToolchain(rust)
-	// Per-toolchain target cache: stable and 1.94 produce incompatible artifacts,
+	// Per-toolchain target cache: stable and 1.94.1 produce incompatible artifacts,
 	// so they must not share a target dir (kept separate from the Phase-02 gates'
 	// `fraiseql-rust-target`, which holds clippy/rustdoc check artifacts).
 	// `test2-` bump (2026-06-30): the `test-` volume held stale fraiseql-cli/-db

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -499,6 +499,16 @@ func (m *FraiseqlCi) Test(
 		"cargo test -p fraiseql-server --features rest,export-csv,export-xlsx --lib routes::rest::streaming::",
 		"cargo test -p fraiseql-server --features functions --lib routes::functions::",
 		"cargo test -p fraiseql-server --features cdc-outbound --lib cdc_outbound::",
+		// #975: the same module again with the Kafka sink compiled in. Both runs
+		// are needed and neither substitutes for the other — validate_kind's
+		// accept-kafka and refuse-kafka-by-name halves are `cfg`-gated against
+		// each other, so each is invisible in the other's leg.
+		"cargo test -p fraiseql-server --features cdc-kafka --lib cdc_outbound::",
+		// #975: the cdc-sinks crate's own rdkafka-bound unit tests (partition-key
+		// contract, produce-error classification, and the broker-free proof that
+		// TLS is compiled in). The always-compiled endpoint guard runs in the
+		// default leg above; this is the half that needs the feature.
+		"cargo test -p fraiseql-cdc-sinks --features cdc-kafka --lib kafka::",
 		// The #612-M config-coverage manifest gate ('every ServerConfig leaf has a
 		// named consumer'). Another test binary no leg had ever run — it caught
 		// P18's new `subscription_auth_recheck_secs` key only in a LOCAL full test
@@ -617,6 +627,13 @@ const (
 	// started with `-js -m 8222`.
 	natsImage    = "ghcr.io/fraiseql/nats:2.10-alpine"
 	natsBindHost = "nats"
+
+	// kafkaImage / kafkaBindHost — the Apache Kafka broker for the #975 outbound
+	// CDC sink. Kafka 4.x is KRaft-only, so this is one container with no
+	// ZooKeeper sidecar. The JVM image is preferred over `apache/kafka-native`
+	// (~1 s boot vs ~10 s) for fidelity on a durability-critical path.
+	kafkaImage    = "ghcr.io/fraiseql/kafka:4.3.1"
+	kafkaBindHost = "kafka"
 
 	// mailhogImage / mailhogBindHost — the MailHog SMTP sink for the #349 email
 	// happy-path test. Speaks real SMTP on 1025 (plaintext) and exposes an HTTP
@@ -1911,6 +1928,15 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// JetStream (DATABASE_URL + NATS_URL + FRAISEQL_NATS_ALLOW_PLAINTEXT below).
 		"cargo test -p fraiseql-cdc-sinks --test cdc_drain_pg -- --ignored --test-threads=1",
 		"cargo test -p fraiseql-cdc-sinks --features cdc-nats-jetstream --test cdc_nats_e2e -- --ignored --test-threads=1",
+		// #975: the same drain-through assertions against the bound Kafka broker
+		// (DATABASE_URL + KAFKA_BOOTSTRAP + FRAISEQL_KAFKA_ALLOW_PLAINTEXT below).
+		// Asserted THROUGH the drain, and the entity-keyed partition affinity is
+		// only meaningful because the suite creates its topic with 6 partitions.
+		"cargo test -p fraiseql-cdc-sinks --features cdc-kafka --test cdc_kafka_e2e -- --ignored --test-threads=1",
+		// #975: the same drain-through assertions against the bound Kafka broker
+		// (DATABASE_URL + KAFKA_BOOTSTRAP + FRAISEQL_KAFKA_ALLOW_PLAINTEXT below).
+		// Asserted THROUGH the drain, and the entity-keyed partition affinity is
+		// only meaningful because the suite creates its topic with 6 partitions.
 		// #382: the SERVER's outbound-CDC mount — [cdc_outbound] built through
 		// the real path drains the outbox to the bound JetStream, and an
 		// unreachable broker refuses to boot. Before this the drain engine was
@@ -1953,11 +1979,21 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		WithServiceBinding(pgBindHost, m.pgService(source)).
 		WithServiceBinding(redisBindHost, m.redisService()).
 		WithServiceBinding(natsBindHost, m.natsService()).
+		WithServiceBinding(kafkaBindHost, m.kafkaService()).
 		WithServiceBinding(mailhogBindHost, m.mailhogService()).
 		WithEnvVariable("DATABASE_URL", dbURL).
 		WithEnvVariable("TEST_DATABASE_URL", dbURL).
 		WithEnvVariable("REDIS_URL", redisURL).
 		WithEnvVariable("NATS_URL", natsURL).
+		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
+		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
+		WithEnvVariable("KAFKA_BOOTSTRAP", kafkaBindHost+":9092").
+		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
+		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
+		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
+		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
+		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
+		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
 		WithEnvVariable("MAILHOG_SMTP_HOST", mailhogBindHost).
 		WithEnvVariable("MAILHOG_SMTP_PORT", "1025").
 		WithEnvVariable("MAILHOG_API", fmt.Sprintf("http://%s:8025", mailhogBindHost)).
@@ -1972,6 +2008,9 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// The bound JetStream service speaks plaintext nats:// (bridge_integration);
 		// opt into plaintext for the test broker (L-nats-plaintext).
 		WithEnvVariable("FRAISEQL_NATS_ALLOW_PLAINTEXT", "true").
+		// Likewise the bound Kafka broker: PLAINTEXT listener, so the sink's
+		// transport guard needs the same explicit dev opt-in (#975).
+		WithEnvVariable("FRAISEQL_KAFKA_ALLOW_PLAINTEXT", "true").
 		WithExec([]string{"bash", "-c", script}).
 		Stdout(ctx)
 }
@@ -2016,6 +2055,32 @@ func (m *FraiseqlCi) natsService() *dagger.Service {
 		From(natsImage).
 		WithExposedPort(4222).
 		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true, Args: []string{"-js", "-m", "8222"}})
+}
+
+// kafkaService returns a started single-node Kafka broker in KRaft mode (no
+// ZooKeeper). `advertised.listeners` must name the Dagger bind host, not
+// localhost: librdkafka connects to the bootstrap server, is handed the
+// advertised address, and then connects to *that* — an advertised `localhost`
+// would send every produce back into the test container.
+func (m *FraiseqlCi) kafkaService() *dagger.Service {
+	return dag.Container().
+		From(kafkaImage).
+		WithEnvVariable("KAFKA_NODE_ID", "1").
+		WithEnvVariable("KAFKA_PROCESS_ROLES", "broker,controller").
+		WithEnvVariable("KAFKA_LISTENERS", "PLAINTEXT://:9092,CONTROLLER://:9093").
+		WithEnvVariable("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://"+kafkaBindHost+":9092").
+		WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
+		WithEnvVariable(
+			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+			"CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT",
+		).
+		WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", "1@localhost:9093").
+		WithEnvVariable("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1").
+		WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1").
+		WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1").
+		WithEnvVariable("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0").
+		WithExposedPort(9092).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 }
 
 // mailhogService is the MailHog SMTP sink: SMTP on 1025 (plaintext) and an HTTP

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -635,6 +635,14 @@ const (
 	kafkaImage    = "ghcr.io/fraiseql/kafka:4.3.1"
 	kafkaBindHost = "kafka"
 
+	// localstackImage / localstackBindHost — the AWS emulator backing the #975
+	// Kinesis outbound CDC sink. Only the `kinesis` service is enabled; the image
+	// starts every service in SERVICES and nothing else here needs the rest.
+	// Pinned like every other broker image — only `minio` and `fake-gcs-server`
+	// ride `:latest`, and those are weekly-refreshed by design.
+	localstackImage    = "ghcr.io/fraiseql/localstack:3.8"
+	localstackBindHost = "localstack"
+
 	// mailhogImage / mailhogBindHost — the MailHog SMTP sink for the #349 email
 	// happy-path test. Speaks real SMTP on 1025 (plaintext) and exposes an HTTP
 	// API on 8025 to inspect captured messages; the test sends through lettre and
@@ -1933,10 +1941,12 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// Asserted THROUGH the drain, and the entity-keyed partition affinity is
 		// only meaningful because the suite creates its topic with 6 partitions.
 		"cargo test -p fraiseql-cdc-sinks --features cdc-kafka --test cdc_kafka_e2e -- --ignored --test-threads=1",
-		// #975: the same drain-through assertions against the bound Kafka broker
-		// (DATABASE_URL + KAFKA_BOOTSTRAP + FRAISEQL_KAFKA_ALLOW_PLAINTEXT below).
-		// Asserted THROUGH the drain, and the entity-keyed partition affinity is
-		// only meaningful because the suite creates its topic with 6 partitions.
+		// #975: the same drain-through assertions against the bound LocalStack
+		// Kinesis (DATABASE_URL + KINESIS_ENDPOINT + FRAISEQL_KINESIS_ALLOW_PLAINTEXT
+		// below). The entity-keyed shard affinity is only meaningful because the
+		// suite creates its stream with 4 shards — on a single-shard stream the
+		// assertion passes with any partition key at all, including a per-message one.
+		"cargo test -p fraiseql-cdc-sinks --features cdc-kinesis --test cdc_kinesis_e2e -- --ignored --test-threads=1",
 		// #382: the SERVER's outbound-CDC mount — [cdc_outbound] built through
 		// the real path drains the outbox to the bound JetStream, and an
 		// unreachable broker refuses to boot. Before this the drain engine was
@@ -1980,6 +1990,7 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		WithServiceBinding(redisBindHost, m.redisService()).
 		WithServiceBinding(natsBindHost, m.natsService()).
 		WithServiceBinding(kafkaBindHost, m.kafkaService()).
+		WithServiceBinding(localstackBindHost, m.localstackService()).
 		WithServiceBinding(mailhogBindHost, m.mailhogService()).
 		WithEnvVariable("DATABASE_URL", dbURL).
 		WithEnvVariable("TEST_DATABASE_URL", dbURL).
@@ -1988,12 +1999,11 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
 		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
 		WithEnvVariable("KAFKA_BOOTSTRAP", kafkaBindHost+":9092").
-		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
-		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
-		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
-		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
-		// Scheme-less on purpose: this is librdkafka's `bootstrap.servers` shape,
-		// which the sink's own kafka:// / kafka+ssl:// scheme is prefixed onto.
+		// Scheme-ful on purpose, and the opposite of KAFKA_BOOTSTRAP above: this
+		// is the AWS SDK's endpoint-URL override, which the Kinesis sink screens
+		// through `resolve_kinesis_endpoint_url`. It is http://, so the leg must
+		// also declare the plaintext opt-in and a development environment below.
+		WithEnvVariable("KINESIS_ENDPOINT", fmt.Sprintf("http://%s:4566", localstackBindHost)).
 		WithEnvVariable("MAILHOG_SMTP_HOST", mailhogBindHost).
 		WithEnvVariable("MAILHOG_SMTP_PORT", "1025").
 		WithEnvVariable("MAILHOG_API", fmt.Sprintf("http://%s:8025", mailhogBindHost)).
@@ -2011,6 +2021,15 @@ func (m *FraiseqlCi) integrationObservers(ctx context.Context, source *dagger.Di
 		// Likewise the bound Kafka broker: PLAINTEXT listener, so the sink's
 		// transport guard needs the same explicit dev opt-in (#975).
 		WithEnvVariable("FRAISEQL_KAFKA_ALLOW_PLAINTEXT", "true").
+		// And the bound LocalStack endpoint, which is http://. The Kinesis guard
+		// permits an unencrypted override only under this opt-in, a development
+		// environment, and a loopback-or-bound host (#975).
+		WithEnvVariable("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", "true").
+		// Dummy static credentials: without them the AWS provider chain walks out
+		// to IMDS and the suite waits on a network timeout instead of failing fast.
+		WithEnvVariable("AWS_ACCESS_KEY_ID", "test").
+		WithEnvVariable("AWS_SECRET_ACCESS_KEY", "test").
+		WithEnvVariable("AWS_EC2_METADATA_DISABLED", "true").
 		WithExec([]string{"bash", "-c", script}).
 		Stdout(ctx)
 }
@@ -2080,6 +2099,20 @@ func (m *FraiseqlCi) kafkaService() *dagger.Service {
 		WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1").
 		WithEnvVariable("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0").
 		WithExposedPort(9092).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
+}
+
+// localstackService returns a started LocalStack with only the Kinesis service
+// enabled, backing the #975 outbound CDC sink. `SERVICES=kinesis` keeps boot to
+// the one API the suite uses; the image otherwise starts every emulator it ships.
+func (m *FraiseqlCi) localstackService() *dagger.Service {
+	return dag.Container().
+		From(localstackImage).
+		WithEnvVariable("SERVICES", "kinesis").
+		// LocalStack signs nothing, but the AWS SDK still requires credentials to
+		// be resolvable; these match the dummy pair the leg exports to the tests.
+		WithEnvVariable("AWS_DEFAULT_REGION", "us-east-1").
+		WithExposedPort(4566).
 		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true})
 }
 

--- a/.github/workflows/dagger-feature-matrix.yml
+++ b/.github/workflows/dagger-feature-matrix.yml
@@ -4,7 +4,7 @@ name: Dagger — feature matrix
 # `cargo check --features …` combos (feature-matrix / database-matrix /
 # storage-matrix / functions-matrix) onto one parameterized Dagger fn, with the
 # combo list as typed Go data (.dagger/feature-combos.go). cargo check / clippy only
-# — no test binaries, so NO backing services: it only pulls the rust:1.94 base (from
+# — no test binaries, so NO backing services: it only pulls the rust:1.94.1 base (from
 # the private ghcr.io/fraiseql mirror, see mirror-base-images.yml). Runs on the
 # self-hosted runner (fraiseql-8core) at ~$0/min, reusing the box's cargo/sccache
 # cache volumes (warm = fast). See parity-notes.md.

--- a/.github/workflows/dagger-test.yml
+++ b/.github/workflows/dagger-test.yml
@@ -1,7 +1,7 @@
 name: Dagger — test
 
 # Phase 03 workspace test suite (Track 0). Runs the workspace test suite
-# on the self-hosted runner (fraiseql-8core) at ~$0/min, for both the MSRV (1.94)
+# on the self-hosted runner (fraiseql-8core) at ~$0/min, for both the MSRV (1.94.1)
 # and latest-stable toolchains. `dagger call test --rust=<tc>` does the full
 # cargo build --all-features + the feature-scoped cargo test invocations + doctests,
 # reusing the box's cargo/target/sccache cache volumes (warm = fast).

--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -7,8 +7,9 @@ name: Mirror base images to ghcr.io
 # `dagger call` leg fails resolving `rust:1.94` / `postgres:16` / etc.
 #
 # This job mirrors each of those images into ghcr.io/fraiseql/*, which the Dagger
-# engine then pulls anonymously (public packages) with NO Docker Hub involvement —
-# exactly how it already pulls the public ghcr.io/apollographql/router image. crane
+# engine then pulls with the workflow GITHUB_TOKEN (`permissions: packages: read`) and
+# NO Docker Hub involvement. All ten mirrors are PRIVATE packages; the legs authenticate
+# rather than pulling anonymously, unlike the public ghcr.io/apollographql/router. crane
 # copies registry-to-registry (all platforms, no local `docker pull`), so it does not
 # itself touch the self-hosted runner: it runs on a GitHub-hosted runner with a fresh
 # IP and its own Docker Hub budget, pulling each image once.
@@ -56,8 +57,19 @@ jobs:
         run: |
           set -euo pipefail
           # src (Docker Hub) | dst (ghcr.io/fraiseql, org/name flattened to fraiseql/<name>)
+          #
+          # DATA ONLY between the quotes: every non-blank line is split on '|' and fed to
+          # crane, so a comment line inside the string is copied as an image name and fails
+          # the job. The string is double-quoted, so a backtick in there would also run as
+          # command substitution. Keep prose out here.
+          #
+          # Both the floating rust:1.94 and the patch-pinned rust:1.94.1 are mirrored.
+          # Docker's rust:1.94 tracks the newest 1.94.x, so a leg pinned to it silently
+          # stops testing the rust-version we declare the day 1.94.2 ships; .dagger pins
+          # the exact patch, and the floating tag stays so an older checkout still resolves.
           IMAGES="
           docker.io/library/rust:1.94|ghcr.io/fraiseql/rust:1.94
+          docker.io/library/rust:1.94.1|ghcr.io/fraiseql/rust:1.94.1
           docker.io/library/ubuntu:24.04|ghcr.io/fraiseql/ubuntu:24.04
           docker.io/library/postgres:16|ghcr.io/fraiseql/postgres:16
           docker.io/pgvector/pgvector:pg16|ghcr.io/fraiseql/pgvector:pg16
@@ -84,9 +96,15 @@ jobs:
           done <<< "$IMAGES"
           exit $rc
 
-      - name: Reminder — packages must be public
+      - name: Reminder — a NEW package name needs repository access, a new tag does not
         run: |
-          echo "Mirror complete. On FIRST publish each package is private; the Dagger"
-          echo "engine pulls anonymously, so set these public once at:"
-          echo "  https://github.com/orgs/fraiseql/packages?tab=packages&q=<name>"
-          echo "Packages: rust ubuntu postgres redis nats vault mailhog fake-gcs-server minio"
+          echo "Mirror complete. All ten mirrored packages are PRIVATE, and every Dagger leg"
+          echo "pulls them fine: the legs authenticate with the workflow GITHUB_TOKEN under"
+          echo "'permissions: packages: read'. Nothing here needs to be made public."
+          echo
+          echo "A ghcr package is the IMAGE NAME; tags live inside it. So adding a tag to an"
+          echo "existing name (rust:1.94 -> rust:1.94.1) inherits that package's access and"
+          echo "needs no action. Only a brand-new package NAME does, and then the fix is to"
+          echo "grant the fraiseql/fraiseql repo access — not to publish it publicly:"
+          echo "  https://github.com/orgs/fraiseql/packages/container/<name>/settings"
+          echo "Packages: rust ubuntu postgres pgvector redis nats vault mailhog fake-gcs-server minio"

--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -75,6 +75,7 @@ jobs:
           docker.io/pgvector/pgvector:pg16|ghcr.io/fraiseql/pgvector:pg16
           docker.io/library/redis:7-alpine|ghcr.io/fraiseql/redis:7-alpine
           docker.io/library/nats:2.10-alpine|ghcr.io/fraiseql/nats:2.10-alpine
+          docker.io/apache/kafka:4.3.1|ghcr.io/fraiseql/kafka:4.3.1
           docker.io/hashicorp/vault:1.17|ghcr.io/fraiseql/vault:1.17
           docker.io/mailhog/mailhog:v1.0.1|ghcr.io/fraiseql/mailhog:v1.0.1
           docker.io/fsouza/fake-gcs-server:latest|ghcr.io/fraiseql/fake-gcs-server:latest

--- a/.github/workflows/mirror-base-images.yml
+++ b/.github/workflows/mirror-base-images.yml
@@ -76,6 +76,7 @@ jobs:
           docker.io/library/redis:7-alpine|ghcr.io/fraiseql/redis:7-alpine
           docker.io/library/nats:2.10-alpine|ghcr.io/fraiseql/nats:2.10-alpine
           docker.io/apache/kafka:4.3.1|ghcr.io/fraiseql/kafka:4.3.1
+          docker.io/localstack/localstack:3.8|ghcr.io/fraiseql/localstack:3.8
           docker.io/hashicorp/vault:1.17|ghcr.io/fraiseql/vault:1.17
           docker.io/mailhog/mailhog:v1.0.1|ghcr.io/fraiseql/mailhog:v1.0.1
           docker.io/fsouza/fake-gcs-server:latest|ghcr.io/fraiseql/fake-gcs-server:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and it breaks because that scheme authenticated nothing about the message. See the
   Security entry for the full account.
 
-- **The minimum supported Rust version is now 1.94 (was 1.92) (#933).** Required to clear
+- **The minimum supported Rust version is now 1.94.1 (was 1.92) (#933, #975).** Required to clear
   RUSTSEC-2026-0222 (`wasmtime`: stores can mix up type indices between engines): the 44.x
   line we shipped has no patched release, and every patched line (46.0.2 / 47.0.3) pulls
   cranelift 0.133, which requires 1.94. The same bump also clears **RUSTSEC-2026-0188**
@@ -54,10 +54,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   `wasmtime` and `wasmtime-wasi` move together to 46.0.2 (opt-in `runtime-wasm` feature;
   not in a default build). `rust-version`, `rust-toolchain.toml`, the Dagger MSRV leg and
-  its mirrored `rust:1.94` base image all move in lockstep. Two published crates carried
+  its mirrored base image all move in lockstep. Two published crates carried
   MSRV metadata that was already untrue and now inherit the workspace value:
   `fraiseql-storage` claimed `1.75`, and `fraiseql-federation` declared no `rust-version`
   at all.
+
+  The floor is stated to the **patch** (1.94.1, not 1.94.0) for two reasons. `aws-sdk-kinesis`
+  — needed by the Kinesis CDC sink (#975) — declares `rust-version = 1.94.1`, so a 1.94.0 floor
+  would pin us to an older release of it. More importantly, 1.94.0 was a floor **no CI leg has
+  ever tested**: `rust-toolchain.toml` said `channel = "1.94"`, which rustup resolves to the
+  newest 1.94.x, and Docker's `rust:1.94` tag *is* 1.94.1 — so the declared minimum and the
+  verified minimum had quietly diverged. The Dagger base image is now pinned to the exact patch
+  (`ghcr.io/fraiseql/rust:1.94.1`) rather than the floating tag, so they cannot diverge again the
+  day 1.94.2 ships.
 
 - **`computed` is pinned as an authoring-only flag (#927).** Python's
   `@fraiseql.field(computed=True)` and F#'s `[<GraphQLField(Computed = true)>]` both used to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1434,6 +1434,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Outbound CDC: the Apache Kafka sink (#975).** `kind = "kafka"` behind the `cdc-kafka`
+  feature, reusing the existing drain worker, backoff and dead-lettering unchanged. A binary
+  built without the feature refuses the kind *by name* and says which feature to rebuild
+  with, rather than accepting the sink and dropping its events.
+
+  Kafka's `bootstrap.servers` is a scheme-less `host:port` list, so transport security is not
+  expressible in the endpoint the way `tls://` is for NATS. The sink defines its own schemes
+  — `kafka+ssl://`, `kafka+sasl-ssl://`, and plaintext `kafka://` behind
+  `FRAISEQL_KAFKA_ALLOW_PLAINTEXT` plus `FRAISEQL_ENV=development` — and maps each to an
+  explicit `security.protocol`. A **scheme-less endpoint is refused rather than defaulted**,
+  because librdkafka would read it as `PLAINTEXT`, and **every** broker in the list is
+  screened, so one metadata address cannot ride along behind a legitimate one.
+
+  SASL credentials come from `FRAISEQL_KAFKA_SASL_{MECHANISM,USERNAME,PASSWORD}`. The
+  mechanism is required rather than defaulted (librdkafka's default is `GSSAPI`, which these
+  builds cannot perform, and no default suits every broker). `PLAIN`, `SCRAM-SHA-256` and
+  `SCRAM-SHA-512` are supported; Kerberos is refused by name, as supporting it is the sole
+  reason to link Cyrus libsasl2.
+
+  Records are keyed by entity identity (`{object_type}:{object_id}`) so an entity's changes
+  share a partition — Kafka orders only within one — with `enable.idempotence` on and the
+  `(object_type, seq)` dedup key in both the payload and a `fraiseql-msg-id` header. Kafka's
+  topic charset is narrower than a NATS subject's, so a template that renders outside
+  `[a-zA-Z0-9._-]` dead-letters rather than being re-routed.
+
 - **Render transforms: resize modes, crop, effects and watermarks (#973).** #370 shipped the
   render endpoint with resize, format conversion and the resource bounds that make exposing
   image transforms safe. The operations themselves were resize-and-re-encode only, with one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1459,6 +1459,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   topic charset is narrower than a NATS subject's, so a template that renders outside
   `[a-zA-Z0-9._-]` dead-letters rather than being re-routed.
 
+- **Outbound CDC: the AWS Kinesis sink (#975).** `kind = "kinesis"` behind the `cdc-kinesis`
+  feature, reusing the drain worker, backoff and dead-lettering unchanged. As for Kafka, a
+  binary built without the feature refuses the kind *by name* and says which feature to
+  rebuild with. `pulsar` keeps a named refusal too, rather than falling through to
+  "unknown kind" — configuring it should say it is unimplemented, not imply a typo.
+
+  Kinesis is not addressed by a broker list: the SDK resolves a regional HTTPS endpoint from
+  a region name, so the configured endpoint carries only the region — `kinesis://eu-west-3`
+  — and a scheme-less value is refused rather than guessed. The region is constrained to
+  `[a-z0-9-]` starting with a letter, since it is interpolated into the endpoint the SDK
+  resolves. Credentials come from the standard AWS provider chain, never from the TOML.
+
+  The one route to an unencrypted endpoint is `FRAISEQL_KINESIS_ENDPOINT_URL`. An `https://`
+  override is taken as given — a VPC interface endpoint resolves into RFC 1918 space and
+  vetoing it would be wrong — while an `http://` override additionally requires
+  `FRAISEQL_KINESIS_ALLOW_PLAINTEXT`, `FRAISEQL_ENV=development`, and a host that survives
+  the same screening the Kafka sink applies, so the development hatch cannot reach an
+  instance-metadata address.
+
+  Records carry the same entity-identity partition key as the Kafka sink
+  (`{object_type}:{object_id}`), which pins one entity's changes to one shard — Kinesis
+  orders only within a shard — with `(object_type, seq)` in the payload for consumer dedup.
+  `SequenceNumberForOrdering` is deliberately not used: the drain publishes serially and
+  head-of-line-blocks, so arrival order already is `seq` order, and threading it would mean
+  unbounded per-key state. Stream names are validated against Kinesis's own rules
+  (`[a-zA-Z0-9_.-]`, capped at 128 — narrower than Kafka's 249), and a name it cannot accept
+  dead-letters rather than being re-routed. `InvalidArgumentException` is the only permanent
+  `PutRecord` failure; a missing stream and throttling both retry, because dead-lettering
+  them would discard events no retry needed to lose.
+
 - **Render transforms: resize modes, crop, effects and watermarks (#973).** #370 shipped the
   render endpoint with resize, format conversion and the resource bounds that make exposing
   image transforms safe. The operations themselves were resize-and-re-encode only, with one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3664,6 +3664,7 @@ dependencies = [
  "fraiseql-guard",
  "fraiseql-test-support",
  "futures",
+ "rdkafka",
  "serde",
  "serde_json",
  "sqlx",
@@ -7491,6 +7492,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.5"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -918,10 +918,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-s3"
-version = "1.137.0"
+name = "aws-sdk-kinesis"
+version = "1.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
+checksum = "8813f0c10350594d1a16a8edf44b6b20f351df315d2928d2e5d7ad5442003e73"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f9420d3a2467eed22ed3635ca653653162c386a0b0f65c78189f9bd3c1379e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -935,6 +962,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
@@ -955,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.102.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -968,6 +996,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -980,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.104.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -993,6 +1022,7 @@ dependencies = [
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -1005,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.107.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0d328ba962af23ecfa3c9f23b98d3d35e325fa218d7f13d17a6bf522f8a560"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1019,6 +1049,7 @@ dependencies = [
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
@@ -1031,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1058,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1069,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.8"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1090,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.21"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -1101,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.6"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1123,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1153,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.7"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -1164,28 +1195,31 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
+ "aws-smithy-xml",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1209,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1227,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1238,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1249,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd 0.8.0",
  "bytes",
@@ -1275,18 +1309,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.15"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.16"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2136,7 +2173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3098,7 +3135,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3313,7 +3350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3660,6 +3697,8 @@ name = "fraiseql-cdc-sinks"
 version = "2.14.1"
 dependencies = [
  "async-nats 0.49.1",
+ "aws-config",
+ "aws-sdk-kinesis",
  "chrono",
  "fraiseql-guard",
  "fraiseql-test-support",
@@ -5280,7 +5319,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6055,7 +6094,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7940,7 +7979,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8670,7 +8709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8954,7 +8993,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9513,7 +9552,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11197,7 +11236,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,8 +114,21 @@ insta = {version = "1.38", features = ["yaml"]}
 proptest = "1.4"
 # Random
 rand = "0.9"
-# Kafka
-rdkafka = {version = "0.39", features = ["tokio"]}
+# Kafka. `ssl` is NOT in rdkafka's defaults (`libz` + `tokio` only), and without it the
+# bundled librdkafka is built with no OpenSSL at all — `security.protocol=SSL` then fails
+# at runtime rather than connecting, which would leave the accepting half of the CDC
+# sink's transport guard untestable (#975). It links system libssl/libcrypto, which the
+# Dagger rustBase already installs (libssl-dev).
+#
+# `sasl` is deliberately NOT enabled. It is not additive to `ssl`: rdkafka maps
+# `sasl -> gssapi -> ["ssl", "sasl2-sys"]`, so it only adds Cyrus/GSSAPI (Kerberos) while
+# making system libsasl2 a hard build-time requirement (sasl2-sys panics without
+# libsasl2-dev) and a runtime `.so` dependency. `ssl` alone already compiles the PLAIN,
+# SCRAM and OAUTHBEARER mechanisms — verified in the built librdkafka: `WITH_SASL_SCRAM`
+# and `WITH_SASL_OAUTHBEARER` are set, `WITH_SASL_CYRUS` is not, and the link line is
+# `-lssl -lcrypto -lz` with no `-lsasl2`. That covers every managed-Kafka auth mode
+# `kafka+sasl-ssl://` needs; only Kerberos is out of reach.
+rdkafka = {version = "0.39", features = ["tokio", "ssl"]}
 regex = "1.10"
 # Redis client (consolidated across auth/core/observers/server — F015)
 redis = {version = "1", features = ["aio", "tokio-comp", "connection-manager"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,5 +376,8 @@ homepage = "https://fraiseql.dev"
 keywords = ["graphql", "database", "compiler", "sql"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fraiseql/fraiseql"
-rust-version = "1.94"  # MSRV — wasmtime 46's cranelift 0.133 requires 1.94 (#933)
+rust-version = "1.94.1"  # MSRV — wasmtime 46's cranelift 0.133 needs 1.94 (#933); the
+# patch is pinned because aws-sdk-kinesis 1.112 floors at 1.94.1 (#975) and because CI
+# has always run 1.94.1 — Docker's rust:1.94 tracks the newest patch, so a 1.94.0 floor
+# was a claim no leg ever tested.
 version = "2.14.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 # Stage 1: Builder - use rust image for target arch
-FROM --platform=$BUILDPLATFORM rust:1.92-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.94.1-slim AS builder
 
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/crates/fraiseql-cdc-sinks/Cargo.toml
+++ b/crates/fraiseql-cdc-sinks/Cargo.toml
@@ -1,6 +1,8 @@
 [dependencies]
 fraiseql-guard = {workspace = true}
 async-nats = {version = "0.49", optional = true}
+aws-config = {version = "1", optional = true}
+aws-sdk-kinesis = {version = "1", optional = true}
 chrono = {workspace = true}
 rdkafka = {workspace = true, optional = true}
 serde = {version = "1.0", features = ["derive"]}
@@ -26,6 +28,10 @@ default = []
 # Apache Kafka. Unlike async-nats this pulls a C library (librdkafka, built from
 # source by rdkafka-sys) and links system libssl/libcrypto/libz.
 cdc-kafka = ["dep:rdkafka"]
+# AWS Kinesis Data Streams. Pulls the AWS SDK and, with it, a second optional
+# aws-* dependency tree — see the RUSTSEC-2026-0098/0099/0104 entries in deny.toml,
+# whose justification names this feature as well as aws-s3.
+cdc-kinesis = ["dep:aws-sdk-kinesis", "dep:aws-config"]
 cdc-nats-jetstream = ["dep:async-nats"]
 
 [lints]

--- a/crates/fraiseql-cdc-sinks/Cargo.toml
+++ b/crates/fraiseql-cdc-sinks/Cargo.toml
@@ -2,6 +2,7 @@
 fraiseql-guard = {workspace = true}
 async-nats = {version = "0.49", optional = true}
 chrono = {workspace = true}
+rdkafka = {workspace = true, optional = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {workspace = true}
 sqlx = {version = "0.8", features = ["postgres", "runtime-tokio", "uuid", "chrono", "json"]}
@@ -17,10 +18,14 @@ futures = "0.3"
 tokio = {workspace = true, features = ["test-util"]}
 
 [features]
-# Off by default: the broker client (async-nats, pure-Rust) is pulled only when a
-# deployment enables the NATS JetStream sink. The default build stays broker-free;
-# the drain worker + all pure encoding/sanitisation logic compile unconditionally.
+# Off by default: each broker client is pulled only when a deployment enables its
+# sink. The default build stays broker-free; the drain worker, the endpoint
+# guards and all pure encoding/sanitisation logic compile unconditionally, so the
+# refusing half of every transport guard runs in the cheap unit-test leg.
 default = []
+# Apache Kafka. Unlike async-nats this pulls a C library (librdkafka, built from
+# source by rdkafka-sys) and links system libssl/libcrypto/libz.
+cdc-kafka = ["dep:rdkafka"]
 cdc-nats-jetstream = ["dep:async-nats"]
 
 [lints]

--- a/crates/fraiseql-cdc-sinks/README.md
+++ b/crates/fraiseql-cdc-sinks/README.md
@@ -14,10 +14,18 @@ FraiseQL's change spine into a durable event stream for downstream systems.
   transaction held across broker calls**.
 - **Ordered from the head** — a transiently failing row blocks its successors
   (head-of-line blocking) instead of being overtaken; a dead-lettered row releases them.
-- **NATS JetStream sink** (enable the `cdc-nats-jetstream` feature). The broker client
-  (`async-nats`, pure Rust) is pulled in only when this feature is on; the default build is
-  broker-free and the drain worker plus all encoding/sanitisation logic compile
-  unconditionally.
+- **Three broker sinks**, each behind its own feature — `cdc-nats-jetstream` (NATS
+  `JetStream`, via pure-Rust `async-nats`), `cdc-kafka` (Apache Kafka, via `rdkafka`, which
+  builds librdkafka from source and links system OpenSSL), and `cdc-kinesis` (AWS Kinesis
+  Data Streams, via the AWS SDK). A broker client is pulled in only when its feature is on;
+  the default build is broker-free, and the drain worker plus **all** endpoint guards,
+  encoding and sanitisation logic compile unconditionally.
+- **Transport guards that refuse rather than default.** Every sink screens its endpoint
+  before a client is constructed, and each guard is *pure* — no broker type appears in its
+  signature — so the refusing half is exercised by the default, broker-free test build
+  rather than only where that broker's feature is on. Plaintext is refused unless the
+  broker's own opt-in is set **and** `FRAISEQL_ENV` declares development, and on that path
+  the host is screened so the escape hatch cannot reach an instance-metadata address.
 - **At-least-once delivery** — a broker outage accumulates backlog and retries with capped
   exponential backoff rather than losing events; a permanent failure (e.g. an un-renderable
   subject) is dead-lettered. Consumers dedup on `(object_type, seq)`, carried as the NATS

--- a/crates/fraiseql-cdc-sinks/src/kafka.rs
+++ b/crates/fraiseql-cdc-sinks/src/kafka.rs
@@ -1,0 +1,182 @@
+//! The Apache Kafka outbound sink (feature `cdc-kafka`).
+//!
+//! Publishes each change event to a rendered topic with an idempotent producer.
+//! The endpoint parsing, transport guard and topic-charset validation this sink
+//! depends on live in [`crate::sink`] and are always compiled — see the note
+//! there. This module holds only what genuinely needs rdkafka.
+
+use std::time::Duration;
+
+use rdkafka::{
+    ClientConfig,
+    error::KafkaError,
+    message::{Header, OwnedHeaders},
+    producer::{FutureProducer, FutureRecord},
+    types::RDKafkaErrorCode,
+};
+
+use crate::{
+    error::{CdcError, Result},
+    event::ChangeEvent,
+    sink::{
+        CdcSink, CdcSinkConfig, KafkaSecurityProtocol, PublishOutcome, SinkKind,
+        guard_kafka_endpoint, render_kafka_topic, resolve_kafka_sasl,
+    },
+};
+
+/// How long `send` may wait for space in the local producer queue.
+///
+/// Bounded so a full queue surfaces as a retryable failure the drain worker can
+/// back off on, rather than parking the drain tick indefinitely.
+const ENQUEUE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bound on librdkafka's own end-to-end delivery attempt (`message.timeout.ms`).
+///
+/// Left well under the drain's retry cadence so a broker outage produces a
+/// classified `Transient` outcome per attempt instead of an unbounded stall.
+const MESSAGE_TIMEOUT_MS: &str = "30000";
+
+/// A sink that publishes change events to Apache Kafka.
+pub struct KafkaSink {
+    config:   CdcSinkConfig,
+    producer: FutureProducer,
+}
+
+impl KafkaSink {
+    /// Build an idempotent Kafka producer for this sink.
+    ///
+    /// `endpoint` must carry an explicit scheme — `kafka+ssl://`,
+    /// `kafka+sasl-ssl://`, or plaintext `kafka://` under the development opt-in.
+    /// It is screened by [`guard_kafka_endpoint`] before any client is
+    /// constructed; the payload here is the full row after-image of every
+    /// mutation, so a scheme-less endpoint is refused rather than silently taken
+    /// as `PLAINTEXT` the way librdkafka would take it.
+    ///
+    /// `enable.idempotence` is on: librdkafka then holds `acks=all`, bounded
+    /// in-flight requests and producer-side retries, which together give
+    /// no-duplicates-from-retry *and* per-partition ordering. Since the message
+    /// key pins each entity to one partition, that is per-entity ordering.
+    ///
+    /// SASL credentials and any custom CA are supplied through the standard
+    /// librdkafka environment (`extra` config is not yet exposed); the scheme
+    /// only decides `security.protocol`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdcError::Config`] for an unsafe or malformed endpoint, or
+    /// [`CdcError::Connection`] if the producer cannot be created.
+    pub fn connect(endpoint: &str, config: CdcSinkConfig) -> Result<Self> {
+        let endpoint = guard_kafka_endpoint(endpoint)?;
+
+        let mut client = ClientConfig::new();
+        client
+            .set("bootstrap.servers", &endpoint.bootstrap_servers)
+            .set("security.protocol", endpoint.security_protocol.as_str())
+            .set("enable.idempotence", "true")
+            .set("message.timeout.ms", MESSAGE_TIMEOUT_MS)
+            .set("compression.type", "lz4");
+
+        if endpoint.security_protocol == KafkaSecurityProtocol::SaslSsl {
+            let sasl = resolve_kafka_sasl()?;
+            client
+                .set("sasl.mechanism", sasl.mechanism.as_str())
+                .set("sasl.username", &sasl.username)
+                .set("sasl.password", &sasl.password);
+        }
+
+        let producer: FutureProducer = client
+            .create()
+            .map_err(|e| CdcError::Connection(format!("kafka producer: {e}")))?;
+
+        Ok(Self { config, producer })
+    }
+
+    /// The partition key for an event.
+    ///
+    /// This is the entity's identity, **not** the per-message dedup key. Kafka
+    /// hashes the key to choose a partition, and ordering is only guaranteed
+    /// within a partition — so keying by anything unique per message (a `seq`,
+    /// say) would scatter an entity's changes across every partition and destroy
+    /// the ordering the idempotent producer is there to provide. Consumer dedup
+    /// is served separately by the `(object_type, seq)` pair, which travels in
+    /// the payload and in the `fraiseql-msg-id` header.
+    ///
+    /// Falls back to the object type alone when a row carries no `object_id`,
+    /// which keeps the key deterministic (never null, never random) and degrades
+    /// to per-table rather than per-entity ordering.
+    fn partition_key(ev: &ChangeEvent) -> String {
+        ev.object_id
+            .map_or_else(|| ev.object_type.clone(), |id| format!("{}:{}", ev.object_type, id))
+    }
+}
+
+impl CdcSink for KafkaSink {
+    fn name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn kind(&self) -> SinkKind {
+        SinkKind::Kafka
+    }
+
+    fn matches(&self, ev: &ChangeEvent) -> bool {
+        self.config.matches(ev)
+    }
+
+    async fn publish(&self, ev: &ChangeEvent) -> PublishOutcome {
+        let topic = match render_kafka_topic(&self.config.subject_template, ev) {
+            Ok(topic) => topic,
+            Err(reason) => return PublishOutcome::Permanent(format!("topic render: {reason}")),
+        };
+        let payload = match serde_json::to_vec(ev) {
+            Ok(payload) => payload,
+            Err(error) => return PublishOutcome::Permanent(format!("encode: {error}")),
+        };
+
+        let key = Self::partition_key(ev);
+        let msg_id = format!("{}:{}", ev.object_type, ev.seq);
+        let headers = OwnedHeaders::new()
+            .insert(Header {
+                key:   "fraiseql-msg-id",
+                value: Some(&msg_id),
+            })
+            .insert(Header {
+                key:   "fraiseql-op",
+                value: Some(ev.op.as_str()),
+            });
+
+        let record = FutureRecord::to(&topic).key(&key).payload(&payload).headers(headers);
+
+        match self.producer.send(record, ENQUEUE_TIMEOUT).await {
+            Ok(_) => PublishOutcome::Published,
+            Err((error, _)) => classify(&error),
+        }
+    }
+}
+
+/// Classify a produce failure as retryable or dead-letter.
+///
+/// The default is [`PublishOutcome::Transient`], deliberately: the drain worker
+/// dead-letters on its own `max_attempts` ceiling anyway, so a misclassified
+/// transient error costs a delay, while a misclassified permanent one discards a
+/// change event. Only failures that *cannot* succeed on redelivery of the same
+/// bytes are permanent.
+fn classify(error: &KafkaError) -> PublishOutcome {
+    let permanent = matches!(
+        error,
+        KafkaError::MessageProduction(
+            RDKafkaErrorCode::MessageSizeTooLarge
+                | RDKafkaErrorCode::MessageBatchTooLarge
+                | RDKafkaErrorCode::InvalidTopic
+                | RDKafkaErrorCode::InvalidRecord
+        )
+    );
+    if permanent {
+        PublishOutcome::Permanent(format!("publish: {error}"))
+    } else {
+        PublishOutcome::Transient(format!("publish: {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-cdc-sinks/src/kafka.rs
+++ b/crates/fraiseql-cdc-sinks/src/kafka.rs
@@ -20,7 +20,7 @@ use crate::{
     event::ChangeEvent,
     sink::{
         CdcSink, CdcSinkConfig, KafkaSecurityProtocol, PublishOutcome, SinkKind,
-        guard_kafka_endpoint, render_kafka_topic, resolve_kafka_sasl,
+        entity_partition_key, guard_kafka_endpoint, render_kafka_topic, resolve_kafka_sasl,
     },
 };
 
@@ -90,24 +90,6 @@ impl KafkaSink {
 
         Ok(Self { config, producer })
     }
-
-    /// The partition key for an event.
-    ///
-    /// This is the entity's identity, **not** the per-message dedup key. Kafka
-    /// hashes the key to choose a partition, and ordering is only guaranteed
-    /// within a partition — so keying by anything unique per message (a `seq`,
-    /// say) would scatter an entity's changes across every partition and destroy
-    /// the ordering the idempotent producer is there to provide. Consumer dedup
-    /// is served separately by the `(object_type, seq)` pair, which travels in
-    /// the payload and in the `fraiseql-msg-id` header.
-    ///
-    /// Falls back to the object type alone when a row carries no `object_id`,
-    /// which keeps the key deterministic (never null, never random) and degrades
-    /// to per-table rather than per-entity ordering.
-    fn partition_key(ev: &ChangeEvent) -> String {
-        ev.object_id
-            .map_or_else(|| ev.object_type.clone(), |id| format!("{}:{}", ev.object_type, id))
-    }
 }
 
 impl CdcSink for KafkaSink {
@@ -133,7 +115,7 @@ impl CdcSink for KafkaSink {
             Err(error) => return PublishOutcome::Permanent(format!("encode: {error}")),
         };
 
-        let key = Self::partition_key(ev);
+        let key = entity_partition_key(ev);
         let msg_id = format!("{}:{}", ev.object_type, ev.seq);
         let headers = OwnedHeaders::new()
             .insert(Header {

--- a/crates/fraiseql-cdc-sinks/src/kafka/tests.rs
+++ b/crates/fraiseql-cdc-sinks/src/kafka/tests.rs
@@ -1,0 +1,146 @@
+//! Tests for the parts of the Kafka sink that need rdkafka in scope.
+//!
+//! The endpoint guard and topic charset are pure and tested in
+//! `crate::sink::tests`, where they run in the always-compiled unit-test leg.
+//! What is left here is the partition-key contract and the produce-error
+//! classification — both of which name rdkafka types.
+
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+use uuid::Uuid;
+
+use super::{KafkaSink, classify};
+use crate::{
+    event::{ChangeEvent, ChangeOp},
+    sink::{CdcSinkConfig, PublishOutcome},
+};
+
+#[test]
+fn tls_endpoints_are_accepted_because_openssl_is_compiled_in() {
+    // The accepting half of the transport guard, assertable without a broker.
+    //
+    // Producer creation is where librdkafka validates `security.protocol`, and
+    // without rdkafka's `ssl` feature this call fails with *"Unsupported value
+    // \"ssl\" ... OpenSSL not available at build time"*. That is what made the
+    // accepting half untestable before, and a guard suite proving only the
+    // refusing half is #816's shape again — green, and half a guard.
+    //
+    // No connection is attempted here: librdkafka fetches metadata lazily on a
+    // background thread, so an unreachable broker still yields a producer.
+    let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+    let sink = KafkaSink::connect("kafka+ssl://broker.invalid:9092", cfg);
+    assert!(
+        sink.is_ok(),
+        "kafka+ssl:// must be constructible — is rdkafka's `ssl` feature still on? {:?}",
+        sink.err().map(|e| e.to_string())
+    );
+}
+
+#[test]
+fn sasl_ssl_endpoints_refuse_before_librdkafka_can_default_to_kerberos() {
+    // Belt-and-braces over the pure `resolve_kafka_sasl` tests: assert the sink
+    // actually consults it, so a future refactor cannot leave `sasl.mechanism`
+    // unset and inherit librdkafka's GSSAPI default (which this build has no
+    // provider for).
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KAFKA_SASL_MECHANISM", None::<&str>),
+            ("FRAISEQL_KAFKA_SASL_USERNAME", None),
+            ("FRAISEQL_KAFKA_SASL_PASSWORD", None),
+        ],
+        || {
+            let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+            let err = KafkaSink::connect("kafka+sasl-ssl://broker.invalid:9092", cfg)
+                .err()
+                .expect("sasl-ssl without a mechanism must be refused")
+                .to_string();
+            assert!(
+                err.contains("FRAISEQL_KAFKA_SASL_MECHANISM"),
+                "should be our named refusal, not librdkafka's: {err}"
+            );
+        },
+    );
+}
+
+#[test]
+fn sasl_ssl_builds_a_producer_once_credentials_are_present() {
+    // Proves the mechanism/credential values we emit are ones librdkafka accepts —
+    // it validates them at client creation (PLAIN and SCRAM both reject a missing
+    // username there).
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KAFKA_SASL_MECHANISM", Some("SCRAM-SHA-512")),
+            ("FRAISEQL_KAFKA_SASL_USERNAME", Some("u")),
+            ("FRAISEQL_KAFKA_SASL_PASSWORD", Some("p")),
+        ],
+        || {
+            let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+            let sink = KafkaSink::connect("kafka+sasl-ssl://broker.invalid:9092", cfg);
+            assert!(sink.is_ok(), "{:?}", sink.err().map(|e| e.to_string()));
+        },
+    );
+}
+
+#[test]
+fn partition_key_is_the_entity_identity_not_the_sequence() {
+    // The property that matters: two changes to the *same* entity must share a
+    // key (same partition, ordered), and the sequence must not enter the key.
+    let id = Uuid::from_u128(0xfeed);
+    let first = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(id);
+    let second = ChangeEvent::new(9_999, "tb_post", ChangeOp::Update).with_object_id(id);
+
+    assert_eq!(KafkaSink::partition_key(&first), KafkaSink::partition_key(&second));
+    assert_eq!(KafkaSink::partition_key(&first), format!("tb_post:{id}"));
+    assert!(
+        !KafkaSink::partition_key(&first).contains('1'),
+        "the seq must not appear in the key — it would scatter an entity across partitions"
+    );
+}
+
+#[test]
+fn partition_key_separates_distinct_entities() {
+    let a = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(Uuid::from_u128(1));
+    let b = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(Uuid::from_u128(2));
+    assert_ne!(KafkaSink::partition_key(&a), KafkaSink::partition_key(&b));
+}
+
+#[test]
+fn partition_key_is_deterministic_without_an_object_id() {
+    // Never null (librdkafka would then pick a partition at random, losing even
+    // per-table ordering) and never varying between two calls.
+    let ev = ChangeEvent::new(7, "tb_post", ChangeOp::Custom);
+    assert_eq!(KafkaSink::partition_key(&ev), "tb_post");
+    assert_eq!(KafkaSink::partition_key(&ev), KafkaSink::partition_key(&ev));
+}
+
+#[test]
+fn oversized_messages_are_permanent_and_everything_else_retries() {
+    use rdkafka::{error::KafkaError, types::RDKafkaErrorCode};
+
+    for code in [
+        RDKafkaErrorCode::MessageSizeTooLarge,
+        RDKafkaErrorCode::MessageBatchTooLarge,
+        RDKafkaErrorCode::InvalidTopic,
+        RDKafkaErrorCode::InvalidRecord,
+    ] {
+        assert!(
+            matches!(classify(&KafkaError::MessageProduction(code)), PublishOutcome::Permanent(_)),
+            "{code:?} cannot succeed on redelivery of the same bytes"
+        );
+    }
+
+    // A broker outage, a full queue and a leader election must all retry — the
+    // drain's own max_attempts ceiling is what eventually dead-letters them.
+    for code in [
+        RDKafkaErrorCode::BrokerTransportFailure,
+        RDKafkaErrorCode::QueueFull,
+        RDKafkaErrorCode::NotLeaderForPartition,
+        RDKafkaErrorCode::RequestTimedOut,
+        RDKafkaErrorCode::TopicAuthorizationFailed,
+    ] {
+        assert!(
+            matches!(classify(&KafkaError::MessageProduction(code)), PublishOutcome::Transient(_)),
+            "{code:?} must retry rather than discard the change event"
+        );
+    }
+}

--- a/crates/fraiseql-cdc-sinks/src/kafka/tests.rs
+++ b/crates/fraiseql-cdc-sinks/src/kafka/tests.rs
@@ -7,13 +7,8 @@
 
 #![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
 
-use uuid::Uuid;
-
 use super::{KafkaSink, classify};
-use crate::{
-    event::{ChangeEvent, ChangeOp},
-    sink::{CdcSinkConfig, PublishOutcome},
-};
+use crate::sink::{CdcSinkConfig, PublishOutcome};
 
 #[test]
 fn tls_endpoints_are_accepted_because_openssl_is_compiled_in() {
@@ -81,37 +76,9 @@ fn sasl_ssl_builds_a_producer_once_credentials_are_present() {
     );
 }
 
-#[test]
-fn partition_key_is_the_entity_identity_not_the_sequence() {
-    // The property that matters: two changes to the *same* entity must share a
-    // key (same partition, ordered), and the sequence must not enter the key.
-    let id = Uuid::from_u128(0xfeed);
-    let first = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(id);
-    let second = ChangeEvent::new(9_999, "tb_post", ChangeOp::Update).with_object_id(id);
-
-    assert_eq!(KafkaSink::partition_key(&first), KafkaSink::partition_key(&second));
-    assert_eq!(KafkaSink::partition_key(&first), format!("tb_post:{id}"));
-    assert!(
-        !KafkaSink::partition_key(&first).contains('1'),
-        "the seq must not appear in the key — it would scatter an entity across partitions"
-    );
-}
-
-#[test]
-fn partition_key_separates_distinct_entities() {
-    let a = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(Uuid::from_u128(1));
-    let b = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(Uuid::from_u128(2));
-    assert_ne!(KafkaSink::partition_key(&a), KafkaSink::partition_key(&b));
-}
-
-#[test]
-fn partition_key_is_deterministic_without_an_object_id() {
-    // Never null (librdkafka would then pick a partition at random, losing even
-    // per-table ordering) and never varying between two calls.
-    let ev = ChangeEvent::new(7, "tb_post", ChangeOp::Custom);
-    assert_eq!(KafkaSink::partition_key(&ev), "tb_post");
-    assert_eq!(KafkaSink::partition_key(&ev), KafkaSink::partition_key(&ev));
-}
+// The partition-key properties moved to `sink::tests` with the key itself: it is
+// shared with the Kinesis sink and pure, so it belongs in the always-compiled leg
+// rather than only where `cdc-kafka` is on.
 
 #[test]
 fn oversized_messages_are_permanent_and_everything_else_retries() {

--- a/crates/fraiseql-cdc-sinks/src/kinesis.rs
+++ b/crates/fraiseql-cdc-sinks/src/kinesis.rs
@@ -1,0 +1,170 @@
+//! The AWS Kinesis Data Streams outbound sink (feature `cdc-kinesis`).
+//!
+//! Publishes each change event to a rendered stream with `PutRecord`. The region
+//! parsing, endpoint-override guard, stream-name validation and partition key this
+//! sink depends on all live in [`crate::sink`] and are always compiled — see the
+//! note there. This module holds only what genuinely needs the AWS SDK.
+
+use aws_sdk_kinesis::{
+    Client, error::SdkError, operation::put_record::PutRecordError, primitives::Blob,
+};
+
+use crate::{
+    error::Result,
+    event::ChangeEvent,
+    sink::{
+        CdcSink, CdcSinkConfig, PublishOutcome, SinkKind, entity_partition_key,
+        guard_kinesis_endpoint, render_kinesis_stream, resolve_kinesis_endpoint_url,
+    },
+};
+
+/// A sink that publishes change events to AWS Kinesis Data Streams.
+pub struct KinesisSink {
+    config: CdcSinkConfig,
+    client: Client,
+}
+
+impl KinesisSink {
+    /// Build a Kinesis client for this sink.
+    ///
+    /// `endpoint` names the region as `kinesis://<region>` and is screened by
+    /// [`guard_kinesis_endpoint`] before any client is constructed. Credentials
+    /// come from the standard AWS provider chain (environment, profile, IMDS, IRSA
+    /// for EKS) rather than from sink config, because they are secrets and the
+    /// config is destined for a TOML surface.
+    ///
+    /// Transport is HTTPS: the SDK resolves the regional endpoint itself. The one
+    /// way to reach a plaintext endpoint is `FRAISEQL_KINESIS_ENDPOINT_URL`, which
+    /// [`resolve_kinesis_endpoint_url`] refuses unless the operator has opted in,
+    /// declared a development environment, and pointed it at loopback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CdcError::Config`](crate::error::CdcError::Config) for an
+    /// unsafe or malformed endpoint or
+    /// endpoint-URL override.
+    pub async fn connect(endpoint: &str, config: CdcSinkConfig) -> Result<Self> {
+        let endpoint = guard_kinesis_endpoint(endpoint)?;
+        let override_url = resolve_kinesis_endpoint_url()?;
+
+        // `BehaviorVersion::latest()` is set explicitly: the SDK panics at client
+        // construction if no behaviour version is pinned, and the alternative —
+        // the `behavior-version-latest` cargo feature — hides that choice in a
+        // manifest where it reads as incidental.
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(endpoint.region.clone()));
+        if let Some(url) = override_url {
+            loader = loader.endpoint_url(url);
+        }
+        let aws = loader.load().await;
+
+        Ok(Self {
+            config,
+            client: Client::new(&aws),
+        })
+    }
+}
+
+impl CdcSink for KinesisSink {
+    fn name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn kind(&self) -> SinkKind {
+        SinkKind::Kinesis
+    }
+
+    fn matches(&self, ev: &ChangeEvent) -> bool {
+        self.config.matches(ev)
+    }
+
+    async fn publish(&self, ev: &ChangeEvent) -> PublishOutcome {
+        let stream = match render_kinesis_stream(&self.config.subject_template, ev) {
+            Ok(stream) => stream,
+            Err(reason) => return PublishOutcome::Permanent(format!("stream render: {reason}")),
+        };
+        let payload = match serde_json::to_vec(ev) {
+            Ok(payload) => payload,
+            Err(error) => return PublishOutcome::Permanent(format!("encode: {error}")),
+        };
+
+        // No `sequence_number_for_ordering`: it would require holding the previous
+        // record's sequence number per partition key, which is unbounded state for
+        // a firehose, and it buys nothing here. The drain publishes strictly
+        // serially and head-of-line-blocks an unfinished row, so record N is
+        // durably stored before N+1 is sent — arrival order already is `seq` order.
+        // Consumers dedup on the `(object_type, seq)` pair in the payload.
+        let result = self
+            .client
+            .put_record()
+            .stream_name(&stream)
+            .partition_key(entity_partition_key(ev))
+            .data(Blob::new(payload))
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => PublishOutcome::Published,
+            Err(error) => classify(&error),
+        }
+    }
+}
+
+/// Classify a `PutRecord` failure as retryable or dead-letter.
+///
+/// The default is [`PublishOutcome::Transient`], deliberately, for the reason the
+/// Kafka sink states: the drain dead-letters on its own `max_attempts` ceiling
+/// anyway, so a misclassified transient error costs a delay, while a misclassified
+/// permanent one discards a change event. Only failures that *cannot* succeed on
+/// redelivery of the same bytes are permanent.
+///
+/// `InvalidArgumentException` is the only modelled `PutRecord` failure that
+/// qualifies — a payload over the record limit, or a partition key Kinesis rejects,
+/// fails identically on every redelivery of the same bytes.
+///
+/// Everything else retries. `ResourceNotFoundException` in particular is
+/// **transient**, not permanent: a stream that does not exist yet may be created,
+/// and dead-lettering the backlog for a stream an operator is mid-way through
+/// provisioning would lose events no retry needed to lose. Throttling
+/// (`ProvisionedThroughputExceededException`) is the ordinary Kinesis back-pressure
+/// signal and is exactly what backoff is for, and `AccessDeniedException` is
+/// commonly an IAM propagation delay.
+///
+/// The message is built from the modelled error's `Display`, never the `SdkError`'s
+/// `Debug`: the latter can carry the raw HTTP response, and this string is
+/// persisted to the `last_error` column.
+fn classify<R>(error: &SdkError<PutRecordError, R>) -> PublishOutcome {
+    match error {
+        SdkError::ServiceError(service) => classify_service(service.err()),
+        SdkError::TimeoutError(_) => PublishOutcome::Transient("publish: timeout".to_owned()),
+        SdkError::DispatchFailure(_) => {
+            PublishOutcome::Transient("publish: dispatch failure".to_owned())
+        },
+        SdkError::ResponseError(_) => {
+            PublishOutcome::Transient("publish: malformed response".to_owned())
+        },
+        SdkError::ConstructionFailure(_) => {
+            PublishOutcome::Transient("publish: request construction failed".to_owned())
+        },
+        _ => PublishOutcome::Transient("publish: unknown SDK failure".to_owned()),
+    }
+}
+
+/// The service-error half of [`classify`] — the part that carries the actual
+/// transient-vs-permanent decision.
+///
+/// Split out so it is testable directly: constructing an [`SdkError::ServiceError`]
+/// requires a raw HTTP response, whose types are not re-exported by
+/// `aws-sdk-kinesis`, and the classification rule should not go untested for want
+/// of two dev-dependencies.
+fn classify_service(error: &PutRecordError) -> PublishOutcome {
+    let detail = format!("publish: {error}");
+    if matches!(error, PutRecordError::InvalidArgumentException(_)) {
+        PublishOutcome::Permanent(detail)
+    } else {
+        PublishOutcome::Transient(detail)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fraiseql-cdc-sinks/src/kinesis/tests.rs
+++ b/crates/fraiseql-cdc-sinks/src/kinesis/tests.rs
@@ -1,0 +1,155 @@
+//! Tests for the parts of the Kinesis sink that need the AWS SDK in scope.
+//!
+//! The endpoint guard, the endpoint-URL override guard and the stream charset are
+//! pure and tested in `crate::sink::tests`, where they run in the always-compiled
+//! unit-test leg. What is left here is that the sink actually *consults* them, plus
+//! the `PutRecord` error classification — which names SDK types.
+
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+
+use super::KinesisSink;
+use crate::sink::{CdcSink, CdcSinkConfig, SinkKind};
+
+/// Dummy static credentials, so `load()` resolves from the environment instead of
+/// walking the provider chain out to IMDS (which would make these tests wait on a
+/// network timeout in CI).
+fn creds_plus<'a>(vars: Vec<(&'a str, Option<&'a str>)>) -> Vec<(&'a str, Option<&'a str>)> {
+    let mut all = vec![
+        ("AWS_ACCESS_KEY_ID", Some("test")),
+        ("AWS_SECRET_ACCESS_KEY", Some("test")),
+        ("AWS_EC2_METADATA_DISABLED", Some("true")),
+    ];
+    all.extend(vars);
+    all
+}
+
+#[tokio::test]
+async fn connect_consults_the_endpoint_guard() {
+    // Belt-and-braces over the pure `guard_kinesis_endpoint` tests: assert the sink
+    // actually calls it, so a refactor cannot leave a scheme-less region accepted.
+    // `Box::pin`: the AWS SDK's client-construction future is large enough to trip
+    // `clippy::large_futures` on the stack.
+    let refused = Box::pin(temp_env::async_with_vars(
+        creds_plus(vec![("FRAISEQL_KINESIS_ENDPOINT_URL", None)]),
+        async {
+            let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+            KinesisSink::connect("us-east-1", cfg).await
+        },
+    ))
+    .await;
+    let err = refused.err().expect("a scheme-less endpoint must be refused").to_string();
+    assert!(err.contains("kinesis://"), "should be our named refusal: {err}");
+}
+
+#[tokio::test]
+async fn connect_consults_the_endpoint_url_guard() {
+    // The plaintext override must be refused by the sink, not merely by the pure
+    // helper. Loopback host, so the refusal is attributable to the missing opt-in.
+    let refused = Box::pin(temp_env::async_with_vars(
+        creds_plus(vec![
+            ("FRAISEQL_KINESIS_ENDPOINT_URL", Some("http://localhost:4566")),
+            ("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", None),
+        ]),
+        async {
+            let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+            KinesisSink::connect("kinesis://us-east-1", cfg).await
+        },
+    ))
+    .await;
+    let err = refused
+        .err()
+        .expect("an unopted-in http:// override must be refused")
+        .to_string();
+    assert!(
+        err.contains("FRAISEQL_KINESIS_ALLOW_PLAINTEXT"),
+        "should name the opt-in: {err}"
+    );
+}
+
+#[tokio::test]
+async fn connect_builds_a_client_for_a_valid_region() {
+    // The accepting half, assertable without a broker: no request is sent at
+    // construction, so an unreachable endpoint still yields a client.
+    let sink = Box::pin(temp_env::async_with_vars(
+        creds_plus(vec![("FRAISEQL_KINESIS_ENDPOINT_URL", None)]),
+        async {
+            let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+            KinesisSink::connect("kinesis://eu-west-3", cfg).await
+        },
+    ))
+    .await;
+    let sink = sink.expect("a valid kinesis:// region must be constructible");
+    assert_eq!(sink.kind(), SinkKind::Kinesis);
+    assert_eq!(sink.name(), "primary");
+}
+
+#[tokio::test]
+async fn connect_accepts_a_loopback_plaintext_override_when_opted_in() {
+    // The LocalStack path the e2e suite depends on.
+    let sink = Box::pin(temp_env::async_with_vars(
+        creds_plus(vec![
+            ("FRAISEQL_KINESIS_ENDPOINT_URL", Some("http://127.0.0.1:4566")),
+            ("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", Some("true")),
+            ("FRAISEQL_ENV", Some("development")),
+            ("FRAISEQL_PROFILE", None),
+            ("KUBERNETES_SERVICE_HOST", None),
+        ]),
+        async {
+            let cfg = CdcSinkConfig::new("primary", "fraiseql.{table}");
+            KinesisSink::connect("kinesis://us-east-1", cfg).await
+        },
+    ))
+    .await;
+    assert!(sink.is_ok(), "{:?}", sink.err().map(|e| e.to_string()));
+}
+
+#[test]
+fn only_invalid_argument_is_permanent_and_everything_else_retries() {
+    use aws_sdk_kinesis::{
+        operation::put_record::PutRecordError,
+        types::error::{
+            AccessDeniedException, InternalFailureException, InvalidArgumentException,
+            ProvisionedThroughputExceededException, ResourceNotFoundException,
+        },
+    };
+
+    use super::classify_service;
+    use crate::sink::PublishOutcome;
+
+    // A rejected argument — an oversized record, a partition key Kinesis will not
+    // take — fails identically on every redelivery of the same bytes.
+    assert!(matches!(
+        classify_service(&PutRecordError::InvalidArgumentException(
+            InvalidArgumentException::builder().message("bad partition key").build()
+        )),
+        PublishOutcome::Permanent(_)
+    ));
+
+    // Everything else must retry rather than discard the change event: a missing
+    // stream may still be created, throttling is what backoff is for, an IAM denial
+    // is commonly a propagation delay, and an internal failure is AWS's problem.
+    assert!(matches!(
+        classify_service(&PutRecordError::ResourceNotFoundException(
+            ResourceNotFoundException::builder().message("no such stream").build()
+        )),
+        PublishOutcome::Transient(_)
+    ));
+    assert!(matches!(
+        classify_service(&PutRecordError::ProvisionedThroughputExceededException(
+            ProvisionedThroughputExceededException::builder().message("slow down").build()
+        )),
+        PublishOutcome::Transient(_)
+    ));
+    assert!(matches!(
+        classify_service(&PutRecordError::AccessDeniedException(
+            AccessDeniedException::builder().message("denied").build()
+        )),
+        PublishOutcome::Transient(_)
+    ));
+    assert!(matches!(
+        classify_service(&PutRecordError::InternalFailureException(
+            InternalFailureException::builder().message("boom").build()
+        )),
+        PublishOutcome::Transient(_)
+    ));
+}

--- a/crates/fraiseql-cdc-sinks/src/lib.rs
+++ b/crates/fraiseql-cdc-sinks/src/lib.rs
@@ -18,9 +18,14 @@
 //!
 //! # Layered optionality
 //!
-//! The drain worker and all pure encoding/sanitisation logic compile
-//! unconditionally; each broker sink is gated behind its own feature. The first
-//! shipped sink is NATS `JetStream` (`cdc-nats-jetstream`).
+//! The drain worker, every endpoint guard and all pure encoding/sanitisation
+//! logic compile unconditionally; each broker sink is gated behind its own
+//! feature — NATS `JetStream` (`cdc-nats-jetstream`), Apache Kafka
+//! (`cdc-kafka`) and AWS Kinesis (`cdc-kinesis`).
+//!
+//! Guards live alongside the sink trait rather than beside their clients because
+//! they are pure: that keeps the *refusing* half of each one in the cheap,
+//! broker-free test build instead of only where its feature is enabled.
 //!
 //! ```
 //! use fraiseql_cdc_sinks::{ChangeEvent, ChangeOp, CdcSinkConfig, render_subject};

--- a/crates/fraiseql-cdc-sinks/src/lib.rs
+++ b/crates/fraiseql-cdc-sinks/src/lib.rs
@@ -38,15 +38,21 @@ mod event;
 mod migrations;
 mod sink;
 
+#[cfg(feature = "cdc-kafka")]
+mod kafka;
 #[cfg(feature = "cdc-nats-jetstream")]
 mod nats;
 
 pub use drain::{DrainStats, DrainWorker};
 pub use error::{CdcError, Result};
 pub use event::{ChangeEvent, ChangeOp};
+#[cfg(feature = "cdc-kafka")]
+pub use kafka::KafkaSink;
 pub use migrations::outbox_sink_state_migration_sql;
 #[cfg(feature = "cdc-nats-jetstream")]
 pub use nats::NatsJetStreamSink;
 pub use sink::{
-    CdcSink, CdcSinkConfig, PublishOutcome, SinkKind, next_attempt_delay, render_subject,
+    CdcSink, CdcSinkConfig, KafkaEndpoint, KafkaSaslCredentials, KafkaSaslMechanism,
+    KafkaSecurityProtocol, PublishOutcome, SinkKind, guard_kafka_endpoint, next_attempt_delay,
+    render_kafka_topic, render_subject, resolve_kafka_sasl, validate_kafka_topic,
 };

--- a/crates/fraiseql-cdc-sinks/src/lib.rs
+++ b/crates/fraiseql-cdc-sinks/src/lib.rs
@@ -40,6 +40,8 @@ mod sink;
 
 #[cfg(feature = "cdc-kafka")]
 mod kafka;
+#[cfg(feature = "cdc-kinesis")]
+mod kinesis;
 #[cfg(feature = "cdc-nats-jetstream")]
 mod nats;
 
@@ -48,11 +50,15 @@ pub use error::{CdcError, Result};
 pub use event::{ChangeEvent, ChangeOp};
 #[cfg(feature = "cdc-kafka")]
 pub use kafka::KafkaSink;
+#[cfg(feature = "cdc-kinesis")]
+pub use kinesis::KinesisSink;
 pub use migrations::outbox_sink_state_migration_sql;
 #[cfg(feature = "cdc-nats-jetstream")]
 pub use nats::NatsJetStreamSink;
 pub use sink::{
     CdcSink, CdcSinkConfig, KafkaEndpoint, KafkaSaslCredentials, KafkaSaslMechanism,
-    KafkaSecurityProtocol, PublishOutcome, SinkKind, guard_kafka_endpoint, next_attempt_delay,
-    render_kafka_topic, render_subject, resolve_kafka_sasl, validate_kafka_topic,
+    KafkaSecurityProtocol, KinesisEndpoint, PublishOutcome, SinkKind, entity_partition_key,
+    guard_kafka_endpoint, guard_kinesis_endpoint, next_attempt_delay, render_kafka_topic,
+    render_kinesis_stream, render_subject, resolve_kafka_sasl, resolve_kinesis_endpoint_url,
+    validate_kafka_topic, validate_kinesis_stream,
 };

--- a/crates/fraiseql-cdc-sinks/src/sink.rs
+++ b/crates/fraiseql-cdc-sinks/src/sink.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::event::ChangeEvent;
+use crate::{error::CdcError, event::ChangeEvent};
 
 /// Which broker a sink targets. Serialised `kebab-case` so TOML `kind =
 /// "nats-jetstream"` round-trips.
@@ -17,7 +17,7 @@ use crate::event::ChangeEvent;
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum SinkKind {
-    /// Apache Kafka (not yet implemented — see the #382 umbrella).
+    /// Apache Kafka (feature `cdc-kafka`).
     Kafka,
     /// NATS `JetStream`. Renamed explicitly so the TOML `kind` is the compact
     /// `"nats-jetstream"` rather than kebab-case's `"nats-jet-stream"`.
@@ -200,6 +200,386 @@ fn sanitize_segment(segment: &str) -> Result<String, String> {
 pub fn next_attempt_delay(attempt: u32) -> Duration {
     let secs = 1u64.checked_shl(attempt.saturating_sub(1)).unwrap_or(u64::MAX).min(300);
     Duration::from_secs(secs)
+}
+
+// ── Kafka endpoint parsing + transport guard ─────────────────────────────────
+//
+// Pure, and therefore here rather than in the feature-gated `kafka` module: no
+// rdkafka type appears in these signatures, so the *refusing* half of the guard
+// is exercised by the always-compiled unit-test leg instead of only where
+// `cdc-kafka` is enabled. The NATS guard lives behind `cdc-nats-jetstream` and is
+// only ever run there — worth not repeating.
+
+/// The transport security a Kafka endpoint declares.
+///
+/// librdkafka's own `security.protocol` default is `PLAINTEXT`, so this is always
+/// set explicitly from the endpoint scheme rather than left to the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KafkaSecurityProtocol {
+    /// Unencrypted. Reachable only via the development opt-in.
+    Plaintext,
+    /// TLS, no SASL authentication.
+    Ssl,
+    /// TLS plus a SASL mechanism (`PLAIN`, `SCRAM-SHA-*` or `OAUTHBEARER`; the
+    /// mechanism and credentials are supplied separately).
+    SaslSsl,
+}
+
+impl KafkaSecurityProtocol {
+    /// The literal librdkafka `security.protocol` value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Plaintext => "plaintext",
+            Self::Ssl => "ssl",
+            Self::SaslSsl => "sasl_ssl",
+        }
+    }
+}
+
+/// A Kafka endpoint that has passed [`guard_kafka_endpoint`].
+///
+/// There is no other constructor and the struct is `#[non_exhaustive]`, so a
+/// value of this type *is* the proof that the guard ran — `bootstrap_servers`
+/// cannot be obtained by skipping it.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct KafkaEndpoint {
+    /// The protocol to set on the producer, derived from the scheme.
+    pub security_protocol: KafkaSecurityProtocol,
+    /// The scheme-stripped, comma-separated `host:port` list for librdkafka.
+    pub bootstrap_servers: String,
+}
+
+/// Env var that permits an unencrypted `kafka://` endpoint.
+///
+/// Honoured only when `FRAISEQL_ENV` declares a development environment. Named
+/// and parsed like the NATS sink's flag so the two cannot disagree about what the
+/// operator asked for.
+const KAFKA_ALLOW_PLAINTEXT_ENV: &str = "FRAISEQL_KAFKA_ALLOW_PLAINTEXT";
+
+/// Kafka's own topic-name length cap.
+const KAFKA_TOPIC_MAX_LEN: usize = 249;
+
+/// Parse and screen a Kafka endpoint, returning the producer settings it implies.
+///
+/// `bootstrap.servers` is a comma-separated `host:port` list with **no URL
+/// scheme**, so transport security is not expressible in it the way `tls://` is
+/// for NATS. This requires a scheme of our own — `kafka+ssl://`,
+/// `kafka+sasl-ssl://`, or plaintext `kafka://` — maps it to an explicit
+/// `security.protocol`, and strips it before the list reaches librdkafka.
+///
+/// A **scheme-less endpoint is refused, not defaulted**: librdkafka would take it
+/// as `PLAINTEXT`, which is the silent downgrade #816 shipped for NATS.
+///
+/// Plaintext additionally requires the [`KAFKA_ALLOW_PLAINTEXT_ENV`] opt-in *and*
+/// a declared development environment. On that path **every** broker in the list
+/// is screened through [`fraiseql_guard::net`], not just the first: librdkafka
+/// contacts each bootstrap server, so one `169.254.169.254:9092` hiding behind a
+/// loopback entry would otherwise turn the dev escape hatch into an SSRF licence.
+///
+/// Screening is deliberately *not* applied to the encrypted schemes. MSK and
+/// every VPC-hosted cluster address brokers in RFC 1918 space, which
+/// [`fraiseql_guard::net::blocked_host_reason`] refuses — the guard exists to stop
+/// the plaintext escape hatch reaching further than localhost, not to veto where
+/// an operator points an encrypted connection.
+///
+/// # Errors
+///
+/// Returns [`CdcError::Config`] for a missing or unsupported scheme, a malformed
+/// or empty broker list, an unopted-in plaintext endpoint, or any blocked broker
+/// host on the plaintext path.
+pub fn guard_kafka_endpoint(endpoint: &str) -> crate::error::Result<KafkaEndpoint> {
+    let Some((scheme, rest)) = endpoint.split_once("://") else {
+        return Err(CdcError::Config(format!(
+            "kafka endpoint {endpoint:?} has no scheme. bootstrap.servers carries no \
+             transport security, and librdkafka reads a bare list as PLAINTEXT, so the \
+             scheme is required here rather than defaulted: use kafka+ssl://host:port, \
+             kafka+sasl-ssl://host:port, or kafka://host:port for a dev broker."
+        )));
+    };
+
+    let security_protocol = match scheme.to_ascii_lowercase().as_str() {
+        "kafka" => KafkaSecurityProtocol::Plaintext,
+        "kafka+ssl" => KafkaSecurityProtocol::Ssl,
+        "kafka+sasl-ssl" => KafkaSecurityProtocol::SaslSsl,
+        other => {
+            return Err(CdcError::Config(format!(
+                "unsupported kafka endpoint scheme {other:?} in {endpoint:?}: use \
+                 kafka+ssl://, kafka+sasl-ssl://, or kafka:// (plaintext, dev only)."
+            )));
+        },
+    };
+
+    let brokers = parse_broker_list(rest, endpoint)?;
+
+    if security_protocol == KafkaSecurityProtocol::Plaintext {
+        if !fraiseql_guard::deployment::insecure_bypass_allowed(
+            fraiseql_guard::deployment::env_opt_in(KAFKA_ALLOW_PLAINTEXT_ENV),
+        ) {
+            return Err(CdcError::Config(format!(
+                "refusing plaintext kafka:// endpoint {endpoint:?}: change events would \
+                 cross the wire in the clear. Use kafka+ssl:// or kafka+sasl-ssl://, or \
+                 set {KAFKA_ALLOW_PLAINTEXT_ENV}=true with FRAISEQL_ENV=development for \
+                 dev/CI."
+            )));
+        }
+
+        // Opted in and in development. The opt-in exists to reach a broker on
+        // localhost; it must not also unlock the instance-metadata service or an
+        // internal network. Every entry is checked — librdkafka contacts them all.
+        for broker in &brokers {
+            let host = broker_host(broker);
+            if fraiseql_guard::net::is_loopback_host(host) {
+                continue;
+            }
+            if let Some(reason) = fraiseql_guard::net::blocked_host_reason(host) {
+                return Err(CdcError::Config(format!(
+                    "refusing kafka endpoint {endpoint:?}: bootstrap server {broker:?} \
+                     is not permitted ({reason}). The plaintext opt-in reaches loopback \
+                     brokers only."
+                )));
+            }
+        }
+    }
+
+    Ok(KafkaEndpoint {
+        security_protocol,
+        bootstrap_servers: brokers.join(","),
+    })
+}
+
+/// Split and validate the scheme-stripped broker list.
+///
+/// Entries are trimmed of surrounding whitespace. An empty entry is an error
+/// rather than a silent drop — a trailing comma must not quietly shrink the
+/// bootstrap set. Userinfo and path/query/fragment components are refused
+/// outright: none is legal in `bootstrap.servers`, and accepting them would let a
+/// host be masked the way `nats://user:pw@host` masked one before #816.
+fn parse_broker_list(rest: &str, endpoint: &str) -> crate::error::Result<Vec<String>> {
+    let mut brokers = Vec::new();
+    for raw in rest.split(',') {
+        let entry = raw.trim();
+        if entry.is_empty() {
+            return Err(CdcError::Config(format!(
+                "kafka endpoint {endpoint:?} has an empty bootstrap server entry; an \
+                 empty entry is refused rather than dropped so the broker list cannot \
+                 silently shrink."
+            )));
+        }
+        if let Some(bad) = entry.chars().find(|c| matches!(c, '@' | '/' | '?' | '#')) {
+            return Err(CdcError::Config(format!(
+                "kafka bootstrap server {entry:?} in {endpoint:?} contains {bad:?}. \
+                 bootstrap.servers accepts host:port only — userinfo and path \
+                 components are not valid there and can mask the real host."
+            )));
+        }
+        if broker_host(entry).is_empty() {
+            return Err(CdcError::Config(format!(
+                "kafka bootstrap server {entry:?} in {endpoint:?} has no host."
+            )));
+        }
+        brokers.push(entry.to_owned());
+    }
+    Ok(brokers)
+}
+
+/// Extract the host from a `host:port` bootstrap entry.
+///
+/// `IPv6` literals keep their brackets, which both
+/// [`fraiseql_guard::net::is_loopback_host`] and
+/// [`fraiseql_guard::net::blocked_host_reason`] handle.
+fn broker_host(entry: &str) -> &str {
+    if entry.starts_with('[') {
+        if let Some(end) = entry.find(']') {
+            return &entry[..=end];
+        }
+    }
+    entry.split(':').next().unwrap_or(entry)
+}
+
+/// A SASL mechanism this build can actually perform.
+///
+/// Deliberately not the full Kafka set. rdkafka's `sasl` feature — which is what
+/// pulls Cyrus libsasl2 and with it `GSSAPI`/Kerberos — is not enabled, because it
+/// is not additive: `sasl` implies `ssl` and adds nothing but Kerberos, at the
+/// cost of a hard build-time and runtime dependency on libsasl2. `ssl` alone
+/// compiles `PLAIN`, `SCRAM-SHA-*` and `OAUTHBEARER`, which is every mechanism a
+/// managed Kafka offers. librdkafka reports the same list itself when asked for
+/// `GSSAPI`: *"Current build options: PLAIN `SASL_SCRAM` OAUTHBEARER"*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KafkaSaslMechanism {
+    /// Username/password in the clear *inside* the TLS session (Confluent Cloud).
+    Plain,
+    /// SCRAM-SHA-256 (Redpanda Cloud's default).
+    ScramSha256,
+    /// SCRAM-SHA-512 (AWS MSK's default).
+    ScramSha512,
+}
+
+impl KafkaSaslMechanism {
+    /// The literal librdkafka `sasl.mechanism` value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Plain => "PLAIN",
+            Self::ScramSha256 => "SCRAM-SHA-256",
+            Self::ScramSha512 => "SCRAM-SHA-512",
+        }
+    }
+}
+
+/// Resolved SASL settings for a `kafka+sasl-ssl://` endpoint.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct KafkaSaslCredentials {
+    /// The mechanism to authenticate with.
+    pub mechanism: KafkaSaslMechanism,
+    /// The SASL username.
+    pub username:  String,
+    /// The SASL password.
+    pub password:  String,
+}
+
+/// Env var naming the SASL mechanism for a `kafka+sasl-ssl://` endpoint.
+const KAFKA_SASL_MECHANISM_ENV: &str = "FRAISEQL_KAFKA_SASL_MECHANISM";
+/// Env var carrying the SASL username.
+const KAFKA_SASL_USERNAME_ENV: &str = "FRAISEQL_KAFKA_SASL_USERNAME";
+/// Env var carrying the SASL password.
+const KAFKA_SASL_PASSWORD_ENV: &str = "FRAISEQL_KAFKA_SASL_PASSWORD";
+
+/// Resolve the SASL mechanism and credentials for a `kafka+sasl-ssl://` endpoint.
+///
+/// Credentials come from the environment rather than the sink config because they
+/// are secrets and the config is destined for a TOML surface.
+///
+/// The mechanism is **required, not defaulted**. librdkafka's own default is
+/// `GSSAPI`, which this build cannot perform at all — leaving it implicit means
+/// `kafka+sasl-ssl://` fails at client creation with advice to *"recompile
+/// librdkafka with libsasl2"*, which is both confusing and the wrong fix here.
+/// There is also no defensible default among the three supported mechanisms:
+/// Confluent Cloud wants `PLAIN`, MSK `SCRAM-SHA-512`, Redpanda `SCRAM-SHA-256`.
+///
+/// # Errors
+///
+/// Returns [`CdcError::Config`] if the mechanism is unset, unsupported by this
+/// build, or if credentials are missing. Never echoes the password.
+pub fn resolve_kafka_sasl() -> crate::error::Result<KafkaSaslCredentials> {
+    let raw = std::env::var(KAFKA_SASL_MECHANISM_ENV).unwrap_or_default();
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(CdcError::Config(format!(
+            "kafka+sasl-ssl:// requires {KAFKA_SASL_MECHANISM_ENV}. librdkafka would \
+             otherwise default to GSSAPI, which this build cannot perform, and no default \
+             fits every broker (Confluent Cloud uses PLAIN, MSK SCRAM-SHA-512, Redpanda \
+             SCRAM-SHA-256). Set it to PLAIN, SCRAM-SHA-256 or SCRAM-SHA-512."
+        )));
+    }
+
+    let mechanism = match raw.to_ascii_uppercase().as_str() {
+        "PLAIN" => KafkaSaslMechanism::Plain,
+        "SCRAM-SHA-256" => KafkaSaslMechanism::ScramSha256,
+        "SCRAM-SHA-512" => KafkaSaslMechanism::ScramSha512,
+        "GSSAPI" | "KERBEROS" => {
+            return Err(CdcError::Config(format!(
+                "SASL mechanism {raw:?} is not available: this build links no Cyrus \
+                 libsasl2, so Kerberos cannot be performed. librdkafka's own error here \
+                 suggests recompiling it, which is not the fix — enabling rdkafka's `sasl` \
+                 feature would add a hard libsasl2 build and runtime dependency for \
+                 Kerberos alone. Use PLAIN, SCRAM-SHA-256 or SCRAM-SHA-512."
+            )));
+        },
+        "OAUTHBEARER" => {
+            return Err(CdcError::Config(
+                "SASL mechanism \"OAUTHBEARER\" is compiled in but not wired up: it needs \
+                 a token-refresh callback, and a producer that never refreshes its token \
+                 fails once the first one expires. Refused by name rather than half-wired. \
+                 Use PLAIN, SCRAM-SHA-256 or SCRAM-SHA-512."
+                    .to_owned(),
+            ));
+        },
+        other => {
+            return Err(CdcError::Config(format!(
+                "unsupported SASL mechanism {other:?}: use PLAIN, SCRAM-SHA-256 or \
+                 SCRAM-SHA-512."
+            )));
+        },
+    };
+
+    let username = std::env::var(KAFKA_SASL_USERNAME_ENV).unwrap_or_default();
+    let password = std::env::var(KAFKA_SASL_PASSWORD_ENV).unwrap_or_default();
+    if username.is_empty() || password.is_empty() {
+        return Err(CdcError::Config(format!(
+            "SASL mechanism {} requires both {KAFKA_SASL_USERNAME_ENV} and \
+             {KAFKA_SASL_PASSWORD_ENV}.",
+            mechanism.as_str()
+        )));
+    }
+
+    Ok(KafkaSaslCredentials {
+        mechanism,
+        username,
+        password,
+    })
+}
+
+/// Validate a rendered topic against Kafka's own topic-name rules.
+///
+/// Kafka permits `[a-zA-Z0-9._-]` only, caps names at 249 characters, and
+/// reserves `.` and `..`. This is a *narrower* charset than a NATS subject, so a
+/// template that renders legally for the NATS sink can be illegal here — hence a
+/// separate check rather than reuse of [`render_subject`]'s sanitiser alone.
+///
+/// # Errors
+///
+/// Returns a description of the violation, which the caller reports as
+/// [`PublishOutcome::Permanent`] (dead-letter) — never a silent re-route to a
+/// different topic.
+pub fn validate_kafka_topic(topic: &str) -> Result<(), String> {
+    if topic.is_empty() {
+        return Err("kafka topic is empty".to_owned());
+    }
+    if topic == "." || topic == ".." {
+        return Err(format!("kafka reserves the topic name {topic:?}"));
+    }
+    if topic.chars().count() > KAFKA_TOPIC_MAX_LEN {
+        return Err(format!(
+            "kafka topic is {} characters, over the {KAFKA_TOPIC_MAX_LEN}-character cap",
+            topic.chars().count()
+        ));
+    }
+    for c in topic.chars() {
+        if !(c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-') {
+            return Err(format!(
+                "kafka topic {topic:?} contains illegal character {c:?}; Kafka allows \
+                 [a-zA-Z0-9._-] only"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Render a topic template for Kafka: [`render_subject`] then
+/// [`validate_kafka_topic`].
+///
+/// Both checks are load-bearing and neither subsumes the other. `render_subject`
+/// refuses an illegal character *inside an interpolated value* — which is what
+/// stops a crafted tenant key injecting a `.` separator, still a live risk here
+/// because `.` is a legal Kafka topic character and would sail through the
+/// charset check. [`validate_kafka_topic`] then judges the whole rendered string
+/// against Kafka's narrower charset, catching template literals (`/`, `:`, `+`)
+/// that NATS accepts.
+///
+/// # Errors
+///
+/// Returns a description of the violation; the caller reports it as
+/// [`PublishOutcome::Permanent`].
+pub fn render_kafka_topic(template: &str, ev: &ChangeEvent) -> Result<String, String> {
+    let topic = render_subject(template, ev)?;
+    validate_kafka_topic(&topic)?;
+    Ok(topic)
 }
 
 #[cfg(test)]

--- a/crates/fraiseql-cdc-sinks/src/sink.rs
+++ b/crates/fraiseql-cdc-sinks/src/sink.rs
@@ -273,7 +273,7 @@ const KAFKA_TOPIC_MAX_LEN: usize = 249;
 /// A **scheme-less endpoint is refused, not defaulted**: librdkafka would take it
 /// as `PLAINTEXT`, which is the silent downgrade #816 shipped for NATS.
 ///
-/// Plaintext additionally requires the [`KAFKA_ALLOW_PLAINTEXT_ENV`] opt-in *and*
+/// Plaintext additionally requires the `FRAISEQL_KAFKA_ALLOW_PLAINTEXT` opt-in *and*
 /// a declared development environment. On that path **every** broker in the list
 /// is screened through [`fraiseql_guard::net`], not just the first: librdkafka
 /// contacts each bootstrap server, so one `169.254.169.254:9092` hiding behind a
@@ -559,6 +559,291 @@ pub fn validate_kafka_topic(topic: &str) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+/// The partition key for an event: the changed entity's identity.
+///
+/// Shared by every sink whose broker partitions by a hashed key — Kafka hashes it
+/// to choose a partition, Kinesis MD5-hashes it to choose a shard — and both order
+/// records only *within* one of those. Keying by anything unique per message (a
+/// `seq`, say) would therefore scatter one entity's changes across every partition
+/// and destroy the ordering the idempotent producer exists to provide. Consumer
+/// dedup is served separately by the `(object_type, seq)` pair, which travels in
+/// the payload.
+///
+/// Falls back to the object type alone when a row carries no `object_id`, which
+/// keeps the key deterministic (never null, never random) and degrades to
+/// per-table rather than per-entity ordering.
+///
+/// The result is bounded well under Kinesis's 256-character partition-key limit: a
+/// PostgreSQL identifier is at most 63 bytes, plus a separator and a 36-character
+/// UUID.
+#[must_use]
+pub fn entity_partition_key(ev: &ChangeEvent) -> String {
+    ev.object_id
+        .map_or_else(|| ev.object_type.clone(), |id| format!("{}:{}", ev.object_type, id))
+}
+
+// ── Kinesis endpoint parsing + transport guard ───────────────────────────────
+//
+// Pure, and here rather than in the feature-gated `kinesis` module for the same
+// reason the Kafka guard is: no aws-sdk type appears in these signatures, so the
+// refusing half runs in the always-compiled unit-test leg.
+
+/// Env var that permits an unencrypted `http://` Kinesis endpoint override.
+///
+/// Honoured only when `FRAISEQL_ENV` declares a development environment, like the
+/// Kafka and NATS flags it is named after.
+const KINESIS_ALLOW_PLAINTEXT_ENV: &str = "FRAISEQL_KINESIS_ALLOW_PLAINTEXT";
+
+/// Env var carrying an endpoint-URL override (`LocalStack`, a VPC interface
+/// endpoint). Absent means the SDK resolves the real regional endpoint.
+const KINESIS_ENDPOINT_URL_ENV: &str = "FRAISEQL_KINESIS_ENDPOINT_URL";
+
+/// Kinesis's own stream-name length cap.
+const KINESIS_STREAM_MAX_LEN: usize = 128;
+
+/// Longest region identifier accepted. AWS's longest today is well under this.
+const KINESIS_REGION_MAX_LEN: usize = 64;
+
+/// A Kinesis endpoint that has passed [`guard_kinesis_endpoint`].
+///
+/// There is no other constructor and the struct is `#[non_exhaustive]`, so a value
+/// of this type *is* the proof that the guard ran.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct KinesisEndpoint {
+    /// The AWS region, lowercased.
+    pub region: String,
+}
+
+/// Parse and screen a Kinesis endpoint, returning the region it names.
+///
+/// Unlike Kafka, Kinesis is not addressed by a broker list: the AWS SDK resolves a
+/// regional HTTPS endpoint from a region name. The configured endpoint therefore
+/// carries **only** the region, in the form `kinesis://<region>`. A scheme-less
+/// value is refused rather than taken as a bare region — it keeps the sink kind
+/// unambiguous in `[cdc_outbound]` and matches the contract
+/// [`guard_kafka_endpoint`] states.
+///
+/// The region is constrained to `[a-z0-9-]` starting with a letter because it is
+/// interpolated into the endpoint the SDK resolves; an unconstrained value is an
+/// injection seam, not merely a typo. It is lowercased on the way through, since
+/// AWS region identifiers are canonically lowercase and the alternative is an
+/// opaque signature failure from the far end.
+///
+/// Transport security is *not* expressed here: absent an override the SDK talks
+/// HTTPS to AWS. The escape hatch is [`resolve_kinesis_endpoint_url`], which is
+/// where the plaintext guard lives.
+///
+/// # Errors
+///
+/// Returns [`CdcError::Config`] for a missing or unsupported scheme, an empty
+/// region, a region carrying userinfo/path/query components, or one outside the
+/// permitted charset.
+pub fn guard_kinesis_endpoint(endpoint: &str) -> crate::error::Result<KinesisEndpoint> {
+    let Some((scheme, rest)) = endpoint.split_once("://") else {
+        return Err(CdcError::Config(format!(
+            "kinesis endpoint {endpoint:?} has no scheme: use kinesis://<region>, e.g. \
+             kinesis://us-east-1. The scheme is required rather than defaulted so the sink \
+             kind stays unambiguous."
+        )));
+    };
+
+    if !scheme.eq_ignore_ascii_case("kinesis") {
+        return Err(CdcError::Config(format!(
+            "unsupported kinesis endpoint scheme {scheme:?} in {endpoint:?}: use \
+             kinesis://<region>. The transport is chosen by the AWS SDK (HTTPS) or by \
+             {KINESIS_ENDPOINT_URL_ENV}, not by this scheme."
+        )));
+    }
+
+    if let Some(bad) = rest.chars().find(|c| matches!(c, '@' | '/' | '?' | '#')) {
+        return Err(CdcError::Config(format!(
+            "kinesis endpoint {endpoint:?} contains {bad:?}. A kinesis:// endpoint carries \
+             an AWS region and nothing else — userinfo, path and query components are not \
+             valid there and can mask the region actually used."
+        )));
+    }
+
+    let region = rest.to_ascii_lowercase();
+    validate_aws_region(&region, endpoint)?;
+    Ok(KinesisEndpoint { region })
+}
+
+/// Validate an already-lowercased AWS region identifier.
+fn validate_aws_region(region: &str, endpoint: &str) -> crate::error::Result<()> {
+    if region.is_empty() {
+        return Err(CdcError::Config(format!(
+            "kinesis endpoint {endpoint:?} names no region: use kinesis://<region>."
+        )));
+    }
+    if region.len() > KINESIS_REGION_MAX_LEN {
+        return Err(CdcError::Config(format!(
+            "kinesis region in {endpoint:?} is {} characters, over the \
+             {KINESIS_REGION_MAX_LEN}-character cap",
+            region.len()
+        )));
+    }
+    if !region.starts_with(|c: char| c.is_ascii_lowercase()) {
+        return Err(CdcError::Config(format!(
+            "kinesis region in {endpoint:?} must start with a letter; AWS regions look like \
+             us-east-1 or eu-west-3."
+        )));
+    }
+    if let Some(bad) = region.chars().find(|c| !(c.is_ascii_alphanumeric() || *c == '-')) {
+        return Err(CdcError::Config(format!(
+            "kinesis region in {endpoint:?} contains illegal character {bad:?}; an AWS region \
+             is [a-z0-9-] only, e.g. us-east-1."
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve the optional endpoint-URL override, screening it when unencrypted.
+///
+/// Absent (or blank) means **no override**: the SDK resolves the real regional
+/// endpoint, which is HTTPS. That is the production shape and is not an error.
+///
+/// An `https://` override is accepted as given. Screening is deliberately not
+/// applied to it, for the reason it is not applied to `kafka+ssl://`: a VPC
+/// interface endpoint for Kinesis resolves into RFC 1918 space, which
+/// [`fraiseql_guard::net::blocked_host_reason`] refuses, and the guard exists to
+/// stop the *plaintext* escape hatch reaching further than localhost — not to veto
+/// where an operator points an encrypted connection.
+///
+/// An `http://` override carries the full row after-image of every mutation in the
+/// clear, so it requires the `FRAISEQL_KINESIS_ALLOW_PLAINTEXT` opt-in *and* a
+/// declared development environment, *and* a loopback host. That combination is
+/// what a `LocalStack` container needs and nothing more; without the host check the
+/// dev escape hatch would double as an SSRF licence into the instance-metadata
+/// service.
+///
+/// # Errors
+///
+/// Returns [`CdcError::Config`] for a missing or unsupported scheme, a URL
+/// carrying userinfo/path/query components, an unopted-in `http://` override, or a
+/// non-loopback host on the plaintext path.
+pub fn resolve_kinesis_endpoint_url() -> crate::error::Result<Option<String>> {
+    let raw = std::env::var(KINESIS_ENDPOINT_URL_ENV).unwrap_or_default();
+    let url = raw.trim();
+    if url.is_empty() {
+        return Ok(None);
+    }
+
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return Err(CdcError::Config(format!(
+            "{KINESIS_ENDPOINT_URL_ENV}={url:?} has no scheme: use https://host[:port], or \
+             http://localhost:port for a dev endpoint under \
+             {KINESIS_ALLOW_PLAINTEXT_ENV}=true."
+        )));
+    };
+
+    let plaintext = match scheme.to_ascii_lowercase().as_str() {
+        "https" => false,
+        "http" => true,
+        other => {
+            return Err(CdcError::Config(format!(
+                "unsupported scheme {other:?} in {KINESIS_ENDPOINT_URL_ENV}={url:?}: the \
+                 Kinesis API speaks HTTPS; use https://, or http:// for a dev endpoint."
+            )));
+        },
+    };
+
+    let authority = rest.strip_suffix('/').unwrap_or(rest);
+    if let Some(bad) = authority.chars().find(|c| matches!(c, '@' | '/' | '?' | '#')) {
+        return Err(CdcError::Config(format!(
+            "{KINESIS_ENDPOINT_URL_ENV}={url:?} contains {bad:?}. An endpoint override is a \
+             host and optional port — userinfo and path components are not valid there and \
+             can mask the real host."
+        )));
+    }
+    let host = broker_host(authority);
+    if host.is_empty() {
+        return Err(CdcError::Config(format!("{KINESIS_ENDPOINT_URL_ENV}={url:?} has no host.")));
+    }
+
+    if plaintext {
+        if !fraiseql_guard::deployment::insecure_bypass_allowed(
+            fraiseql_guard::deployment::env_opt_in(KINESIS_ALLOW_PLAINTEXT_ENV),
+        ) {
+            return Err(CdcError::Config(format!(
+                "refusing plaintext {KINESIS_ENDPOINT_URL_ENV}={url:?}: change events would \
+                 cross the wire in the clear. Use https://, or set \
+                 {KINESIS_ALLOW_PLAINTEXT_ENV}=true with FRAISEQL_ENV=development for \
+                 dev/CI against LocalStack."
+            )));
+        }
+        // Loopback is what the opt-in exists for. Any other host is screened —
+        // identically to the Kafka guard's plaintext path, so the two cannot
+        // disagree about what the operator asked for. A CI bind hostname
+        // (`localstack`) resolves to none of the blocked classes and is admitted;
+        // the instance-metadata address and RFC 1918 space are not.
+        if !fraiseql_guard::net::is_loopback_host(host) {
+            if let Some(reason) = fraiseql_guard::net::blocked_host_reason(host) {
+                return Err(CdcError::Config(format!(
+                    "refusing {KINESIS_ENDPOINT_URL_ENV}={url:?}: host {host:?} is not \
+                     permitted ({reason}). The plaintext opt-in reaches a dev endpoint, not \
+                     the instance-metadata service or an internal network."
+                )));
+            }
+        }
+    }
+
+    Ok(Some(url.to_owned()))
+}
+
+/// Validate a rendered stream name against Kinesis's own rules.
+///
+/// Kinesis permits `[a-zA-Z0-9_.-]` and caps names at 128 characters — a
+/// *narrower* cap than Kafka's 249, so a template that renders legally for the
+/// Kafka sink can be illegal here. Hence a separate check rather than reuse of
+/// [`validate_kafka_topic`].
+///
+/// # Errors
+///
+/// Returns a description of the violation, which the caller reports as
+/// [`PublishOutcome::Permanent`] (dead-letter) — never a silent re-route to a
+/// different stream.
+pub fn validate_kinesis_stream(stream: &str) -> Result<(), String> {
+    if stream.is_empty() {
+        return Err("kinesis stream name is empty".to_owned());
+    }
+    if stream.chars().count() > KINESIS_STREAM_MAX_LEN {
+        return Err(format!(
+            "kinesis stream name is {} characters, over the \
+             {KINESIS_STREAM_MAX_LEN}-character cap",
+            stream.chars().count()
+        ));
+    }
+    for c in stream.chars() {
+        if !(c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-') {
+            return Err(format!(
+                "kinesis stream name {stream:?} contains illegal character {c:?}; Kinesis \
+                 allows [a-zA-Z0-9_.-] only"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Render a stream-name template for Kinesis: [`render_subject`] then
+/// [`validate_kinesis_stream`].
+///
+/// Both checks are load-bearing, exactly as on the Kafka path. `render_subject`
+/// refuses an illegal character *inside an interpolated value*, which is what stops
+/// a crafted tenant key injecting a `.` separator — still a live risk here because
+/// `.` is a legal Kinesis stream character and would pass the charset check.
+/// [`validate_kinesis_stream`] then judges the whole rendered string.
+///
+/// # Errors
+///
+/// Returns a description of the violation; the caller reports it as
+/// [`PublishOutcome::Permanent`].
+pub fn render_kinesis_stream(template: &str, ev: &ChangeEvent) -> Result<String, String> {
+    let stream = render_subject(template, ev)?;
+    validate_kinesis_stream(&stream)?;
+    Ok(stream)
 }
 
 /// Render a topic template for Kafka: [`render_subject`] then

--- a/crates/fraiseql-cdc-sinks/src/sink/tests.rs
+++ b/crates/fraiseql-cdc-sinks/src/sink/tests.rs
@@ -490,3 +490,358 @@ fn render_kafka_topic_rejects_an_injected_separator_before_kafka_sees_it() {
     let ev = ChangeEvent::new(1, "tb_post.evil", ChangeOp::Insert);
     assert!(render_kafka_topic("fraiseql.{table}", &ev).is_err());
 }
+
+// ── Shared partition key ──────────────────────────────────────────────────────
+
+#[test]
+fn entity_partition_key_pins_one_entity_to_one_partition() {
+    // Both Kafka and Kinesis hash this key to choose a partition/shard, and both
+    // order only *within* one. Keying by anything unique per message (`seq`, say)
+    // would scatter an entity's changes across every partition and destroy the
+    // ordering the sinks exist to preserve — so the key is the entity's identity.
+    let id = Uuid::from_u128(0xfeed);
+    let insert = ChangeEvent::new(1, "tb_post", ChangeOp::Insert).with_object_id(id);
+    let update = ChangeEvent::new(9_999, "tb_post", ChangeOp::Update).with_object_id(id);
+    assert_eq!(
+        entity_partition_key(&insert),
+        entity_partition_key(&update),
+        "two changes to one entity must land on one partition"
+    );
+    assert_eq!(entity_partition_key(&insert), format!("tb_post:{id}"));
+    assert!(
+        !entity_partition_key(&update).contains("9999"),
+        "the seq must not appear in the key — it would scatter an entity across partitions"
+    );
+
+    let other = ChangeEvent::new(2, "tb_post", ChangeOp::Insert).with_object_id(Uuid::from_u128(2));
+    assert_ne!(
+        entity_partition_key(&insert),
+        entity_partition_key(&other),
+        "distinct entities must be free to spread across partitions"
+    );
+}
+
+#[test]
+fn entity_partition_key_degrades_to_the_table_without_an_object_id() {
+    // Deterministic — never null, never random — so a row with no `object_id`
+    // still orders consistently, just per-table rather than per-entity.
+    let ev = ChangeEvent::new(1, "tb_post", ChangeOp::Insert);
+    assert_eq!(entity_partition_key(&ev), "tb_post");
+    assert_eq!(entity_partition_key(&ev), entity_partition_key(&ev));
+}
+
+// ── Kinesis endpoint + region guard ───────────────────────────────────────────
+//
+// Pure, and here for the same reason the Kafka guard is: no aws-sdk type appears
+// in these signatures, so the refusing half runs in the always-compiled leg.
+
+/// Run `f` with the Kinesis plaintext opt-in and endpoint override both absent.
+fn without_kinesis_optin<T>(f: impl FnOnce() -> T) -> T {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", None::<&str>),
+            ("FRAISEQL_KINESIS_ENDPOINT_URL", None),
+        ],
+        f,
+    )
+}
+
+/// Run `f` with an endpoint-URL override set and the plaintext opt-in absent.
+fn with_kinesis_url<T>(url: &str, f: impl FnOnce() -> T) -> T {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KINESIS_ENDPOINT_URL", Some(url)),
+            ("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", None),
+        ],
+        f,
+    )
+}
+
+/// Run `f` with an override set, opted in to plaintext, in a declared dev env.
+fn with_kinesis_url_optin<T>(url: &str, f: impl FnOnce() -> T) -> T {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KINESIS_ENDPOINT_URL", Some(url)),
+            ("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", Some("true")),
+            ("FRAISEQL_ENV", Some("development")),
+            ("FRAISEQL_PROFILE", None),
+            ("KUBERNETES_SERVICE_HOST", None),
+        ],
+        f,
+    )
+}
+
+#[test]
+fn kinesis_endpoint_refuses_scheme_less_input() {
+    // A bare region is what an operator reaches for first. Requiring the scheme
+    // keeps the sink kind unambiguous and matches the Kafka endpoint's contract.
+    // Each refusal is paired with the same value *plus* a scheme, so the failure
+    // is attributable to the missing scheme and to nothing else.
+    for region in ["us-east-1", "eu-west-3", "ap-southeast-2"] {
+        assert!(
+            guard_kinesis_endpoint(region).is_err(),
+            "a scheme-less endpoint must be refused, not defaulted: {region}"
+        );
+        assert!(
+            guard_kinesis_endpoint(&format!("kinesis://{region}")).is_ok(),
+            "control: the same region must be accepted once a scheme is given"
+        );
+    }
+}
+
+#[test]
+fn kinesis_endpoint_refuses_unknown_schemes() {
+    // Every value here carries a legal region, so an unknown scheme that fell
+    // through to "accept" would pass — the refusal is attributable to the scheme.
+    for endpoint in [
+        "https://us-east-1",
+        "kafka://us-east-1",
+        "nats://us-east-1",
+        "kinesis+ssl://us-east-1",
+        "aws-kinesis://us-east-1",
+        "://us-east-1",
+    ] {
+        assert!(
+            guard_kinesis_endpoint(endpoint).is_err(),
+            "only kinesis:// is supported: {endpoint}"
+        );
+    }
+    assert!(guard_kinesis_endpoint("kinesis://us-east-1").is_ok(), "control");
+}
+
+#[test]
+fn kinesis_endpoint_extracts_and_normalises_the_region() {
+    // AWS region identifiers are canonically lowercase; normalising here beats a
+    // confusing SignatureDoesNotMatch from the far end.
+    assert_eq!(guard_kinesis_endpoint("kinesis://us-east-1").unwrap().region, "us-east-1");
+    assert_eq!(guard_kinesis_endpoint("KINESIS://US-East-1").unwrap().region, "us-east-1");
+    assert_eq!(
+        guard_kinesis_endpoint("kinesis://us-gov-west-1").unwrap().region,
+        "us-gov-west-1"
+    );
+}
+
+#[test]
+fn kinesis_endpoint_refuses_an_empty_or_illegal_region() {
+    // The region is interpolated into the endpoint the SDK resolves, so an
+    // unconstrained value is an injection seam rather than merely a typo.
+    for endpoint in [
+        "kinesis://",
+        "kinesis://us east 1",
+        "kinesis://us_east_1",
+        "kinesis://us-east-1.evil.example.com",
+        "kinesis://-us-east-1",
+        "kinesis://us-east-1:443",
+    ] {
+        assert!(
+            guard_kinesis_endpoint(endpoint).is_err(),
+            "an AWS region is [a-z0-9-] starting with a letter: {endpoint}"
+        );
+    }
+}
+
+#[test]
+fn kinesis_endpoint_refuses_userinfo_path_and_query_components() {
+    // None is legal in a region, and each can mask the value actually used.
+    for endpoint in [
+        "kinesis://user@us-east-1",
+        "kinesis://us-east-1/stream",
+        "kinesis://us-east-1?region=eu-west-1",
+        "kinesis://us-east-1#eu-west-1",
+    ] {
+        assert!(guard_kinesis_endpoint(endpoint).is_err(), "must refuse {endpoint}");
+    }
+}
+
+// ── Kinesis endpoint-URL override ─────────────────────────────────────────────
+
+#[test]
+fn kinesis_endpoint_url_absent_means_the_aws_resolver() {
+    // No override is the production shape: the SDK resolves the real regional
+    // endpoint, which is HTTPS. `None` here must not be an error.
+    without_kinesis_optin(|| {
+        assert_eq!(resolve_kinesis_endpoint_url().unwrap(), None);
+    });
+    // An override set to whitespace is treated as absent, not as a malformed URL.
+    with_kinesis_url("   ", || {
+        assert_eq!(resolve_kinesis_endpoint_url().unwrap(), None);
+    });
+}
+
+#[test]
+fn kinesis_endpoint_url_refuses_plaintext_without_the_optin() {
+    // Change events carry the full row after-image; http:// puts them on the wire
+    // in the clear. Loopback hosts are used deliberately — the refusal must come
+    // from the missing opt-in, not from host screening.
+    for url in ["http://localhost:4566", "http://127.0.0.1:4566"] {
+        with_kinesis_url(url, || {
+            assert!(resolve_kinesis_endpoint_url().is_err(), "plaintext needs the opt-in: {url}");
+        });
+        with_kinesis_url_optin(url, || {
+            assert!(
+                resolve_kinesis_endpoint_url().is_ok(),
+                "control: the same URL is accepted once opted in: {url}"
+            );
+        });
+    }
+}
+
+#[test]
+fn kinesis_plaintext_optin_is_inert_in_production() {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KINESIS_ENDPOINT_URL", Some("http://localhost:4566")),
+            ("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", Some("true")),
+            ("FRAISEQL_ENV", Some("production")),
+        ],
+        || {
+            assert!(resolve_kinesis_endpoint_url().is_err());
+        },
+    );
+}
+
+#[test]
+fn kinesis_plaintext_optin_is_screened_not_unrestricted() {
+    // The opt-in exists to reach a dev LocalStack — on localhost, or on a CI bind
+    // hostname when the suite runs in a container network. It must not double as a
+    // licence to reach the instance-metadata service or an internal network.
+    //
+    // These are exactly the Kafka guard's plaintext-path semantics, deliberately:
+    // the two flags must not disagree about what the operator asked for.
+    for url in [
+        "http://localhost:4566",
+        "http://127.0.0.1:4566",
+        "http://[::1]:4566",
+        // The Dagger shape: a service bound as `localstack` in the container
+        // network. Not loopback, and blocked by none of the screened classes.
+        "http://localstack:4566",
+    ] {
+        with_kinesis_url_optin(url, || {
+            assert!(resolve_kinesis_endpoint_url().is_ok(), "dev LocalStack must work: {url}");
+        });
+    }
+    for url in [
+        "http://169.254.169.254",
+        "http://metadata.google.internal",
+        "http://10.0.0.5:4566",
+        "http://192.168.1.10:4566",
+    ] {
+        with_kinesis_url_optin(url, || {
+            assert!(
+                resolve_kinesis_endpoint_url().is_err(),
+                "the plaintext opt-in must not reach {url}"
+            );
+        });
+    }
+}
+
+#[test]
+fn kinesis_refuses_every_blocked_corpus_entry_even_when_opted_in() {
+    // The corpus test that would have caught #816, on this transport.
+    use fraiseql_guard::net::vectors::{MUST_BLOCK, url_host};
+    for (addr, why) in MUST_BLOCK {
+        if fraiseql_guard::net::is_loopback_host(addr) {
+            continue;
+        }
+        let url = format!("http://{}:4566", url_host(addr));
+        with_kinesis_url_optin(&url, || {
+            assert!(resolve_kinesis_endpoint_url().is_err(), "must refuse {addr} ({why})");
+        });
+    }
+}
+
+#[test]
+fn https_endpoint_url_permits_private_range_by_design() {
+    // Pinned so it is not "fixed" into a regression, exactly as for kafka+ssl://:
+    // a VPC interface endpoint for Kinesis resolves into RFC 1918 space, which
+    // `blocked_host_reason` refuses. Screening belongs on the plaintext escape
+    // hatch, not on an encrypted endpoint the operator chose.
+    for url in [
+        "https://vpce-0abc-kinesis.us-east-1.vpce.amazonaws.com",
+        "https://10.0.1.5:443",
+        "https://kinesis.eu-west-1.amazonaws.com",
+    ] {
+        with_kinesis_url(url, || {
+            assert!(
+                resolve_kinesis_endpoint_url().is_ok(),
+                "an encrypted endpoint may point into private space: {url}"
+            );
+        });
+    }
+}
+
+#[test]
+fn kinesis_endpoint_url_refuses_scheme_less_and_unknown_schemes() {
+    // Opted in throughout, and every host is loopback, so neither the plaintext
+    // policy nor host screening can be what refuses these.
+    for url in [
+        "localhost:4566",
+        "ftp://localhost:4566",
+        "ws://localhost:4566",
+        "://localhost",
+    ] {
+        with_kinesis_url_optin(url, || {
+            assert!(resolve_kinesis_endpoint_url().is_err(), "must refuse {url}");
+        });
+    }
+    with_kinesis_url_optin("http://localhost:4566", || {
+        assert!(resolve_kinesis_endpoint_url().is_ok(), "control");
+    });
+}
+
+#[test]
+fn kinesis_endpoint_url_refuses_userinfo_and_credentials_in_the_url() {
+    // `http://user:pw@host` is the shape that masked a host before #816.
+    with_kinesis_url_optin("http://user:pw@localhost:4566", || {
+        assert!(resolve_kinesis_endpoint_url().is_err());
+    });
+}
+
+// ── Kinesis stream-name validation ────────────────────────────────────────────
+
+#[test]
+fn kinesis_stream_accepts_the_legal_charset() {
+    for name in [
+        "fraiseql",
+        "fraiseql.tb_post",
+        "fraiseql-changes_1",
+        "a",
+        &"x".repeat(128),
+    ] {
+        assert!(validate_kinesis_stream(name).is_ok(), "must accept {name}");
+    }
+}
+
+#[test]
+fn kinesis_stream_rejects_illegal_chars_and_overlong_names() {
+    // Kinesis allows [a-zA-Z0-9_.-] only and caps names at 128 — a *narrower*
+    // cap than Kafka's 249, so a template legal for the Kafka sink can be illegal
+    // here. Hence a separate check rather than reuse of the Kafka validator.
+    for name in [
+        "",
+        "fraiseql/post",
+        "fraiseql post",
+        "fraiseql:post",
+        "fraiseql*",
+        "frais€ql",
+    ] {
+        assert!(validate_kinesis_stream(name).is_err(), "must reject {name:?}");
+    }
+    assert!(
+        validate_kinesis_stream(&"x".repeat(129)).is_err(),
+        "128 is the Kinesis cap, and it is not Kafka's 249"
+    );
+    assert!(validate_kafka_topic(&"x".repeat(129)).is_ok(), "control: legal for Kafka");
+}
+
+#[test]
+fn render_kinesis_stream_rejects_an_injected_separator_before_kinesis_sees_it() {
+    // `.` is a legal Kinesis stream character, so a crafted tenant/table value
+    // carrying one would sail through the charset check; the NATS sanitiser in
+    // `render_subject` is what stops it escaping into another stream namespace.
+    let ev = ChangeEvent::new(1, "tb_post.evil", ChangeOp::Insert);
+    assert!(render_kinesis_stream("fraiseql.{table}", &ev).is_err());
+
+    let ok = ChangeEvent::new(1, "tb_post", ChangeOp::Insert);
+    assert_eq!(render_kinesis_stream("fraiseql.{table}", &ok).unwrap(), "fraiseql.tb_post");
+}

--- a/crates/fraiseql-cdc-sinks/src/sink/tests.rs
+++ b/crates/fraiseql-cdc-sinks/src/sink/tests.rs
@@ -95,3 +95,398 @@ fn backoff_is_monotonic_and_capped() {
     assert_eq!(next_attempt_delay(20), Duration::from_secs(300));
     assert_eq!(next_attempt_delay(u32::MAX), Duration::from_secs(300));
 }
+
+// ── Kafka endpoint guard ──────────────────────────────────────────────────────
+//
+// These live here, not in `kafka.rs`, because the guard is pure: it names no
+// rdkafka type. That keeps the *refusing* half in the cheap always-compiled test
+// leg instead of only where `cdc-kafka` is on — the NATS guard's placement behind
+// its own feature is the thing not to repeat.
+
+/// Run `f` with the Kafka plaintext opt-in explicitly absent.
+fn without_kafka_optin<T>(f: impl FnOnce() -> T) -> T {
+    temp_env::with_var_unset("FRAISEQL_KAFKA_ALLOW_PLAINTEXT", f)
+}
+
+/// Run `f` opted in to plaintext and in a declared development environment.
+fn with_kafka_optin<T>(f: impl FnOnce() -> T) -> T {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KAFKA_ALLOW_PLAINTEXT", Some("true")),
+            ("FRAISEQL_ENV", Some("development")),
+            ("FRAISEQL_PROFILE", None),
+            ("KUBERNETES_SERVICE_HOST", None),
+        ],
+        f,
+    )
+}
+
+#[test]
+fn kafka_endpoint_refuses_scheme_less_input() {
+    // `bootstrap.servers` has no scheme, so a bare list is what an operator will
+    // reach for first. librdkafka would silently treat it as PLAINTEXT; refusing
+    // beats defaulting (the #816 lesson, in the one shape Kafka can express it).
+    //
+    // Asserted *with* the plaintext opt-in on, and against loopback hosts, so the
+    // only thing that can produce the refusal is the missing scheme. Run without
+    // the opt-in this test passes even when the scheme check is deleted entirely —
+    // the plaintext policy refuses it first, and the assertion proves nothing.
+    with_kafka_optin(|| {
+        for endpoint in [
+            "localhost:9092",
+            "127.0.0.1:9092,localhost:9093",
+            "[::1]:9092",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_err(),
+                "a scheme-less endpoint must be refused, not defaulted: {endpoint}"
+            );
+            // The same brokers *with* a scheme are accepted, so the refusal above
+            // is attributable to the scheme and nothing else.
+            assert!(
+                guard_kafka_endpoint(&format!("kafka://{endpoint}")).is_ok(),
+                "control: the same brokers must be accepted once a scheme is given"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_endpoint_refuses_unknown_schemes() {
+    // Opted in, loopback hosts: an unknown scheme that fell through to Plaintext
+    // would be *accepted* here, so the refusal is attributable to the scheme match.
+    // Without the opt-in this passes even with the match arm deleted.
+    with_kafka_optin(|| {
+        for endpoint in [
+            "ssl://localhost:9092",
+            "http://localhost:9092",
+            "nats://localhost:9092",
+            "kafka+sasl-plaintext://localhost:9092",
+            "kafka+ssl+sasl://localhost:9092",
+            "://localhost:9092",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_err(),
+                "only kafka://, kafka+ssl:// and kafka+sasl-ssl:// are supported: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_endpoint_maps_scheme_to_an_explicit_security_protocol() {
+    // librdkafka's own default is PLAINTEXT, so the protocol must be set from the
+    // scheme rather than left unset.
+    without_kafka_optin(|| {
+        let ssl = guard_kafka_endpoint("kafka+ssl://b1:9092,b2:9092").unwrap();
+        assert_eq!(ssl.security_protocol, KafkaSecurityProtocol::Ssl);
+        assert_eq!(ssl.security_protocol.as_str(), "ssl");
+
+        let sasl = guard_kafka_endpoint("kafka+sasl-ssl://b1:9092").unwrap();
+        assert_eq!(sasl.security_protocol, KafkaSecurityProtocol::SaslSsl);
+        assert_eq!(sasl.security_protocol.as_str(), "sasl_ssl");
+    });
+
+    with_kafka_optin(|| {
+        let plain = guard_kafka_endpoint("kafka://localhost:9092").unwrap();
+        assert_eq!(plain.security_protocol, KafkaSecurityProtocol::Plaintext);
+        assert_eq!(plain.security_protocol.as_str(), "plaintext");
+    });
+}
+
+#[test]
+fn kafka_endpoint_strips_the_scheme_from_bootstrap_servers() {
+    without_kafka_optin(|| {
+        let ep =
+            guard_kafka_endpoint("kafka+ssl://b1.example.com:9092, b2.example.com:9093").unwrap();
+        assert_eq!(ep.bootstrap_servers, "b1.example.com:9092,b2.example.com:9093");
+    });
+}
+
+#[test]
+fn kafka_endpoint_is_case_insensitive_in_the_scheme() {
+    without_kafka_optin(|| {
+        let ep = guard_kafka_endpoint("KAFKA+SSL://B1.Example.COM:9092").unwrap();
+        assert_eq!(ep.security_protocol, KafkaSecurityProtocol::Ssl);
+    });
+}
+
+#[test]
+fn kafka_endpoint_refuses_plaintext_without_the_optin() {
+    without_kafka_optin(|| {
+        for endpoint in ["kafka://broker.example.com:9092", "kafka://localhost:9092"] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_err(),
+                "plaintext kafka:// carries the full row after-image in the clear: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_plaintext_optin_is_inert_in_production() {
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KAFKA_ALLOW_PLAINTEXT", Some("true")),
+            ("FRAISEQL_ENV", Some("production")),
+        ],
+        || {
+            assert!(guard_kafka_endpoint("kafka://localhost:9092").is_err());
+        },
+    );
+}
+
+#[test]
+fn kafka_plaintext_optin_permits_loopback_brokers() {
+    with_kafka_optin(|| {
+        for endpoint in [
+            "kafka://localhost:9092",
+            "kafka://127.0.0.1:9092",
+            "kafka://[::1]:9092",
+            "kafka://localhost:9092,127.0.0.1:9093",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_ok(),
+                "the opt-in exists to reach a dev broker on localhost: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_plaintext_refuses_the_whole_list_when_any_broker_is_blocked() {
+    // The property NATS has no equivalent for: it takes one URL, Kafka takes a
+    // list. Guarding only the first entry would let a metadata address ride along
+    // behind a loopback broker, and librdkafka contacts every bootstrap server.
+    with_kafka_optin(|| {
+        for endpoint in [
+            "kafka://169.254.169.254:9092",
+            "kafka://localhost:9092,169.254.169.254:9092",
+            "kafka://169.254.169.254:9092,localhost:9092",
+            "kafka://localhost:9092,localhost:9093,metadata.google.internal:9092,localhost:9094",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_err(),
+                "one blocked broker must refuse the whole endpoint: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_endpoint_refuses_userinfo_and_path_components() {
+    // Neither is legal in `bootstrap.servers`. Accepting them would let a host be
+    // masked the way `nats://user:pw@host` masked one before #816.
+    with_kafka_optin(|| {
+        for endpoint in [
+            "kafka://user:pw@169.254.169.254:9092",
+            "kafka://localhost:9092/path",
+            "kafka://localhost:9092?x=1",
+            "kafka://localhost:9092#frag",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_err(),
+                "userinfo/path components are not valid bootstrap servers: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_endpoint_refuses_empty_broker_entries() {
+    without_kafka_optin(|| {
+        for endpoint in [
+            "kafka+ssl://",
+            "kafka+ssl://b:9092,",
+            "kafka+ssl://,b:9092",
+            "kafka+ssl://b:9092,,c:9092",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_err(),
+                "an empty broker entry must not be silently dropped: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn ssl_endpoints_permit_private_range_brokers_by_design() {
+    // Deliberate, and pinned so it is not "fixed" into a regression: MSK and every
+    // VPC-hosted cluster put brokers in RFC 1918 space, which `is_blocked_ip`
+    // refuses. Host screening therefore applies on the *plaintext opt-in* path,
+    // where it stops the escape hatch doubling as an SSRF licence — not to an
+    // encrypted endpoint the operator explicitly pointed at their own network.
+    without_kafka_optin(|| {
+        for endpoint in [
+            "kafka+ssl://10.0.1.5:9092,10.0.2.5:9092",
+            "kafka+sasl-ssl://b-1.msk.eu-west-1.amazonaws.com:9096",
+            "kafka+ssl://192.168.1.10:9092",
+        ] {
+            assert!(
+                guard_kafka_endpoint(endpoint).is_ok(),
+                "an encrypted endpoint may point into private space: {endpoint}"
+            );
+        }
+    });
+}
+
+#[test]
+fn kafka_refuses_every_blocked_corpus_entry_even_when_opted_in() {
+    use fraiseql_guard::net::vectors::{MUST_BLOCK, url_host};
+    with_kafka_optin(|| {
+        for (addr, why) in MUST_BLOCK {
+            // Loopback is the one thing the opt-in exists to permit.
+            if fraiseql_guard::net::is_loopback_host(addr) {
+                continue;
+            }
+            let endpoint = format!("kafka://{}:9092", url_host(addr));
+            assert!(guard_kafka_endpoint(&endpoint).is_err(), "must refuse {addr} ({why})");
+            // And again hidden behind a legitimate broker.
+            let endpoint = format!("kafka://localhost:9092,{}:9092", url_host(addr));
+            assert!(
+                guard_kafka_endpoint(&endpoint).is_err(),
+                "must refuse {addr} ({why}) even in second position"
+            );
+        }
+    });
+}
+
+// ── Kafka SASL resolution ─────────────────────────────────────────────────────
+
+/// Run `f` with the three SASL env vars set to the given values.
+fn with_sasl_env<T>(
+    mechanism: Option<&str>,
+    creds: Option<(&str, &str)>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let (user, pass) = creds.map_or((None, None), |(u, p)| (Some(u), Some(p)));
+    temp_env::with_vars(
+        [
+            ("FRAISEQL_KAFKA_SASL_MECHANISM", mechanism),
+            ("FRAISEQL_KAFKA_SASL_USERNAME", user),
+            ("FRAISEQL_KAFKA_SASL_PASSWORD", pass),
+        ],
+        f,
+    )
+}
+
+#[test]
+fn sasl_mechanism_is_required_not_defaulted() {
+    // librdkafka's default is GSSAPI, which this build cannot perform; leaving it
+    // implicit produces a client-creation error advising a librdkafka recompile.
+    with_sasl_env(None, Some(("u", "p")), || {
+        assert!(resolve_kafka_sasl().is_err());
+    });
+    with_sasl_env(Some("   "), Some(("u", "p")), || {
+        assert!(resolve_kafka_sasl().is_err(), "whitespace is not a mechanism");
+    });
+}
+
+#[test]
+fn sasl_accepts_the_three_mechanisms_this_build_supports() {
+    for (raw, expected) in [
+        ("PLAIN", KafkaSaslMechanism::Plain),
+        ("plain", KafkaSaslMechanism::Plain),
+        ("SCRAM-SHA-256", KafkaSaslMechanism::ScramSha256),
+        ("SCRAM-SHA-512", KafkaSaslMechanism::ScramSha512),
+    ] {
+        with_sasl_env(Some(raw), Some(("u", "p")), || {
+            let resolved = resolve_kafka_sasl().unwrap();
+            assert_eq!(resolved.mechanism, expected, "{raw}");
+            assert_eq!(resolved.username, "u");
+            assert_eq!(resolved.password, "p");
+        });
+    }
+}
+
+#[test]
+fn sasl_refuses_kerberos_by_name_rather_than_letting_librdkafka_mislead() {
+    // librdkafka's own message here is "recompile librdkafka with libsasl2", which
+    // is not the fix in this repo — dropping rdkafka's `sasl` feature was a
+    // deliberate call, so the refusal explains that instead.
+    for raw in ["GSSAPI", "gssapi", "Kerberos"] {
+        with_sasl_env(Some(raw), Some(("u", "p")), || {
+            let err = resolve_kafka_sasl().unwrap_err().to_string();
+            assert!(err.contains("Kerberos"), "should name Kerberos: {err}");
+            assert!(err.contains("SCRAM-SHA-512"), "should point at a mechanism that works: {err}");
+        });
+    }
+}
+
+#[test]
+fn sasl_refuses_oauthbearer_as_unwired_rather_than_half_wiring_it() {
+    with_sasl_env(Some("OAUTHBEARER"), Some(("u", "p")), || {
+        assert!(resolve_kafka_sasl().is_err());
+    });
+}
+
+#[test]
+fn sasl_requires_both_credentials() {
+    for creds in [None, Some(("u", "")), Some(("", "p"))] {
+        with_sasl_env(Some("SCRAM-SHA-512"), creds, || {
+            assert!(resolve_kafka_sasl().is_err(), "{creds:?} must not authenticate");
+        });
+    }
+}
+
+#[test]
+fn sasl_errors_never_echo_the_password() {
+    with_sasl_env(Some("NOPE"), Some(("user", "hunter2")), || {
+        let err = resolve_kafka_sasl().unwrap_err().to_string();
+        assert!(!err.contains("hunter2"), "password leaked into an error: {err}");
+    });
+    with_sasl_env(Some("PLAIN"), Some(("user", "")), || {
+        let err = resolve_kafka_sasl().unwrap_err().to_string();
+        assert!(!err.contains("hunter2"));
+    });
+}
+
+// ── Kafka topic charset ───────────────────────────────────────────────────────
+
+#[test]
+fn kafka_topic_accepts_the_legal_charset() {
+    let at_cap = "x".repeat(249);
+    for topic in ["fraiseql.tb_post", "a", "A-Z.0-9_x", at_cap.as_str()] {
+        assert!(validate_kafka_topic(topic).is_ok(), "should accept {topic:?}");
+    }
+}
+
+#[test]
+fn kafka_topic_rejects_chars_nats_would_accept() {
+    // NATS subjects allow far more than `[a-zA-Z0-9._-]`, so a template that
+    // renders cleanly for NATS can be illegal in Kafka.
+    for topic in [
+        "fraiseql/tb_post",
+        "fraiseql:tb_post",
+        "fraiseql+tb_post",
+        "tb post",
+        "tb\u{e9}",
+    ] {
+        assert!(validate_kafka_topic(topic).is_err(), "should reject {topic:?}");
+    }
+}
+
+#[test]
+fn kafka_topic_rejects_empty_dot_dotdot_and_overlong() {
+    for topic in ["", ".", ".."] {
+        assert!(validate_kafka_topic(topic).is_err(), "should reject {topic:?}");
+    }
+    assert!(validate_kafka_topic(&"x".repeat(250)).is_err(), "249 is the Kafka cap");
+}
+
+#[test]
+fn render_kafka_topic_rejects_a_nats_legal_but_kafka_illegal_render() {
+    let ev = ChangeEvent::new(1, "tb_post", ChangeOp::Insert);
+    // `/` passes the NATS sanitiser and is illegal in a Kafka topic.
+    assert!(render_kafka_topic("fraiseql/{table}", &ev).is_err());
+    assert_eq!(render_kafka_topic("fraiseql.{table}", &ev).unwrap(), "fraiseql.tb_post");
+}
+
+#[test]
+fn render_kafka_topic_rejects_an_injected_separator_before_kafka_sees_it() {
+    // The NATS sanitiser already refuses a `.` inside an interpolated segment;
+    // assert it still holds on the Kafka path, where `.` is a *legal* topic
+    // character and so would otherwise pass the charset check unnoticed.
+    let ev = ChangeEvent::new(1, "tb_post.evil", ChangeOp::Insert);
+    assert!(render_kafka_topic("fraiseql.{table}", &ev).is_err());
+}

--- a/crates/fraiseql-cdc-sinks/tests/cdc_kafka_e2e.rs
+++ b/crates/fraiseql-cdc-sinks/tests/cdc_kafka_e2e.rs
@@ -1,0 +1,291 @@
+//! End-to-end: outbox → drain → real Apache Kafka.
+//!
+//! The assertions are made **through the drain**, not against the sink directly:
+//! seed the outbox with rows shaped exactly as the #366 external-write capture
+//! trigger produces them, tick the `DrainWorker`, then read the broker back. That
+//! is what proves the seam, rather than proving `KafkaSink::publish` in isolation.
+//!
+//! `#[ignore]` — needs both a real Postgres (`DATABASE_URL`) and a real Kafka
+//! (`KAFKA_BOOTSTRAP`). Run with:
+//! `cargo test -p fraiseql-cdc-sinks --features cdc-kafka --test cdc_kafka_e2e -- --ignored
+//! --test-threads=1`.
+
+#![cfg(feature = "cdc-kafka")]
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(clippy::literal_string_with_formatting_args)] // Reason: topic-template placeholders, not format args
+
+use std::time::Duration;
+
+use fraiseql_cdc_sinks::{CdcSinkConfig, DrainWorker, KafkaSink, outbox_sink_state_migration_sql};
+use rdkafka::{
+    ClientConfig, Message,
+    admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
+    client::DefaultClientContext,
+    consumer::{Consumer, StreamConsumer},
+    message::Headers,
+};
+use serde_json::{Value, json};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use uuid::Uuid;
+
+/// The bootstrap list, or `None` when no reachable broker is bound.
+///
+/// Resolved through `fraiseql_test_support::services::kafka()` so "available"
+/// means *reachable*, not merely configured (#879) — a suite that hard-fails in
+/// setup on an absent broker reads as a regression rather than a skip.
+async fn bootstrap() -> Option<String> {
+    fraiseql_test_support::services::kafka().await.map(|s| s.url().to_owned())
+}
+
+/// Announce a skip on stderr.
+///
+/// A test that returns early reads as `ok` in the summary, which is how a leg
+/// that stops binding its broker keeps reporting green over a suite that asserts
+/// nothing. `tools/check-suite-coverage.py` is the gate that keeps this suite in
+/// a leg with a `kafka` service; this line is what makes the skip visible in the
+/// log if it ever is not.
+#[allow(clippy::print_stderr)] // Reason: a silent skip is exactly the failure mode being prevented
+fn skipped() {
+    eprintln!("SKIP: KAFKA_BOOTSTRAP is unset — the Kafka drain-through assertions did NOT run");
+}
+
+/// The dev opt-in the guard requires for a plaintext `kafka://` broker.
+fn allow_plaintext_for_local() {
+    if std::env::var("FRAISEQL_KAFKA_ALLOW_PLAINTEXT").is_err() {
+        // This suite runs single-threaded (`--test-threads=1`), so there is no
+        // concurrent environment access. (`set_var` is safe on edition 2021.)
+        std::env::set_var("FRAISEQL_KAFKA_ALLOW_PLAINTEXT", "true");
+    }
+    if std::env::var("FRAISEQL_ENV").is_err() {
+        std::env::set_var("FRAISEQL_ENV", "development");
+    }
+}
+
+async fn pool() -> PgPool {
+    let url = fraiseql_test_support::database_url();
+    PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap()
+}
+
+async fn setup_schema(pool: &PgPool) {
+    // #942/#982: the change-log table comes from the ONE shared provisioner.
+    sqlx::raw_sql(&fraiseql_test_support::changelog::entity_change_log_provision_sql())
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql(outbox_sink_state_migration_sql()).execute(pool).await.unwrap();
+}
+
+/// Insert a row shaped as the #366 capture trigger writes it.
+async fn seed(
+    pool: &PgPool,
+    object_type: &str,
+    op: &str,
+    tenant: Uuid,
+    object_id: Uuid,
+    after: Option<Value>,
+    before: Option<Value>,
+) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO core.tb_entity_change_log
+             (object_type, modification_type, object_id, tenant_id, object_data, object_data_before)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING seq",
+    )
+    .bind(object_type)
+    .bind(op)
+    .bind(object_id)
+    .bind(tenant)
+    .bind(after)
+    .bind(before)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// Partitions for the test topic.
+///
+/// Explicit, and greater than one, because the partition-affinity assertion is
+/// **vacuous on a single-partition topic** — auto-creation would give exactly
+/// that, and the test would then pass with any partition key at all, including a
+/// per-message one.
+const TEST_PARTITIONS: i32 = 6;
+
+/// Create the test topic with [`TEST_PARTITIONS`] partitions.
+async fn create_topic(bootstrap: &str, topic: &str) {
+    let admin: AdminClient<DefaultClientContext> =
+        ClientConfig::new().set("bootstrap.servers", bootstrap).create().unwrap();
+    admin
+        .create_topics(
+            &[NewTopic::new(
+                topic,
+                TEST_PARTITIONS,
+                TopicReplication::Fixed(1),
+            )],
+            &AdminOptions::new(),
+        )
+        .await
+        .unwrap();
+}
+
+/// One record read back off the broker.
+struct Record {
+    payload:   Value,
+    key:       String,
+    msg_id:    Option<String>,
+    partition: i32,
+}
+
+/// Consume `expected` records from `topic`, starting at the beginning.
+async fn collect(bootstrap: &str, topic: &str, group: &str, expected: usize) -> Vec<Record> {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", bootstrap)
+        .set("group.id", group)
+        .set("auto.offset.reset", "earliest")
+        .set("enable.auto.commit", "false")
+        .create()
+        .unwrap();
+    consumer.subscribe(&[topic]).unwrap();
+
+    let mut out = Vec::new();
+    for _ in 0..expected {
+        match tokio::time::timeout(Duration::from_secs(20), consumer.recv()).await {
+            Ok(Ok(msg)) => {
+                let payload: Value = serde_json::from_slice(msg.payload().unwrap()).unwrap();
+                let key = String::from_utf8(msg.key().unwrap_or_default().to_vec()).unwrap();
+                let msg_id = msg.headers().and_then(|hs| {
+                    (0..hs.count())
+                        .map(|i| hs.get(i))
+                        .find(|h| h.key == "fraiseql-msg-id")
+                        .and_then(|h| h.value.map(|v| String::from_utf8_lossy(v).into_owned()))
+                });
+                out.push(Record {
+                    payload,
+                    key,
+                    msg_id,
+                    partition: msg.partition(),
+                });
+            },
+            _ => break,
+        }
+    }
+    out
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + Kafka"]
+async fn external_capture_rows_drain_to_kafka_in_seq_order() {
+    allow_plaintext_for_local();
+    let Some(bootstrap) = bootstrap().await else {
+        skipped();
+        return;
+    };
+    let pool = pool().await;
+    setup_schema(&pool).await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    // Kafka topics allow [a-zA-Z0-9._-] only, so the table name doubles as a
+    // topic segment and must stay inside that charset.
+    let table = format!("tbpost{suffix}");
+    let tenant = Uuid::new_v4();
+    let entity = Uuid::new_v4();
+
+    // Capture-trigger-shaped rows for ONE entity: INSERT (after only), UPDATE
+    // (after + pre-image), DELETE (no after-image, pre-image only). One entity is
+    // the point — it must land on one partition, in order.
+    seed(&pool, &table, "INSERT", tenant, entity, Some(json!({ "v": 1 })), None).await;
+    seed(
+        &pool,
+        &table,
+        "UPDATE",
+        tenant,
+        entity,
+        Some(json!({ "v": 2 })),
+        Some(json!({ "v": 1 })),
+    )
+    .await;
+    seed(&pool, &table, "DELETE", tenant, entity, None, Some(json!({ "v": 2 }))).await;
+
+    let topic = format!("cdctest.{table}");
+    create_topic(&bootstrap, &topic).await;
+
+    let config = CdcSinkConfig::new(format!("sink{suffix}"), "cdctest.{table}".to_owned())
+        .with_tables(vec![table.clone()]);
+    let sink = KafkaSink::connect(&format!("kafka://{bootstrap}"), config.clone()).unwrap();
+
+    let worker = DrainWorker::new(pool.clone(), sink, config);
+    let stats = worker.tick().await.unwrap();
+    assert_eq!(stats.enqueued, 3);
+    assert_eq!(stats.published, 3, "all three rows must reach the broker");
+    assert_eq!(stats.dead, 0);
+
+    let records = collect(&bootstrap, &topic, &format!("verify{suffix}"), 3).await;
+    assert_eq!(records.len(), 3, "expected 3 broker records off {topic}");
+
+    let expected_key = format!("{table}:{entity}");
+    let mut seqs = Vec::new();
+    for (i, record) in records.iter().enumerate() {
+        let seq = record.payload["seq"].as_i64().unwrap();
+        seqs.push(seq);
+        assert_eq!(record.key, expected_key, "record {i} keyed off entity identity");
+        assert_eq!(
+            record.msg_id.as_deref(),
+            Some(format!("{table}:{seq}").as_str()),
+            "fraiseql-msg-id dedup key mismatch on record {i}"
+        );
+    }
+
+    // The load-bearing pair: one entity's changes share a partition, and arrive
+    // in seq order. Either alone would pass with a broken partition key.
+    assert!(
+        records.iter().all(|r| r.partition == records[0].partition),
+        "one entity's changes must share a partition; got {:?}",
+        records.iter().map(|r| r.partition).collect::<Vec<_>>()
+    );
+    assert!(seqs.windows(2).all(|w| w[0] < w[1]), "records out of seq order: {seqs:?}");
+
+    // The DELETE record has a null after-image and a present pre-image.
+    let delete = records.iter().find(|r| r.payload["op"] == "delete").expect("a delete record");
+    assert!(delete.payload["after"].is_null(), "delete after-image should be null");
+    assert_eq!(delete.payload["before"], json!({ "v": 2 }));
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + Kafka"]
+async fn a_topic_kafka_cannot_accept_dead_letters_without_publishing() {
+    allow_plaintext_for_local();
+    let Some(bootstrap) = bootstrap().await else {
+        skipped();
+        return;
+    };
+    let pool = pool().await;
+    setup_schema(&pool).await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    // `/` passes the NATS subject sanitiser and is illegal in a Kafka topic, so
+    // this is the charset difference the sink must catch — as a dead-letter,
+    // never a silent re-route to some other topic.
+    let table = format!("tb/evil{suffix}");
+    let tenant = Uuid::new_v4();
+    let sink_name = format!("sink{suffix}");
+
+    seed(&pool, &table, "INSERT", tenant, Uuid::new_v4(), Some(json!({ "v": 1 })), None).await;
+
+    let config = CdcSinkConfig::new(sink_name.clone(), "cdctest.{table}".to_owned())
+        .with_tables(vec![table.clone()]);
+    let sink = KafkaSink::connect(&format!("kafka://{bootstrap}"), config.clone()).unwrap();
+
+    let worker = DrainWorker::new(pool.clone(), sink, config);
+    let stats = worker.tick().await.unwrap();
+    assert_eq!(stats.enqueued, 1);
+    assert_eq!(stats.published, 0);
+    assert_eq!(stats.dead, 1, "a Kafka-illegal topic must dead-letter");
+
+    let dead: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM core.tb_cdc_sink_state WHERE sink_name = $1 AND status = 'dead'",
+    )
+    .bind(&sink_name)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(dead, 1);
+}

--- a/crates/fraiseql-cdc-sinks/tests/cdc_kinesis_e2e.rs
+++ b/crates/fraiseql-cdc-sinks/tests/cdc_kinesis_e2e.rs
@@ -1,0 +1,324 @@
+//! End-to-end: outbox → drain → real AWS Kinesis (`LocalStack`).
+//!
+//! The assertions are made **through the drain**, not against the sink directly:
+//! seed the outbox with rows shaped exactly as the #366 external-write capture
+//! trigger produces them, tick the `DrainWorker`, then read the stream back. That
+//! is what proves the seam, rather than proving `KinesisSink::publish` in
+//! isolation.
+//!
+//! `#[ignore]` — needs both a real Postgres (`DATABASE_URL`) and a Kinesis endpoint
+//! (`KINESIS_ENDPOINT`, a `LocalStack` URL). Run with:
+//! `cargo test -p fraiseql-cdc-sinks --features cdc-kinesis --test cdc_kinesis_e2e --
+//! --ignored --test-threads=1`.
+//!
+//! Locally:
+//! `docker run -d --name p18-localstack -p 4566:4566 -e SERVICES=kinesis
+//! localstack/localstack:3.8`, then
+//! `KINESIS_ENDPOINT=http://127.0.0.1:4566 DATABASE_URL=... cargo test ... -- --ignored
+//! --test-threads=1`. Remove the container when done.
+
+#![cfg(feature = "cdc-kinesis")]
+#![allow(clippy::unwrap_used)] // Reason: test code, panics are acceptable
+#![allow(clippy::panic)] // Reason: test code — a stream that never goes ACTIVE must fail the suite loudly
+#![allow(clippy::literal_string_with_formatting_args)] // Reason: stream-template placeholders, not format args
+
+use std::time::Duration;
+
+use aws_sdk_kinesis::{Client, types::ShardIteratorType};
+use fraiseql_cdc_sinks::{
+    CdcSinkConfig, DrainWorker, KinesisSink, outbox_sink_state_migration_sql,
+};
+use serde_json::{Value, json};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use uuid::Uuid;
+
+/// The `LocalStack` endpoint, or `None` when none is bound.
+///
+/// Resolved through `fraiseql_test_support::services::kinesis()` so "available"
+/// means *reachable*, not merely configured (#879) — a suite that hard-fails in
+/// setup on an absent endpoint reads as a regression rather than a skip.
+async fn endpoint() -> Option<String> {
+    fraiseql_test_support::services::kinesis().await.map(|s| s.url().to_owned())
+}
+
+/// Announce a skip on stderr.
+///
+/// A test that returns early reads as `ok` in the summary, which is how a leg that
+/// stops binding its endpoint keeps reporting green over a suite that asserts
+/// nothing. `tools/check-suite-coverage.py` is the gate that keeps this suite in a
+/// leg with a `kinesis` service; this line is what makes the skip visible in the
+/// log if it ever is not.
+#[allow(clippy::print_stderr)] // Reason: a silent skip is exactly the failure mode being prevented
+fn skipped() {
+    eprintln!("SKIP: KINESIS_ENDPOINT is unset — the Kinesis drain-through assertions did NOT run");
+}
+
+/// The region the sink is pointed at. `LocalStack` accepts any.
+const TEST_REGION: &str = "us-east-1";
+
+/// Set the dev opt-ins the guard requires for a plaintext `LocalStack` endpoint,
+/// plus the dummy credentials the AWS provider chain needs.
+fn allow_plaintext_for_local(endpoint: &str) {
+    // This suite runs single-threaded (`--test-threads=1`), so there is no
+    // concurrent environment access. (`set_var` is safe on edition 2021.)
+    std::env::set_var("FRAISEQL_KINESIS_ENDPOINT_URL", endpoint);
+    if std::env::var("FRAISEQL_KINESIS_ALLOW_PLAINTEXT").is_err() {
+        std::env::set_var("FRAISEQL_KINESIS_ALLOW_PLAINTEXT", "true");
+    }
+    if std::env::var("FRAISEQL_ENV").is_err() {
+        std::env::set_var("FRAISEQL_ENV", "development");
+    }
+    if std::env::var("AWS_ACCESS_KEY_ID").is_err() {
+        std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+        std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+    }
+    std::env::set_var("AWS_EC2_METADATA_DISABLED", "true");
+}
+
+async fn pool() -> PgPool {
+    let url = fraiseql_test_support::database_url();
+    PgPoolOptions::new().max_connections(4).connect(&url).await.unwrap()
+}
+
+async fn setup_schema(pool: &PgPool) {
+    // #942/#982: the change-log table comes from the ONE shared provisioner.
+    sqlx::raw_sql(&fraiseql_test_support::changelog::entity_change_log_provision_sql())
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql(outbox_sink_state_migration_sql()).execute(pool).await.unwrap();
+}
+
+/// Insert a row shaped as the #366 capture trigger writes it.
+async fn seed(
+    pool: &PgPool,
+    object_type: &str,
+    op: &str,
+    tenant: Uuid,
+    object_id: Uuid,
+    after: Option<Value>,
+    before: Option<Value>,
+) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO core.tb_entity_change_log
+             (object_type, modification_type, object_id, tenant_id, object_data, object_data_before)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING seq",
+    )
+    .bind(object_type)
+    .bind(op)
+    .bind(object_id)
+    .bind(tenant)
+    .bind(after)
+    .bind(before)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// Shards for the test stream.
+///
+/// Explicit, and greater than one, because the shard-affinity assertion is
+/// **vacuous on a single-shard stream** — the test would then pass with any
+/// partition key at all, including a per-message one.
+const TEST_SHARDS: i32 = 4;
+
+/// An admin client pointed at `LocalStack`, for stream setup and read-back.
+async fn admin_client(endpoint: &str) -> Client {
+    let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_config::Region::new(TEST_REGION))
+        .endpoint_url(endpoint)
+        .load()
+        .await;
+    Client::new(&cfg)
+}
+
+/// Create the test stream and wait for it to become ACTIVE.
+async fn create_stream(client: &Client, stream: &str) {
+    client
+        .create_stream()
+        .stream_name(stream)
+        .shard_count(TEST_SHARDS)
+        .send()
+        .await
+        .unwrap();
+
+    // Kinesis streams are CREATING before they are ACTIVE; a PutRecord against a
+    // CREATING stream fails, so wait rather than race it.
+    for _ in 0..60 {
+        let described = client.describe_stream_summary().stream_name(stream).send().await.unwrap();
+        let status = described.stream_description_summary().map(|d| d.stream_status().clone());
+        if matches!(status, Some(aws_sdk_kinesis::types::StreamStatus::Active)) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!("stream {stream} did not become ACTIVE");
+}
+
+/// One record read back off the stream.
+struct Record {
+    payload:       Value,
+    partition_key: String,
+    shard_id:      String,
+}
+
+/// Read every record from every shard of `stream`, from `TRIM_HORIZON`.
+async fn collect(client: &Client, stream: &str) -> Vec<Record> {
+    let shards = client.list_shards().stream_name(stream).send().await.unwrap();
+    let mut out = Vec::new();
+
+    for shard in shards.shards() {
+        let iter = client
+            .get_shard_iterator()
+            .stream_name(stream)
+            .shard_id(shard.shard_id())
+            .shard_iterator_type(ShardIteratorType::TrimHorizon)
+            .send()
+            .await
+            .unwrap();
+        let Some(mut cursor) = iter.shard_iterator().map(ToOwned::to_owned) else {
+            continue;
+        };
+
+        // Poll a few times: a just-written record is not always returned by the
+        // first GetRecords call on a fresh iterator.
+        for _ in 0..8 {
+            let records = client.get_records().shard_iterator(&cursor).send().await.unwrap();
+            for record in records.records() {
+                out.push(Record {
+                    payload:       serde_json::from_slice(record.data().as_ref()).unwrap(),
+                    partition_key: record.partition_key().to_owned(),
+                    shard_id:      shard.shard_id().to_owned(),
+                });
+            }
+            match records.next_shard_iterator() {
+                Some(next) => cursor = next.to_owned(),
+                None => break,
+            }
+            if !out.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    }
+    out
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + Kinesis (LocalStack)"]
+async fn external_capture_rows_drain_to_kinesis_in_seq_order() {
+    let Some(endpoint) = endpoint().await else {
+        skipped();
+        return;
+    };
+    allow_plaintext_for_local(&endpoint);
+    let pool = pool().await;
+    setup_schema(&pool).await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    // Kinesis stream names allow [a-zA-Z0-9_.-] only, so the table name doubles as
+    // a stream segment and must stay inside that charset.
+    let table = format!("tbpost{suffix}");
+    let tenant = Uuid::new_v4();
+    let entity = Uuid::new_v4();
+
+    // Capture-trigger-shaped rows for ONE entity: INSERT (after only), UPDATE
+    // (after + pre-image), DELETE (no after-image, pre-image only). One entity is
+    // the point — it must land on one shard, in order.
+    seed(&pool, &table, "INSERT", tenant, entity, Some(json!({ "v": 1 })), None).await;
+    seed(
+        &pool,
+        &table,
+        "UPDATE",
+        tenant,
+        entity,
+        Some(json!({ "v": 2 })),
+        Some(json!({ "v": 1 })),
+    )
+    .await;
+    seed(&pool, &table, "DELETE", tenant, entity, None, Some(json!({ "v": 2 }))).await;
+
+    let stream = format!("cdctest.{table}");
+    let client = admin_client(&endpoint).await;
+    create_stream(&client, &stream).await;
+
+    let config = CdcSinkConfig::new(format!("sink{suffix}"), "cdctest.{table}".to_owned())
+        .with_tables(vec![table.clone()]);
+    let sink = KinesisSink::connect(&format!("kinesis://{TEST_REGION}"), config.clone())
+        .await
+        .unwrap();
+
+    let worker = DrainWorker::new(pool.clone(), sink, config);
+    let stats = worker.tick().await.unwrap();
+    assert_eq!(stats.enqueued, 3);
+    assert_eq!(stats.published, 3, "all three rows must reach the stream");
+    assert_eq!(stats.dead, 0);
+
+    let records = collect(&client, &stream).await;
+    assert_eq!(records.len(), 3, "expected 3 records off {stream}");
+
+    let expected_key = format!("{table}:{entity}");
+    let mut seqs = Vec::new();
+    for (i, record) in records.iter().enumerate() {
+        seqs.push(record.payload["seq"].as_i64().unwrap());
+        assert_eq!(record.partition_key, expected_key, "record {i} keyed off entity identity");
+    }
+
+    // The load-bearing pair: one entity's changes share a shard, and arrive in seq
+    // order. Either alone would pass with a broken partition key.
+    assert!(
+        records.iter().all(|r| r.shard_id == records[0].shard_id),
+        "one entity's changes must share a shard; got {:?}",
+        records.iter().map(|r| &r.shard_id).collect::<Vec<_>>()
+    );
+    assert!(seqs.windows(2).all(|w| w[0] < w[1]), "records out of seq order: {seqs:?}");
+
+    // The DELETE record has a null after-image and a present pre-image.
+    let delete = records.iter().find(|r| r.payload["op"] == "delete").expect("a delete record");
+    assert!(delete.payload["after"].is_null(), "delete after-image should be null");
+    assert_eq!(delete.payload["before"], json!({ "v": 2 }));
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres + Kinesis (LocalStack)"]
+async fn a_stream_name_kinesis_cannot_accept_dead_letters_without_publishing() {
+    let Some(endpoint) = endpoint().await else {
+        skipped();
+        return;
+    };
+    allow_plaintext_for_local(&endpoint);
+    let pool = pool().await;
+    setup_schema(&pool).await;
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    // `/` passes the NATS subject sanitiser and is illegal in a Kinesis stream
+    // name, so this is the charset difference the sink must catch — as a
+    // dead-letter, never a silent re-route to some other stream.
+    let table = format!("tb/evil{suffix}");
+    let tenant = Uuid::new_v4();
+    let sink_name = format!("sink{suffix}");
+
+    seed(&pool, &table, "INSERT", tenant, Uuid::new_v4(), Some(json!({ "v": 1 })), None).await;
+
+    let config = CdcSinkConfig::new(sink_name.clone(), "cdctest.{table}".to_owned())
+        .with_tables(vec![table.clone()]);
+    let sink = KinesisSink::connect(&format!("kinesis://{TEST_REGION}"), config.clone())
+        .await
+        .unwrap();
+
+    let worker = DrainWorker::new(pool.clone(), sink, config);
+    let stats = worker.tick().await.unwrap();
+    assert_eq!(stats.enqueued, 1);
+    assert_eq!(stats.published, 0);
+    assert_eq!(stats.dead, 1, "a Kinesis-illegal stream name must dead-letter");
+
+    let dead: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM core.tb_cdc_sink_state WHERE sink_name = $1 AND status = 'dead'",
+    )
+    .bind(&sink_name)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(dead, 1);
+}

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -191,6 +191,11 @@ azure-blob = ["fraiseql-storage/azure-blob"]
 storage-transforms = ["fraiseql-storage/transforms"]
 # Outbound CDC (#382): drains the change-log outbox to external brokers.
 cdc-outbound = ["dep:fraiseql-cdc-sinks"]
+# Adds the Kafka sink to the outbound drain. Separate from `cdc-outbound` because
+# it pulls librdkafka (a C library built from source) and links system OpenSSL,
+# which the NATS sink does not — a deployment that only drains to NATS should not
+# pay for it. With this off, `kind = "kafka"` stays refused by name at boot.
+cdc-kafka = ["cdc-outbound", "fraiseql-cdc-sinks/cdc-kafka"]
 # CLI argument parsing (clap-derived Cli/ServerArgs structs)
 cli = ["dep:clap"]
 gcs = ["fraiseql-storage/gcs"]

--- a/crates/fraiseql-server/Cargo.toml
+++ b/crates/fraiseql-server/Cargo.toml
@@ -196,6 +196,12 @@ cdc-outbound = ["dep:fraiseql-cdc-sinks"]
 # which the NATS sink does not — a deployment that only drains to NATS should not
 # pay for it. With this off, `kind = "kafka"` stays refused by name at boot.
 cdc-kafka = ["cdc-outbound", "fraiseql-cdc-sinks/cdc-kafka"]
+# Adds the AWS Kinesis sink to the outbound drain. Separate from `cdc-outbound`
+# for the same reason as `cdc-kafka`: it pulls the whole aws-sdk/aws-smithy tree,
+# which a NATS-only deployment should not pay for, and which carries the opt-in
+# rustls-0.21 advisory ignores recorded in deny.toml. With this off,
+# `kind = "kinesis"` stays refused by name at boot.
+cdc-kinesis = ["cdc-outbound", "fraiseql-cdc-sinks/cdc-kinesis"]
 # CLI argument parsing (clap-derived Cli/ServerArgs structs)
 cli = ["dep:clap"]
 gcs = ["fraiseql-storage/gcs"]

--- a/crates/fraiseql-server/src/cdc_outbound/mod.rs
+++ b/crates/fraiseql-server/src/cdc_outbound/mod.rs
@@ -43,6 +43,9 @@ pub enum ConfiguredSink {
     /// Apache Kafka (feature `cdc-kafka`).
     #[cfg(feature = "cdc-kafka")]
     Kafka(fraiseql_cdc_sinks::KafkaSink),
+    /// AWS Kinesis Data Streams (feature `cdc-kinesis`).
+    #[cfg(feature = "cdc-kinesis")]
+    Kinesis(fraiseql_cdc_sinks::KinesisSink),
 }
 
 impl CdcSink for ConfiguredSink {
@@ -51,6 +54,8 @@ impl CdcSink for ConfiguredSink {
             Self::NatsJetStream(sink) => sink.name(),
             #[cfg(feature = "cdc-kafka")]
             Self::Kafka(sink) => sink.name(),
+            #[cfg(feature = "cdc-kinesis")]
+            Self::Kinesis(sink) => sink.name(),
         }
     }
 
@@ -59,6 +64,8 @@ impl CdcSink for ConfiguredSink {
             Self::NatsJetStream(sink) => sink.kind(),
             #[cfg(feature = "cdc-kafka")]
             Self::Kafka(sink) => sink.kind(),
+            #[cfg(feature = "cdc-kinesis")]
+            Self::Kinesis(sink) => sink.kind(),
         }
     }
 
@@ -67,6 +74,8 @@ impl CdcSink for ConfiguredSink {
             Self::NatsJetStream(sink) => sink.matches(ev),
             #[cfg(feature = "cdc-kafka")]
             Self::Kafka(sink) => sink.matches(ev),
+            #[cfg(feature = "cdc-kinesis")]
+            Self::Kinesis(sink) => sink.matches(ev),
         }
     }
 
@@ -75,6 +84,8 @@ impl CdcSink for ConfiguredSink {
             Self::NatsJetStream(sink) => sink.publish(ev).await,
             #[cfg(feature = "cdc-kafka")]
             Self::Kafka(sink) => sink.publish(ev).await,
+            #[cfg(feature = "cdc-kinesis")]
+            Self::Kinesis(sink) => sink.publish(ev).await,
         }
     }
 }
@@ -204,6 +215,12 @@ async fn build_one(
         #[cfg(feature = "cdc-kafka")]
         "kafka" => ConfiguredSink::Kafka(
             fraiseql_cdc_sinks::KafkaSink::connect(&section.endpoint, sink_config.clone())
+                .map_err(connect_failed)?,
+        ),
+        #[cfg(feature = "cdc-kinesis")]
+        "kinesis" => ConfiguredSink::Kinesis(
+            fraiseql_cdc_sinks::KinesisSink::connect(&section.endpoint, sink_config.clone())
+                .await
                 .map_err(connect_failed)?,
         ),
         _ => {

--- a/crates/fraiseql-server/src/cdc_outbound/mod.rs
+++ b/crates/fraiseql-server/src/cdc_outbound/mod.rs
@@ -17,16 +17,72 @@ mod tests;
 
 use std::time::Duration;
 
-use fraiseql_cdc_sinks::{CdcSinkConfig, DrainWorker, NatsJetStreamSink};
+use fraiseql_cdc_sinks::{
+    CdcSink, CdcSinkConfig, ChangeEvent, DrainWorker, NatsJetStreamSink, PublishOutcome, SinkKind,
+};
 use sqlx::PgPool;
 use tracing::{error, info, warn};
 
 use crate::server_config::cdc_outbound::{CdcOutboundConfig, CdcSinkSectionConfig};
 
+/// Every sink kind this binary can drain to, as one concrete type.
+///
+/// `CdcSink::publish` is an RPITIT (`-> impl Future + Send`), which makes the
+/// trait **not** dyn-safe — `Box<dyn CdcSink>` will not compile. So the drain
+/// worker is made generic over this enum and each method delegates, rather than
+/// over a trait object. Variants are feature-gated, so a build without
+/// `cdc-kafka` carries no rdkafka and no dead arm.
+// Reason: exactly one value per configured sink, built at boot and held by its
+// DrainWorker for the process lifetime — it is never moved in a hot path or
+// stored in a collection, so boxing would buy an allocation and a deref per
+// publish and save nothing.
+#[allow(clippy::large_enum_variant)]
+pub enum ConfiguredSink {
+    /// NATS `JetStream` (always available with `cdc-outbound`).
+    NatsJetStream(NatsJetStreamSink),
+    /// Apache Kafka (feature `cdc-kafka`).
+    #[cfg(feature = "cdc-kafka")]
+    Kafka(fraiseql_cdc_sinks::KafkaSink),
+}
+
+impl CdcSink for ConfiguredSink {
+    fn name(&self) -> &str {
+        match self {
+            Self::NatsJetStream(sink) => sink.name(),
+            #[cfg(feature = "cdc-kafka")]
+            Self::Kafka(sink) => sink.name(),
+        }
+    }
+
+    fn kind(&self) -> SinkKind {
+        match self {
+            Self::NatsJetStream(sink) => sink.kind(),
+            #[cfg(feature = "cdc-kafka")]
+            Self::Kafka(sink) => sink.kind(),
+        }
+    }
+
+    fn matches(&self, ev: &ChangeEvent) -> bool {
+        match self {
+            Self::NatsJetStream(sink) => sink.matches(ev),
+            #[cfg(feature = "cdc-kafka")]
+            Self::Kafka(sink) => sink.matches(ev),
+        }
+    }
+
+    async fn publish(&self, ev: &ChangeEvent) -> PublishOutcome {
+        match self {
+            Self::NatsJetStream(sink) => sink.publish(ev).await,
+            #[cfg(feature = "cdc-kafka")]
+            Self::Kafka(sink) => sink.publish(ev).await,
+        }
+    }
+}
+
 /// One configured sink's drain worker, ready to be ticked.
 pub struct SinkDrain {
     name:   String,
-    worker: DrainWorker<NatsJetStreamSink>,
+    worker: DrainWorker<ConfiguredSink>,
     tick:   Duration,
 }
 
@@ -134,28 +190,40 @@ async fn build_one(
         sink_config.max_attempts = max_attempts;
     }
 
-    // Only `nats-jetstream` reaches here: `validate()` refused every other
-    // kind by name before any connection was attempted.
-    let sink = NatsJetStreamSink::connect(&section.endpoint, sink_config.clone())
-        .await
-        .map_err(|e| {
-            format!(
-                "[cdc_outbound] sink {:?} could not connect to {}: {e}. Refusing to boot \
-                 rather than starting a drain that publishes nowhere.",
-                section.name, section.endpoint
-            )
-        })?;
+    // Only kinds this build compiled in reach here: `validate()` refused every
+    // other one by name before any connection was attempted.
+    let connect_failed = |e: fraiseql_cdc_sinks::CdcError| {
+        format!(
+            "[cdc_outbound] sink {:?} could not connect to {}: {e}. Refusing to boot \
+             rather than starting a drain that publishes nowhere.",
+            section.name, section.endpoint
+        )
+    };
 
-    if let Some(ref stream) = section.ensure_stream {
-        sink.ensure_stream(stream, vec![subject_wildcard(&section.subject_template)])
-            .await
-            .map_err(|e| {
-                format!(
-                    "[cdc_outbound] sink {:?}: could not ensure JetStream stream {stream:?}: {e}",
-                    section.name
-                )
-            })?;
-    }
+    let sink = match section.kind.to_ascii_lowercase().as_str() {
+        #[cfg(feature = "cdc-kafka")]
+        "kafka" => ConfiguredSink::Kafka(
+            fraiseql_cdc_sinks::KafkaSink::connect(&section.endpoint, sink_config.clone())
+                .map_err(connect_failed)?,
+        ),
+        _ => {
+            let sink = NatsJetStreamSink::connect(&section.endpoint, sink_config.clone())
+                .await
+                .map_err(connect_failed)?;
+            if let Some(ref stream) = section.ensure_stream {
+                sink.ensure_stream(stream, vec![subject_wildcard(&section.subject_template)])
+                    .await
+                    .map_err(|e| {
+                        format!(
+                            "[cdc_outbound] sink {:?}: could not ensure JetStream stream \
+                             {stream:?}: {e}",
+                            section.name
+                        )
+                    })?;
+            }
+            ConfiguredSink::NatsJetStream(sink)
+        },
+    };
 
     Ok(SinkDrain {
         name: section.name.clone(),

--- a/crates/fraiseql-server/src/cdc_outbound/tests.rs
+++ b/crates/fraiseql-server/src/cdc_outbound/tests.rs
@@ -53,7 +53,9 @@ fn invalid_sections_are_refused_by_name() {
             "duplicate sink name",
         ),
         (config(vec![sink("", "nats-jetstream")]), "empty name"),
-        (config(vec![sink("a", "kinesis")]), "not implemented yet"),
+        // `kinesis` is no longer here: it is implemented as of #975 and its
+        // accept/refuse pair is cfg-gated, so it is covered by the dedicated tests
+        // below rather than by a blanket "not implemented" expectation.
         (config(vec![sink("a", "pulsar")]), "not implemented yet"),
         (config(vec![sink("a", "rabbitmq")]), "unknown kind"),
     ];
@@ -115,6 +117,57 @@ fn kafka_is_refused_by_name_when_the_sink_is_not_compiled_in() {
         !err.contains("unknown kind"),
         "must be refused by name, not as an unknown kind: {err}"
     );
+}
+
+/// `kind = "kinesis"` is accepted only by a binary that compiled the sink in —
+/// the same cfg-gated pair as kafka, and needing the same two legs to cover.
+#[cfg(feature = "cdc-kinesis")]
+#[test]
+fn kinesis_is_accepted_when_the_sink_is_compiled_in() {
+    assert!(config(vec![sink("warehouse", "kinesis")]).validate().is_ok());
+    assert!(
+        config(vec![sink("warehouse", "KINESIS")]).validate().is_ok(),
+        "kind is case-folded"
+    );
+}
+
+#[cfg(not(feature = "cdc-kinesis"))]
+#[test]
+fn kinesis_is_refused_by_name_when_the_sink_is_not_compiled_in() {
+    let err = config(vec![sink("warehouse", "kinesis")])
+        .validate()
+        .expect_err("must be refused");
+    assert!(err.contains("cdc-kinesis"), "should name the missing feature: {err}");
+    assert!(
+        !err.contains("unknown kind"),
+        "must be refused by name, not as an unknown kind: {err}"
+    );
+}
+
+/// Pulsar keeps its **named** refusal, in every feature configuration.
+///
+/// #975 recommended dropping the name so `pulsar` would fall through to the
+/// generic "unknown kind" error. That was declined: an operator who configures it
+/// should be told the kind exists and is not implemented, not that they made a
+/// typo. This test pins the arm so it cannot be dropped by accident.
+#[test]
+fn pulsar_is_refused_by_name_not_as_an_unknown_kind() {
+    let err = config(vec![sink("warehouse", "pulsar")])
+        .validate()
+        .expect_err("must be refused");
+    assert!(err.contains("pulsar"), "should name the kind: {err}");
+    assert!(
+        !err.contains("unknown kind"),
+        "the named refusal is deliberate — see #975's declined recommendation: {err}"
+    );
+
+    // Positive control: a genuinely unknown kind *does* get the unknown-kind
+    // error, so the assertion above is about pulsar's arm and not about the
+    // message being unreachable.
+    let unknown = config(vec![sink("warehouse", "rabbitmq")])
+        .validate()
+        .expect_err("must be refused");
+    assert!(unknown.contains("unknown kind"), "control: {unknown}");
 }
 
 /// A configured section with no database pool refuses to boot: the outbox and

--- a/crates/fraiseql-server/src/cdc_outbound/tests.rs
+++ b/crates/fraiseql-server/src/cdc_outbound/tests.rs
@@ -53,7 +53,6 @@ fn invalid_sections_are_refused_by_name() {
             "duplicate sink name",
         ),
         (config(vec![sink("", "nats-jetstream")]), "empty name"),
-        (config(vec![sink("a", "kafka")]), "not implemented yet"),
         (config(vec![sink("a", "kinesis")]), "not implemented yet"),
         (config(vec![sink("a", "pulsar")]), "not implemented yet"),
         (config(vec![sink("a", "rabbitmq")]), "unknown kind"),
@@ -86,6 +85,36 @@ fn invalid_sections_are_refused_by_name() {
 #[test]
 fn a_valid_section_validates() {
     assert!(config(vec![sink("warehouse", "nats-jetstream")]).validate().is_ok());
+}
+
+/// `kind = "kafka"` is accepted only by a binary that compiled the sink in.
+///
+/// The two halves run in different legs by construction — a `cfg(not(feature))`
+/// test never runs where the feature is on — so both a default-feature leg and a
+/// `cdc-kafka` leg are needed to cover this pair. That is the point: the failure
+/// this guards against is a feature-off binary accepting the kind and then
+/// dropping every event.
+#[cfg(feature = "cdc-kafka")]
+#[test]
+fn kafka_is_accepted_when_the_sink_is_compiled_in() {
+    assert!(config(vec![sink("warehouse", "kafka")]).validate().is_ok());
+    assert!(
+        config(vec![sink("warehouse", "KAFKA")]).validate().is_ok(),
+        "kind is case-folded"
+    );
+}
+
+#[cfg(not(feature = "cdc-kafka"))]
+#[test]
+fn kafka_is_refused_by_name_when_the_sink_is_not_compiled_in() {
+    let err = config(vec![sink("warehouse", "kafka")])
+        .validate()
+        .expect_err("must be refused");
+    assert!(err.contains("cdc-kafka"), "should name the missing feature: {err}");
+    assert!(
+        !err.contains("unknown kind"),
+        "must be refused by name, not as an unknown kind: {err}"
+    );
 }
 
 /// A configured section with no database pool refuses to boot: the outbox and

--- a/crates/fraiseql-server/src/server_config/cdc_outbound.rs
+++ b/crates/fraiseql-server/src/server_config/cdc_outbound.rs
@@ -152,9 +152,10 @@ impl CdcOutboundConfig {
 /// is refused as unknown: either way the server does not boot believing it is
 /// replicating changes it would in fact drop on the floor.
 ///
-/// `kafka` is accepted only when the `cdc-kafka` feature compiled the sink in.
-/// A binary built without it keeps refusing the kind **by name** — never
-/// accept-then-drop, which is the failure mode this function exists to prevent.
+/// `kafka` and `kinesis` are each accepted only when the matching feature
+/// compiled the sink in. A binary built without one keeps refusing that kind **by
+/// name** — never accept-then-drop, which is the failure mode this function exists
+/// to prevent.
 fn validate_kind(sink: &str, kind: &str) -> Result<(), String> {
     match kind.to_ascii_lowercase().as_str() {
         "nats-jetstream" => Ok(()),
@@ -166,16 +167,30 @@ fn validate_kind(sink: &str, kind: &str) -> Result<(), String> {
              this binary. Rebuild with the `cdc-kafka` feature. Refusing to boot rather than \
              silently draining nothing."
         )),
-        known @ ("kinesis" | "pulsar") => Err(format!(
-            "[cdc_outbound] sink {sink:?}: kind {known:?} is not implemented yet (#382 tracks \
+        #[cfg(feature = "cdc-kinesis")]
+        "kinesis" => Ok(()),
+        #[cfg(not(feature = "cdc-kinesis"))]
+        "kinesis" => Err(format!(
+            "[cdc_outbound] sink {sink:?}: kind \"kinesis\" is implemented but not compiled \
+             into this binary. Rebuild with the `cdc-kinesis` feature. Refusing to boot rather \
+             than silently draining nothing."
+        )),
+        // Pulsar keeps a *named* refusal rather than falling through to "unknown
+        // kind". #975 recommended dropping the name; that was declined
+        // deliberately. The cost is one match arm, and the benefit is that an
+        // operator who configures it is told what is actually happening instead of
+        // being told they made a typo.
+        "pulsar" => Err(format!(
+            "[cdc_outbound] sink {sink:?}: kind \"pulsar\" is not implemented yet (#382 tracks \
              it). Refusing to boot rather than silently draining nothing."
         )),
         other => Err(format!(
             "[cdc_outbound] sink {sink:?}: unknown kind {other:?}; expected \"nats-jetstream\"{}",
-            if cfg!(feature = "cdc-kafka") {
-                " or \"kafka\""
-            } else {
-                ""
+            match (cfg!(feature = "cdc-kafka"), cfg!(feature = "cdc-kinesis")) {
+                (true, true) => ", \"kafka\" or \"kinesis\"",
+                (true, false) => " or \"kafka\"",
+                (false, true) => " or \"kinesis\"",
+                (false, false) => "",
             }
         )),
     }

--- a/crates/fraiseql-server/src/server_config/cdc_outbound.rs
+++ b/crates/fraiseql-server/src/server_config/cdc_outbound.rs
@@ -151,15 +151,32 @@ impl CdcOutboundConfig {
 /// A recognised-but-unimplemented kind is refused by name, and an unknown one
 /// is refused as unknown: either way the server does not boot believing it is
 /// replicating changes it would in fact drop on the floor.
+///
+/// `kafka` is accepted only when the `cdc-kafka` feature compiled the sink in.
+/// A binary built without it keeps refusing the kind **by name** — never
+/// accept-then-drop, which is the failure mode this function exists to prevent.
 fn validate_kind(sink: &str, kind: &str) -> Result<(), String> {
     match kind.to_ascii_lowercase().as_str() {
         "nats-jetstream" => Ok(()),
-        known @ ("kafka" | "kinesis" | "pulsar") => Err(format!(
+        #[cfg(feature = "cdc-kafka")]
+        "kafka" => Ok(()),
+        #[cfg(not(feature = "cdc-kafka"))]
+        "kafka" => Err(format!(
+            "[cdc_outbound] sink {sink:?}: kind \"kafka\" is implemented but not compiled into \
+             this binary. Rebuild with the `cdc-kafka` feature. Refusing to boot rather than \
+             silently draining nothing."
+        )),
+        known @ ("kinesis" | "pulsar") => Err(format!(
             "[cdc_outbound] sink {sink:?}: kind {known:?} is not implemented yet (#382 tracks \
              it). Refusing to boot rather than silently draining nothing."
         )),
         other => Err(format!(
-            "[cdc_outbound] sink {sink:?}: unknown kind {other:?}; expected \"nats-jetstream\""
+            "[cdc_outbound] sink {sink:?}: unknown kind {other:?}; expected \"nats-jetstream\"{}",
+            if cfg!(feature = "cdc-kafka") {
+                " or \"kafka\""
+            } else {
+                ""
+            }
         )),
     }
 }

--- a/crates/fraiseql-test-support/src/services.rs
+++ b/crates/fraiseql-test-support/src/services.rs
@@ -31,6 +31,8 @@ const GCS_ENDPOINT_ENV: &str = "GCS_ENDPOINT";
 const VAULT_ADDR_ENV: &str = "VAULT_ADDR";
 /// `vault()` token env var.
 const VAULT_TOKEN_ENV: &str = "VAULT_TOKEN";
+/// `kafka()` bootstrap-servers env var.
+const KAFKA_BOOTSTRAP_ENV: &str = "KAFKA_BOOTSTRAP";
 
 /// A provisioned service: a connection URL plus an optional liveness guard.
 ///
@@ -122,6 +124,28 @@ pub async fn gcs() -> Option<Service> {
     resolve_env(GCS_ENDPOINT_ENV).await
 }
 
+/// Apache Kafka. Env: `KAFKA_BOOTSTRAP`.
+///
+/// Unlike every other service here the value is **scheme-less** — it is
+/// librdkafka's `bootstrap.servers` shape, a comma-separated `host:port` list.
+/// The first entry is probed for reachability, and the value returned by
+/// [`Service::url`] is the list verbatim, ready to be prefixed with the sink's
+/// own `kafka+ssl://` / `kafka://` scheme by the caller.
+#[allow(clippy::unused_async)] // Reason: uniform async getter family; a local spawn path would land here
+pub async fn kafka() -> Option<Service> {
+    let bootstrap = env_url(KAFKA_BOOTSTRAP_ENV)?;
+    // Probe through the shared, unit-tested `host_port` parser by giving it the
+    // scheme it requires, rather than re-implementing host splitting here.
+    let first = bootstrap.split(',').next().unwrap_or("").trim();
+    match probe(&format!("kafka://{first}")) {
+        Ok(()) => Some(Service::from_url(bootstrap)),
+        Err(reason) => {
+            announce_skip(KAFKA_BOOTSTRAP_ENV, &reason);
+            None
+        },
+    }
+}
+
 /// `HashiCorp` Vault. Env: `VAULT_ADDR` + `VAULT_TOKEN` (both required).
 #[must_use]
 pub fn vault() -> Option<Vault> {
@@ -148,18 +172,23 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Wrap an env-provided URL as a [`Service`] only if its host:port accepts TCP
 /// connections; otherwise announce the skip and return `None`. This is what makes
 /// "available" mean *reachable* rather than *configured* (#879).
-#[allow(clippy::print_stderr)] // Reason: a silent skip is the failure mode this crate exists to prevent; stderr is the test log
 fn reachable_service(name: &str, url: String) -> Option<Service> {
     match probe(&url) {
         Ok(()) => Some(Service::from_url(url)),
         Err(reason) => {
-            eprintln!(
-                "SKIP: {name} is set but the service is unreachable ({reason}); \
-                 treating it as unavailable"
-            );
+            announce_skip(name, &reason);
             None
         },
     }
+}
+
+/// Announce an unreachable-service skip on stderr.
+#[allow(clippy::print_stderr)] // Reason: a silent skip is the failure mode this crate exists to prevent; stderr is the test log
+fn announce_skip(name: &str, reason: &str) {
+    eprintln!(
+        "SKIP: {name} is set but the service is unreachable ({reason}); \
+         treating it as unavailable"
+    );
 }
 
 /// Attempt one short-timeout TCP connect to the URL's host:port.
@@ -215,6 +244,7 @@ fn default_port(scheme: &str) -> Option<u16> {
         "postgres" | "postgresql" => Some(5432),
         "redis" | "rediss" => Some(6379),
         "nats" => Some(4222),
+        "kafka" => Some(9092),
         "http" => Some(80),
         "https" => Some(443),
         _ => None,

--- a/crates/fraiseql-test-support/src/services.rs
+++ b/crates/fraiseql-test-support/src/services.rs
@@ -33,6 +33,8 @@ const VAULT_ADDR_ENV: &str = "VAULT_ADDR";
 const VAULT_TOKEN_ENV: &str = "VAULT_TOKEN";
 /// `kafka()` bootstrap-servers env var.
 const KAFKA_BOOTSTRAP_ENV: &str = "KAFKA_BOOTSTRAP";
+/// `kinesis()` endpoint env var.
+const KINESIS_ENDPOINT_ENV: &str = "KINESIS_ENDPOINT";
 
 /// A provisioned service: a connection URL plus an optional liveness guard.
 ///
@@ -144,6 +146,16 @@ pub async fn kafka() -> Option<Service> {
             None
         },
     }
+}
+
+/// AWS Kinesis, via a `LocalStack` endpoint. Env: `KINESIS_ENDPOINT` (the endpoint
+/// URL, e.g. `http://localstack:4566`).
+///
+/// Returns the endpoint URL, which the caller passes to the sink through
+/// `FRAISEQL_KINESIS_ENDPOINT_URL`; the sink's own configured endpoint carries the
+/// region (`kinesis://<region>`), which `LocalStack` does not care about.
+pub async fn kinesis() -> Option<Service> {
+    resolve_env(KINESIS_ENDPOINT_ENV).await
 }
 
 /// `HashiCorp` Vault. Env: `VAULT_ADDR` + `VAULT_TOKEN` (both required).

--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,9 @@ ignore = [
   # bollard or migrate off rustls-pemfile if still blocked.
   {id = "RUSTSEC-2025-0134", reason = "rustls-pemfile deprecated-crate advisory; DEV-dependency only (fraiseql-wire test deps / bollard), no production exposure; deadline 2026-10-01"},
   # rustls-webpki name-constraint bugs; transitive via aws-smithy-http-client (rustls 0.21).
-  # Affects optional aws-s3 feature only; no exploit path in default configuration.
+  # Affects the OPT-IN aws-* features only — `aws-s3` (fraiseql-storage/fraiseql-server) and,
+  # since #975, `cdc-kinesis` (fraiseql-cdc-sinks). Neither is in the default build, so there is
+  # no exploit path in a default configuration.
   # 2026-06-11 spike: aws-config's HTTP-client features (default-https-client / client-hyper /
   # rustls) ALL route to aws-smithy-runtime's legacy rustls-0.21 connector (legacy-rustls-ring);
   # no clean feature selects rustls 0.23 — the modern client needs a code-level HttpClient swap
@@ -38,13 +40,18 @@ ignore = [
   # it is real engineering (custom hyper-rustls 0.27 HttpClient), out of scope for a hygiene
   # phase and non-urgent (opt-in feature, no default-build exposure). Tracked as a standalone
   # aws-stack rustls-0.23 migration.
-  # deadline: 2026-09-01 — re-evaluate when the standalone aws-* bump lands.
-  {id = "RUSTSEC-2026-0098", reason = "rustls-webpki name-constraint URI bug; transitive via aws-smithy-http-client (rustls 0.21); optional aws-s3 feature only. Deadline 2026-09-01."},
+  # 2026-08-12 (#975): re-checked against the coordinated aws-* bump that Kinesis required
+  # (aws-sdk-kinesis 1.112, aws-config 1.10.1, aws-smithy-http-client 1.3.0). rustls 0.21.12 is
+  # STILL what aws-smithy-http-client pulls, so the bump does not resolve these and the ignores
+  # remain load-bearing.
+  # deadline: 2026-09-01 — re-evaluate when the standalone aws-* bump lands. NOTE: an expiring
+  # ignore turns the REQUIRED `security` check red on a date rather than on a push (#1108).
+  {id = "RUSTSEC-2026-0098", reason = "rustls-webpki name-constraint URI bug; transitive via aws-smithy-http-client (rustls 0.21); opt-in aws-s3 and cdc-kinesis features only. Deadline 2026-09-01."},
   {id = "RUSTSEC-2026-0099", reason = "rustls-webpki wildcard name-constraint bug; same cause as RUSTSEC-2026-0098. Deadline 2026-09-01."},
   # rustls-webpki 0.101.7: CRL parsing panic; transitive via aws-smithy-http-client (rustls 0.21).
-  # Affects optional aws-s3 feature only; same root cause as RUSTSEC-2026-0098/0099.
+  # Affects the opt-in aws-s3 and cdc-kinesis features only; same root cause as 0098/0099.
   # deadline: 2026-09-01 — resolved when aws-sdk migrates to rustls 0.23.
-  {id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic; transitive via aws-smithy-http-client (rustls 0.21); optional aws-s3 feature only. Deadline 2026-09-01."},
+  {id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic; transitive via aws-smithy-http-client (rustls 0.21); opt-in aws-s3 and cdc-kinesis features only. Deadline 2026-09-01."},
   # quick-xml DoS pair (published 2026-07-02): RUSTSEC-2026-0194 (quadratic run time when checking
   # a start tag for duplicate attribute names) + RUSTSEC-2026-0195 (unbounded namespace-declaration
   # allocation in NsReader → memory-exhaustion DoS). Transitive ONLY via samael 0.0.21 (SAML SP,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -514,7 +514,7 @@ struct MockDatabaseAdapter {
 }
 
 // Note: #[async_trait] is currently required for dyn-compatible async traits.
-// Native dyn-async-trait with Send is not yet stable in Rust 1.94 (MSRV),
+// Native dyn-async-trait with Send is not yet stable in Rust 1.94.1 (MSRV),
 // and dynosaur is incompatible due to Tokio's Send requirement on futures.
 #[async_trait]
 impl DatabaseAdapter for MockDatabaseAdapter {

--- a/docs/features/cdc-outbound.md
+++ b/docs/features/cdc-outbound.md
@@ -81,21 +81,24 @@ costs latency, never events.
 |---|---|
 | `nats-jetstream` | Supported |
 | `kafka` | Supported — requires the `cdc-kafka` build feature |
-| `kinesis` | Recognised; refuses to boot (tracked in #382) |
+| `kinesis` | Supported — requires the `cdc-kinesis` build feature |
 | `pulsar` | Recognised; refuses to boot (tracked in #382) |
 
 Payloads are JSON. Avro/Protobuf with a schema registry is planned.
 
-A binary built without `cdc-kafka` refuses `kind = "kafka"` **by name**, telling
-you which feature to rebuild with — it never accepts the sink and then drops its
-events.
+A binary built without `cdc-kafka` or `cdc-kinesis` refuses the matching `kind`
+**by name**, telling you which feature to rebuild with — it never accepts the
+sink and then drops its events. `pulsar` is likewise refused *by name* rather
+than as an unknown kind, so configuring it tells you it is unimplemented instead
+of implying a typo.
 
 Plaintext endpoints are refused unless the broker's opt-in
-(`FRAISEQL_NATS_ALLOW_PLAINTEXT=true` or `FRAISEQL_KAFKA_ALLOW_PLAINTEXT=true`)
-is set **and** `FRAISEQL_ENV=development` — change events carry business data and
-must not cross the wire in the clear. On the plaintext path every host is
-screened, so the development escape hatch reaches loopback brokers only and
-cannot be used to reach an instance-metadata address.
+(`FRAISEQL_NATS_ALLOW_PLAINTEXT`, `FRAISEQL_KAFKA_ALLOW_PLAINTEXT` or
+`FRAISEQL_KINESIS_ALLOW_PLAINTEXT`, each `=true`) is set **and**
+`FRAISEQL_ENV=development` — change events carry business data and must not cross
+the wire in the clear. On the plaintext path every host is screened, so the
+development escape hatch cannot be used to reach an instance-metadata address or
+an internal network.
 
 ### Kafka endpoints
 
@@ -127,6 +130,46 @@ broker (Confluent Cloud uses `PLAIN`, MSK `SCRAM-SHA-512`, Redpanda
 `SCRAM-SHA-256`). Kerberos/GSSAPI is deliberately not supported — it is the only
 mechanism that would require linking Cyrus libsasl2, and every managed Kafka
 offers one of the three above.
+
+### Kinesis endpoints
+
+Kinesis is not addressed by a broker list: the AWS SDK resolves a regional HTTPS
+endpoint from a region name. The configured endpoint therefore carries only the
+region, and — as for Kafka — a scheme-less value is refused rather than guessed:
+
+```toml
+[[cdc_outbound.sinks]]
+name = "warehouse"
+kind = "kinesis"
+endpoint = "kinesis://eu-west-3"
+subject_template = "fraiseql.{table}"
+```
+
+The region is constrained to `[a-z0-9-]` starting with a letter, because it is
+interpolated into the endpoint the SDK resolves. Credentials come from the
+standard AWS provider chain (environment, profile, IMDS, IRSA), never from the
+TOML.
+
+Stream names are validated against Kinesis's own rules — `[a-zA-Z0-9_.-]`, capped
+at **128** characters, which is narrower than Kafka's 249 — so a template that
+renders legally for the Kafka sink can still be rejected here. A rendered name
+Kinesis cannot accept is dead-lettered, never silently re-routed.
+
+Each record's partition key is the changed entity's identity
+(`{object_type}:{object_id}`). Kinesis hashes it to choose a shard and orders
+records only *within* a shard, so this is what keeps one entity's changes
+ordered; consumer dedup is served separately by the `(object_type, seq)` pair in
+the payload.
+
+| Variable | Meaning |
+|---|---|
+| `FRAISEQL_KINESIS_ENDPOINT_URL` | Endpoint override — a VPC interface endpoint, or LocalStack in development. Absent means the SDK resolves the real regional endpoint. |
+| `FRAISEQL_KINESIS_ALLOW_PLAINTEXT` | Permits an `http://` override, in a development environment only |
+
+An `https://` override is accepted as given, including into RFC 1918 space — a
+VPC interface endpoint resolves there and vetoing it would be wrong. Screening
+applies to the `http://` escape hatch, which exists to reach a development
+emulator and not the instance-metadata service.
 
 Kafka topic names are narrower than NATS subjects (`[a-zA-Z0-9._-]`, at most 249
 characters, and never `.` or `..`). A `subject_template` that renders outside

--- a/docs/features/cdc-outbound.md
+++ b/docs/features/cdc-outbound.md
@@ -54,7 +54,8 @@ configured to go nowhere is a mistake worth surfacing.
 ## Delivery guarantees
 
 - **At-least-once.** Consumers deduplicate on `(object_type, seq)`, carried in the record (for NATS,
-  as the `Nats-Msg-Id` header, which JetStream also uses for its own dedup window).
+  as the `Nats-Msg-Id` header, which JetStream also uses for its own dedup window; for Kafka, as the
+  `fraiseql-msg-id` header).
 - **Ordered per sink.** The drain claims a contiguous prefix and publishes in `seq` order; a
   transient failure blocks its successors rather than letting them overtake it.
 - **No silent loss.** A transient failure retries with exponential backoff; exhausting
@@ -79,13 +80,60 @@ costs latency, never events.
 | `kind` | Status |
 |---|---|
 | `nats-jetstream` | Supported |
-| `kafka` | Recognised; refuses to boot (tracked in #382) |
+| `kafka` | Supported — requires the `cdc-kafka` build feature |
 | `kinesis` | Recognised; refuses to boot (tracked in #382) |
 | `pulsar` | Recognised; refuses to boot (tracked in #382) |
 
 Payloads are JSON. Avro/Protobuf with a schema registry is planned.
 
-Plaintext `nats://` endpoints are refused unless
-`FRAISEQL_NATS_ALLOW_PLAINTEXT=true` **and** `FRAISEQL_ENV=development` are both
-set — change events carry business data and must not cross the wire in the
-clear.
+A binary built without `cdc-kafka` refuses `kind = "kafka"` **by name**, telling
+you which feature to rebuild with — it never accepts the sink and then drops its
+events.
+
+Plaintext endpoints are refused unless the broker's opt-in
+(`FRAISEQL_NATS_ALLOW_PLAINTEXT=true` or `FRAISEQL_KAFKA_ALLOW_PLAINTEXT=true`)
+is set **and** `FRAISEQL_ENV=development` — change events carry business data and
+must not cross the wire in the clear. On the plaintext path every host is
+screened, so the development escape hatch reaches loopback brokers only and
+cannot be used to reach an instance-metadata address.
+
+### Kafka endpoints
+
+`bootstrap.servers` is a comma-separated `host:port` list with no URL scheme, so
+transport security is not expressible in it. FraiseQL requires a scheme of its
+own and maps it to an explicit `security.protocol`:
+
+| Endpoint | `security.protocol` |
+|---|---|
+| `kafka+ssl://b1:9092,b2:9092` | `SSL` |
+| `kafka+sasl-ssl://b1:9096` | `SASL_SSL` |
+| `kafka://localhost:9092` | `PLAINTEXT` (development opt-in only) |
+
+A **scheme-less endpoint is refused, not defaulted** — librdkafka would read it
+as `PLAINTEXT`. Every broker in the list is validated, so one bad entry refuses
+the whole endpoint rather than being silently skipped.
+
+`kafka+sasl-ssl://` reads its credentials from the environment, not the TOML:
+
+| Variable | Meaning |
+|---|---|
+| `FRAISEQL_KAFKA_SASL_MECHANISM` | `PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512` — required |
+| `FRAISEQL_KAFKA_SASL_USERNAME` | SASL username |
+| `FRAISEQL_KAFKA_SASL_PASSWORD` | SASL password |
+
+The mechanism is required rather than defaulted: librdkafka's own default is
+`GSSAPI`, which these builds cannot perform, and no single default fits every
+broker (Confluent Cloud uses `PLAIN`, MSK `SCRAM-SHA-512`, Redpanda
+`SCRAM-SHA-256`). Kerberos/GSSAPI is deliberately not supported — it is the only
+mechanism that would require linking Cyrus libsasl2, and every managed Kafka
+offers one of the three above.
+
+Kafka topic names are narrower than NATS subjects (`[a-zA-Z0-9._-]`, at most 249
+characters, and never `.` or `..`). A `subject_template` that renders outside
+that charset dead-letters the event rather than being re-routed to another topic.
+
+Records are keyed by entity identity (`{object_type}:{object_id}`), which pins
+all of one entity's changes to a single partition — Kafka only orders within a
+partition. The `(object_type, seq)` consumer dedup key travels in the payload and
+in the `fraiseql-msg-id` header. The producer runs with `enable.idempotence`, so
+producer-side retries neither duplicate nor reorder.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -8,7 +8,7 @@ PostgreSQL (`tools/quickstart-smoke.sh`), so if it is printed here, it works.
 
 ## Prerequisites
 
-- **Rust** 1.94+ (install via [rustup](https://rustup.rs))
+- **Rust** 1.94.1+ (install via [rustup](https://rustup.rs))
 - **PostgreSQL** 14+ running locally (or Docker: `docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16`)
 - **Python 3.11+** for schema authoring
 

--- a/docs/operations/compiled-schema-lifecycle.md
+++ b/docs/operations/compiled-schema-lifecycle.md
@@ -62,7 +62,7 @@ Deployment: Server downloads from S3 at startup
 ### Option B: Compile into Docker image
 
 ```dockerfile
-FROM rust:1.94 AS builder
+FROM rust:1.94.1 AS builder
 COPY fraiseql.toml types.json ./
 RUN fraiseql compile fraiseql.toml
 

--- a/examples/federation/basic/orders-service/Dockerfile
+++ b/examples/federation/basic/orders-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92 AS builder
+FROM rust:1.94.1 AS builder
 
 WORKDIR /app
 

--- a/examples/federation/basic/users-service/Dockerfile
+++ b/examples/federation/basic/users-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92 AS builder
+FROM rust:1.94.1 AS builder
 
 WORKDIR /app
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,5 +5,5 @@
 # Nightly is required only for rustfmt (some advanced formatting options).
 # Use `cargo +nightly fmt` or `make fmt` for formatting; all other commands
 # (check, clippy, test, build) use this stable toolchain.
-channel = "1.94"
+channel = "1.94.1"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/tools/check-guard-parity.sh
+++ b/tools/check-guard-parity.sh
@@ -165,13 +165,19 @@ hatch_files=$(
 # Comments are stripped before looking for the production check: a doc comment
 # that merely *names* `insecure_bypass` is prose, not a gate. (The async-trait
 # ratchet was fooled exactly this way.)
+#
+# `grep -E … >/dev/null` rather than `grep -qE`: under `set -o pipefail`, a `-q`
+# grep exits at the FIRST match, the upstream awk is then killed by SIGPIPE (141),
+# and the pipeline reports failure even though the match succeeded. That made this
+# check report a *correctly* gated file as ungated whenever the file was long
+# enough for awk still to be writing — a false positive that grows with file size.
 ungated_hatch_files=""
 for file in $hatch_files; do
   if ! awk '
         /#\[cfg\(test\)\]/ { exit }
         /^[[:space:]]*(\/\/|\*)/ { next }
         { print }
-      ' "$file" | grep -qE 'insecure_bypass|is_production'; then
+      ' "$file" | grep -E 'insecure_bypass|is_production' >/dev/null; then
     ungated_hatch_files="${ungated_hatch_files}${file}"$'\n'
   fi
 done
@@ -214,7 +220,9 @@ for file in $writers; do
   # Match the CALL, not the mention: a `use super::upload_guard::authorize_upload;`
   # left behind after the call was deleted satisfied a bare grep, and this check went
   # green through its own red-capability proof. Imports and comments are stripped first.
-  if ! grep -vE '^[[:space:]]*(//|\*|use )' "$file" | grep -qE 'authorize_upload[[:space:]]*\('; then
+  # `>/dev/null` rather than `-q` for the same pipefail/SIGPIPE reason as above.
+  if ! grep -vE '^[[:space:]]*(//|\*|use )' "$file" \
+    | grep -E 'authorize_upload[[:space:]]*\(' >/dev/null; then
     ungated_writers="${ungated_writers}${file}"$'\n'
   fi
 done

--- a/tools/check-suite-coverage.py
+++ b/tools/check-suite-coverage.py
@@ -48,36 +48,63 @@ ENV_READ = r'(?:var|var_os|env!)\(\s*"{name}"'
 SERVICES = {
     "postgres": {
         "detect": re.compile(
-            r"test_support::postgres\(|try_database_url\(|\bdatabase_url\(\)|"
+            r"(?:test_support|services)::postgres\(|try_database_url\(|\bdatabase_url\(\)|"
             + ENV_READ.format(name="(?:TLS_)?DATABASE_URL")
         ),
         "satisfied_by": {"DATABASE_URL", "TLS_DATABASE_URL"},
     },
     "redis": {
-        "detect": re.compile(r"test_support::redis\(|" + ENV_READ.format(name="REDIS_URL")),
+        "detect": re.compile(
+            r"(?:test_support|services)::redis\(|" + ENV_READ.format(name="REDIS_URL")
+        ),
         "satisfied_by": {"REDIS_URL"},
     },
     "nats": {
-        "detect": re.compile(r"test_support::nats\(|" + ENV_READ.format(name="NATS_URL")),
+        "detect": re.compile(
+            r"(?:test_support|services)::nats\(|" + ENV_READ.format(name="NATS_URL")
+        ),
         "satisfied_by": {"NATS_URL"},
     },
     "minio": {
-        "detect": re.compile(r"test_support::minio\(|" + ENV_READ.format(name="MINIO_ENDPOINT")),
+        "detect": re.compile(
+            r"(?:test_support|services)::minio\(|" + ENV_READ.format(name="MINIO_ENDPOINT")
+        ),
         "satisfied_by": {"MINIO_ENDPOINT"},
     },
     "azure_blob": {
         "detect": re.compile(
-            r"test_support::azure_blob\(|" + ENV_READ.format(name="AZURE_BLOB_ENDPOINT")
+            r"(?:test_support|services)::azure_blob\(|"
+            + ENV_READ.format(name="AZURE_BLOB_ENDPOINT")
         ),
         "satisfied_by": {"AZURE_BLOB_ENDPOINT"},
     },
     "gcs": {
-        "detect": re.compile(r"test_support::gcs\(|" + ENV_READ.format(name="GCS_ENDPOINT")),
+        "detect": re.compile(
+            r"(?:test_support|services)::gcs\(|" + ENV_READ.format(name="GCS_ENDPOINT")
+        ),
         "satisfied_by": {"GCS_ENDPOINT"},
     },
     "vault": {
-        "detect": re.compile(r"test_support::vault\(|" + ENV_READ.format(name="VAULT_ADDR")),
+        "detect": re.compile(
+            r"(?:test_support|services)::vault\(|" + ENV_READ.format(name="VAULT_ADDR")
+        ),
         "satisfied_by": {"VAULT_ADDR"},
+    },
+    # #975 outbound CDC sinks. Added *before* the suites that need them: without a
+    # group here a suite reading KAFKA_BOOTSTRAP satisfies this gate merely by
+    # being named in some leg — including one that binds no broker, which is
+    # precisely the #960 shape the gate exists to catch.
+    "kafka": {
+        "detect": re.compile(
+            r"(?:test_support|services)::kafka\(|" + ENV_READ.format(name="KAFKA_BOOTSTRAP")
+        ),
+        "satisfied_by": {"KAFKA_BOOTSTRAP"},
+    },
+    "kinesis": {
+        "detect": re.compile(
+            r"(?:test_support|services)::kinesis\(|" + ENV_READ.format(name="KINESIS_ENDPOINT")
+        ),
+        "satisfied_by": {"KINESIS_ENDPOINT"},
     },
 }
 


### PR DESCRIPTION
Phase 18 of the open-finding remediation program. Closes #975.

Adds the two deferred outbound CDC sinks to P30's drain engine. `DrainWorker`, `CdcSinkConfig`, `render_subject`, the backoff schedule and dead-lettering are reused **unchanged** — the work is the transport guards, the partition keys, and the wiring that makes a feature-off binary refuse by name instead of dropping events.

## Commits

| | |
|---|---|
| `f7caab8a3` | mirror the patch-pinned `rust:1.94.1` base |
| `427764b31` | MSRV 1.94.1 — a floor no leg had ever tested |
| `9282a0b00` | release image's Rust builder moved to that MSRV |
| `f5dbff808` | the Kafka sink, and a scheme Kafka does not have |
| `95f6c328d` | the Kinesis sink, and an endpoint that is only a region |
| `057c06c90` | three sinks, and a README that still claimed one |

## What ships

- `kind = "kafka"` behind `cdc-kafka`; `kind = "kinesis"` behind `cdc-kinesis`. A binary without the feature refuses that kind **by name**, saying which feature to rebuild with.
- `pulsar` keeps a **named** refusal rather than falling through to "unknown kind". #975 recommended dropping the name; declined deliberately — configuring it should say the kind is unimplemented, not imply a typo. Pinned by a test carrying a positive control.
- Both endpoint guards are **pure and always compiled**, living beside the sink trait rather than beside their clients, so the refusing half runs in the cheap broker-free test build instead of only where a broker feature is on. The NATS guard's placement behind its own feature is the thing not repeated.

## Three issue premises that did not survive verification

#975's stated prerequisites keep failing, so each was checked against source before any code:

1. **The `rustBase` change does not exist to make.** `.dagger/main.go` already installed every rdkafka C dependency, and rdkafka was already a workspace dep in `coreTestFeatures`. Cycle 1 collapsed to a verification.
2. **The Kafka partition-key spec was wrong.** `{object_type}:{seq}` scatters one entity across every partition; Kafka orders only *within* a partition.
3. **The Kinesis partition-key spec was wrong too.** `{object_type}` alone pins a whole table to one shard — a 1 MB/s ceiling. Both sinks now share one `entity_partition_key`, hoisted into the always-compiled module.

## Notable engineering decisions

- **No `SequenceNumberForOrdering` on Kinesis.** Verified against `drain.rs:413`: the drain publishes strictly serially and head-of-line-blocks, so record N is durably stored before N+1 is sent — arrival order already *is* `seq` order. Threading it would buy unbounded per-partition-key state for a guarantee the drain already provides.
- **The aws bump is all-or-nothing.** `aws-sdk-kinesis` resolves to 1.109.0 by default, which floors at 1.91.1 and would leave the MSRV rationale citing a version not in the tree. Pinning 1.112.0 requires `aws-config` 1.10.1 **and** `aws-sdk-s3` 1.141.0: a partial bump is a compile error, and stopping at kinesis leaves 6 duplicated `aws-smithy` crates that only `cargo deny check bans` rejects — `advisories` alone stays green.
- **rustls 0.21.12 survives the bump**, so RUSTSEC-2026-0098/0099/0104 remain load-bearing. Their "optional aws-s3 feature only" text is now false and is rewritten to name `cdc-kinesis`. #1108 filed for their 2026-09-01 expiry, which turns the required `security` check red on a date rather than on a push.

## Verification

- **Real-broker drain-through for both sinks**, asserted *through* the drain (seed the outbox, tick, read the broker back), not at the sink. The Kinesis suite was **run against real LocalStack**, not merely written, and proven non-vacuous by keying on `seq` instead of identity — the suite fails. Its stream has 4 shards, because shard affinity is vacuous on one.
- **Coverage gate proven RED in both directions**, including the #960 shape (suite invoked in a leg that binds no service).
- **Guards mutation-tested**: opt-in, host screening, region charset, scheme match and the 128-char cap each kill exactly the tests asserting them.
- Kinesis host screening was first written loopback-only; wiring the Dagger leg caught it, since the bound host is `localstack`. Aligned to the Kafka guard's exact semantics so the two flags cannot disagree.

## Pre-existing, recorded but not fixed here

- `check-crate-sizes.sh` and `check-feature-chains.sh` fail identically on clean `f5dbff808` and are wired into **no** gate — unreferenced scripts.
- P17's `storage_policy_admin_tests` only pass single-threaded (every test `DELETE`s one shared table); nothing enforces it but the invocation flag. CI is unaffected — the `test` leg skips the module and the integration leg serialises it.