### PR TITLE
docs(changelog): the 48 issues [Unreleased] omitted, and a gate that keeps it complete

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -246,6 +246,12 @@ func (m *FraiseqlCi) ShellGates(
 		"make lint-gate-core",
 		"make test-release-tooling",
 		"make test-deadline-gate",
+		// The changelog gate's SELF-TEST only. The gate itself needs real git
+		// history and would pass vacuously here — this function ignores `.git`
+		// and runs `git init -q .` below, so `Closes #N` over the release range
+		// returns nothing. The gate runs in changelog-check.yml and in
+		// release.yml's validate-release, both with fetch-depth: 0 (#1127).
+		"make test-changelog-gate",
 		"bash tools/check-test-imports.sh",
 		"bash tools/check-route-syntax.sh",
 		"bash tools/check-guard-parity.sh",

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,33 +1,35 @@
 name: Changelog Check
 
-# Hosted CI disabled 2026-05-31 — Dagger CI migration (Track 0). pull_request trigger
-# stripped; workflow_dispatch retained as porting spec. See .phases/dagger-adoption/.
+# Revived 2026-08-16 (#1127). This workflow sat `workflow_dispatch:`-only from the
+# 2026-05-31 Dagger migration onwards, so no push and no pull request ever checked
+# changelog completeness — and 48 issues closed since v2.14.1, including an entire
+# security wave of production fail-closed boot changes, went undocumented.
+#
+# It lives here rather than in a Dagger leg because the check needs REAL GIT HISTORY:
+# `.dagger/main.go` declares `+ignore=[".git"]` on Preflight/ShellGates and runs
+# `git init -q .` in the container, where the gate would find zero `Closes #N` and
+# pass vacuously. Hence `fetch-depth: 0` below. The gate's self-test — which builds
+# fixture repositories in a temp dir and needs no history — does run in ShellGates,
+# as `make test-changelog-gate`.
 on:
+  push:
+  pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   changelog-check:
-    name: Changelog Up-to-Date
+    name: Changelog Completeness
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
+          # Full history AND tags: the gate resolves its base from the newest v*
+          # tag, and a shallow clone has neither the tag nor the commits it needs.
           fetch-depth: 0
 
-      - name: Install git-cliff
-        uses: taiki-e/install-action@b550161ef8a7bc4f2a671c0b03a18ac9ccedea1e  # v2
-        with:
-          tool: git-cliff
-
-      - name: Check for unreleased changes
-        run: |
-          UNRELEASED=$(git cliff --unreleased --strip header)
-          if [ -z "$UNRELEASED" ]; then
-            echo "No unreleased changelog entries found"
-            exit 0
-          fi
-          # Check that CHANGELOG.md contains recent changes
-          if ! grep -q "Unreleased\|$(date +%Y-%m)" CHANGELOG.md; then
-            echo "::warning::CHANGELOG.md may not be up to date — run 'make changelog' to preview entries"
-          fi
+      - name: Every issue closed since the last release is documented
+        run: bash tools/check-changelog-issues.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,19 @@ jobs:
           fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          # The changelog gate below resolves its base from the newest v* tag that
+          # is not the tag being validated, and reads `Closes #N` across the whole
+          # release range. A shallow, tagless checkout gives it an empty range and
+          # a vacuous pass (#1127).
+          fetch-depth: 0
+
+      # A tag cannot be cut on an incomplete changelog. 48 issues closed since
+      # v2.14.1 — including an entire security wave of production fail-closed boot
+      # changes — were absent from CHANGELOG.md when this release was scoped, and
+      # nothing in the pipeline noticed (#1127).
+      - name: Changelog documents every issue closed since the last release
+        run: bash tools/check-changelog-issues.sh
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable

--- a/.phases/README.md
+++ b/.phases/README.md
@@ -1,69 +1,73 @@
-# FraiseQL .phases/
+# FraiseQL `.phases/`
 
-## ⭐ Active program (as of 2026-07-27)
+Phase plans for this repository, in the phased-TDD format described in
+`~/.claude/CLAUDE.md`.
 
-[2026-07-27-open-issue-remediation/](2026-07-27-open-issue-remediation/) — **every one of the
-203 open GitHub issues**, assigned to exactly one of 32 phases across 8 waves, targeting
-v2.14.2 (security patch) → v2.19.0+. 158 of the 203 came from the three audit passes.
-Start at its [README](2026-07-27-open-issue-remediation/README.md); the full mapping is in
-[ISSUE-INDEX.md](2026-07-27-open-issue-remediation/ISSUE-INDEX.md) and the ordering
-rationale in [TRIAGE.md](2026-07-27-open-issue-remediation/TRIAGE.md). Five user-owned gates
-(G1–G5) are listed in the README.
-
-The trains below predate it; their remaining work is folded into the program's Wave 7.
+**This file is the only tracked one in `.phases/`** — the directory is gitignored, so the
+plans live on the machine that wrote them and only the code they produce reaches git history.
+That is why this index is worth keeping accurate: it is the sole in-repo record of what is
+running.
 
 ---
 
-**Active train (as of 2026-07-01):**
-[v2.11.0-saga-full-roundtrip/](v2.11.0-saga-full-roundtrip/) — closes the round-trip
-half of the #429 saga umbrella (compensation → recovery → coordinator →
-remote-dispatch → finalize). Phases 01–04 are **merged** (dev `176de7ece`); only
-**Phase 05 (Finalize)** remains — it keeps `unstable-saga` gated and adds a
-`# Stability` docs section (promotion is deferred to the hardening train below).
+## ⭐ Active — v2.15.0 Release Program (2026-08-16)
 
