### PR TITLE
fix(ci): the fuzz matrix names the crate each target actually lives in

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -259,6 +259,9 @@ func (m *FraiseqlCi) ShellGates(
 		// Deploy artifacts must name the version being released, and the chart's
 		// default image must be one this project publishes (#1129).
 		"bash tools/check-deploy-versions.sh",
+		// Every fuzz.yml matrix row must name a target that exists in the crate it
+		// names. One-directional: targets on disk need not be in the matrix (#1128).
+		"bash tools/check-fuzz-targets.sh",
 		"bash tools/check-internal-flag-sites.sh",
 		"bash tools/check-value-json-seam.sh",
 		"bash tools/check-graphql-parse-sites.sh",

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,7 +61,6 @@ jobs:
           - { crate: fraiseql-core,       target: graphql_parser }
           - { crate: fraiseql-core,       target: complexity }
           - { crate: fraiseql-core,       target: schema_deser }
-          - { crate: fraiseql-core,       target: toml_config }
           - { crate: fraiseql-core,       target: value_json_seam }
           - { crate: fraiseql-wire,       target: protocol_decode }
           - { crate: fraiseql-wire,       target: json_validate }
@@ -71,6 +70,13 @@ jobs:
           - { crate: fraiseql-db,         target: projection_generator }
           - { crate: fraiseql-federation, target: subgraph_response }
           - { crate: fraiseql-server,     target: graphql_request }
+          # Lives in fraiseql-server, not fraiseql-core: `5a4a8f86b` (#909) deleted
+          # fraiseql_core::config::FraiseQLConfig — the TOML tree nothing read — and its
+          # fuzz target with it, while the target fuzzing the config loader that IS live
+          # stayed here. The matrix kept naming the old crate, so every scheduled run was
+          # red from at least 2026-05-17 until #1128. tools/check-fuzz-targets.sh now
+          # fails on a row whose target is not in the crate it names.
+          - { crate: fraiseql-server,     target: toml_config }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # pinned; toolchain comes from the input below

--- a/Makefile
+++ b/Makefile
@@ -505,6 +505,15 @@ lint-deploy-security:
 lint-deploy-versions:
 	@bash tools/check-deploy-versions.sh
 
+# Gate: fuzz.yml's matrix may only name targets that exist in the crate it names.
+# `{crate: fraiseql-core, target: toml_config}` named a target that had MOVED to
+# fraiseql-server, so `cargo fuzz build` failed and every scheduled run was red from at
+# least 2026-05-17 (#1128). One-directional by design — 14 of the 26 targets in the tree
+# are deliberately outside the curated "#441 minimum" matrix.
+.PHONY: lint-fuzz-targets
+lint-fuzz-targets:
+	@bash tools/check-fuzz-targets.sh
+
 # Gate: pin the set of production files that READ TypeDefinition.internal (#665), so a
 # property-named flag cannot silently grow new consumers. See tools/check-internal-flag-sites.sh.
 .PHONY: lint-internal-flag
@@ -569,7 +578,7 @@ lint-sdk-dead-surface:
 # test suite or service-backed integration tests — those are `make test` and the
 # separate Dagger test/integration legs.
 .PHONY: preflight
-preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-deploy-versions lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
+preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-deploy-versions lint-fuzz-targets lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
 	@echo "=== preflight: lint-unwrap (UNWRAP_ALLOW_LIMIT=3) ==="
 	@$(MAKE) --no-print-directory lint-unwrap UNWRAP_ALLOW_LIMIT=3
 	@echo "=== preflight: check-test-imports ==="

--- a/crates/fraiseql-server/fuzz/Cargo.lock
+++ b/crates/fraiseql-server/fuzz/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
 name = "fraiseql-storage"
 version = "2.14.1"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "axum",
  "base64",
@@ -3256,6 +3257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,6 +4215,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/tools/changelog-exempt-issues.txt
+++ b/tools/changelog-exempt-issues.txt
@@ -40,3 +40,4 @@
 #1001  test-only: flight_e2e_test's "end-to-end DoGet" tests called no Flight RPC
 #1010  test infra: fraiseql-guard log-capture tests raced on process-global env
 #1103  CI: deny.toml advisory deadlines that would redden the required preflight check on a date; no shipped behaviour change
+#1128  CI: the Fuzz workflow named a target in the wrong crate, so the run was permanently red (12 of 13 legs were green — fail-fast is off); workflow wiring only, no shipped behaviour change

--- a/tools/check-fuzz-targets.sh
+++ b/tools/check-fuzz-targets.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# check-fuzz-targets.sh — fail when .github/workflows/fuzz.yml names a fuzz target that
+# does not exist in the crate it names.
+#
+# Background (#1128): the matrix declared `{ crate: fraiseql-core, target: toml_config }`.
+# That target was MOVED, not deleted — `5a4a8f86b` (#909) removed
+# `fraiseql_core::config::FraiseQLConfig`, the whole TOML tree nothing read, and its fuzz
+# target went with it; a live `toml_config` target now lives in
+# `crates/fraiseql-server/fuzz/`. Right target, wrong crate. `cargo fuzz build` failed with
+# "no bin target named toml_config", and because a scheduled workflow's failure notifies
+# nobody, EVERY run in the visible history — back to 2026-05-17, twelve of them — was red.
+# The libFuzzer campaign (#441) produced no signal for three months.
+#
+# ⚠ ONE-DIRECTIONAL BY DESIGN: every matrix row must exist on disk; a target on disk need
+# NOT be in the matrix. The matrix is the deliberately-curated "#441 minimum" — 14 of the
+# 26 targets in the tree are intentionally outside it, awaiting triage. A bidirectional
+# gate would go red on all 14 immediately and be switched off within a week, which is how
+# a gate becomes a comment.
+#
+# Pure bash, no toolchain, no git history → Dagger ShellGates.
+#
+# Overrides, for testing:
+#   FUZZ_TARGETS_WORKFLOW=<path>   parse this workflow instead of the default
+#   FUZZ_TARGETS_ROOT=<dir>        resolve crates/ under this directory
+set -euo pipefail
+
+if [ -n "${FUZZ_TARGETS_ROOT:-}" ]; then
+  cd "$FUZZ_TARGETS_ROOT"
+elif repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  cd "$repo_root"
+fi
+
+workflow="${FUZZ_TARGETS_WORKFLOW:-.github/workflows/fuzz.yml}"
+
+if [ ! -f "$workflow" ]; then
+  echo "ERROR: fuzz workflow not found: $workflow" >&2
+  exit 1
+fi
+
+status=0
+checked=0
+
+# Matrix rows are single-line `- { crate: X, target: Y }` entries. Parsed with sed rather
+# than a YAML library because this gate runs in the minimal ShellGates container.
+while IFS=$'\t' read -r crate target; do
+  [ -z "$crate" ] && continue
+  checked=$((checked + 1))
+
+  manifest="crates/${crate}/fuzz/Cargo.toml"
+  source_file="crates/${crate}/fuzz/fuzz_targets/${target}.rs"
+
+  if [ ! -f "$manifest" ]; then
+    echo "ERROR: ${crate} / ${target} — no fuzz manifest at ${manifest}"
+    status=1
+    continue
+  fi
+
+  # `name = "<target>"` must appear as a [[bin]] name. Plain grep, no `grep -q`: under
+  # `pipefail` a successful `| grep -q` match kills the producer with SIGPIPE (141) and a
+  # MATCH reads as a failure.
+  if ! grep -E "^name = \"${target}\"$" "$manifest" >/dev/null; then
+    echo "ERROR: ${crate} / ${target} — no [[bin]] named \"${target}\" in ${manifest}"
+    echo "       cargo fuzz will fail with: no bin target named \`${target}\`"
+    # Point at the crate that does have it, if any — this exact defect was a target that
+    # moved between crates, and naming the new home turns a puzzle into a one-line fix.
+    other="$(grep -lE "^name = \"${target}\"$" crates/*/fuzz/Cargo.toml 2>/dev/null | head -1 || true)"
+    if [ -n "$other" ]; then
+      echo "       a target with that name exists in: ${other}"
+    fi
+    status=1
+  fi
+
+  if [ ! -f "$source_file" ]; then
+    echo "ERROR: ${crate} / ${target} — no source at ${source_file}"
+    status=1
+  fi
+done < <(sed -nE 's/^[[:space:]]*-[[:space:]]*\{[[:space:]]*crate:[[:space:]]*([A-Za-z0-9_-]+),[[:space:]]*target:[[:space:]]*([A-Za-z0-9_-]+)[[:space:]]*\}.*/\1\t\2/p' "$workflow")
+
+if [ "$checked" -eq 0 ]; then
+  # A grep-based YAML parser that silently matches nothing would pass forever — the same
+  # fabricated-success shape this gate exists to catch.
+  echo "ERROR: no matrix rows parsed from ${workflow} — the include: format changed" >&2
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: all ${checked} fuzz matrix targets exist in the crate they name."
+fi
+exit "$status"


### PR DESCRIPTION
**P04 of the v2.15.0 release program.** Recommended; does not block the tag.

## The defect

`.github/workflows/fuzz.yml` declared `{ crate: fraiseql-core, target: toml_config }`. That
target was **moved, not deleted**: `5a4a8f86b` (#909) removed
`fraiseql_core::config::FraiseQLConfig` — the TOML tree nothing read — and took its fuzz target
with it, while a `toml_config` target fuzzing the config loader that *is* live stayed in
`crates/fraiseql-server/fuzz/`. Right target, wrong crate, so `cargo fuzz build` failed with
*"no bin target named `toml_config`"* on every scheduled run back to at least 2026-05-17.

## ⚠ I had to correct my own issue before fixing it

#1128's body claimed the campaign "produced no signal for three months". **Measured, that is
false.** `fail-fast: false` is set, so the broken row never aborted the others — the most recent
scheduled run was **12 of 13 legs green**:

```
failure  Fuzz fraiseql-core / toml_config
success  … the other twelve
```

Correction posted on the issue. The real impact is narrower and different in kind:

1. **One target's coverage was lost** — the server's config loader went unfuzzed.
2. **The workflow's status was permanently red, which destroyed its value as a signal.** A run
   that is always red cannot report that a *second* leg has started failing; the badge, the
   notification and the last-run status say the same thing whether one leg is broken or seven
   are. That is the "a gate that cannot pass tells you nothing" family (#1071–#1075), and it —
   not a coverage blackout — is what justifies the gate below.

## Changes

- Matrix row → `{ crate: fraiseql-server, target: toml_config }`, with a comment recording why
  it moved, so the next reader does not "fix" it back.
- **`tools/check-fuzz-targets.sh`** (ShellGates + local `preflight`): every matrix row must have
  both a `[[bin]] name = "<target>"` in that crate's `fuzz/Cargo.toml` and a
  `fuzz_targets/<target>.rs`. When one is missing it reports **which crate does have it** —
  this defect was a target that moved, and naming the new home turns a puzzle into a one-liner.
- `#1128` exempted in `changelog-exempt-issues.txt` (CI wiring, no shipped behaviour change).
  The assurance gap is stated in the release notes instead (P08), with the corrected framing.
- `crates/fraiseql-server/fuzz/Cargo.lock` refreshed — building the target exposed it as stale
  (missing `fraiseql-storage`'s `arc-swap`, `uuid`'s `sha1_smol`). Committed rather than
  discarded: cargo regenerates a stale lockfile silently, so CI was not building what the
  repository recorded.

## ⚠ One-directional by design

Every matrix row must exist on disk; **a target on disk need not be in the matrix**. There are
**26 fuzz targets in the tree and 13 in the matrix** — the other 13 are deliberately outside the
curated "#441 minimum" pending triage, as the matrix comment says. A bidirectional gate would go
red on all of them immediately and be switched off within a week, which is how a gate becomes a
comment.

## Proofs

**RED, before the fix** — names the broken row *and* its real home:

```
ERROR: fraiseql-core / toml_config — no [[bin]] named "toml_config" in crates/fraiseql-core/fuzz/Cargo.toml
       cargo fuzz will fail with: no bin target named `toml_config`
       a target with that name exists in: crates/fraiseql-server/fuzz/Cargo.toml
ERROR: fraiseql-core / toml_config — no source at crates/fraiseql-core/fuzz/fuzz_targets/toml_config.rs
```

**Revert-check after the fix** — restoring `fraiseql-core` reproduces exactly that.

**Empty-parser guard** — the script greps YAML, so a reformatted matrix would otherwise let it
pass over zero rows forever. Against a fixture using the multi-line `- crate:` form:

```
ERROR: no matrix rows parsed from … — the include: format changed
```

**The fix actually builds** — verified, not inferred from the manifest:

```
$ cd crates/fraiseql-server && CARGO_BUILD_JOBS=8 cargo +nightly-2026-07-01 fuzz build toml_config
Finished `release` profile [optimized + debuginfo] target(s) in 4m 21s   (rc=0)
-rwxr-xr-x  334122880  fuzz/target/x86_64-unknown-linux-gnu/release/toml_config
```

`nightly-2026-07-01` is the exact `FUZZ_NIGHTLY` pin the workflow uses, so this is the toolchain
CI runs — not a floating nightly.

**The proof that matters — a green dispatched run:** linked in a comment below.
`headSha` was confirmed equal to the pushed HEAD (`a9b6dc945`) before trusting it, since a
dispatched run uses the **remote** ref and can otherwise be green while testing something else.

## Verification

```
✅ bash tools/check-fuzz-targets.sh   OK: all 13 matrix targets exist in the crate they name
✅ make preflight                     green, gate EXECUTES ("OK: all 13 fuzz matrix targets…")
✅ RED proof + revert-check + empty-parser guard
✅ the relocated target builds under the pinned nightly and links its binary
✅ pre-commit run --from-ref dev --to-ref HEAD   clean
✅ shellcheck tools/check-fuzz-targets.sh        clean
✅ cd .dagger && go build ./... && gofmt -l .    clean
✅ bash tools/check-changelog-issues.sh          OK
✅ no `| grep -q` in the script — under pipefail a successful match kills the producer with
   SIGPIPE (141) and a MATCH reads as a failure
```

Closes #1128
