### PR TITLE
fix(deploy): deploy artifacts carry the released version, and the chart's default image exists

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -256,6 +256,9 @@ func (m *FraiseqlCi) ShellGates(
 		"bash tools/check-route-syntax.sh",
 		"bash tools/check-guard-parity.sh",
 		"bash tools/check-deploy-security.sh",
+		// Deploy artifacts must name the version being released, and the chart's
+		// default image must be one this project publishes (#1129).
+		"bash tools/check-deploy-versions.sh",
 		"bash tools/check-internal-flag-sites.sh",
 		"bash tools/check-value-json-seam.sh",
 		"bash tools/check-graphql-parse-sites.sh",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4098,6 +4098,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existed in this example (`orders`, `products`, `users` against fixtures creating
   `tb_order`, `tb_product`, `tb_user`); they now use the real names and join through the
   surrogate keys as the Trinity schema requires.
+- **The Helm chart's default image exists, and the deploy artifacts name the released
+  version (#1129).** `values.yaml` shipped `repository: fraiseql`, which resolves to
+  `docker.io/library/fraiseql` — the Docker Hub **official-images** namespace, which this
+  project does not and cannot publish to — so `helm install` on the shipped defaults pulled
+  nothing at all. It is now `ghcr.io/fraiseql/server`. Three version strings were also frozen
+  years behind the product because `tools/release.sh` bumped the crates and the SDKs and no
+  deployment artifact: the Dockerfile's `org.opencontainers.image.version` label (2.1.1), the
+  chart's `version`/`appVersion` (2.1.1/2.1.0) and `image.tag` (2.8.0), against a 2.14.1
+  release. `release.sh` now bumps all of them, `Chart.yaml` records that `version` and
+  `appVersion` move in lockstep — the convention that was never written down, which is how
+  they drifted apart — and `tools/check-deploy-versions.sh` fails in ShellGates if any of
+  them drifts again.
 - **These release notes are complete, and a gate keeps them that way (#1127).** 258 issues
   were closed by `Closes #N` since v2.14.1 and **48 appeared nowhere in this file** —
   including the entire secrets/auth/webhooks security wave above, whose bullets are

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN TARGET=$(cat /tmp/rust_target.txt) && \
 # Stage 2: Runtime
 FROM debian:bookworm-slim AS runtime
 
-LABEL org.opencontainers.image.version="2.1.1" \
+LABEL org.opencontainers.image.version="2.14.1" \
       org.opencontainers.image.vendor="FraiseQL" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.description="FraiseQL GraphQL execution engine" \

--- a/Makefile
+++ b/Makefile
@@ -496,6 +496,15 @@ lint-empty-tests:
 lint-deploy-security:
 	@bash tools/check-deploy-security.sh
 
+# Gate: the Dockerfile's OCI version label, the Helm chart's version/appVersion and
+# values.yaml's image.tag must equal the workspace version, and the chart's default
+# image must be one this project publishes. They sat at 2.1.1 / 2.1.0 / 2.8.0 against a
+# 2.14.1 product, and `repository: fraiseql` resolved to an image that does not exist
+# (#1129) — tools/release.sh now bumps them, and this is what says so.
+.PHONY: lint-deploy-versions
+lint-deploy-versions:
+	@bash tools/check-deploy-versions.sh
+
 # Gate: pin the set of production files that READ TypeDefinition.internal (#665), so a
 # property-named flag cannot silently grow new consumers. See tools/check-internal-flag-sites.sh.
 .PHONY: lint-internal-flag
@@ -560,7 +569,7 @@ lint-sdk-dead-surface:
 # test suite or service-backed integration tests — those are `make test` and the
 # separate Dagger test/integration legs.
 .PHONY: preflight
-preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
+preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-deploy-versions lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
 	@echo "=== preflight: lint-unwrap (UNWRAP_ALLOW_LIMIT=3) ==="
 	@$(MAKE) --no-print-directory lint-unwrap UNWRAP_ALLOW_LIMIT=3
 	@echo "=== preflight: check-test-imports ==="

--- a/deploy/kubernetes/helm/fraiseql/Chart.yaml
+++ b/deploy/kubernetes/helm/fraiseql/Chart.yaml
@@ -2,8 +2,14 @@ apiVersion: v2
 name: fraiseql
 description: FraiseQL GraphQL execution engine
 type: application
-version: 2.1.1
-appVersion: "2.1.0"
+# CONVENTION (#1129): `version` (the chart's own packaging version) and `appVersion`
+# (the application it deploys) move in LOCKSTEP with the FraiseQL release, both set by
+# tools/release.sh. The alternative — moving the chart version only when the templates
+# change — is defensible, but it was never written down, which is how these two drifted
+# apart to 2.1.1 / 2.1.0 while the product shipped 2.14.1 and nobody could tell whether
+# that was deliberate. tools/check-deploy-versions.sh enforces the lockstep.
+version: 2.14.1
+appVersion: "2.14.1"
 keywords:
   - graphql
   - database

--- a/deploy/kubernetes/helm/fraiseql/values.yaml
+++ b/deploy/kubernetes/helm/fraiseql/values.yaml
@@ -4,10 +4,17 @@
 
 # Image configuration
 image:
-  repository: fraiseql
+  # Must be an image this project publishes. `fraiseql` alone resolved to
+  # docker.io/library/fraiseql — the Docker Hub official-images namespace — so the
+  # shipped defaults pulled nothing at all (#1129). The Docker Hub mirror is
+  # `fraiseql/server`; tools/check-deploy-versions.sh accepts either.
+  repository: ghcr.io/fraiseql/server
   pullPolicy: IfNotPresent
-  # Pinned for reproducible deploys (never "latest"). Bump on upgrade.
-  tag: "2.8.0"
+  # Pinned for reproducible deploys (never "latest"), and bumped by tools/release.sh —
+  # not by remembering. It sat three releases stale because the comment below asked for
+  # a manual step nobody had a reason to take. tools/check-deploy-versions.sh (ShellGates)
+  # fails if it drifts from the workspace version again.
+  tag: "2.14.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/tools/check-deploy-versions.sh
+++ b/tools/check-deploy-versions.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-deploy-versions.sh — fail when a shipped deployment artifact names a version
+# that is not the one being released, or an image that is not published.
+#
+# Background (#1129): `tools/release.sh` bumped the workspace, the crates, the fuzz
+# crates and the Rust/Python/TypeScript SDK manifests — and no deployment artifact. So
+# the Dockerfile's OCI version label sat at 2.1.1 and the Helm chart at 2.1.1/2.1.0
+# while the product shipped 2.14.1, and `values.yaml` pinned `fraiseql:2.8.0`.
+#
+# Worse than stale: `repository: fraiseql` resolves to `docker.io/library/fraiseql`, the
+# Docker Hub OFFICIAL-IMAGES namespace, which this project does not and cannot publish
+# to. `helm install` on the shipped defaults pulled nothing at all.
+#
+# Nothing caught it. `helm.yml` is workflow_dispatch:-only and only lints — and a lint
+# never resolves an image. `docker-build.yml` is tag-only, so the label is never
+# inspected on a branch.
+#
+# Pure grep/sed, no toolchain, no git history → Dagger ShellGates.
+#
+# Overrides, for testing:
+#   DEPLOY_VERSIONS_ROOT=<dir>   treat this directory as the repo root
+set -euo pipefail
+
+# ShellGates runs `git init -q .`, so rev-parse works there; the override exists for the
+# unit test, which builds a fixture tree in a temp dir.
+if [ -n "${DEPLOY_VERSIONS_ROOT:-}" ]; then
+  cd "$DEPLOY_VERSIONS_ROOT"
+elif repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  cd "$repo_root"
+fi
+
+CARGO_TOML="Cargo.toml"
+DOCKERFILE="Dockerfile"
+CHART="deploy/kubernetes/helm/fraiseql/Chart.yaml"
+VALUES="deploy/kubernetes/helm/fraiseql/values.yaml"
+
+for f in "$CARGO_TOML" "$DOCKERFILE" "$CHART" "$VALUES"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: deploy-version scan target not found: $f" >&2
+    exit 1
+  fi
+done
+
+# ⚠ Anchored, and only the [workspace.package] one. An unanchored `version =` match
+# would happily be satisfied by the first dependency pin in the file.
+version="$(grep -m1 '^version = ' "$CARGO_TOML" | sed -E 's/^version = "([^"]+)".*/\1/')"
+if [ -z "$version" ]; then
+  echo "ERROR: could not read the workspace version from $CARGO_TOML" >&2
+  exit 1
+fi
+
+# Images this repository actually publishes (.github/workflows/docker-build.yml:
+# ghcr.io/<owner>/{server,server-full,tutorial} plus the Docker Hub mirrors). The chart
+# deploys the server, so those are the only two acceptable defaults; the runbooks
+# (docs/runbooks/01-deployment.md) use the ghcr form.
+PUBLISHED_IMAGES="ghcr.io/fraiseql/server fraiseql/server"
+
+status=0
+
+fail() {
+  echo "ERROR: $1"
+  status=1
+}
+
+# ── Dockerfile OCI version label ─────────────────────────────────────────────
+# ⚠ Anchored on the LABEL key. `Dockerfile:8` is `FROM rust:1.94.1-slim`, and a
+# version-shaped match anywhere in the file would rewrite the toolchain pin — which is
+# #1107's subject, not this gate's.
+label="$(grep -oE 'org\.opencontainers\.image\.version="[^"]+"' "$DOCKERFILE" \
+  | head -1 | sed -E 's/.*="([^"]+)"/\1/' || true)"
+if [ -z "$label" ]; then
+  fail "$DOCKERFILE has no org.opencontainers.image.version label."
+elif [ "$label" != "$version" ]; then
+  fail "$DOCKERFILE org.opencontainers.image.version is '$label', workspace is '$version'."
+fi
+
+# ── Helm chart ───────────────────────────────────────────────────────────────
+# Lockstep: `version` (the chart's own packaging version) and `appVersion` (the app it
+# deploys) both track the release. Recorded in the chart header; the alternative —
+# moving the chart version only when templates change — is defensible but was never
+# stated, which is how these drifted to 2.1.1/2.1.0 unnoticed.
+chart_version="$(grep -oE '^version: *[^ ]+' "$CHART" | head -1 | sed -E 's/^version: *//' | tr -d '"' || true)"
+chart_app="$(grep -oE '^appVersion: *[^ ]+' "$CHART" | head -1 | sed -E 's/^appVersion: *//' | tr -d '"' || true)"
+
+[ "$chart_version" = "$version" ] || fail "$CHART version is '$chart_version', workspace is '$version'."
+[ "$chart_app" = "$version" ] || fail "$CHART appVersion is '$chart_app', workspace is '$version'."
+
+# ── values.yaml ──────────────────────────────────────────────────────────────
+image_tag="$(grep -oE '^ *tag: *"?[^"]+"?' "$VALUES" | head -1 | sed -E 's/^ *tag: *//' | tr -d '"' || true)"
+image_repo="$(grep -oE '^ *repository: *"?[^"]+"?' "$VALUES" | head -1 | sed -E 's/^ *repository: *//' | tr -d '"' || true)"
+
+[ "$image_tag" = "$version" ] || fail "$VALUES image.tag is '$image_tag', workspace is '$version'."
+
+repo_ok=0
+for img in $PUBLISHED_IMAGES; do
+  [ "$image_repo" = "$img" ] && repo_ok=1
+done
+if [ "$repo_ok" -ne 1 ]; then
+  fail "$VALUES image.repository is '$image_repo', which this project does not publish."
+  echo "       Published server images: $PUBLISHED_IMAGES"
+  echo "       (A bare name like 'fraiseql' resolves to docker.io/library/fraiseql —"
+  echo "        the Docker Hub official-images namespace — and pulls nothing.)"
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: deploy artifacts all name v${version}, and the chart image is a published one."
+fi
+exit "$status"

--- a/tools/lib/release_helpers.sh
+++ b/tools/lib/release_helpers.sh
@@ -143,6 +143,33 @@ bump_ts_sdk_version() {
     sed -i -E "s/^export const version = \"[^\"]*\"/export const version = \"${version}\"/" "$index_ts"
 }
 
+# Bump the version strings in the shipped deployment artifacts: the Dockerfile's OCI
+# version label, the Helm chart's `version` + `appVersion` (lockstep, see Chart.yaml's
+# header), and values.yaml's `image.tag`.
+#
+# Without this, tools/release.sh bumps the crates and the SDKs and leaves the deploy
+# artifacts frozen — which is exactly what happened: the OCI label sat at 2.1.1 and the
+# chart at 2.1.1/2.1.0 while the product shipped 2.14.1, and `helm install` on the
+# defaults pulled `docker.io/library/fraiseql:2.8.0`, an image that does not exist
+# (#1129). tools/check-deploy-versions.sh is the gate that keeps this honest.
+#
+# ⚠ Every substitution is anchored. `Dockerfile:8` is `FROM rust:1.94.1-slim`, and a
+# blanket version-shaped rewrite would silently move the toolchain pin — a different
+# concern, owned by #1107. Likewise `appVersion:` must not be caught by the `version:`
+# pattern, which is why the chart edits anchor at the start of the line.
+#
+# Usage: bump_deploy_artifacts <version> <Dockerfile> <Chart.yaml> <values.yaml>
+bump_deploy_artifacts() {
+    local version="$1" dockerfile="$2" chart="$3" values="$4"
+    # OCI label only — keyed on the label name, never on a bare version shape.
+    sed -i -E "s|org\.opencontainers\.image\.version=\"[^\"]*\"|org.opencontainers.image.version=\"${version}\"|" "$dockerfile"
+    # Chart: `^version:` and `^appVersion:` are distinct anchors; appVersion keeps its quotes.
+    sed -i -E "s/^version: .*/version: ${version}/" "$chart"
+    sed -i -E "s/^appVersion: .*/appVersion: \"${version}\"/" "$chart"
+    # values.yaml: the indented `tag:` under `image:`. The file has exactly one.
+    sed -i -E "s/^( *)tag: \"[^\"]*\"/\1tag: \"${version}\"/" "$values"
+}
+
 # Honesty gate for the SDK publish jobs: refuse to publish when the SDK manifest
 # version does not match the release version being published. This is the exact
 # frozen state — the manifest stuck at 2.1.6 while v2.3.0–v2.6.0 tags were cut —

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -101,6 +101,17 @@ bump_ts_sdk_version "$VERSION" \
     sdks/official/fraiseql-typescript/src/index.ts
 echo "      Bumped Python + TypeScript SDK manifests."
 
+# Bump the shipped deployment artifacts too. Until #1129 nothing here touched them,
+# so the Dockerfile's OCI label sat at 2.1.1 and the Helm chart at 2.1.1/2.1.0 while
+# the product shipped 2.14.1. tools/check-deploy-versions.sh (ShellGates) fails the
+# moment they drift again — including immediately after this script runs, if this
+# call is ever removed.
+bump_deploy_artifacts "$VERSION" \
+    Dockerfile \
+    deploy/kubernetes/helm/fraiseql/Chart.yaml \
+    deploy/kubernetes/helm/fraiseql/values.yaml
+echo "      Bumped Dockerfile label + Helm chart/values."
+
 echo "      Done."
 
 # ── Step 2: Update CHANGELOG.md ───────────────────────────────────────────────
@@ -161,6 +172,9 @@ RELEASE_FILES=(
     sdks/official/fraiseql-typescript/package.json
     sdks/official/fraiseql-typescript/package-lock.json
     sdks/official/fraiseql-typescript/src/index.ts
+    Dockerfile
+    deploy/kubernetes/helm/fraiseql/Chart.yaml
+    deploy/kubernetes/helm/fraiseql/values.yaml
     "$CHANGELOG"
     "$README"
 )

--- a/tools/tests/release_helpers_test.sh
+++ b/tools/tests/release_helpers_test.sh
@@ -216,6 +216,66 @@ check "bump-ts: lockfile dependency version (zod 3.22.0) untouched" \
 check "bump-ts: index.ts version constant → 2.8.0 (L-ts-version)" \
     "$(grep -c '^export const version = "2.8.0"' "$WORK/index.ts")" "1"
 
+# ── bump_deploy_artifacts (#1129) ──────────────────────────────────────────────
+#
+# The fixtures carry the neighbouring version-shaped strings that a blanket rewrite
+# would eat: the Dockerfile's `FROM rust:1.94.1-slim` toolchain pin (#1107's subject,
+# not this helper's), the chart's `appVersion` sitting next to `version`, and a
+# resource limit in values.yaml that looks nothing like a tag but shares the file.
+
+cat > "$WORK/Dockerfile" <<'EOF'
+FROM --platform=$BUILDPLATFORM rust:1.94.1-slim AS builder
+
+FROM debian:bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.version="2.1.1" \
+      org.opencontainers.image.vendor="FraiseQL"
+EOF
+
+cat > "$WORK/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: fraiseql
+type: application
+version: 2.1.1
+appVersion: "2.1.0"
+EOF
+
+cat > "$WORK/values.yaml" <<'EOF'
+image:
+  repository: ghcr.io/fraiseql/server
+  pullPolicy: IfNotPresent
+  tag: "2.8.0"
+
+resources:
+  limits:
+    memory: 2.0.0Gi
+EOF
+
+bump_deploy_artifacts 2.15.0 "$WORK/Dockerfile" "$WORK/Chart.yaml" "$WORK/values.yaml"
+
+check "bump-deploy: OCI version label → 2.15.0" \
+    "$(grep -c 'org.opencontainers.image.version="2.15.0"' "$WORK/Dockerfile")" "1"
+# The one that matters: a version-shaped sed over the Dockerfile silently moves the
+# toolchain floor, and nothing downstream would say so until a build broke.
+check "bump-deploy: FROM rust:1.94.1-slim toolchain pin untouched" \
+    "$(grep -c 'rust:1.94.1-slim' "$WORK/Dockerfile")" "1"
+check "bump-deploy: chart version → 2.15.0" \
+    "$(grep -c '^version: 2.15.0$' "$WORK/Chart.yaml")" "1"
+check "bump-deploy: chart appVersion → \"2.15.0\" (quotes kept)" \
+    "$(grep -c '^appVersion: "2.15.0"$' "$WORK/Chart.yaml")" "1"
+# `version` and `appVersion` must remain two distinct lines. A substitution that
+# collapsed them (or matched one twice) would leave a count other than 1 each.
+check "bump-deploy: chart still has exactly one version: line" \
+    "$(grep -c '^version: ' "$WORK/Chart.yaml")" "1"
+check "bump-deploy: chart still has exactly one appVersion: line" \
+    "$(grep -c '^appVersion: ' "$WORK/Chart.yaml")" "1"
+check "bump-deploy: values image.tag → 2.15.0" \
+    "$(grep -c 'tag: "2.15.0"' "$WORK/values.yaml")" "1"
+check "bump-deploy: values repository untouched" \
+    "$(grep -c 'repository: ghcr.io/fraiseql/server' "$WORK/values.yaml")" "1"
+check "bump-deploy: unrelated version-shaped value untouched" \
+    "$(grep -c 'memory: 2.0.0Gi' "$WORK/values.yaml")" "1"
+
 # ── Summary ────────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
**P03 of the v2.15.0 release program.** Recommended, does not strictly block the tag — but it
**must land before P09's `make release VERSION=` step**, or the release commit bumps everything
except the deploy artifacts and the new gate goes red on `dev` immediately after the cut.

## The defect

`tools/release.sh` bumped the workspace, the crates, the fuzz crates and the
Rust/Python/TypeScript SDK manifests — and **no deployment artifact**.

| Site | Was | Now |
|---|---|---|
| `Dockerfile:44` OCI version label | `2.1.1` | workspace version |
| `Chart.yaml` `version` | `2.1.1` | workspace version |
| `Chart.yaml` `appVersion` | `2.1.0` | workspace version |
| `values.yaml` `image.tag` | `2.8.0` | workspace version |
| `values.yaml` `image.repository` | `fraiseql` | `ghcr.io/fraiseql/server` |

The last row is the one that matters most: **`repository: fraiseql` resolves to
`docker.io/library/fraiseql`** — the Docker Hub *official-images* namespace, which this project
does not and cannot publish to. The real names are `ghcr.io/fraiseql/{server,server-full,tutorial}`
and their Docker Hub mirrors. `helm install` on the shipped defaults pulled **nothing at all**.

Nothing caught any of it. `helm.yml` is `workflow_dispatch:`-only and only lints — and a lint
never resolves an image. `docker-build.yml` is tag-only, so the label is never inspected on a
branch.

## RED, before the fix

```
$ bash tools/check-deploy-versions.sh
ERROR: Dockerfile org.opencontainers.image.version is '2.1.1', workspace is '2.14.1'.
ERROR: …/Chart.yaml version is '2.1.1', workspace is '2.14.1'.
ERROR: …/Chart.yaml appVersion is '2.1.0', workspace is '2.14.1'.
ERROR: …/values.yaml image.tag is '2.8.0', workspace is '2.14.1'.
ERROR: …/values.yaml image.repository is 'fraiseql', which this project does not publish.
       Published server images: ghcr.io/fraiseql/server fraiseql/server
exit=1
```

Post-fix revert-check — `appVersion` set back to `2.1.0` — fails naming exactly that site.

## The decision the phase asked to be made explicitly

`Chart.yaml` has two fields with different meanings. This PR takes **lockstep**: `version` (the
chart's own packaging version) and `appVersion` (the app it deploys) both track the release, set
by `release.sh`. Recorded in the chart's header, because the *absence* of a written convention is
how they drifted to 2.1.1/2.1.0 with nobody able to say whether it was deliberate.

## A helper test that was not a test

Eight new cases in `release_helpers_test.sh`, whose fixtures deliberately carry the neighbouring
version-shaped strings a blanket rewrite would eat.

**Red-proven:** replacing the label substitution with a blanket
`s|[0-9]+\.[0-9]+\.[0-9]+|$version|g` still satisfies the label assertion and fails

```
FAIL: bump-deploy: FROM rust:1.94.1-slim toolchain pin untouched — expected [1], got [0]
```

That is the whole point — a version-shaped sed over the Dockerfile silently moves the toolchain
floor (#1107's subject, not this one's), and nothing downstream would say so until a build broke.
Dropping the quotes from `appVersion` likewise reddens its own assertion.

⚠ **One assertion was removed because it could not fail.** "appVersion not clobbered by the
`version:` anchor" survived unanchoring the substitution to `s/version: .*/…/`, because
`version:` never matches `appVersion:` regardless — the capital V is not in the pattern. It is
replaced by two that do discriminate: exactly one `^version:` and one `^appVersion:` line must
remain.

## The label was checked on a real image, not inferred

```
$ docker build -t fraiseql-label-check:dev .
$ docker inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' …
2.14.1
```

The readiness pass measured `2.1.1` from this same instruction, so this is a before/after on the
built artifact rather than on the source line.

## Verification

```
✅ bash tools/check-deploy-versions.sh   OK — all artifacts name v2.14.1, image is published
✅ make test-release-tooling             39 checks (9 new)
✅ make preflight                        green, and the gate EXECUTES in it:
                                          "OK: deploy artifacts all name v2.14.1…"
✅ docker build + docker inspect         label reads 2.14.1 on the built image
✅ both chart files parse as YAML; version/appVersion read back as strings
✅ pre-commit run --from-ref dev --to-ref HEAD   clean, no autofix rewrote anything
✅ shellcheck tools/check-deploy-versions.sh     clean
✅ cd .dagger && go build ./... && gofmt -l .    clean
✅ bash tools/check-changelog-issues.sh          OK
```

⚠ **`make helm-lint` could not run locally** — `helm` is not installed on this machine. The
hosted `helm.yml` workflow was dispatched on this branch instead:
https://github.com/fraiseql/fraiseql/actions/runs/31961576713 — its `headSha` was confirmed
equal to the pushed HEAD (`cf3c240fb`) before trusting it, since a dispatched run uses the
**remote** ref and can otherwise be green while testing something else.

## Out of scope, already filed

**#1107** owns the adjacent half — coupling `FROM rust:<v>` to `rust-version`. Deliberately not
touched here beyond ensuring this PR's bump cannot move that pin. **#1133** (both Docker stages
install libpq although nothing links it) is an image-size change and not a release-branch change.

Closes #1129