-**Queued behind it** (all written, `Not Started`):
-- [v2.14.0-saga-hardening/](v2.14.0-saga-hardening/) — the remaining saga work that
-  v2.11.0 deferred, laid out as 7 phases ending in the `unstable-saga` → stable
-  promotion: remote-mutation-name persistence → remote HTTP compensation → `@requires`
-  pre-fetch → concurrency-safe recovery (`SKIP LOCKED`) → transport hardening (mTLS) →
-  strategies + observability → finalize/promote. (Numbered v2.14.0 as the natural
-  successor to the two trains below; re-prioritise earlier if a consumer needs
-  distributed sagas in production.)
-- [v2.12.0-cdc-and-observer-transports/](v2.12.0-cdc-and-observer-transports/) — Kafka +
-  Kinesis sinks (#382) + observer transports + server auto-mount (#428)
-- [v2.13.0-ai-native/](v2.13.0-ai-native/) — actor model / vector similarity DSL /
-  session-state / MCP resources / Python helpers (renumbered off its dead v2.10.0 label —
-  the v2.10.0 slot shipped as the AX cluster #484–#488)
+[2026-08-16-v2.15.0-release/](2026-08-16-v2.15.0-release/) — take `dev` from `c1608e6cd` to a
+tagged, published release, and nothing else. Ten phases: two blockers in the *release record*
+(a changelog that omits 48 closed issues including a whole security wave; a published
+dependency-risk policy whose justification is false against the tree), three optional HIGH
+fixes, the version decision, and the cut.
 
-**Shipped since the release-train era:** v2.9.0 (auth foundation + make-it-real cluster +
-CDC first slice), v2.10.0 (AX feedback cluster #484–#488). The old
-[2026-05-31-release-train/](2026-05-31-release-train/) master orchestration is complete;
-its remaining follow-ups are the three plans above.
+Two decisions belonged to the human and were asked in
+[P00](2026-08-16-v2.15.0-release/phase-00-baseline-decisions-and-filings.md). Both are now
+answered, and recorded there: **V — 2.15.0**, with the changelog's SemVer-adherence sentence
+reworded in P08 so the release ships one claim rather than two against 158 `### Breaking`
+bullets; **H — all three HIGHs hold**, so P05 (#1080), P06 (#1079) and P07 (#1068) all run
+and the release notes carry no HIGH as a known issue. Start at its
+[README](2026-08-16-v2.15.0-release/README.md).
 
-## Archive
+P00 also filed the eight findings the readiness pass had surfaced but deliberately not fixed,
+as **#1127–#1134**.
 
-Completed campaigns moved to [_archive/](_archive/).
+Supporting documents at this level:
 
-## Shipped (previously-deferred, now merged to dev)
+- [RELEASE-READINESS-2.15.0.md](RELEASE-READINESS-2.15.0.md) — the 2026-08-16 verification
+  pass on `c1608e6cd`: what is green, what the blockers are, what was deliberately not run.
+  **Plan from it; do not redo it.**
+- [BACKLOG-2026-08-16.md](BACKLOG-2026-08-16.md) — the 101 open issues, the traps, the gate
+  list, the rig. Current.
+- [NEXT-AGENT-PROMPT.md](NEXT-AGENT-PROMPT.md) — the live handoff.
 
-- [federation-docs-170/](federation-docs-170/) — issue #170 merged via PR #403
-- [freebsd-148/](freebsd-148/) — issue #148 merged via PR #402
+## Not in the release program — decided separately
 
-(Superseded sprint: [2026-05-20-sprint/](2026-05-20-sprint/).)
+- **The 101-issue backlog** (48 audit pass 4 · 47 the last program's rule-6 residue ·
+  6 deferrals). Needs a triage decision, not a phase. Analysis in
+  [BACKLOG-2026-08-16.md](BACKLOG-2026-08-16.md).
+- **G5 — schema-intelligence epic #963/#965**, cross-repo, prerequisite #995.
+- **Deferrals #428 #444 #626 #633**, dispositions commented on each issue.
+
+## Closed programs
+
+| Program | Outcome |
+|---|---|
+| [_archive/2026-08-06-open-finding-remediation/](_archive/2026-08-06-open-finding-remediation/) | **Closed 2026-08-16.** 86 issues → 22 phases; 80 shut. The 6 remaining are exactly the deliberate deferrals. Its §5 is the wave-by-wave record of what each phase cost. |
+| [_archive/2026-07-27-open-issue-remediation/](_archive/2026-07-27-open-issue-remediation/) | **Closed 2026-08-06**, PR #885 merged at `f6f51fa25`. 203 issues → 158 closed on merge + 36 in-phase + 4 deferred. Retrospective: *execution coverage must be a checked artifact*. |
+
+Everything the 2026-05-31 release train and the v2.11–v2.14 trains queued has **shipped**;
+those directories are history, not plans. Completed campaigns live in
+[_archive/](_archive/) and are never modified after archiving.
 
 ## Audit handoffs
 
-- [2026-07-25-audit-pass3/](2026-07-25-audit-pass3/) — framework-wide bug-hunting audit.
-  Pass 1 → issues #715–#738, pass 2 → #739–#788. **Pass 3 not started**: the next-agent
-  prompt, the reusable review-workflow script, and the dedup issue-map are checked in there
-  (force-added past the gitignore) so another terminal can carry it on.
+- [2026-07-25-audit-pass3/](2026-07-25-audit-pass3/) — passes 1–3 (issues #715–#788), the
+  reusable review-workflow script and the dedup issue-map, force-added past the gitignore.
+- Pass 4 (2026-08-09, 210 agents, triple adversarial refutation → #1028–#1080) lives at
+  `_archive/2026-08-06-open-finding-remediation/audit-pass-4/`. ⚠ It is **gitignored and
+  local-only**, and the 53 issue bodies cite that path **without** the `_archive/` segment —
+  it moved when the program was archived.
 
 ## Convention
 
-- `.phases/<date>-sprint/` — active sprint dirs (one per planning cycle)
-- `.phases/_archive/<campaign>/` — completed campaigns; never modified after archive
-- Each campaign subdir has its own README + phase files
-
-See `~/.claude/CLAUDE.md` for the phased-TDD methodology this directory implements.
-
-Note: this directory is gitignored. The plans live locally only; only the code they produce ends up in git history.
+- `.phases/<date>-<name>/` — one directory per program, with its own README + phase files.
+- `.phases/_archive/<campaign>/` — completed campaigns; never modified after archive.
+- One user-owned decision per gate, surfaced in a phase file and answered in writing there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4098,6 +4098,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existed in this example (`orders`, `products`, `users` against fixtures creating
   `tb_order`, `tb_product`, `tb_user`); they now use the real names and join through the
   surrogate keys as the Trinity schema requires.
+- **These release notes are complete, and a gate keeps them that way (#1127).** 258 issues
+  were closed by `Closes #N` since v2.14.1 and **48 appeared nowhere in this file** —
+  including the entire secrets/auth/webhooks security wave above, whose bullets are
+  production fail-closed boot changes an operator needs before upgrading. Nothing had ever
+  checked: `changelog-check.yml` lost its `pull_request` trigger in the Dagger migration and
+  sat `workflow_dispatch:`-only, so no push and no PR ran a completeness check.
+  `tools/check-changelog-issues.sh` now fails when an issue closed since the last release is
+  neither documented nor listed — with a stated reason — in
+  `tools/changelog-exempt-issues.txt`, fails when an exemption names an issue that *is*
+  documented, and enforces one heading per type in the newest section. It runs on push and
+  on pull request, and blocks `release.yml`'s `validate-release`, so a tag cannot be cut on
+  an incomplete changelog.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1507,6 +1507,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bucket name becomes the first segment of every object key, so a bucket carrying one of
   FraiseQL's own namespaces would put caller objects inside the resumable-upload staging area
   or the render cache. The server refuses such a section at boot.
+- **A configured Redis backend that is unavailable refuses to boot in production (#770,
+  #777).** Token revocation, PKCE login state and rate limiting each fell back to per-process
+  in-memory state when the configured Redis URL was malformed, unreachable, or its Cargo
+  feature was not compiled in — a silently absent service wearing a healthy startup log. An
+  operator who configured Redis asked for state shared across replicas: N replicas revoked N
+  separate token sets and enforced N times the rate limit. All three now fail boot with an
+  error naming the config key, the cause and the consequence. `FRAISEQL_ENV=development`
+  downgrades it to a warning; the only sanctioned fallback is the explicit one — remove the
+  Redis URL and accept per-process state.
+- **`[security.token_revocation] backend = "env"` is gone (#770).** It was an undocumented
+  alias for `"memory"`, so a deployment that wrote it got per-process revocation while its
+  configuration read as deliberate. The accepted values are `"memory"`, `"redis"` and
+  `"postgres"`; anything else is refused at boot, by name.
+- **`FRAISEQL_SECRETS_BACKEND` selects a backend instead of being ignored (#856).** Every
+  value built the **environment** backend, so a deployment that set
+  `FRAISEQL_SECRETS_BACKEND=vault` read its secrets from environment variables and logged a
+  healthy start. It now accepts exactly `env`, `file` and `vault`, refuses an unknown value
+  by name, and refuses to boot when the selected backend's own settings are missing:
+  `FRAISEQL_SECRETS_FILE_PATH` for `file`, and `VAULT_ADDR` plus either `VAULT_TOKEN` or
+  `VAULT_ROLE_ID` + `VAULT_SECRET_ID` for `vault`.
+- **Vault `tls_verify = false` is refused in production, and `SecretsBackend` returns a
+  zeroizing `Secret` (#726, #727).** `VAULT_TLS_VERIFY=false` disables certificate
+  verification on the channel carrying every secret, and is now accepted only outside
+  production. `get_secret` and `get_secret_with_expiry` return `Secret` rather than `String`
+  — redacted `Debug`/`Display`, zeroized on drop — so out-of-tree backends and callers must
+  update their signatures. `FRAISEQL_VAULT_ALLOWED_HOSTS` replaces the all-or-nothing SSRF
+  bypass with an exact-host allowlist.
+- **Inbound webhook routes that cannot verify a signature are refused at boot (#781, #787).**
+  `webhook_routes_check` rejects an unknown `provider`, and rejects a provider that needs the
+  deployment's public URL when `public_url` is unset. A route whose `secret_env` is unset is
+  refused in production; in development it is skipped rather than mounted, so the path
+  answers 404 instead of accepting unverified deliveries.
+- **`PostgresSessionStore` refuses to mint a token it cannot sign (#753).** With no RS256 key
+  configured, `generate_access_token` signed each HS256 token with a fresh random key that
+  was a stack local — dropped on return, never stored, never shared with any validator. Every
+  token minted by `auth_callback`, the multi-provider callback and `saml_acs` was a dead blob
+  that 401'd on the next request, so the shipped social-login flow produced logins that
+  "succeeded" and then failed on every API call. It now returns `AuthError::ConfigError`, and
+  `create_session` mints before the INSERT so the fail-loud path leaves no orphan session row.
+  `PostgresSessionStore::new` is documented as the no-signing constructor; use
+  `with_hs256_secret` for HMAC mode with a persistent secret shared with the validating side.
 
 ### Added
 
@@ -3989,6 +4030,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same session variables as the read it describes. The trait default still counts rows
   in memory — correct, and the only option for an adapter that cannot push the count down —
   so this is a performance fix on PostgreSQL, not a behaviour change.
+- **Genuine webhook deliveries are no longer rejected 401 (#781, #787).** The Lemon Squeezy
+  verifier compared a 64-character hex digest against a 44-character Base64 string, so every
+  genuine delivery failed; it compares hex, which is what the provider sends. Stripe sends
+  one `v1` signature per active signing secret and the old parse kept only the last, so
+  during a secret rotation a delivery whose matching signature was not last was rejected for
+  the whole rotation window; the delivery is genuine when any candidate matches, each still
+  compared in constant time. The route also threads the provider's timestamp header and the
+  configured `public_url` into the Slack, Discord, SendGrid and Twilio verifiers, which need
+  them and previously received neither. A 500 from a route no longer names the secret's
+  environment variable.
+- **Vault AppRole tokens are renewed (#726).** `renew_token` took `&mut self` and was
+  therefore unreachable through the `Arc<dyn SecretsBackend>` the manager holds, so an
+  AppRole token expired at its TTL and every subsequent secret read failed. It takes `&self`,
+  and `create_secrets_manager` spawns a renewal loop — proven against a real Vault, surviving
+  past the token TTL.
+- **CLI and environment rate-limit overrides outrank the compiled schema (#774).** Overrides
+  were merged into `rate_limiting` on arrival, erasing which fields the operator had actually
+  set, so the compiled schema shadowed them and `FRAISEQL_RATE_LIMITING_ENABLED=false` did
+  nothing. They are recorded separately and applied per field over the winner, so the
+  implemented precedence matches the documented one.
+- **A custom CA file whose certificates rustls rejects is an error (#887).** `load_custom_ca`
+  counted the `Item::X509Certificate` entries the PEM reader yielded and discarded the
+  `(added, ignored)` result of `add_parsable_certificates`. The reader only base64-decodes
+  the armour — rustls decides whether the DER is usable — so a file of valid PEM armour
+  around unparsable DER returned `Ok` with an **empty** `RootCertStore`. Nothing was trusted,
+  every server certificate was rejected, and the operator debugged the server rather than the
+  CA file they configured, which was reported nowhere. The count comes from `added`, and the
+  error names the path.
+- **PostgreSQL errors carry PostgreSQL's own message (#888).** `tokio_postgres::Error`'s
+  `Display` for a server-side failure is the literal string `db error`; the half that names
+  the relation, the column or the constraint lives on the `DbError` behind `as_db_error()`,
+  which no query path read. `Query execution failed: db error` with `sql_state: Some("42P01")`
+  left the operator to look up the SQLSTATE and then guess which relation was missing. A
+  `pg_detail` helper is routed through all 50 `map_err` sites in the adapter, introspector,
+  relay and query-stats paths.
+- **`--features rest,export-xlsx` compiles without `export-csv` (#920).** The XLSX writer
+  imported `guard_formula_injection` from `streaming::csv`, whose module is gated on
+  `export-csv`, and the two features are independently selectable — so a spreadsheet-export
+  build that excluded CSV failed with `E0432`, and the only workaround was enabling the
+  response format the operator had deliberately excluded. The guard and its sentinels moved
+  to `streaming/mod.rs` under either feature, and two feature-matrix combos now build each
+  writer alone so a cross-module import in either direction reddens CI.
+- **Service accounts reach their seam under `[auth_hs256]` (#934).** A service account
+  presents its secret on `x-api-key` and carries no bearer, but the HS256 middleware is
+  attached as a `route_layer` and ran first, 401'ing the request before the handler's seam
+  was reached. Service accounts worked under `[auth]` and were unreachable under
+  `[auth_hs256]`, so a daemon using the documented seam could not call an HS256-protected
+  endpoint. The layer defers to the handler only when there is no `Authorization` header
+  **and** the presented secret resolves to a declared account — deliberately narrower than an
+  unconditional pass-through, which would answer 200 to a request carrying no credentials.
+- **Flight GraphQL executes through the policy seam (#954).** The `do_get` GraphQL path and
+  the `do_exchange` `Query` arm both need a `QueryExecutor`, and nothing in `fraiseql-server`
+  ever attached one, so the shipped binary refused every Flight GraphQL request with "no
+  executor configured". That refusal was accidental rather than a policy: indistinguishable
+  from an unimplemented transport, and it would have disappeared the moment anyone attached a
+  bare executor — creating the one transport that skips tenant resolution, the
+  suspended-tenant gate, per-tenant concurrency/RPS/cost quotas and trusted-documents mode.
+  `PolicyGatedExecutor` runs the same chokepoints as the HTTP handler, in the same order,
+  calling the same functions.
+- **The `saga-basic` federation example runs on PostgreSQL (#940).** It still provisioned a
+  MySQL 8.0 service and pointed two subgraphs at `mysql://` URLs three phases after MySQL
+  support was removed and `mysql://` became a loud boot refusal — and because its subgraphs
+  are Python simulations it still came up, demonstrating in running form a topology the
+  engine explicitly refuses. It now runs one PostgreSQL instance with three databases, so no
+  transaction can span the stores. Its three handlers also queried tables that have never
+  existed in this example (`orders`, `products`, `users` against fixtures creating
+  `tb_order`, `tb_product`, `tb_user`); they now use the real names and join through the
+  surrogate keys as the Trinity schema requires.
 
 ### Security
 
@@ -4653,6 +4762,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the raw JSON at **both** deserialization sites — the JSON workflow and the TOML /
   multi-file merger — because guarding only one would have left every `--schema-dir` user
   with the original silent drop.
+
+- **Webhook replay protection is keyed on signed material (#751).** `extract_event_id`
+  derived the dedup / idempotency key from the `webhook-id` or `x-github-delivery` **request
+  header**, and no supported provider signs headers — every verifier covers the body only
+  (`HMAC(body)`, Stripe `HMAC(t.body)`, Paddle `HMAC(ts:body)`). That put the entire replay
+  defence under the control of whoever sent the HTTP request: one captured, genuinely signed
+  delivery replayed with a fresh header value passed signature verification, claimed a fresh
+  key in `webhooks.tb_inbound_delivery` and re-fired `after:ingest` — once per replay, and
+  indefinitely for providers without timestamp freshness. The function no longer takes
+  headers at all, so header-independence is a type-level property rather than a behaviour a
+  later edit could regress. The key is the payload's top-level `id`, else a SHA-256 hash of
+  the raw body — `DefaultHasher`'s output is explicitly not stable across Rust releases, and
+  this key is persisted, so a toolchain bump would have reset every stored key and let every
+  historical delivery replay once. `extract_event_type` now prefers the signed payload's
+  `type` over the `x-github-event` header.
+- **TOTP verification is attempt-limited (#752).** `verify_challenge` removed the challenge
+  only on the success paths, so a wrong code left the token valid for its full 5-minute TTL
+  with no attempt counter. With ±1 step tolerance a 6-digit TOTP has 3 valid codes in 10^6,
+  and `/auth/v1/mfa/verify` is mounted with no rate-limit layer — enough to guess a victim's
+  code and mint a full session. A challenge is now consumed after 5 wrong codes, and a
+  per-user sliding-window budget allows 10 failures per 900 seconds so that re-minting a
+  challenge cannot reset the cap; `unenroll` accepts the same secrets and shares the budget.
+  A lockout answers `429 Too Many Requests` with `Retry-After` instead of a generic 422/500.
+- **Email ingest deduplicates per mailbox and folds a content digest (#775).** Every polled
+  mailbox shared one spine dedup namespace keyed `email`, on the sender-chosen `Message-ID`:
+  a message addressed to two configured mailboxes was ingested — and routed — for only
+  whichever poller won, and a sender could pre-claim a `Message-ID` to suppress a later
+  genuine message. `IngestSource::Email` carries the mailbox that received the message, so
+  the key is `email:<mailbox>`, and the dedup key folds a digest of the content.
+- **Field-authorization policies see argument values, not variable markers (#903).**
+  `field_arguments_json` built the policy's `arguments` input with `value_json::decode` and
+  no variable substitution, so an argument written `ssn(mask: $level)` reached the authorizer
+  as `{"$var": "level"}`. A policy of the form `arguments.mask == "full"` therefore never
+  matched and silently took its `otherwise` branch — for every client that passes arguments
+  as variables, which is every generated client. The authorization decision was made on data
+  nobody sent. Both the query and mutation paths now resolve through
+  `value_json::decode_resolved` against the request's variables, as every other reader of the
+  seam already did.
+- **A failed single-use `DELETE` now fails the verification (#984).** `PgOtpStore::verify_otp`
+  and `PgMfaStore::verify_challenge` established their single-use guarantee with a `DELETE`,
+  then discarded its result and returned `Ok`. A transient database failure landing on that
+  one statement — a statement timeout, a failover, a dropped connection — left the OTP code
+  re-verifiable until expiry and the MFA challenge token replayable with any current-window
+  code for the rest of its TTL, while the caller was told the credential had been consumed.
+  The consume closures return `Result<()>` and every call site propagates.
+- **Auth hardening across PKCE, OTP and proxy handling (#737).** The PKCE capacity gate
+  reserves its slot atomically instead of checking and then inserting; the state-encryption
+  key is zeroized on drop; OTP comparison is constant-time; `X-Forwarded-For` parsing takes
+  the rightmost non-proxy hop rather than a client-controlled leftmost entry; `RedisStateStore`
+  returns the real stored expiry and `InMemoryStateStore` enforces expiry.
+- **`lru` 0.18.2 clears RUSTSEC-2026-0253 (#1095).** `LruCache::pop()` was not panic-safe: a
+  panicking key `Drop` skipped `detach()` and left a dangling pointer in the LRU list for the
+  next eviction to walk. Both FraiseQL call sites — `validation::rate_limiting` and
+  federation's `query_plan_cache` — key on `String`, whose `Drop` cannot panic, so the
+  trigger was never reachable here; the lockfile bump clears the advisory outright, with no
+  `deny.toml` exception.
 
 ## [2.14.1] - 2026-07-24
 

--- a/Makefile
+++ b/Makefile
@@ -451,6 +451,15 @@ test-release-tooling:
 test-deadline-gate:
 	@bash tools/tests/check_deadlines_test.sh
 
+# Unit tests for the changelog-completeness gate (#1127). The gate ITSELF cannot
+# run in ShellGates — it needs real git history, and `.dagger/main.go` ignores
+# `.git` and runs `git init -q .` in the container, so it would find zero
+# `Closes #N` and pass vacuously. This self-test builds its own fixture
+# repositories in a temp dir, so it belongs here alongside test-deadline-gate.
+.PHONY: test-changelog-gate
+test-changelog-gate:
+	@bash tools/tests/changelog_gate_test.sh
+
 # Gate: ensure no axum 0.7-style `:param` captures slip back into `.route()` calls.
 # Issue #316 prevention — see `tools/check-route-syntax.sh` for the load-bearing multi-line awk.
 .PHONY: lint-routes
@@ -551,7 +560,7 @@ lint-sdk-dead-surface:
 # test suite or service-backed integration tests — those are `make test` and the
 # separate Dagger test/integration legs.
 .PHONY: preflight
-preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling
+preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
 	@echo "=== preflight: lint-unwrap (UNWRAP_ALLOW_LIMIT=3) ==="
 	@$(MAKE) --no-print-directory lint-unwrap UNWRAP_ALLOW_LIMIT=3
 	@echo "=== preflight: check-test-imports ==="

--- a/tools/changelog-exempt-issues.txt
+++ b/tools/changelog-exempt-issues.txt
@@ -1,0 +1,42 @@
+# Issues that close without a CHANGELOG.md entry.
+#
+# Format: `#N  <why it is not user-facing>`. A bare number is rejected by
+# tools/check-changelog-issues.sh — an exemption without a stated reason cannot be
+# reviewed or pruned, and that is how an allowlist nobody reads absorbs the next
+# real omission.
+#
+# The bar: Keep a Changelog documents what a user or operator of the released
+# artifact can observe. CI plumbing, test-only commits, refactors with no
+# behaviour change, and fixes to test rigs are not that. If in doubt, document it
+# — an over-full changelog costs a reader a line; an under-full one cost this
+# project an entire undocumented security wave (#1127).
+#
+# ⚠ Exempting an issue that IS documented is also a failure. Remove the line
+# instead of leaving both.
+
+#732   refactor only: decomposed execute_graphql_request (~580 lines) into named steps; no behaviour change
+#879   CI: the Dagger test leg hard-failed on PoolTimedOut where it should skip; test-rig behaviour
+#880   CI: the integration leg could validate stale target-cache artifacts; build-hygiene canary
+#884   test-only: adds a workspace-scoped guard for the idempotency-token property already fixed under #900
+#895   test-only: 15 comment-only #[test] bodies that asserted nothing given real assertions
+#898   test-only: pins the rate-limiter Redis boot refusal already shipped under #770/#777
+#902   test-only: pins a multi-root list-of-objects argument shape already fixed under #719
+#907   test-only: every changed path is #[cfg(test)] — tests pin the SSRF-bypass decision instead of mutating process env; production behaviour unchanged
+#908   CI: no Dagger leg ran any fraiseql-arrow test; leg wiring only
+#930   SDK test infra: F# test classes raced on the global SchemaRegistry
+#936   test infra: pipeline_e2e_test clobbered the shared v_user fixture, reddening unrelated tests
+#942   test infra: changelog_handlers lib tests depended on ambient core.tb_entity_change_log
+#960   CI: cascade_rls_against_db self-skipped in every leg — the proof never ran
+#968   test infra: postgres_column_decode_test fixtures lacked drop-first, so re-runs failed
+#971   CI: re-test the Deno suite inside the Dagger sandbox; leg configuration only
+#981   test infra: an inbound-email tracking test time-bombed on a fixture clock
+#982   test infra: a changelog tail test depended on another crate's tests for provisioning
+#986   CI/hooks: check-snapshot-pairing was an orphan gate running in no CI leg
+#987   hooks: pre-commit clippy/fmt argument order made the command malformed
+#988   CI: pre-commit.ci actionlint/shellcheck findings across workflow files
+#992   CI: ~70 server test binaries executed in no leg; leg wiring only
+#996   test infra: the `test` schema fixtures had two owners re-seeding each other
+#997   test rig: the local TLS Postgres was never seeded with v_test_entity
+#1001  test-only: flight_e2e_test's "end-to-end DoGet" tests called no Flight RPC
+#1010  test infra: fraiseql-guard log-capture tests raced on process-global env
+#1103  CI: deny.toml advisory deadlines that would redden the required preflight check on a date; no shipped behaviour change

--- a/tools/check-changelog-issues.sh
+++ b/tools/check-changelog-issues.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# check-changelog-issues.sh — fail when an issue closed since the last release is
+# not documented in CHANGELOG.md, and when the changelog's heading structure drifts.
+#
+# Why this exists: at the v2.15.0 scoping pass, 258 issues had been closed by
+# `Closes #N` since v2.14.1 and **48 appeared nowhere in CHANGELOG.md** — including
+# an entire security wave whose bullets were production fail-closed boot changes
+# (#1127). Nothing had ever checked: `.github/workflows/changelog-check.yml` lost
+# its `pull_request` trigger in the Dagger migration and sat `workflow_dispatch:`-only,
+# so no push and no PR ever ran a completeness check.
+#
+# ⚠ THIS GATE NEEDS REAL GIT HISTORY, so it must NOT be added to the Dagger
+# `ShellGates` list: `.dagger/main.go` declares `+ignore=[".git"]` and runs
+# `git init -q .` in the container, where this script would find zero `Closes #N`
+# and pass vacuously — the fabricated-success shape it exists to prevent. It runs
+# in a hosted workflow with `fetch-depth: 0`, and in release.yml's validate-release.
+# Its *self-test* (fixture repos in a temp dir) is what belongs in ShellGates.
+#
+# Two directions, deliberately:
+#   1. a closed issue that is not documented and not exempt  → fail
+#   2. an exemption naming an issue that IS documented       → fail (stale)
+# A gate that only fails one way rots into an allowlist nobody prunes.
+#
+# Overrides, for testing:
+#   CHANGELOG_CHECK_BASE=<rev>     compare from this rev instead of the last v* tag
+#   CHANGELOG_CHECK_FILE=<path>    changelog to read instead of CHANGELOG.md
+#   CHANGELOG_CHECK_EXEMPT=<path>  exemption list instead of the default
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+changelog="${CHANGELOG_CHECK_FILE:-CHANGELOG.md}"
+exempt_file="${CHANGELOG_CHECK_EXEMPT:-tools/changelog-exempt-issues.txt}"
+
+if [ ! -f "$changelog" ]; then
+  echo "ERROR: changelog not found: $changelog" >&2
+  exit 1
+fi
+
+# ── Base revision ────────────────────────────────────────────────────────────
+#
+# ⚠ On a tag build (release.yml runs on the tag it is validating) a bare
+# `git describe --tags --abbrev=0` returns THE TAG BEING VALIDATED, so the range
+# `<tag>..HEAD` is empty and the gate passes on an empty set — green while
+# checking nothing. Exclude every v* tag that points at HEAD.
+resolve_base() {
+  local describe_args=(--tags --abbrev=0 --match 'v*')
+  local t
+  while IFS= read -r t; do
+    [ -n "$t" ] && describe_args+=(--exclude "$t")
+  done < <(git tag --points-at HEAD --list 'v*' || true)
+
+  local base
+  base="$(git describe "${describe_args[@]}" HEAD 2>/dev/null || true)"
+  if [ -z "$base" ]; then
+    # No prior release tag (a fresh repo, or a shallow clone with no tags —
+    # which is why the callers set fetch-depth: 0). Fall back to the root commit
+    # so the range is the whole history rather than silently empty.
+    base="$(git rev-list --max-parents=0 HEAD | tail -1)"
+  fi
+  printf '%s' "$base"
+}
+
+base="${CHANGELOG_CHECK_BASE:-$(resolve_base)}"
+
+# ── The three sets ───────────────────────────────────────────────────────────
+# `sort -u`, never `sort -un`: numeric order makes `comm` reject its input
+# ("input is not in sorted order") and hand back a wrong, longer answer.
+closed="$(git log "${base}..HEAD" --pretty=%B \
+  | grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+' | sort -u || true)"
+
+documented="$(grep -oE '#[0-9]+' "$changelog" | grep -oE '[0-9]+' | sort -u || true)"
+
+exempt=""
+if [ -f "$exempt_file" ]; then
+  # Format: `#N  <reason>`. A bare number is rejected below — an exemption
+  # without a stated reason is indistinguishable from an oversight.
+  #
+  # Comments also open with `#`, so the discriminator is the character after it:
+  # `#` + digit is an entry and must carry a reason; `#` + anything else is prose.
+  bad_lines="$(awk '
+    /^[[:space:]]*$/           { next }                       # blank
+    /^[[:space:]]*#[0-9]/      { if ($0 !~ /^[[:space:]]*#[0-9]+[[:space:]]+[^[:space:]]/) print; next }
+    /^[[:space:]]*#/           { next }                       # comment prose
+                               { print }                      # anything else
+  ' "$exempt_file")"
+  if [ -n "$bad_lines" ]; then
+    {
+      echo "ERROR: $exempt_file has entries that are not '#N  <reason>':"
+      printf '%s\n' "$bad_lines" | sed 's/^/  /'
+      echo
+      echo "An exemption without a stated reason cannot be reviewed or pruned."
+    } >&2
+    exit 1
+  fi
+  exempt="$(grep -oE '^[[:space:]]*#[0-9]+' "$exempt_file" | grep -oE '[0-9]+' | sort -u || true)"
+fi
+
+failed=0
+
+# ── Direction 1: closed but undocumented and unexempt ────────────────────────
+undocumented="$(comm -23 <(printf '%s\n' "$closed" | grep -vE '^$' || true) \
+                         <(printf '%s\n' "$documented" | grep -vE '^$' || true))"
+missing="$(comm -23 <(printf '%s\n' "$undocumented" | sort -u | grep -vE '^$' || true) \
+                    <(printf '%s\n' "$exempt" | grep -vE '^$' || true))"
+
+if [ -n "$missing" ]; then
+  {
+    echo "ERROR: issues closed since ${base} are absent from ${changelog}:"
+    printf '%s\n' "$missing" | sed 's/^/  #/'
+    echo
+    echo "Document each under the correct existing heading, or add it to"
+    echo "${exempt_file} as '#N  <why it is not user-facing>'."
+  } >&2
+  failed=1
+fi
+
+# ── Direction 2: stale exemptions ────────────────────────────────────────────
+stale="$(comm -12 <(printf '%s\n' "$exempt" | grep -vE '^$' || true) \
+                  <(printf '%s\n' "$documented" | grep -vE '^$' || true))"
+if [ -n "$stale" ]; then
+  {
+    echo "ERROR: ${exempt_file} exempts issues that ARE documented in ${changelog}:"
+    printf '%s\n' "$stale" | sed 's/^/  #/'
+    echo
+    echo "Remove the exemption. Keeping it lets the list rot into an allowlist"
+    echo "nobody prunes, which is how the next omission hides."
+  } >&2
+  failed=1
+fi
+
+# ── Structure: one heading per type in the section under active edit ─────────
+#
+# Scoped to the FIRST `## [...]` section — `[Unreleased]`, or the released
+# version immediately after a cut. Historical sections are left alone: they
+# carry free-form headings ("Migration", "Known limitations") and three genuine
+# duplicates, and rewriting shipped release notes to satisfy a new gate would be
+# falsifying the record.
+structure_errors="$(
+  awk '
+    /^## \[/ { if (seen_section) exit; seen_section = 1; section = $0; next }
+    seen_section && /^### / {
+      h = $0; sub(/^### +/, "", h); sub(/ +$/, "", h)
+      key = tolower(h)
+      count[key]++
+      if (count[key] == 1) order[++n] = key
+      raw[key] = h
+    }
+    END {
+      split("breaking|added|changed|deprecated|removed|fixed|security|known issues", a, "|")
+      for (i in a) allowed[a[i]] = 1
+      for (i = 1; i <= n; i++) {
+        k = order[i]
+        if (!(k in allowed)) printf "unknown heading \"### %s\" — allowed: Breaking, Added, Changed, Deprecated, Removed, Fixed, Security, Known issues\n", raw[k]
+        else if (count[k] > 1) printf "\"### %s\" appears %d times — merge into one heading per type\n", raw[k], count[k]
+      }
+    }
+  ' "$changelog"
+)"
+
+if [ -n "$structure_errors" ]; then
+  {
+    echo "ERROR: heading structure in the newest ${changelog} section:"
+    printf '%s\n' "$structure_errors" | sed 's/^/  /'
+  } >&2
+  failed=1
+fi
+
+if [ "$failed" -eq 0 ]; then
+  n_closed="$(printf '%s\n' "$closed" | grep -cE '^[0-9]+$' || true)"
+  n_exempt="$(printf '%s\n' "$exempt" | grep -cE '^[0-9]+$' || true)"
+  echo "OK: ${n_closed} issues closed since ${base}; all documented in ${changelog} or exempt (${n_exempt})."
+fi
+exit "$failed"

--- a/tools/tests/changelog_gate_test.sh
+++ b/tools/tests/changelog_gate_test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Unit tests for tools/check-changelog-issues.sh.
+#
+# Run directly:  bash tools/tests/changelog_gate_test.sh
+# Exits non-zero if any assertion fails.
+#
+# The gate itself needs real git history, so it CANNOT run in Dagger ShellGates
+# (`+ignore=[".git"]` plus `git init -q .` in the container would leave it looking
+# at an empty repository, finding zero `Closes #N`, and passing vacuously). This
+# self-test builds its own fixture repositories in a temp directory, so it needs no
+# ambient history and does belong there — the same split as
+# `make test-deadline-gate` and `make test-release-tooling`.
+#
+# What is worth pinning here, in order of how badly each would hurt:
+#
+#   1. **Tag-build base resolution.** On the tag build that validates a release,
+#      a bare `git describe --tags --abbrev=0` returns the tag being validated, so
+#      `<tag>..HEAD` is empty and the gate passes having checked nothing — green at
+#      exactly the moment it is the last thing standing between an incomplete
+#      changelog and a published release.
+#   2. **Both failure directions.** A gate that only fails on a missing entry lets
+#      the exemption list rot into an allowlist nobody prunes.
+#   3. **Reason-less exemptions.** `#123` with no prose is indistinguishable from
+#      an oversight six months later.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GATE="$REPO_ROOT/tools/check-changelog-issues.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Fixture repository ───────────────────────────────────────────────────────
+# mk_repo <name> <changelog-body> <exempt-body> [extra-tag-at-head]
+#
+# Layout: one commit + tag v1.0.0, then a commit whose message closes #42 and
+# #43. #42 is the "user-facing" one each case decides what to do with.
+mk_repo() {
+    local name="$1" changelog="$2" exempt="$3" head_tag="${4:-}"
+    local dir="$WORK/$name"
+    mkdir -p "$dir"
+    (
+        cd "$dir"
+        git init -q .
+        # The Dagger container has no global git identity; set it locally or
+        # every fixture commit fails and the whole suite errors out.
+        git config user.email "gate-test@example.invalid"
+        git config user.name "Gate Test"
+        git config commit.gpgsign false
+        # ⚠ A developer whose global config sets tag.gpgSign / tag.forceSignAnnotated
+        # (both are ordinary hardening) turns a lightweight `git tag v1.0.0` into
+        # `fatal: no tag message?` and rc=128 — NO TAG IS CREATED. The gate then
+        # falls back to the root commit, the range covers everything, and the
+        # tag-build assertion below passes for a reason that has nothing to do with
+        # tag resolution. Observed on this machine; pinned here so the fixture is
+        # not at the mercy of ambient configuration.
+        git config tag.gpgSign false
+        git config tag.forceSignAnnotated false
+        echo "seed" > seed.txt
+        git add -A
+        git commit -q -m "seed"
+        git tag v1.0.0
+        printf '%s\n' "$changelog" > CHANGELOG.md
+        printf '%s\n' "$exempt" > exempt.txt
+        git add -A
+        git commit -q -m "fix(x): a change
+
+Closes #42
+Closes #43"
+        [ -n "$head_tag" ] && git tag "$head_tag"
+
+        # A fixture that failed to build must be loud, not silently degrade the
+        # assertion it supports.
+        want_tags="v1.0.0${head_tag:+ $head_tag}"
+        for t in $want_tags; do
+            if [ -z "$(git tag -l "$t")" ]; then
+                echo "FIXTURE ERROR: tag $t was not created in $dir" >&2
+                exit 1
+            fi
+        done
+        if [ "$(git rev-list --count HEAD)" -ne 2 ]; then
+            echo "FIXTURE ERROR: expected 2 commits in $dir" >&2
+            exit 1
+        fi
+    ) || exit 1
+    printf '%s' "$dir"
+}
+
+# run_gate <dir> → combined output; returns the gate's exit code.
+run_gate() {
+    local dir="$1"
+    (
+        cd "$dir"
+        CHANGELOG_CHECK_FILE="$dir/CHANGELOG.md" \
+        CHANGELOG_CHECK_EXEMPT="$dir/exempt.txt" \
+        CHANGELOG_CHECK_BASE="" \
+            bash "$GATE" 2>&1
+    )
+}
+
+# assert <name> <dir> <expected-rc> <expected-substring>
+# An empty expected-substring asserts only the exit code.
+assert() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local name="$1" dir="$2" want_rc="$3" want_sub="$4"
+    local out rc
+    set +e
+    out="$(run_gate "$dir")"
+    rc=$?
+    set -e
+    if [[ "$rc" -eq "$want_rc" && ( -z "$want_sub" || "$out" == *"$want_sub"* ) ]]; then
+        echo "  ok: $name"
+    else
+        echo "  FAIL: $name — rc=$rc (want $want_rc), output did not contain '$want_sub':" >&2
+        printf '%s\n' "$out" | sed 's/^/      /' >&2
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+BOTH_DOCUMENTED='## [Unreleased]
+
+### Fixed
+
+- a thing (#42)
+- another thing (#43)'
+
+ONLY_43='## [Unreleased]
+
+### Fixed
+
+- another thing (#43)'
+
+echo "check-changelog-issues.sh"
+
+# ── Direction 1: a closed issue must be documented ────────────────────────────
+d="$(mk_repo documented "$BOTH_DOCUMENTED" '# none')"
+assert "documented issues pass" "$d" 0 "OK:"
+
+d="$(mk_repo undocumented "$ONLY_43" '# none')"
+assert "an undocumented issue fails, naming it" "$d" 1 "#42"
+
+d="$(mk_repo exempted "$ONLY_43" '#42  internal test-rig change')"
+assert "undocumented but exempt passes" "$d" 0 "OK:"
+
+# ── Direction 2: an exemption for a documented issue is stale ─────────────────
+# Without this the list silently accumulates entries for issues that were later
+# written up, and nobody can tell a live exemption from a dead one.
+d="$(mk_repo stale "$BOTH_DOCUMENTED" '#42  internal test-rig change')"
+assert "an exemption for a documented issue fails" "$d" 1 "exempts issues that ARE documented"
+
+# ── An exemption must carry a reason ──────────────────────────────────────────
+d="$(mk_repo reasonless "$ONLY_43" '#42')"
+assert "a reason-less exemption fails" "$d" 1 "not '#N  <reason>'"
+
+d="$(mk_repo unhashed "$ONLY_43" '42  forgot the hash')"
+assert "an entry with no leading # fails" "$d" 1 "not '#N  <reason>'"
+
+# Comment prose in the exemption file is not an entry and must not trip the
+# format check — the file is meant to be read, so it has to be annotatable.
+d="$(mk_repo commented "$ONLY_43" '# why this file exists
+#42  internal test-rig change')"
+assert "comment lines are not entries" "$d" 0 "OK:"
+
+# ── Tag-build base resolution (the one that matters most) ─────────────────────
+# release.yml validates the tag it is about to publish, so HEAD carries v2.0.0.
+# A bare `git describe --tags --abbrev=0` returns v2.0.0 → the range v2.0.0..HEAD
+# is empty → the gate passes having examined nothing, at exactly the moment it is
+# the last check before publish. Base must resolve to v1.0.0 and #42 must fail.
+d="$(mk_repo tagbuild "$ONLY_43" '# none' v2.0.0)"
+assert "a tag build resolves past the tag being validated" "$d" 1 "#42"
+
+d="$(mk_repo tagbuild_ok "$BOTH_DOCUMENTED" '# none' v2.0.0)"
+assert "a tag build passes when the range is documented" "$d" 0 "OK:"
+
+# ── Structure: one heading per type in the newest section ─────────────────────
+DUPLICATE_HEADING='## [Unreleased]
+
+### Fixed
+
+- a thing (#42)
+
+### Fixed
+
+- another thing (#43)'
+d="$(mk_repo dup_heading "$DUPLICATE_HEADING" '# none')"
+assert "a duplicate heading fails" "$d" 1 "appears 2 times"
+
+UNKNOWN_HEADING='## [Unreleased]
+
+### Fixed
+
+- a thing (#42)
+
+### Miscellaneous
+
+- another thing (#43)'
+d="$(mk_repo unknown_heading "$UNKNOWN_HEADING" '# none')"
+assert "an off-list heading fails" "$d" 1 "unknown heading"
+
+# `Known issues` is on the allow-list because the release phase adds it under the
+# released version; it must not be rejected as an off-list heading.
+KNOWN_ISSUES='## [Unreleased]
+
+### Fixed
+
+- a thing (#42)
+- another thing (#43)
+
+### Known issues
+
+- something that did not make the cut'
+d="$(mk_repo known_issues "$KNOWN_ISSUES" '# none')"
+assert "\"Known issues\" is allowed" "$d" 0 "OK:"
+
+# Older released sections are left alone: they carry free-form headings and
+# genuine duplicates, and rewriting shipped release notes to satisfy a new gate
+# would falsify the record. Only the newest section is checked.
+HISTORICAL_MESS='## [Unreleased]
+
+### Fixed
+
+- a thing (#42)
+- another thing (#43)
+
+## [0.9.0] - 2020-01-01
+
+### Migration
+
+- an old free-form heading
+
+### Fixed
+
+- one
+
+### Fixed
+
+- and again'
+d="$(mk_repo historical "$HISTORICAL_MESS" '# none')"
+assert "older sections are not structure-checked" "$d" 0 "OK:"
+
+echo
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo "FAILED: $TESTS_FAILED of $TESTS_RUN assertions" >&2
+    exit 1
+fi
+echo "PASSED: $TESTS_RUN assertions"


### PR DESCRIPTION
**P01 of the v2.15.0 release program.** Blocker **B1**: the changelog told a false story about
what shipped, and nothing had ever checked.

## The defect

258 issues are closed by `Closes #N` in `v2.14.1..dev`. **48 appeared nowhere in
`CHANGELOG.md`** — including `4b018d0f9` in its entirety, the secrets/auth/webhooks security
wave, whose bullets are production **fail-closed boot changes**: token revocation, PKCE state
and rate limiting now refuse to boot when a configured Redis backend is unavailable;
`tls_verify = false` refuses to boot; the `backend = "env"` alias is gone;
`FRAISEQL_SECRETS_BACKEND` stopped silently building the env backend for every value. An
operator reading the release notes to decide whether to upgrade would have seen none of it.

Nothing caught it because `changelog-check.yml` lost its `pull_request` trigger in the
2026-05-31 Dagger migration and sat `workflow_dispatch:`-only. **No push and no PR has ever
run a changelog check** — for 210 commits.

The entries that *were* present are accurate (four `### Breaking` bullets spot-checked against
source, 4/4). The defect is omission, not accuracy.

## What this PR does

| Commit | |
|---|---|
| `docs(changelog)` | 22 user-facing issues written up under the seven existing headings, each from the commit's **diff** |
| `ci(changelog)` | `tools/check-changelog-issues.sh` + exemption list + 13-assertion self-test, wired into ShellGates, `changelog-check.yml`, `preflight:` and `release.yml`'s `validate-release` |
| `docs(phases)` | `.phases/README.md`, the one tracked file under `.phases/`, was three programs stale |

## Three corrections to the planned split, each verified against source

The phase planned 23 user-facing / 25 internal. Checking rather than inheriting:

- **#907 is test-only.** Every changed path is `#[cfg(test)]` — `insecure_guard::test_override`
  is `#[cfg(test)]`, and `ssrf_test_env` is declared `#[cfg(test)] mod`. Production behaviour
  unchanged → internal.
- **#732 is a pure refactor** ("decompose `execute_graphql_request`, ~580 lines"), not a
  cross-reference to a documented change → internal.
- **#774 needs its own bullet**, not a cross-reference. No existing entry describes it; the
  nearest (#838) documents that the *docs* now match the implemented precedence, while the fix
  that made CLI/env overrides actually take effect went unwritten.
- **#1095 is documented rather than exempted** — an operator scanning for RUSTSEC-2026-0253
  should be able to see the shipped lockfile is clear, with the honest note that the trigger
  was never reachable in FraiseQL's call sites.

Final split: **22 documented / 26 internal.** #898, #902 and #884 were each re-checked before
exempting — all three are test-only commits pinning behaviour already fixed and documented
under #770, #719 and #900.

## Where the gate can live — a constraint, not a preference

⚠ **The gate cannot run in Dagger `ShellGates`.** `.dagger/main.go` declares
`+ignore=[".git"]` on `Preflight` and `ShellGates` and runs `git init -q .` in the container.
A history-dependent script there sees an empty repository, finds zero `Closes #N`, and
**passes vacuously** — the fabricated-success shape this gate exists to prevent. So:

- the **gate** runs in `changelog-check.yml` (push + PR, `fetch-depth: 0`) and in
  `release.yml`'s `validate-release`, so a tag cannot be cut on an incomplete changelog;
- its **self-test**, which builds fixture repositories in a temp dir and needs no ambient
  history, runs in ShellGates as `make test-changelog-gate` — the same split as
  `make test-deadline-gate`.

## Red proofs — every one a revert-check, so no pushed head is red

**1. Tag-build base resolution.** The one that matters most: `release.yml` validates the tag it
is about to publish, so a bare `git describe --tags --abbrev=0` returns *that* tag and the
range is empty. Mutated `git tag --points-at HEAD --list 'v*'` → `true`:

```
FAIL: a tag build resolves past the tag being validated — rc=0 (want 1)
      OK: 0 issues closed since v2.0.0; all documented ... or exempt (0).
```

Green, having examined nothing, at the last gate before publish.

**2. The stale-exemption direction.** Mutated `stale="$(comm -12 …)"` → `stale=""`:

```
FAIL: an exemption for a documented issue fails — rc=0 (want 1)
```

**3. Completeness, on the real tree.** Removed `(#954)` from its bullet:

```
ERROR: issues closed since v2.14.1 are absent from CHANGELOG.md:
  #954
```

Each reverted by reverse string-swap — never `git checkout <file>`, which discards the whole
uncommitted change on a tracked file.

## A fixture that was green for the wrong reason

The self-test's first run printed **13 oks and `fatal: no tag message?` fourteen times**. This
machine's global git config sets `tag.gpgSign=true` and `tag.forceSignAnnotated=true`, which
turns a lightweight `git tag v1.0.0` into rc=128 with **no tag created** — so the gate fell
back to the root commit, the range covered everything, and the tag-build assertion passed for a
reason unrelated to tag resolution. The fixture now pins both settings locally and asserts its
own tags and commit count before any assertion runs on it.

## Found but out of scope → filed, not fixed

- **#1135** — `make preflight` prints "mirrors the Dagger preflight leg. Safe to push." but
  does not run `make test-deadline-gate`. Every `bash tools/check-*.sh` in ShellGates *does*
  have a matching local `lint-*` target; that one self-test is the only hole. This PR adds its
  own gate to **both** lists rather than fixing the pre-existing gap.

## Verification

```
✅ bash tools/check-changelog-issues.sh    OK: 259 issues closed since v2.14.1;
                                           all documented or exempt (26)
✅ make test-changelog-gate                PASSED: 13 assertions
✅ make preflight                          green, and the gate EXECUTES in it —
                                           "check-changelog-issues.sh / PASSED: 13 assertions"
                                           appears in the log, not just a green tick
✅ pre-commit run --from-ref dev --to-ref HEAD   all hooks pass, no autofix rewrote anything
✅ shellcheck on both new scripts          clean
✅ cd .dagger && go build ./... && gofmt -l .   clean
✅ actionlint (via pre-commit)             both workflows clean
✅ markdownlint                            0 errors on CHANGELOG.md
```

⚠ **Note for the merge decision:** `changelog-check` is a new hosted check and is **not** in
the repo's required set (the dev ruleset requires exactly `preflight` + `security`). It will
report on every push and PR but will not block a merge until someone adds it to the ruleset.
What *does* block is `release.yml`'s `validate-release`, which is the path that matters for the
tag.

Closes #1127
