### PR TITLE
docs(security): the dependency-risk policy describes this tree, and two gates keep it that way

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -23,9 +23,12 @@ ignore = [
   # upstream fix exists either way) but must be re-argued on the real path.
   # deadline: 2026-10-01 — re-evaluate sqlx 0.9 release status and resolve #1110.
   "RUSTSEC-2023-0071",
-  # rustls-pemfile: unmaintained; blocked on upstream bollard migration to rustls-pem.
-  # DEV-dependency only (fraiseql-wire test deps / bollard) — no production runtime exposure.
-  # deadline: 2026-10-01 — matches deny.toml; re-check bollard release cadence at the next sweep.
+  # rustls-pemfile: deprecated in favour of rustls-pki-types' own PEM support.
+  # ⚠ CORRECTED 2026-08-16 (#1137): the "DEV-dependency only (fraiseql-wire test deps /
+  # bollard) — no production runtime exposure" grounds recorded here and in deny.toml were
+  # false. rustls-pemfile 2.2.0 is a direct [dependencies] entry of fraiseql-wire and reaches
+  # fraiseql-server in the DEFAULT build. Accepted as a maintenance risk, not on absence.
+  # deadline: 2026-10-01 — matches deny.toml; migrate fraiseql-wire off rustls-pemfile.
   "RUSTSEC-2025-0134",
   # rustls-webpki name-constraint bugs; transitive via aws-smithy-http-client (rustls 0.21);
   # opt-in aws-s3 and cdc-kinesis features only, absent from the default build.
@@ -42,7 +45,9 @@ ignore = [
   "RUSTSEC-2026-0194",
   "RUSTSEC-2026-0195",
   # crossbeam-epoch 0.9.18 fmt::Pointer invalid-pointer deref; only on Debug-formatting an
-  # invalid Atomic/Shared pointer (never done). Transitive via rayon (criterion dev-deps).
+  # invalid Atomic/Shared pointer (never done).
+  # ⚠ CORRECTED 2026-08-16 (#1137): "transitive via rayon (criterion dev-deps)" was false —
+  # it arrives via moka 0.12 -> fraiseql-core in the DEFAULT build. Accepted on usage.
   # deadline: 2026-10-01 — matches deny.toml.
   "RUSTSEC-2026-0204"
 ]

--- a/.dagger/security.go
+++ b/.dagger/security.go
@@ -45,6 +45,7 @@ func (m *FraiseqlCi) Security(
 	}{
 		{"compliance", m.Compliance},
 		{"crypto-providers", m.CryptoProviders},
+		{"advisory-paths", m.AdvisoryPaths},
 		{"cargo-deny", m.CargoDeny},
 		{"cargo-audit", m.CargoAudit},
 	}
@@ -111,6 +112,33 @@ func (m *FraiseqlCi) CryptoProviders(
 		WithMountedDirectory("/src", source).
 		WithWorkdir("/src").
 		WithExec([]string{"bash", "tools/check-crypto-providers.sh"}).
+		Stdout(ctx)
+}
+
+// AdvisoryPaths runs tools/check-advisory-paths.sh: every accepted advisory in
+// docs/dependency-risk-policy.md declares how the vulnerable crate is reached
+// (default-build / feature-gated:<f> / not-compiled), and the gate checks that claim
+// against `cargo tree` rather than trusting the prose.
+//
+// This exists because three of the eight acceptances were carried by sentences the
+// dependency graph contradicts — RUSTSEC-2023-0071 named `sqlx-mysql`, removed with
+// #374 (#1110); RUSTSEC-2025-0134 claimed dev-dependency-only; RUSTSEC-2026-0204
+// claimed criterion dev-deps (#1137). check-audit-lockstep.sh compares advisory IDS
+// and both machine-read files carried the same wrong story, and `cargo deny` has no
+// opinion about whether a `reason` string is true.
+//
+// It lives here rather than in ShellGates because it needs cargo. Like
+// CryptoProviders it runs on denyBase — `cargo tree` needs only `cargo metadata`
+// (cargo on PATH plus the warm registry cache); nothing compiles.
+func (m *FraiseqlCi) AdvisoryPaths(
+	ctx context.Context,
+	// +ignore=["target", "**/target", ".git"]
+	source *dagger.Directory,
+) (string, error) {
+	return m.denyBase().
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
+		WithExec([]string{"bash", "tools/check-advisory-paths.sh"}).
 		Stdout(ctx)
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4824,6 +4824,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   key is zeroized on drop; OTP comparison is constant-time; `X-Forwarded-For` parsing takes
   the rightmost non-proxy hop rather than a client-controlled leftmost entry; `RedisStateStore`
   returns the real stored expiry and `InMemoryStateStore` enforces expiry.
+- **The published dependency-risk policy describes this tree (#1110).**
+  `docs/dependency-risk-policy.md` asserted that `rsa` reached FraiseQL only through
+  `sqlx-mysql`, "lockfile-only; never compiled". `sqlx-mysql` left the tree with #374 —
+  `cargo tree -i sqlx-mysql --all-features` prints nothing — and `rsa@0.9.10` is in the
+  **default** build via `jsonwebtoken` 10.4, where `generate_rs256_token`
+  (`session_postgres.rs:175`) signs access tokens with an RSA **private** key: an
+  attacker-triggerable private-key operation, which is the shape the Marvin Attack targets.
+  `deny.toml` was corrected on 2026-08-13; the document users actually read was not. The
+  policy now also publishes **all eight** accepted advisories rather than four, carries the
+  deadlines `deny.toml` carries (three were stale, and two of those read as already lapsed),
+  states that `deny.toml` is the source of truth, and replaces the acceptance criterion
+  "the vulnerable code path is not reachable in default configurations" — which three current
+  acceptances contradict — with the two arguments an acceptance may actually make: **absence**
+  from the build, or **usage** that never reaches the defect. The acceptances themselves are
+  unchanged; there is no fixed `rsa` release either way.
 - **`lru` 0.18.2 clears RUSTSEC-2026-0253 (#1095).** `LruCache::pop()` was not panic-safe: a
   panicking key `Drop` skipped `detach()` and left a dangling pointer in the LRU list for the
   next eviction to walk. Both FraiseQL call sites — `validation::rate_limiting` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4839,6 +4839,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   acceptances contradict — with the two arguments an acceptance may actually make: **absence**
   from the build, or **usage** that never reaches the defect. The acceptances themselves are
   unchanged; there is no fixed `rsa` release either way.
+- **Two more advisory acceptances stop resting on dependency paths that do not exist
+  (#1137).** Checking the other seven acceptances the way #1110 was checked found the same
+  defect twice more, and in both cases the false sentence was the load-bearing one.
+  RUSTSEC-2025-0134 was accepted as "DEV-dependency only (fraiseql-wire test deps / bollard)
+  — no production runtime exposure", but `rustls-pemfile@2.2.0` is a direct `[dependencies]`
+  entry of `fraiseql-wire` and reaches `fraiseql-server` in the default build.
+  RUSTSEC-2026-0204 was accepted as "transitive via rayon (criterion dev-deps)", but
+  `crossbeam-epoch@0.9.18` arrives via `moka` → `fraiseql-core`, the result cache. Both
+  acceptances still stand — one is a deprecated-crate maintenance advisory with no exploit
+  path, the other triggers only on Debug-formatting an invalid pointer, which `moka` does not
+  do — but they now stand on stated grounds that are true. Nothing had caught them because
+  `check-audit-lockstep.sh` compares advisory **ids** and both files carried the same wrong
+  story.
 - **`lru` 0.18.2 clears RUSTSEC-2026-0253 (#1095).** `LruCache::pop()` was not panic-safe: a
   panicking key `Drop` skipped `detach()` and left a dangling pointer in the LRU list for the
   next eviction to walk. Both FraiseQL call sites — `validation::rate_limiting` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4851,7 +4851,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path, the other triggers only on Debug-formatting an invalid pointer, which `moka` does not
   do — but they now stand on stated grounds that are true. Nothing had caught them because
   `check-audit-lockstep.sh` compares advisory **ids** and both files carried the same wrong
-  story.
+  story. Two gates now do: that script is extended to compare the **published policy** as a
+  third file, on ids *and* deadlines, and a new `tools/check-advisory-paths.sh` checks each
+  row's `default-build` / `feature-gated:<f>` / `not-compiled` claim against `cargo tree` in
+  the Dagger `security` leg — so an acceptance can no longer be carried by a dependency path
+  that does not exist.
 - **`lru` 0.18.2 clears RUSTSEC-2026-0253 (#1095).** `LruCache::pop()` was not panic-safe: a
   panicking key `Drop` skipped `detach()` and left a dangling pointer in the LRU list for the
   next eviction to walk. Both FraiseQL call sites — `validation::rate_limiting` and

--- a/deny.toml
+++ b/deny.toml
@@ -30,13 +30,20 @@ ignore = [
   # but it must be re-argued on the real path rather than re-approved on this text.
   # deadline: 2026-10-01 — re-evaluate sqlx 0.9 release status and resolve #1110.
   {id = "RUSTSEC-2023-0071", reason = "No fixed rsa release. Recorded mysql-feature justification is stale — real path is jsonwebtoken in the default build; under review in #1110. Deadline 2026-10-01."},
-  # rustls-pemfile: blocked on upstream bollard migration from pem 0.x to rustls-pem.
-  # Re-evaluated 2026-07-02: rustls-pemfile 2.2.0 is a DEV-dependency only (fraiseql-wire
-  # test deps / bollard test infra) — no production runtime exposure; low-severity
-  # deprecated/unmaintained-crate advisory. bollard 0.20 still pins pem 0.x upstream.
-  # deadline: 2026-10-01 — re-check bollard release cadence at the next dep sweep; drop
-  # bollard or migrate off rustls-pemfile if still blocked.
-  {id = "RUSTSEC-2025-0134", reason = "rustls-pemfile deprecated-crate advisory; DEV-dependency only (fraiseql-wire test deps / bollard), no production exposure; deadline 2026-10-01"},
+  # rustls-pemfile: deprecated in favour of rustls-pki-types' own PEM support.
+  # ⚠ CORRECTED 2026-08-16 (#1137). The recorded grounds — "DEV-dependency only (fraiseql-wire
+  # test deps / bollard test infra), no production runtime exposure" — were FALSE:
+  # rustls-pemfile 2.2.0 is a direct `[dependencies]` entry of fraiseql-wire
+  # (crates/fraiseql-wire/Cargo.toml:37) and an optional one of fraiseql-db, so
+  # `cargo tree -i rustls-pemfile -e normal` (normal edges, DEFAULT features) resolves it
+  # through to fraiseql-server. bollard is not on that path at all.
+  # The acceptance still stands, on different grounds: this is a deprecated/unmaintained-crate
+  # advisory, not an exploitable defect, so being in the build is a maintenance risk rather
+  # than an attack path. The real resolution path is FraiseQL's own — move fraiseql-wire's PEM
+  # parsing to rustls-pki-types — not bollard's upstream migration.
+  # deadline: 2026-10-01 — migrate fraiseql-wire off rustls-pemfile, or re-accept with the
+  # maintenance risk stated.
+  {id = "RUSTSEC-2025-0134", reason = "rustls-pemfile deprecated-crate advisory (maintenance risk, not an exploitable defect). IN THE DEFAULT BUILD via fraiseql-wire's direct dependency — the previous dev-only justification was false, corrected in #1137. Deadline 2026-10-01."},
   # rustls-webpki name-constraint bugs; transitive via aws-smithy-http-client (rustls 0.21).
   # Affects the OPT-IN aws-* features only — `aws-s3` (fraiseql-storage/fraiseql-server) and,
   # since #975, `cdc-kinesis` (fraiseql-cdc-sinks). Neither is in the default build, so there is
@@ -93,7 +100,16 @@ ignore = [
   # quick-xml (validating SAML parsing) or dropping samael.
   {id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic duplicate-attribute-name check (DoS); transitive via samael (auth-saml opt-in only); samael pins quick-xml 0.37.5, no fix in range. Deadline 2026-10-01."},
   {id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration allocation in NsReader (memory-exhaustion DoS); same cause/path as RUSTSEC-2026-0194 (samael, auth-saml opt-in). Deadline 2026-10-01."},
-  {id = "RUSTSEC-2026-0204", reason = "crossbeam-epoch 0.9.18 fmt::Pointer invalid-pointer dereference; only triggers when Debug/Pointer-formatting an invalid Atomic/Shared pointer, which FraiseQL never does. Transitive via rayon (criterion dev-deps). Deadline 2026-10-01."}
+  # crossbeam-epoch 0.9.18: fmt::Pointer dereferences an invalid Atomic/Shared.
+  # ⚠ CORRECTED 2026-08-16 (#1137). The recorded path — "transitive via rayon (criterion
+  # dev-deps)" — was FALSE: `cargo tree -i crossbeam-epoch@0.9.18 -e normal` on DEFAULT
+  # features resolves it through moka 0.12 → fraiseql-core, the result cache. It is in the
+  # shipped binary. rayon/criterion may also pull it, but they are not why it is there.
+  # The acceptance stands on USAGE, which is what always actually carried it: reaching the
+  # defect requires Debug/Pointer-formatting an invalid Atomic/Shared, which moka does not do
+  # and FraiseQL does not do.
+  # deadline: 2026-10-01 — re-check moka's dependency range for a fixed crossbeam-epoch.
+  {id = "RUSTSEC-2026-0204", reason = "crossbeam-epoch 0.9.18 fmt::Pointer invalid-pointer dereference; only triggers when Debug/Pointer-formatting an invalid Atomic/Shared pointer, which moka and FraiseQL never do. IN THE DEFAULT BUILD via moka -> fraiseql-core — the previous rayon/criterion dev-dep path was false, corrected in #1137. Deadline 2026-10-01."}
 ]
 unmaintained = "workspace"
 

--- a/docs/dependency-risk-policy.md
+++ b/docs/dependency-risk-policy.md
@@ -32,9 +32,9 @@ A CVE is accepted only when **all** of the following are true:
 
 **`deny.toml` is the source of truth.** This table is its published rendering: edit
 `deny.toml` (and `.cargo/audit.toml`, which is kept in lockstep with it) first, then this
-table. `tools/check-advisory-policy-lockstep.sh` fails when the three files disagree on which
-advisories are accepted or on their deadlines, and `tools/check-advisory-paths.sh` fails when
-the **Exposure** column below disagrees with `cargo tree`.
+table. `tools/check-audit-lockstep.sh` fails when the three files disagree on which advisories
+are accepted or on their deadlines, and `tools/check-advisory-paths.sh` fails when the
+**Exposure** column below disagrees with `cargo tree`.
 
 The **Exposure** column is machine-readable, and is checked against the real dependency graph
 on every run of the Dagger `security` leg:
@@ -214,5 +214,5 @@ When adding a new `[[bans.skip]]` or `[[advisories.ignore]]` entry:
    from `cargo tree -i <crate>@<version> -e normal`** — not from what the upstream advisory
    or the previous entry says
 6. Run `cargo deny check` to confirm the entry resolves the warning, then
-   `bash tools/check-advisory-policy-lockstep.sh` and `bash tools/check-advisory-paths.sh`
+   `bash tools/check-audit-lockstep.sh` and `bash tools/check-advisory-paths.sh`
    to confirm the three files agree and the exposure claim is true

--- a/docs/dependency-risk-policy.md
+++ b/docs/dependency-risk-policy.md
@@ -11,54 +11,163 @@ hard review deadline.
 A CVE is accepted only when **all** of the following are true:
 
 1. No upstream fix is available (`ignore-unfixed: true` in Trivy)
-2. The vulnerable code path is not reachable in default configurations
+2. **The exposure is stated accurately and argued.** Three of the eight current acceptances
+   are for crates that *are* in the default build, so "not reachable in a default
+   configuration" is not a precondition — it is one of two arguments that can carry an
+   acceptance, and the row must say which one it is making:
+   - **absence** — the crate is not compiled into the default artifact (`feature-gated:<f>`
+     or `not-compiled`), so a default deployment cannot reach the defect; or
+   - **usage** — the crate is in the build, but the specific vulnerable operation is not
+     performed, or the advisory is a maintenance one with no exploit path. This argument must
+     name the operation and why FraiseQL does not perform it.
+
+   An acceptance may not be carried by an absence claim that `cargo tree` contradicts. Until
+   2026-08-16 three of them were, which is why `tools/check-advisory-paths.sh` exists.
 3. The risk is documented with a specific mitigation strategy
 4. A review deadline is set (maximum 6 months from acceptance)
-5. The entry includes a `reason` field in `deny.toml`
+5. The entry includes a `reason` field in `deny.toml`, and the `Exposure` value in the table
+   below matches what the dependency graph actually shows
 
 ## Current Accepted Advisories
 
-| Advisory | Crate | Path | Mitigation | Deadline |
-|----------|-------|------|------------|---------|
-| RUSTSEC-2023-0071 | `rsa` | `sqlx-mysql` (lockfile-only; never compiled) | MySQL support removed in v2.15.0; crate not built into any artifact | 2026-10-01 |
-| RUSTSEC-2025-0134 | `rustls-pemfile` | `bollard` (optional Docker feature) | Blocked on bollard upstream; assess drop | 2026-07-01 |
-| RUSTSEC-2026-0098 | `rustls-webpki` | `aws-smithy-http-client` (optional `aws-s3`) | Optional feature; no default exploit path | 2026-06-15 |
-| RUSTSEC-2026-0099 | `rustls-webpki` | `aws-smithy-http-client` (optional `aws-s3`) | Same as above | 2026-06-15 |
+**`deny.toml` is the source of truth.** This table is its published rendering: edit
+`deny.toml` (and `.cargo/audit.toml`, which is kept in lockstep with it) first, then this
+table. `tools/check-advisory-policy-lockstep.sh` fails when the three files disagree on which
+advisories are accepted or on their deadlines, and `tools/check-advisory-paths.sh` fails when
+the **Exposure** column below disagrees with `cargo tree`.
+
+The **Exposure** column is machine-readable, and is checked against the real dependency graph
+on every run of the Dagger `security` leg:
+
+| Value | Meaning, and what the gate verifies |
+|---|---|
+| `default-build` | `cargo tree -i <crate>@<version> -e normal` on default features resolves the crate — it is compiled into the shipped artifact |
+| `feature-gated:<f>` | absent from the default build with normal edges; present with `--features <f>` |
+| `not-compiled` | absent even with `--all-features` — present in `Cargo.lock` only |
+
+`-e normal` excludes dev- and build-dependency edges, so "not in the shipped binary" is
+established by construction rather than asserted in prose. Every crate is named **with its
+version**: two versions of the same crate can coexist, and an unqualified spec is ambiguous
+(see the RUSTSEC-2026-0098 row).
+
+| Advisory | Crate | Path | Exposure | Mitigation | Deadline |
+|----------|-------|------|----------|------------|---------|
+| RUSTSEC-2023-0071 | `rsa@0.9.10` | `jsonwebtoken` 10.4 → `fraiseql-auth` | `default-build` | No fixed `rsa` release exists. The exposure is RS256 access-token signing (`session_postgres.rs:175`), an attacker-triggerable private-key operation — the shape Marvin targets. Re-argue on this path by the deadline; do not re-approve on the old `sqlx-mysql` text | 2026-10-01 |
+| RUSTSEC-2025-0134 | `rustls-pemfile@2.2.0` | direct dependency of `fraiseql-wire`; optional in `fraiseql-db` | `default-build` | Deprecated/unmaintained-crate advisory, not an exploitable defect, so presence in the build is not itself an exploit path. Blocked on `bollard` migrating off `pem` 0.x upstream | 2026-10-01 |
+| RUSTSEC-2026-0098 | `rustls-webpki@0.101.7` | `aws-smithy-http-client` (rustls 0.21) → `aws-config` | `feature-gated:aws-s3` | Certificate-validation defect reachable only on a TLS handshake an `aws-*` client makes against a hostile or misissued chain. Not in the default build; not remotely triggerable by a FraiseQL client. Blocked on the aws stack reaching rustls 0.23 (#1111) | 2026-12-01 |
+| RUSTSEC-2026-0099 | `rustls-webpki@0.101.7` | `aws-smithy-http-client` (rustls 0.21) → `aws-config` | `feature-gated:aws-s3` | Same root cause and same reasoning as RUSTSEC-2026-0098 | 2026-12-01 |
+| RUSTSEC-2026-0104 | `rustls-webpki@0.101.7` | `aws-smithy-http-client` (rustls 0.21) → `aws-config` | `feature-gated:aws-s3` | CRL-parsing panic; same root cause and same reasoning as RUSTSEC-2026-0098 | 2026-12-01 |
+| RUSTSEC-2026-0194 | `quick-xml@0.37.5` | `samael` 0.0.21 → `fraiseql-auth` | `feature-gated:auth-saml` | Quadratic run time checking a start tag for duplicate attribute names. SAML SP only, opt-in; `samael` pins `quick-xml` 0.37.5 and no fix is in range | 2026-10-01 |
+| RUSTSEC-2026-0195 | `quick-xml@0.37.5` | `samael` 0.0.21 → `fraiseql-auth` | `feature-gated:auth-saml` | Unbounded namespace-declaration allocation in `NsReader`. Same path and same upstream block as RUSTSEC-2026-0194 | 2026-10-01 |
+| RUSTSEC-2026-0204 | `crossbeam-epoch@0.9.18` | `moka` 0.12 → `fraiseql-core` | `default-build` | Invalid-pointer dereference reachable only when `fmt::Pointer` Debug-formats an invalid `Atomic`/`Shared`, which `moka` does not do. Accepted on usage grounds, not on absence from the build | 2026-10-01 |
+
+⚠ Three of these rows were corrected on 2026-08-16 after being checked against `cargo tree`
+rather than trusted: RUSTSEC-2023-0071 claimed `sqlx-mysql` (gone since #374, and `rsa` in
+fact arrives via `jsonwebtoken` in the **default** build — #1110); RUSTSEC-2025-0134 claimed
+dev-dependency-only; RUSTSEC-2026-0204 claimed criterion dev-dependencies (#1137). All three
+acceptances still stand, but two of them stood on sentences that were false, which is the
+condition the `Exposure` gate now makes impossible to leave in place.
 
 ## Resolution Tracking
 
 ### RUSTSEC-2023-0071 (RSA Marvin Attack)
 
-**Root cause**: `sqlx-mysql` uses the `rsa` crate, which has a timing sidechannel.
+**Root cause**: the `rsa` crate has a timing sidechannel in its private-key operations.
 
-**Status**: FraiseQL's MySQL adapter and `mysql` Cargo feature were removed in
-v2.15.0, so `sqlx-mysql` is never compiled into any FraiseQL artifact. It remains
-in `Cargo.lock` only as an unbuilt member of the sqlx workspace dependency, which
-is why the `deny.toml` acceptance entry still exists.
+**Status**: `rsa@0.9.10` is in the **default build**, reached as
+`jsonwebtoken 10.4 → fraiseql-auth`. `fraiseql-auth`'s `generate_rs256_token`
+(`crates/fraiseql-auth/src/session_postgres.rs:175`) signs access tokens with an RSA
+**private** key, so the vulnerable operation is one an unauthenticated caller can trigger by
+completing a login. That is the shape the Marvin Attack targets.
 
-**Blocked on**: `sqlx` upgrade to 0.9+ (which drops the vulnerable path from the
-lockfile). `sqlx 0.9.0-alpha.1` is available as of 2026-04-25 — monitor for stable
-release.
+This entry previously recorded the opposite — "`sqlx-mysql`, lockfile-only, never compiled".
+That path was removed with MySQL support in #374; `cargo tree -i sqlx-mysql --all-features`
+prints nothing. The acceptance was corrected in `deny.toml` on 2026-08-13 and here on
+2026-08-16 (#1110).
 
-**Review action by 2026-10-01**:
+**Blocked on**: nothing upstream — there is no fixed `rsa` release, and none is scheduled.
+The `sqlx 0.9` upgrade that used to be the tracked resolution path is irrelevant to the real
+dependency edge.
 
-1. If `sqlx 0.9` stable is released: upgrade and remove this entry
-2. If still blocked: keep the acceptance — the code path is present in the
-   lockfile only and is never built
+**Review action by 2026-10-01**: the choice is between continuing to accept the timing
+sidechannel on RS256 signing and moving RS256 issuance off `jsonwebtoken`'s `rsa` backend.
+Decide that, on this path. Re-approving on the removed MySQL text is not a review.
 
-### RUSTSEC-2026-0098 / RUSTSEC-2026-0099 (rustls-webpki name constraints)
+### RUSTSEC-2025-0134 (rustls-pemfile deprecated)
 
-**Root cause**: `aws-smithy-http-client` depends on `rustls 0.21` via `hyper-rustls 0.24`.
+**Root cause**: `rustls-pemfile` is deprecated in favour of `rustls-pki-types`' own PEM
+support. This is a maintenance advisory, not an exploitable defect.
 
-**Blocked on**: `aws-sdk-s3` migrating to `hyper-rustls 0.27` (rustls 0.23).
+**Status**: `rustls-pemfile@2.2.0` is a direct `[dependencies]` entry of `fraiseql-wire`
+(`Cargo.toml:37`) and an optional one of `fraiseql-db`, so it **is** in the default build.
+The acceptance previously recorded "DEV-dependency only … no production runtime exposure",
+which was false (#1137). It stands anyway — a deprecated crate in the build is a maintenance
+risk, not an attack path — but on those grounds, not the old ones.
 
-**Review action by 2026-06-15**:
+**Blocked on**: `bollard` migrating off `pem` 0.x upstream, and on `fraiseql-wire` moving its
+own PEM parsing to `rustls-pki-types`. The second is in FraiseQL's hands and is the real
+resolution path.
 
-1. Check `aws-sdk-s3` changelog for rustls 0.23 migration
-2. If migrated: upgrade `aws-sdk-s3` and remove the `[[bans.skip]]` entries for
-   `hyper-rustls 0.24.2`, `tokio-rustls 0.24.1`, `rustls 0.21.12`
-3. If not migrated: evaluate pinning the aws-sdk feature behind a more restrictive
-   opt-in or sourcing an alternative S3 client
+**Review action by 2026-10-01**: migrate `fraiseql-wire` off `rustls-pemfile`, or re-accept
+with the maintenance risk stated.
+
+### RUSTSEC-2026-0098 / -0099 / -0104 (rustls-webpki 0.101.7)
+
+**Root cause**: `aws-smithy-http-client` pulls `rustls 0.21`, which pulls
+`rustls-webpki 0.101.7` — two name-constraint bugs and a CRL-parsing panic.
+
+**Status**: `feature-gated:aws-s3`. Verified by construction, not assertion: with default
+features `cargo tree -i rustls-webpki@0.101.7 -e normal` does not resolve the package at all,
+and the default build carries only `rustls-webpki@0.103.13` via `rustls 0.23`. All three
+defects are certificate-**validation** bugs, reachable only on a TLS handshake an `aws-*`
+client makes against a hostile or misissued chain — an operator who opted into S3 or Kinesis
+*and* whose AWS endpoint is already being impersonated. They are not reachable by a FraiseQL
+client.
+
+**Blocked on**: the aws stack reaching rustls 0.23. **Ruled out — do not retry**: the #975
+coordinated bump moved `aws-sdk-kinesis` to 1.112, `aws-config` to 1.10.1, `aws-sdk-s3` to
+1.141 and `aws-smithy-http-client` to 1.3.0, and `rustls 0.21.12` survived all of it. Every
+`aws-config` HTTP-client feature (`default-https-client` / `client-hyper` / `rustls`) routes
+to `aws-smithy-runtime`'s legacy rustls-0.21 connector. The fix is a code-level custom
+`hyper-rustls 0.27` `HttpClient`, tracked as **#1111**.
+
+**Review action by 2026-12-01** — deliberately staggered off the 2026-10-01 cluster so that
+six acceptances do not lapse on one day and block every open branch at once:
+
+1. Check whether `aws-smithy-http-client` has a rustls-0.23 path
+2. If it does: upgrade and remove the `[[bans.skip]]` entries for `hyper-rustls 0.24.2`,
+   `tokio-rustls 0.24.1`, `rustls 0.21.12`
+3. If not: progress #1111, or state why the opt-in exposure remains acceptable
+
+### RUSTSEC-2026-0194 / -0195 (quick-xml DoS pair)
+
+**Root cause**: quadratic duplicate-attribute checking, and unbounded namespace-declaration
+allocation in `NsReader`.
+
+**Status**: `feature-gated:auth-saml`. `quick-xml@0.37.5` arrives via
+`samael 0.0.21 → fraiseql-auth` and is absent from the default build. A deployment that
+enables SAML SP support is parsing attacker-supplied XML assertions, so the exposure is real
+for that configuration.
+
+**Blocked on**: `samael` pinning `quick-xml` 0.37.5 with no fixed version in range.
+
+**Review action by 2026-10-01**: check for a `samael` release that relaxes the pin; otherwise
+state whether SAML SP deployments should carry a request-size limit in front of assertion
+parsing.
+
+### RUSTSEC-2026-0204 (crossbeam-epoch invalid pointer)
+
+**Root cause**: `fmt::Pointer` on an invalid `Atomic`/`Shared` dereferences it.
+
+**Status**: `default-build` — `crossbeam-epoch@0.9.18` arrives via `moka 0.12 → fraiseql-core`,
+the result cache, not via `rayon`/`criterion` dev-dependencies as previously recorded
+(#1137). Accepted on **usage** grounds: reaching the defect requires Debug-formatting an
+invalid pointer, which `moka` does not do and FraiseQL does not do.
+
+**Blocked on**: a `crossbeam-epoch` release `moka` will take.
+
+**Review action by 2026-10-01**: re-check `moka`'s dependency range for a fixed
+`crossbeam-epoch`.
 
 ## Dependency Upgrade Policy
 
@@ -96,7 +205,14 @@ The current skip list primarily falls into these categories:
 When adding a new `[[bans.skip]]` or `[[advisories.ignore]]` entry:
 
 1. Add a `reason` field explaining the root cause
-2. For advisories: include the deadline in the reason string
+2. For advisories: include the deadline in the reason string, and a
+   `# deadline: YYYY-MM-DD` comment line — `tools/check-deadlines.sh` greps for exactly that
+   spelling, and prose forms match nothing
 3. Update the "Skip entries last reviewed" date in the deny.toml header
-4. Add the entry to the table above in this document
-5. Run `cargo deny check` to confirm the entry resolves the warning
+4. Mirror the advisory id and deadline into `.cargo/audit.toml`
+5. Add the entry to the accepted-advisories table above, **with its `Exposure` value derived
+   from `cargo tree -i <crate>@<version> -e normal`** — not from what the upstream advisory
+   or the previous entry says
+6. Run `cargo deny check` to confirm the entry resolves the warning, then
+   `bash tools/check-advisory-policy-lockstep.sh` and `bash tools/check-advisory-paths.sh`
+   to confirm the three files agree and the exposure claim is true

--- a/tools/check-advisory-paths.sh
+++ b/tools/check-advisory-paths.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# check-advisory-paths.sh — fail when the published exposure claim for an accepted
+# advisory disagrees with the actual dependency graph.
+#
+# Why this exists: three of the eight acceptances in docs/dependency-risk-policy.md were
+# carried by sentences that `cargo tree` contradicts — RUSTSEC-2023-0071 claimed `rsa`
+# reached FraiseQL only through `sqlx-mysql` (removed with #374; it arrives via
+# jsonwebtoken in the DEFAULT build, #1110), RUSTSEC-2025-0134 claimed dev-dependency-only,
+# and RUSTSEC-2026-0204 claimed criterion dev-deps (#1137). Nothing checked, because
+# check-audit-lockstep.sh compares advisory IDS and both machine-read files carried the
+# same wrong story, while `cargo deny` has no opinion about whether a `reason` is true.
+#
+# This needs cargo, so it runs in the Dagger `security` leg rather than ShellGates.
+#
+# The claim lives in the policy table's `Exposure` column:
+#
+#   default-build        `cargo tree -i <crate>@<ver> -e normal` resolves it on default features
+#   feature-gated:<f>    absent on default features; present with --features <f>
+#   not-compiled         absent even with --all-features
+#
+# `-e normal` excludes dev- and build-dependency edges, so "not in the shipped binary" is
+# established by construction rather than asserted in prose.
+#
+# Overrides, for testing:
+#   ADVISORY_PATHS_DOC=<path>   read this policy document instead of the default
+set -euo pipefail
+
+# ⚠ Do NOT `cd "$(git rev-parse --show-toplevel)"` unconditionally. This runs in the
+# Dagger `security` leg, whose container mounts the source with `+ignore=[".git"]` and —
+# unlike ShellGates — never runs `git init`. `git rev-parse` fails there, and under
+# `set -e` the whole gate dies before checking anything. The sibling gate that already
+# runs in this leg (check-crypto-providers.sh) simply relies on the container workdir.
+# So: use the repo root when git can tell us, otherwise stay where we are — and let the
+# missing-file check below fail loudly if that turns out to be the wrong place.
+if repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  cd "$repo_root"
+fi
+
+doc_file="${ADVISORY_PATHS_DOC:-docs/dependency-risk-policy.md}"
+
+if [ ! -f "$doc_file" ]; then
+  echo "ERROR: policy document not found: $doc_file" >&2
+  exit 1
+fi
+
+# resolves <spec> [extra cargo args…] → prints "present" | "absent" | "error:<detail>"
+#
+# ⚠ Exit codes alone do not answer this question, and neither does grepping for "error":
+#
+#   * a crate that is in Cargo.lock but out of the resolved graph exits **0** and prints
+#     `warning: nothing to print.`  (this is what sqlx-mysql does)
+#   * a crate that is not in the graph at all exits **101** with
+#     `did not match any packages`
+#   * an UNVERSIONED spec matching two versions also exits 101, with `is ambiguous` — a
+#     naive gate reads that as "absent" and passes on precisely the advisory whose
+#     non-default status it was supposed to prove. rustls-webpki resolves to both 0.101.7
+#     and 0.103.13 in this workspace, so this is not hypothetical.
+#   * cargo colours its diagnostics, so ANSI escapes precede the word `error`.
+#
+# So: discriminate on the tree's ROOT LINE (`<crate> v<version>`), and treat ambiguity as
+# a gate error rather than as absence.
+resolves() {
+  local spec="$1"; shift
+  local name="${spec%@*}"
+  local out rc
+  set +e
+  out="$(cargo tree -i "$spec" -e normal "$@" 2>&1)"
+  rc=$?
+  set -e
+
+  if printf '%s\n' "$out" | grep -qE 'is ambiguous'; then
+    printf 'error:ambiguous spec %s — name the exact version' "$spec"
+    return
+  fi
+  if [ "$rc" -eq 0 ] && printf '%s\n' "$out" | grep -qE "^${name} v[0-9]"; then
+    printf 'present'
+    return
+  fi
+  if [ "$rc" -eq 0 ] || printf '%s\n' "$out" | grep -qE 'did not match any packages'; then
+    printf 'absent'
+    return
+  fi
+  printf 'error:cargo tree exited %s for %s' "$rc" "$spec"
+}
+
+status=0
+checked=0
+
+# Rows are `| RUSTSEC-… | `crate@version` | path | exposure | mitigation | date |`.
+while IFS=$'\t' read -r id spec exposure; do
+  [ -z "$id" ] && continue
+  checked=$((checked + 1))
+
+  case "$exposure" in
+    default-build)
+      got="$(resolves "$spec")"
+      case "$got" in
+        present) ;;
+        absent)
+          echo "ERROR: $id claims 'default-build' but $spec is absent from the default build."
+          status=1 ;;
+        error:*)
+          echo "ERROR: $id — ${got#error:}"
+          status=1 ;;
+      esac
+      ;;
+    not-compiled)
+      got="$(resolves "$spec" --all-features)"
+      case "$got" in
+        absent) ;;
+        present)
+          echo "ERROR: $id claims 'not-compiled' but $spec resolves with --all-features."
+          status=1 ;;
+        error:*)
+          echo "ERROR: $id — ${got#error:}"
+          status=1 ;;
+      esac
+      ;;
+    feature-gated:*)
+      feature="${exposure#feature-gated:}"
+      if [ -z "$feature" ]; then
+        echo "ERROR: $id — 'feature-gated:' with no feature named."
+        status=1
+        continue
+      fi
+      got_default="$(resolves "$spec")"
+      case "$got_default" in
+        error:*)
+          echo "ERROR: $id — ${got_default#error:}"
+          status=1
+          continue ;;
+        present)
+          echo "ERROR: $id claims 'feature-gated:$feature' but $spec is in the DEFAULT build."
+          status=1
+          continue ;;
+      esac
+      # The feature is declared on fraiseql-server for every advisory here; the gate
+      # enables it there rather than guessing an owner from the feature name.
+      got_feature="$(resolves "$spec" --features "fraiseql-server/$feature")"
+      case "$got_feature" in
+        present) ;;
+        absent)
+          echo "ERROR: $id claims 'feature-gated:$feature' but $spec does not appear with that feature enabled."
+          echo "       Either the feature name is wrong or the acceptance is for a crate nothing pulls."
+          status=1 ;;
+        error:*)
+          echo "ERROR: $id — ${got_feature#error:}"
+          status=1 ;;
+      esac
+      ;;
+    *)
+      echo "ERROR: $id has an unrecognised Exposure value '$exposure'."
+      echo "       Expected: default-build | feature-gated:<feature> | not-compiled"
+      status=1
+      ;;
+  esac
+done < <(awk -F'|' '
+  /^\| *RUSTSEC-[0-9]{4}-[0-9]{4,}/ {
+    id = $2; gsub(/[^A-Z0-9-]/, "", id)
+    spec = $3; gsub(/[` \t]/, "", spec)
+    # Named `exposure`, not `exp`: exp is an awk builtin and assigning to it is a
+    # syntax error. No apostrophes in this block — it is inside a single-quoted string.
+    exposure = $5; gsub(/[` \t]/, "", exposure)
+    print id "\t" spec "\t" exposure
+  }
+' "$doc_file")
+
+if [ "$checked" -eq 0 ]; then
+  # A parser that silently matches nothing reports success for an empty check — the
+  # fabricated-success shape this whole family of gates exists to close.
+  echo "ERROR: no accepted-advisory rows found in $doc_file — the table format changed" >&2
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: all $checked published advisory exposure claims match the dependency graph."
+fi
+exit "$status"

--- a/tools/check-audit-lockstep.sh
+++ b/tools/check-audit-lockstep.sh
@@ -1,42 +1,137 @@
 #!/usr/bin/env bash
-# check-audit-lockstep.sh — fail if deny.toml and .cargo/audit.toml drift apart.
+# check-audit-lockstep.sh — fail if the three files that record accepted advisories
+# drift apart: deny.toml, .cargo/audit.toml, and docs/dependency-risk-policy.md.
 #
-# Background: deny.toml (cargo-deny, the Dagger security gate) and
-# .cargo/audit.toml (cargo-audit, the `make audit` gate) each carry an
-# [advisories].ignore list. When an advisory is accepted in one but not the
-# other, `make audit` / `make security` exit non-zero on a clean tree while CI
-# stays green — training developers to ignore the failure. This gate requires
-# the two ignore sets to match exactly.
+# Background: deny.toml (cargo-deny, the Dagger security gate) and .cargo/audit.toml
+# (cargo-audit, the `make audit` gate) each carry an [advisories].ignore list. When an
+# advisory is accepted in one but not the other, `make audit` / `make security` exit
+# non-zero on a clean tree while CI stays green — training developers to ignore the
+# failure.
+#
+# ⚠ Extended 2026-08-16 to a THIRD file (#1110). The two-file check passed for months
+# while the published policy — the only one of the three that users and auditors read —
+# listed **four** of the eight accepted advisories and carried three deadlines that
+# disagreed with deny.toml, two of them reading as already lapsed. Both machine-read
+# files agreed with each other, which is exactly why comparing only those two could not
+# see it.
+#
+# What this gate does NOT check is whether a stated dependency path is true; that is
+# tools/check-advisory-paths.sh, which needs cargo and so runs in the security leg.
+#
+# Overrides, for testing:
+#   LOCKSTEP_DENY=<path> LOCKSTEP_AUDIT=<path> LOCKSTEP_DOC=<path>
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
+
+deny_file="${LOCKSTEP_DENY:-deny.toml}"
+audit_file="${LOCKSTEP_AUDIT:-.cargo/audit.toml}"
+doc_file="${LOCKSTEP_DOC:-docs/dependency-risk-policy.md}"
+
+for f in "$deny_file" "$audit_file" "$doc_file"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: lockstep scan target not found: $f" >&2
+    exit 1
+  fi
+done
 
 # Extract the double-quoted RUSTSEC ids from $1. In deny.toml these are the
 # `id = "RUSTSEC-…"` table fields; in audit.toml the bare `"RUSTSEC-…"` strings.
 # Prose mentions inside `reason = "…"` strings are not wrapped in their own
 # quotes, so they are not matched.
 ids_in() {
-  grep -oE '"RUSTSEC-[0-9]{4}-[0-9]{4,}"' "$1" | tr -d '"' | sort -u
+  grep -oE '"RUSTSEC-[0-9]{4}-[0-9]{4,}"' "$1" | tr -d '"' | sort -u || true
 }
 
-deny_ids="$(ids_in deny.toml)"
-audit_ids="$(ids_in .cargo/audit.toml)"
+# The published table's rows: `| RUSTSEC-… | crate | path | exposure | mitigation | date |`.
+# Anchored at the line start so prose mentioning an id elsewhere in the document is not
+# mistaken for an acceptance row.
+doc_ids() {
+  grep -oE '^\| *RUSTSEC-[0-9]{4}-[0-9]{4,}' "$doc_file" \
+    | grep -oE 'RUSTSEC-[0-9]{4}-[0-9]{4,}' | sort -u || true
+}
 
-only_deny="$(comm -23 <(printf '%s\n' "$deny_ids") <(printf '%s\n' "$audit_ids"))"
-only_audit="$(comm -13 <(printf '%s\n' "$deny_ids") <(printf '%s\n' "$audit_ids"))"
+# id<TAB>deadline for deny.toml. Each `{id = …, reason = "… Deadline YYYY-MM-DD …"}`
+# entry is one line, so the id and its date are read from the same line — no positional
+# guessing from the surrounding comment blocks, which deliberately cover several ids at
+# once (0098/0099/0104 share one, 0194/0195 share another).
+deny_deadlines() {
+  grep -oE '\{ *id *= *"RUSTSEC-[0-9]{4}-[0-9]{4,}".*' "$deny_file" \
+    | sed -nE 's/.*"(RUSTSEC-[0-9]{4}-[0-9]{4,})".*[Dd]eadline[: ]+([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1\t\2/p' \
+    | sort -u || true
+}
+
+# id<TAB>deadline for the published table: last non-empty cell of the row.
+doc_deadlines() {
+  awk -F'|' '
+    /^\| *RUSTSEC-[0-9]{4}-[0-9]{4,}/ {
+      id = $2; gsub(/[^A-Z0-9-]/, "", id)
+      for (i = NF; i > 0; i--) {
+        cell = $i
+        gsub(/^[ \t]+|[ \t]+$/, "", cell)
+        if (cell ~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) { print id "\t" cell; break }
+      }
+    }
+  ' "$doc_file" | sort -u
+}
+
+deny_ids="$(ids_in "$deny_file")"
+audit_ids="$(ids_in "$audit_file")"
+policy_ids="$(doc_ids)"
 
 status=0
-if [ -n "$only_deny" ]; then
-  echo "ERROR: advisories ignored in deny.toml but NOT in .cargo/audit.toml:"
-  printf '%s\n' "$only_deny" | sed 's/^/  - /'
-  status=1
-fi
-if [ -n "$only_audit" ]; then
-  echo "ERROR: advisories ignored in .cargo/audit.toml but NOT in deny.toml:"
-  printf '%s\n' "$only_audit" | sed 's/^/  - /'
-  status=1
-fi
+
+report_diff() {
+  local label_a="$1" label_b="$2" a="$3" b="$4"
+  local only
+  only="$(comm -23 <(printf '%s\n' "$a") <(printf '%s\n' "$b"))"
+  if [ -n "$only" ]; then
+    echo "ERROR: advisories accepted in ${label_a} but NOT in ${label_b}:"
+    printf '%s\n' "$only" | sed 's/^/  - /'
+    status=1
+  fi
+}
+
+report_diff "$deny_file" "$audit_file" "$deny_ids" "$audit_ids"
+report_diff "$audit_file" "$deny_file" "$audit_ids" "$deny_ids"
+report_diff "$deny_file" "$doc_file" "$deny_ids" "$policy_ids"
+report_diff "$doc_file" "$deny_file" "$policy_ids" "$deny_ids"
+
+# ── Deadlines: the published date must be the one deny.toml carries ──────────
+#
+# ⚠ Do NOT solve this by adding the doc to DEADLINE_CHECK_FILES. check-deadlines.sh
+# greps for `# deadline: YYYY-MM-DD` COMMENT lines, which a markdown table column is
+# not — it would scan the file, match nothing, and read as coverage. With equality
+# enforced here, check-deadlines.sh's existing scan of deny.toml covers the published
+# dates transitively.
+deny_dl="$(deny_deadlines)"
+doc_dl="$(doc_deadlines)"
+
+while IFS=$'\t' read -r id date; do
+  [ -z "$id" ] && continue
+  want="$(printf '%s\n' "$deny_dl" | awk -F'\t' -v i="$id" '$1 == i {print $2}')"
+  if [ -z "$want" ]; then
+    echo "ERROR: ${doc_file} publishes a deadline for ${id} but ${deny_file} states none."
+    echo "       Every acceptance needs a 'Deadline YYYY-MM-DD' in its deny.toml reason."
+    status=1
+  elif [ "$want" != "$date" ]; then
+    echo "ERROR: deadline mismatch for ${id}: ${doc_file} says ${date}, ${deny_file} says ${want}."
+    echo "       deny.toml is the source of truth — correct the published table."
+    status=1
+  fi
+done < <(printf '%s\n' "$doc_dl")
+
+# An accepted advisory with no published deadline at all: the row exists but its date
+# cell is missing or malformed, which would otherwise slip through the loop above.
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  if [ -z "$(printf '%s\n' "$doc_dl" | awk -F'\t' -v i="$id" '$1 == i {print $2}')" ]; then
+    echo "ERROR: ${doc_file} lists ${id} without a YYYY-MM-DD deadline cell."
+    status=1
+  fi
+done < <(printf '%s\n' "$policy_ids")
 
 if [ "$status" -eq 0 ]; then
-  echo "OK: deny.toml and .cargo/audit.toml advisory ignore lists are in lockstep."
+  n="$(printf '%s\n' "$deny_ids" | grep -cE '^RUSTSEC-' || true)"
+  echo "OK: ${n} accepted advisories agree across ${deny_file}, ${audit_file} and ${doc_file} (ids and deadlines)."
 fi
 exit "$status"


### PR DESCRIPTION
**P02 of the v2.15.0 release program.** Blocker **B2**: the published dependency-risk policy
asserted things about this tree that are false, and nothing compared it to anything.

## The defect that was known

`docs/dependency-risk-policy.md` published:

> RUSTSEC-2023-0071 | `rsa` | `sqlx-mysql` (lockfile-only; never compiled) | MySQL support
> removed in v2.15.0; crate not built into any artifact

```
$ cargo tree -i rsa -p fraiseql-auth
rsa v0.9.10
└── jsonwebtoken v10.4.0
    └── fraiseql-auth v2.14.1          # the DEFAULT build

$ cargo tree -i sqlx-mysql --all-features
warning: nothing to print.             # MySQL left with #374
```

and `session_postgres.rs:175` signs access tokens with an RSA **private** key — an
attacker-triggerable private-key operation, the shape Marvin targets. `deny.toml` was
corrected on 2026-08-13; the document users and auditors read was not.

## Two defects that were not

Checking the other seven acceptances the same way — `cargo tree -e normal`, so
dev-dependency edges are excluded by construction — found **two more false justifications**,
and in both the false sentence was the load-bearing one. Filed as **#1137** and fixed here.

| Advisory | Recorded grounds | Reality |
|---|---|---|
| RUSTSEC-2025-0134 | "DEV-dependency only (fraiseql-wire test deps / bollard) — no production runtime exposure" | `rustls-pemfile@2.2.0` is a direct `[dependencies]` entry of `fraiseql-wire` (`Cargo.toml:37`), reaching `fraiseql-server` in the default build. `bollard` is not on the path at all |
| RUSTSEC-2026-0204 | "Transitive via rayon (criterion dev-deps)" | `crossbeam-epoch@0.9.18` arrives via `moka 0.12 → fraiseql-core`, the result cache |

**Both acceptances still stand** — one is a deprecated-crate maintenance advisory with no
exploit path, the other triggers only on Debug-formatting an invalid pointer, which `moka`
does not do. But they now stand on grounds that are true. An acceptance whose stated grounds
are false cannot be reviewed: the next reader re-approves it on text that does not describe
the software.

## Also fixed: the policy contradicted itself

Acceptance criterion 2 read *"The vulnerable code path is not reachable in default
configurations"* — which **three of the eight current acceptances violate**. It now names the
two arguments an acceptance may actually make: **absence** from the build, or **usage** that
never reaches the defect, with each row required to say which. An absence claim `cargo tree`
contradicts may not carry an acceptance.

Plus: all **eight** advisories are published (was four — -0104, -0194, -0195 and -0204 were
accepted but unpublished), and **three deadlines** corrected to the `deny.toml` values
(2026-07-01 → 2026-10-01; both `rustls-webpki` rows 2026-06-15 → 2026-12-01). A reader saw
three lapsed acceptances that were not lapsed.

## The gates

**`check-audit-lockstep.sh`, extended from two files to three** (ShellGates). It compared
`deny.toml` and `.cargo/audit.toml` — both of which carried the same wrong story, so they
agreed. That is exactly why comparing only the two machine-read files could not see any of
this. It now also compares the published policy, on ids **and** deadlines. Extended rather
than paralleled, per the phase: one gate, one place to look.

**`check-advisory-paths.sh`, new** (Dagger `security` leg — needs cargo). Each row declares
`default-build` / `feature-gated:<f>` / `not-compiled`, checked against `cargo tree -e normal`.

### Three traps it had to be built around, each measured rather than assumed

- **Exit codes do not answer the question.** A crate in `Cargo.lock` but out of the resolved
  graph exits **0** with `warning: nothing to print.`; a crate absent entirely exits **101**.
  The gate discriminates on the tree's root line — not the exit code, and not by grepping for
  `error`, which cargo colours and also prints on ordinary failures.
- **An unversioned spec is ambiguous and also exits 101.** `rustls-webpki` resolves to both
  0.101.7 and 0.103.13 here, so a naive gate reads 101 as "absent" and passes on precisely the
  advisory whose non-default status it was meant to prove. Ambiguity is a gate error; every
  row names its version.
- **A parser that matches nothing must fail**, not report success over zero rows. It caught
  its own first bug: `exp` is an awk builtin, the parser died, and the guard turned what would
  have been a silent green into a loud red.

## Red proofs — five, each reverted by reverse string-swap

```
1. RUSTSEC-2023-0071 default-build → not-compiled (the original false claim's shape):
   ERROR: RUSTSEC-2023-0071 claims 'not-compiled' but rsa@0.9.10 resolves with --all-features.

2. unversioned spec, feature-gated row:
   ERROR: RUSTSEC-2026-0098 claims 'feature-gated:aws-s3' but rustls-webpki is in the DEFAULT build.

3. unversioned spec, not-compiled row (exercises the ambiguity branch — not dead code):
   ERROR: RUSTSEC-2026-0104 — ambiguous spec rustls-webpki — name the exact version

4. published deadline disagreeing with deny.toml:
   ERROR: deadline mismatch for RUSTSEC-2026-0194: docs/… says 2026-06-15, deny.toml says 2026-10-01.

5. a row dropped from the published table:
   ERROR: advisories accepted in deny.toml but NOT in docs/dependency-risk-policy.md:
     - RUSTSEC-2026-0204
```

## Red-proven in the container's shape, not only locally

```
$ dagger call advisory-paths --source=.
OK: all 8 published advisory exposure claims match the dependency graph.

# with RUSTSEC-2025-0134 mutated to claim feature-gated:
✘ withExec bash tools/check-advisory-paths.sh   ERROR
ERROR: RUSTSEC-2025-0134 claims 'feature-gated:aws-s3' but rustls-pemfile@2.2.0 is in the DEFAULT build.
```

⚠ This mattered. The `security` leg mounts source with `+ignore=[".git"]` and, unlike
ShellGates, never runs `git init` — an unconditional `cd "$(git rev-parse --show-toplevel)"`
dies there under `set -e` before checking anything. The script uses the repo root when git can
supply it and the container workdir otherwise, and a wrong cwd is a loud missing-file failure
(verified from a non-repo directory).

## Scope

#1110 asks that the acceptance stop resting on a false justification. **Whether to keep
accepting RUSTSEC-2023-0071 at all is a deadline-bound decision** already tracked by
`check-deadlines.sh` (2026-10-01) and is deliberately not made here — the review action is
rewritten to name the real choice (accept the sidechannel on RS256 signing, or move RS256
issuance off `jsonwebtoken`'s `rsa` backend) instead of "check whether sqlx 0.9 is out", which
is irrelevant to the real dependency edge.

## Verification

```
✅ bash tools/check-audit-lockstep.sh    OK: 8 accepted advisories agree across all three
                                          files (ids and deadlines)
✅ bash tools/check-advisory-paths.sh    OK: all 8 exposure claims match the graph
✅ dagger call advisory-paths            green in the real security container
✅ cargo deny check                      advisories ok, bans ok, licenses ok, sources ok
✅ bash tools/check-deadlines.sh         OK — no date moved in deny.toml; the doc copied its dates
✅ bash tools/check-changelog-issues.sh  OK: 261 closed since v2.14.1, all documented or exempt
✅ make preflight                        green
✅ pre-commit run --from-ref dev --to-ref HEAD   all hooks pass, no autofix rewrote anything
✅ shellcheck both scripts               clean
✅ cd .dagger && go build ./... && gofmt -l .   clean
```

Closes #1110
Closes #1137
