### PR TITLE
fix(cache): a read that straddles a mutation can no longer undo it in the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4098,6 +4098,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existed in this example (`orders`, `products`, `users` against fixtures creating
   `tb_order`, `tb_product`, `tb_user`); they now use the real names and join through the
   surrogate keys as the Trinity schema requires.
+- **A read that straddles a mutation can no longer undo it in the cache (#1079).** A cached
+  read is `get` → miss → **await the database** → `put`. A mutation that committed and
+  invalidated while a read was awaiting the database evicted nothing — the read's key is not
+  in the reverse index yet — and the read's `put` then stored rows fetched *before* the
+  mutation. The client that had just written saw its own write vanish on the next read, and
+  the entry survived until the next invalidation touching that view, a size eviction, a
+  schema reload or a restart. Registering the key before inserting (#740) made it *visible*
+  to a concurrent invalidation but did not fence the insert, so an invalidation landing
+  between registration and insert collected a key that was not stored yet and the insert
+  landed stale regardless. Both caches now carry a monotonic invalidation generation: the
+  read snapshots it before the round trip, and the write is discarded — silently, with its
+  index registrations removed — if the counter moved. A fenced-out read still returns its
+  rows to the caller; it is simply not cached, because turning a benign race into a request
+  failure would be worse than the staleness it prevents.
+  **Preconditions: the cache must have been explicitly enabled** (`CacheConfig::enabled` is
+  `false` by default) **and the view annotated** with `cache_ttl_seconds`; session-variable
+  reads bypass the cache entirely. The fix covers the row cache, the response cache — the
+  mutation runner invalidates both in the same block, so whole GraphQL responses were
+  stranded too — and the fact-table cache, which has the same shape.
+  **Breaking for library embedders:** `QueryResultCache::put` / `put_arc` and
+  `ResponseCache::put` take an additional trailing `fence: Option<u64>`. Pass
+  `Some(cache.invalidation_generation())` snapshotted before the work whose result is being
+  stored; `None` stores unconditionally and is only correct when the value cannot have raced
+  a mutation.
 - **The in-memory rate limiter evicts stale buckets, so `max_buckets` is a cap and not a
   lockout (#1080).** `InMemoryRateLimiter::cleanup()` and the `cleanup_interval_secs` knob both
   existed and the knob's documentation promised a background task — but **nothing ever called

--- a/crates/fraiseql-core/benches/cache.rs
+++ b/crates/fraiseql-core/benches/cache.rs
@@ -36,7 +36,7 @@ fn bench_cache_put_get(c: &mut Criterion) {
             let key = i;
             i = i.wrapping_add(1);
             cache
-                .put(key, result.clone(), vec!["v_user".to_string()], None, Some("User"))
+                .put(key, result.clone(), vec!["v_user".to_string()], None, Some("User"), None)
                 .unwrap();
             let _ = cache.get(key).unwrap();
         });
@@ -56,7 +56,9 @@ fn bench_cache_put_get(c: &mut Criterion) {
         let result = make_result();
         // Warm up 100 entries
         for i in 0..100_u64 {
-            cache.put(i, result.clone(), vec!["v_user".to_string()], None, None).unwrap();
+            cache
+                .put(i, result.clone(), vec!["v_user".to_string()], None, None, None)
+                .unwrap();
         }
         let mut i: u64 = 0;
         b.iter(|| {
@@ -72,7 +74,9 @@ fn bench_cache_put_get(c: &mut Criterion) {
         b.iter(|| {
             let cache = QueryResultCache::new(CacheConfig::with_max_entries(10_000));
             for i in 0..100_u64 {
-                cache.put(i, result.clone(), vec!["v_user".to_string()], None, None).unwrap();
+                cache
+                    .put(i, result.clone(), vec!["v_user".to_string()], None, None, None)
+                    .unwrap();
             }
             cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
         });

--- a/crates/fraiseql-core/benches/cache_concurrent_bench.rs
+++ b/crates/fraiseql-core/benches/cache_concurrent_bench.rs
@@ -46,7 +46,14 @@ fn make_result() -> Vec<JsonbValue> {
 /// Pre-populate the cache with `KEY_COUNT` entries.
 fn populate(cache: &QueryResultCache) {
     for i in 0..KEY_COUNT {
-        let _ = cache.put(i as u64, make_result(), vec!["users".to_string()], None, Some("users"));
+        let _ = cache.put(
+            i as u64,
+            make_result(),
+            vec!["users".to_string()],
+            None,
+            Some("users"),
+            None,
+        );
     }
 }
 
@@ -117,6 +124,7 @@ fn bench_cache_writes(c: &mut Criterion) {
                                         vec!["users".to_string()],
                                         None,
                                         Some("users"),
+                                        None,
                                     );
                                 }
                             })
@@ -162,6 +170,7 @@ fn bench_cache_mixed(c: &mut Criterion) {
                                     vec!["users".to_string()],
                                     None,
                                     Some("users"),
+                                    None,
                                 );
                             } else {
                                 let _ = c.get((i % KEY_COUNT) as u64);
@@ -203,6 +212,7 @@ fn bench_cache_latency(c: &mut Criterion) {
                 vec!["users".to_string()],
                 None,
                 Some("users"),
+                None,
             );
         });
     });

--- a/crates/fraiseql-core/benches/memory_profile.rs
+++ b/crates/fraiseql-core/benches/memory_profile.rs
@@ -77,7 +77,7 @@ fn profile_cache_put_get() {
     // 1000 put + get cycles
     for i in 0_u64..1000 {
         cache
-            .put(i, result.clone(), vec!["view_a".to_string()], None, Some("User"))
+            .put(i, result.clone(), vec!["view_a".to_string()], None, Some("User"), None)
             .unwrap();
     }
     for i in 0_u64..1000 {

--- a/crates/fraiseql-core/src/cache/adapter/mod.rs
+++ b/crates/fraiseql-core/src/cache/adapter/mod.rs
@@ -316,6 +316,11 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
     /// # Ok(())
     /// # }
     /// ```
+    /// ⚠ A `0` TTL means the entry lives until a mutation invalidates it, so its
+    /// correctness rests entirely on invalidation being unmissable. That is what the
+    /// generation fence guarantees (#1079): a read whose database round trip straddled an
+    /// invalidation refuses to cache, instead of storing pre-mutation rows that — at TTL 0
+    /// — nothing would ever expire.
     #[must_use]
     pub fn with_view_ttl_overrides(mut self, overrides: HashMap<String, u64>) -> Self {
         self.cacheable_views = overrides.keys().cloned().collect();

--- a/crates/fraiseql-core/src/cache/adapter/query.rs
+++ b/crates/fraiseql-core/src/cache/adapter/query.rs
@@ -99,6 +99,12 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
             return Ok(cached_arc);
         }
 
+        // Snapshot the invalidation generation BEFORE the round trip (#1079). A mutation
+        // that commits and invalidates while we await the database would otherwise evict
+        // nothing — this key is not in the reverse index yet — and the put below would
+        // store rows fetched before that mutation, undoing it in the cache.
+        let fence = self.cache.invalidation_generation();
+
         // Miss: wrap result in Arc, give a clone to the cache, return the Arc.
         // The Vec contents are never copied — the cache and the caller share the
         // same allocation via Arc reference counting.
@@ -120,6 +126,7 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
             self.accessed_views_for(view),
             ttl,
             entity_type.as_deref(),
+            Some(fence),
         )?;
 
         Ok(arc)
@@ -175,6 +182,9 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
             return Ok(cached_arc);
         }
 
+        // Snapshot before the round trip — see the sibling path above (#1079).
+        let fence = self.cache.invalidation_generation();
+
         // Miss: wrap result in Arc, give a clone to the cache, return the Arc.
         let arc = Arc::new(
             self.adapter
@@ -196,6 +206,7 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
             self.accessed_views_for(view),
             ttl,
             entity_type.as_deref(),
+            Some(fence),
         )?;
 
         Ok(arc)

--- a/crates/fraiseql-core/src/cache/fact_table_cache.rs
+++ b/crates/fraiseql-core/src/cache/fact_table_cache.rs
@@ -181,6 +181,10 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
             return Ok(results);
         }
 
+        // Snapshot before the round trip (#1079): this path has the same
+        // get → miss → await → put shape as the row cache, so it strands the same way.
+        let fence = self.cache.invalidation_generation();
+
         // Cache miss - execute query
         let result = self.adapter.execute_raw_query(sql).await?;
 
@@ -196,6 +200,7 @@ impl<A: DatabaseAdapter> CachedDatabaseAdapter<A> {
             vec![table_name], // Track which fact table this query reads
             None,             // Fact-table queries use the global TTL
             None,             // No entity-type index for raw queries
+            Some(fence),
         )?;
 
         Ok(result)

--- a/crates/fraiseql-core/src/cache/response_cache.rs
+++ b/crates/fraiseql-core/src/cache/response_cache.rs
@@ -110,6 +110,14 @@ pub struct ResponseCache {
     hits:       AtomicU64,
     misses:     AtomicU64,
     next_epoch: AtomicU64,
+
+    /// Bumped by every invalidation, so a read that straddled one can tell (#1079).
+    ///
+    /// Same defect and same fence as `QueryResultCache`: registering the key before
+    /// `store.insert` makes it *visible* to a concurrent `invalidate_views`, but does not
+    /// stop the insert that follows. Whole GraphQL responses are stranded here, not just
+    /// row sets, so fixing only the row cache would leave the user-visible half live.
+    invalidation_generation: AtomicU64,
 }
 
 impl ResponseCache {
@@ -148,6 +156,7 @@ impl ResponseCache {
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
             next_epoch: AtomicU64::new(0),
+            invalidation_generation: AtomicU64::new(0),
         }
     }
 
@@ -177,7 +186,21 @@ impl ResponseCache {
         }
     }
 
+    /// Snapshot of the invalidation generation, for fencing a cache write (#1079).
+    ///
+    /// Take this before the work whose result is being cached, and pass it to
+    /// [`put`](Self::put).
+    #[must_use]
+    pub fn invalidation_generation(&self) -> u64 {
+        self.invalidation_generation.load(Ordering::Acquire)
+    }
+
     /// Store a response in the cache.
+    ///
+    /// `fence` is a snapshot from [`invalidation_generation`](Self::invalidation_generation)
+    /// taken before the work that produced `response`. If an invalidation landed since,
+    /// the entry is discarded rather than stored — the caller keeps its response, it is
+    /// simply not cached. `None` stores unconditionally.
     ///
     /// # Errors
     ///
@@ -188,8 +211,14 @@ impl ResponseCache {
         security_hash: u64,
         response: Arc<Value>,
         accessed_views: Vec<String>,
+        fence: Option<u64>,
     ) -> Result<()> {
         if !self.enabled {
+            return Ok(());
+        }
+
+        // Cheap pre-check; the authoritative one is after registration (#1079).
+        if fence.is_some_and(|snapshot| snapshot != self.invalidation_generation()) {
             return Ok(());
         }
 
@@ -207,6 +236,18 @@ impl ResponseCache {
         let reference: IndexRef = (key, epoch);
         for view in &accessed_views {
             self.view_index.entry(view.clone()).or_default().insert(reference);
+        }
+
+        // The fence (#1079): authoritative check, after registration and before insert.
+        // Deregistration is symmetric with the eviction listener's, so no index row
+        // survives pointing at a key that was never stored.
+        if fence.is_some_and(|snapshot| snapshot != self.invalidation_generation()) {
+            for view in &accessed_views {
+                if let Some(keys) = self.view_index.get(view) {
+                    keys.remove(&reference);
+                }
+            }
+            return Ok(());
         }
 
         let entry = Arc::new(ResponseEntry {
@@ -227,6 +268,9 @@ impl ResponseCache {
     ///
     /// This method is infallible with the moka backend and always returns `Ok`.
     pub fn invalidate_views(&self, views: &[ViewName]) -> Result<u64> {
+        // Bump before collecting keys (#1079) — the window may be too wide, never too narrow.
+        self.invalidation_generation.fetch_add(1, Ordering::Release);
+
         // Dedup by cache key: an entry mid-replacement is registered under two
         // epochs, and one reading several of `views` is registered once per view.
         let mut to_remove: std::collections::HashSet<(u64, u64)> = std::collections::HashSet::new();

--- a/crates/fraiseql-core/src/cache/result.rs
+++ b/crates/fraiseql-core/src/cache/result.rs
@@ -174,12 +174,14 @@ impl moka::Expiry<u64, Arc<CachedResult>> for CacheEntryExpiry {
 ///
 /// // Cache a result
 /// let result = vec![JsonbValue::new(json!({"id": 1, "name": "Alice"}))];
+/// let fence = cache.invalidation_generation(); // snapshot before the read (#1079)
 /// cache.put(
 ///     12345_u64,
 ///     result.clone(),
 ///     vec!["v_user".to_string()],
-///     None, // use global TTL
-///     None, // no entity type index
+///     None,        // use global TTL
+///     None,        // no entity type index
+///     Some(fence), // discard the write if an invalidation raced the read
 /// ).unwrap();
 ///
 /// // Retrieve from cache
@@ -224,6 +226,22 @@ pub struct QueryResultCache {
     /// Source of [`CachedResult::epoch`] values. Monotonic for the process
     /// lifetime; wrap-around at 2^64 puts is not reachable.
     next_epoch: AtomicU64,
+
+    /// Bumped by every invalidation, so a read that straddled one can tell (#1079).
+    ///
+    /// A read is `get` → miss → **await the database** → `put`. An invalidation landing
+    /// inside that await evicts nothing (the key is not in `view_index` yet) and the `put`
+    /// then stores rows fetched *before* the mutation committed — the client that just
+    /// wrote sees its own write vanish on the next read.
+    ///
+    /// The counter is **global**, not per view: a skipped cache write costs one uncached
+    /// read, whereas a stale entry costs correctness, and a per-view map would inherit
+    /// every lifetime question `view_index` already has. If a benchmark ever shows the
+    /// hit-rate loss matters, refine it then — with a measurement, not a guess.
+    ///
+    /// Distinct from [`next_epoch`](Self::next_epoch), which identifies one entry instance
+    /// so the eviction listener does not deregister a replacement (#740).
+    invalidation_generation: AtomicU64,
 }
 
 /// Cache metrics for monitoring.
@@ -344,7 +362,19 @@ impl QueryResultCache {
             view_index,
             entity_index,
             next_epoch: AtomicU64::new(0),
+            invalidation_generation: AtomicU64::new(0),
         }
+    }
+
+    /// Snapshot of the invalidation generation, for fencing a cache write (#1079).
+    ///
+    /// Take this **before** the database round trip and hand it to
+    /// [`put_arc`](Self::put_arc). If any invalidation lands while the read is in flight,
+    /// the counter moves and the write is refused — the rows are still returned to the
+    /// caller, they are simply not cached.
+    #[must_use]
+    pub fn invalidation_generation(&self) -> u64 {
+        self.invalidation_generation.load(Ordering::Acquire)
     }
 
     /// Returns whether caching is enabled.
@@ -402,10 +432,18 @@ impl QueryResultCache {
     /// * `accessed_views` - List of views accessed by this query
     /// * `ttl_override` - Per-entry TTL in seconds; `None` uses `CacheConfig::ttl_seconds`
     /// * `entity_type` - Optional GraphQL type name for entity-ID indexing
+    /// * `fence` - Generation snapshot from
+    ///   [`invalidation_generation`](Self::invalidation_generation), taken **before** the database
+    ///   round trip whose rows are being stored. `None` stores unconditionally, and is only correct
+    ///   when the value did not come from a read that could have raced a mutation (a test fixture,
+    ///   or a synchronous re-population).
     ///
     /// # Errors
     ///
     /// This method is infallible. The `Result` return type is kept for API compatibility.
+    /// A fenced-out write is **not** an error — the caller already has its rows; they are
+    /// simply not cached. Turning a benign race into a request failure would be worse than
+    /// the staleness this prevents.
     pub fn put_arc(
         &self,
         cache_key: u64,
@@ -413,8 +451,16 @@ impl QueryResultCache {
         accessed_views: Vec<String>,
         ttl_override: Option<u64>,
         entity_type: Option<&str>,
+        fence: Option<u64>,
     ) -> Result<()> {
         if !self.config.enabled {
+            return Ok(());
+        }
+
+        // Cheap pre-check: if an invalidation already landed, do no work at all. The
+        // authoritative check is after registration, below — this one only saves the
+        // serialisation and index churn in the common case.
+        if fence.is_some_and(|snapshot| snapshot != self.invalidation_generation()) {
             return Ok(());
         }
 
@@ -487,6 +533,37 @@ impl QueryResultCache {
                 .insert(reference);
         }
 
+        // ── The fence (#1079) ───────────────────────────────────────────────
+        //
+        // Authoritative check, AFTER registration and BEFORE `store.insert`. The
+        // pre-check at the top of this function is only an optimisation; this is the
+        // one that closes the window, because #740's "register before insert" makes the
+        // key *visible* to a concurrent `invalidate_views` but does not stop the insert
+        // that follows. An invalidation landing between the registrations above and the
+        // insert below collects a key that is not in the store yet — invalidating
+        // nothing — and the insert then lands stale.
+        //
+        // Deregistration is symmetric with the eviction listener's: the same
+        // `(cache_key, epoch)` reference, removed from the same two indexes, so no index
+        // row survives pointing at a key that was never stored. No moka call is made
+        // while a DashMap guard is held — the listener runs synchronously on the calling
+        // thread and re-enters `view_index`, which is why that rule exists.
+        if fence.is_some_and(|snapshot| snapshot != self.invalidation_generation()) {
+            for view in &accessed_views {
+                if let Some(keys) = self.view_index.get(view) {
+                    keys.remove(&reference);
+                }
+            }
+            for (et, id) in &*entity_refs {
+                if let Some(by_type) = self.entity_index.get(et) {
+                    if let Some(keys) = by_type.get(id) {
+                        keys.remove(&reference);
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         let cached = CachedResult {
             result,
             accessed_views,
@@ -536,7 +613,8 @@ impl QueryResultCache {
     /// let cache = QueryResultCache::new(CacheConfig::default());
     ///
     /// let result = vec![JsonbValue::new(json!({"id": "uuid-1"}))];
-    /// cache.put(0xabc123, result, vec!["v_user".to_string()], None, Some("User"))?;
+    /// let fence = cache.invalidation_generation();
+    /// cache.put(0xabc123, result, vec!["v_user".to_string()], None, Some("User"), Some(fence))?;
     /// # Ok::<(), fraiseql_core::error::FraiseQLError>(())
     /// ```
     pub fn put(
@@ -546,8 +624,9 @@ impl QueryResultCache {
         accessed_views: Vec<String>,
         ttl_override: Option<u64>,
         entity_type: Option<&str>,
+        fence: Option<u64>,
     ) -> Result<()> {
-        self.put_arc(cache_key, Arc::new(result), accessed_views, ttl_override, entity_type)
+        self.put_arc(cache_key, Arc::new(result), accessed_views, ttl_override, entity_type, fence)
     }
 
     /// Invalidate entries accessing specified views.
@@ -584,6 +663,12 @@ impl QueryResultCache {
         if !self.config.enabled {
             return Ok(0);
         }
+
+        // Bump BEFORE collecting keys (#1079). A read whose database round trip
+        // straddles this call must observe the move even if it snapshotted a moment
+        // ago — ordering the bump first means the window can only ever be too wide
+        // (a refused cache write), never too narrow (a stale entry).
+        self.invalidation_generation.fetch_add(1, Ordering::Release);
 
         // Collect keys first (releases DashMap guards) then invalidate.
         // Moka's eviction listener fires synchronously on the calling thread, so
@@ -639,6 +724,9 @@ impl QueryResultCache {
         if !self.config.enabled {
             return Ok(0);
         }
+
+        // Bump BEFORE collecting keys (#1079) — see invalidate_views.
+        self.invalidation_generation.fetch_add(1, Ordering::Release);
 
         // Short-circuit: if entity_type has no indexed entries, skip the DashMap
         // lookup entirely.  Covers cold-cache and write-heavy workloads where no
@@ -728,6 +816,8 @@ impl QueryResultCache {
     /// # Ok::<(), fraiseql_core::error::FraiseQLError>(())
     /// ```
     pub fn clear(&self) -> Result<()> {
+        // Bump first (#1079): a read in flight across a clear must not repopulate it.
+        self.invalidation_generation.fetch_add(1, Ordering::Release);
         self.store.invalidate_all();
         // Reset indexes and memory counter synchronously — don't rely on the
         // async eviction listener to do this.

--- a/crates/fraiseql-core/src/cache/tests.rs
+++ b/crates/fraiseql-core/src/cache/tests.rs
@@ -349,7 +349,7 @@ mod response_cache_tests {
         let response = Arc::new(serde_json::json!({"data": {"users": []}}));
 
         cache
-            .put(1, 0, response.clone(), vec!["v_user".to_string()])
+            .put(1, 0, response.clone(), vec!["v_user".to_string()], None)
             .expect("put should succeed");
         let result = cache.get(1, 0).expect("get should succeed");
         assert!(result.is_some());
@@ -366,10 +366,10 @@ mod response_cache_tests {
 
         // Same query key (1), different security hashes
         cache
-            .put(1, 100, admin_response.clone(), vec!["v_user".to_string()])
+            .put(1, 100, admin_response.clone(), vec!["v_user".to_string()], None)
             .expect("put admin");
         cache
-            .put(1, 200, user_response.clone(), vec!["v_user".to_string()])
+            .put(1, 200, user_response.clone(), vec!["v_user".to_string()], None)
             .expect("put user");
 
         let admin_result = cache.get(1, 100).expect("get admin").expect("admin hit");
@@ -385,10 +385,10 @@ mod response_cache_tests {
         let cache = ResponseCache::new(enabled_config());
 
         cache
-            .put(1, 0, Arc::new(serde_json::json!("r1")), vec!["v_user".to_string()])
+            .put(1, 0, Arc::new(serde_json::json!("r1")), vec!["v_user".to_string()], None)
             .expect("put 1");
         cache
-            .put(2, 0, Arc::new(serde_json::json!("r2")), vec!["v_post".to_string()])
+            .put(2, 0, Arc::new(serde_json::json!("r2")), vec!["v_post".to_string()], None)
             .expect("put 2");
 
         // Flush pending moka writes before invalidation
@@ -409,7 +409,9 @@ mod response_cache_tests {
         let cache = ResponseCache::new(ResponseCacheConfig::default());
         assert!(!cache.is_enabled());
 
-        cache.put(1, 0, Arc::new(serde_json::json!("r")), vec![]).expect("put disabled");
+        cache
+            .put(1, 0, Arc::new(serde_json::json!("r")), vec![], None)
+            .expect("put disabled");
         assert!(cache.get(1, 0).expect("get disabled").is_none());
     }
 
@@ -417,7 +419,7 @@ mod response_cache_tests {
     fn test_metrics() {
         let cache = ResponseCache::new(enabled_config());
 
-        cache.put(1, 0, Arc::new(serde_json::json!("r")), vec![]).expect("put");
+        cache.put(1, 0, Arc::new(serde_json::json!("r")), vec![], None).expect("put");
         cache.run_pending_tasks();
         let _ = cache.get(1, 0); // hit
         let _ = cache.get(2, 0); // miss
@@ -543,7 +545,7 @@ mod response_cache_tests {
     fn test_invalidate_empty_views_is_noop() {
         let cache = ResponseCache::new(enabled_config());
         cache
-            .put(1, 0, Arc::new(serde_json::json!("r")), vec!["v_user".to_string()])
+            .put(1, 0, Arc::new(serde_json::json!("r")), vec!["v_user".to_string()], None)
             .expect("put");
         cache.run_pending_tasks();
 
@@ -556,7 +558,7 @@ mod response_cache_tests {
     fn test_invalidate_nonexistent_view_is_noop() {
         let cache = ResponseCache::new(enabled_config());
         cache
-            .put(1, 0, Arc::new(serde_json::json!("r")), vec!["v_user".to_string()])
+            .put(1, 0, Arc::new(serde_json::json!("r")), vec!["v_user".to_string()], None)
             .expect("put");
         cache.run_pending_tasks();
 
@@ -573,13 +575,13 @@ mod response_cache_tests {
 
         // Same query, different users, same view
         cache
-            .put(1, 100, Arc::new(serde_json::json!("admin")), vec!["v_user".to_string()])
+            .put(1, 100, Arc::new(serde_json::json!("admin")), vec!["v_user".to_string()], None)
             .expect("put admin");
         cache
-            .put(1, 200, Arc::new(serde_json::json!("user")), vec!["v_user".to_string()])
+            .put(1, 200, Arc::new(serde_json::json!("user")), vec!["v_user".to_string()], None)
             .expect("put user");
         cache
-            .put(1, 0, Arc::new(serde_json::json!("anon")), vec!["v_user".to_string()])
+            .put(1, 0, Arc::new(serde_json::json!("anon")), vec!["v_user".to_string()], None)
             .expect("put anon");
         cache.run_pending_tasks();
 
@@ -598,13 +600,13 @@ mod response_cache_tests {
         let cache = ResponseCache::new(enabled_config());
 
         cache
-            .put(1, 0, Arc::new(serde_json::json!("users")), vec!["v_user".to_string()])
+            .put(1, 0, Arc::new(serde_json::json!("users")), vec!["v_user".to_string()], None)
             .expect("put users");
         cache
-            .put(2, 0, Arc::new(serde_json::json!("posts")), vec!["v_post".to_string()])
+            .put(2, 0, Arc::new(serde_json::json!("posts")), vec!["v_post".to_string()], None)
             .expect("put posts");
         cache
-            .put(3, 0, Arc::new(serde_json::json!("tags")), vec!["v_tag".to_string()])
+            .put(3, 0, Arc::new(serde_json::json!("tags")), vec!["v_tag".to_string()], None)
             .expect("put tags");
         cache.run_pending_tasks();
 
@@ -631,6 +633,7 @@ mod response_cache_tests {
                 0,
                 Arc::new(serde_json::json!("joined")),
                 vec!["v_user".to_string(), "v_post".to_string()],
+                None,
             )
             .expect("put");
         cache.run_pending_tasks();
@@ -652,10 +655,10 @@ mod response_cache_tests {
         let cache = ResponseCache::new(enabled_config());
 
         cache
-            .put(1, 0, Arc::new(serde_json::json!("response_1")), vec![])
+            .put(1, 0, Arc::new(serde_json::json!("response_1")), vec![], None)
             .expect("put q1");
         cache
-            .put(2, 0, Arc::new(serde_json::json!("response_2")), vec![])
+            .put(2, 0, Arc::new(serde_json::json!("response_2")), vec![], None)
             .expect("put q2");
         cache.run_pending_tasks();
 
@@ -677,6 +680,7 @@ mod response_cache_tests {
                     sec_hash,
                     Arc::new(serde_json::json!(format!("response_for_user_{sec_hash}"))),
                     vec![],
+                    None,
                 )
                 .expect("put");
         }
@@ -2242,7 +2246,7 @@ mod result_tests {
         let result = test_result();
 
         // Put
-        cache.put(1_u64, result, vec!["v_user".to_string()], None, None).unwrap();
+        cache.put(1_u64, result, vec!["v_user".to_string()], None, None, None).unwrap();
 
         // Get
         let cached = cache.get(1_u64).unwrap();
@@ -2259,7 +2263,9 @@ mod result_tests {
     fn test_cache_hit_updates_hit_count() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // First hit
         cache.get(1_u64).unwrap();
@@ -2284,7 +2290,9 @@ mod result_tests {
 
         let cache = QueryResultCache::new(config);
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // Wait for expiry
         std::thread::sleep(std::time::Duration::from_secs(2));
@@ -2315,6 +2323,7 @@ mod result_tests {
                 vec!["v_ref".to_string()],
                 Some(1), // 1-second per-entry override
                 None,
+                None,
             )
             .unwrap();
 
@@ -2331,7 +2340,7 @@ mod result_tests {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
         cache
-            .put(1_u64, test_result(), vec!["v_live".to_string()], Some(0), None)
+            .put(1_u64, test_result(), vec!["v_live".to_string()], Some(0), None, None)
             .unwrap();
 
         let result = cache.get(1_u64).unwrap();
@@ -2348,7 +2357,9 @@ mod result_tests {
 
         let cache = QueryResultCache::new(config);
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // Should still be valid
         let result = cache.get(1_u64).unwrap();
@@ -2370,9 +2381,15 @@ mod result_tests {
         let cache = QueryResultCache::new(config);
 
         // Add 3 entries (max is 2); moka will evict one
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
-        cache.put(2_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
-        cache.put(3_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(2_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(3_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // Run pending tasks to flush evictions
         cache.run_pending_tasks();
@@ -2391,7 +2408,9 @@ mod result_tests {
         let cache = QueryResultCache::new(config);
 
         // Put should be no-op
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // Get should return None
         assert!(cache.get(1_u64).unwrap().is_none(), "Cache disabled should always miss");
@@ -2408,8 +2427,12 @@ mod result_tests {
     fn test_invalidate_single_view() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
-        cache.put(2_u64, test_result(), vec!["v_post".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(2_u64, test_result(), vec!["v_post".to_string()], None, None, None)
+            .unwrap();
 
         // Invalidate v_user
         let invalidated = cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
@@ -2424,10 +2447,14 @@ mod result_tests {
     fn test_invalidate_multiple_views() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
-        cache.put(2_u64, test_result(), vec!["v_post".to_string()], None, None).unwrap();
         cache
-            .put(3_u64, test_result(), vec!["v_product".to_string()], None, None)
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(2_u64, test_result(), vec!["v_post".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(3_u64, test_result(), vec!["v_product".to_string()], None, None, None)
             .unwrap();
 
         // Invalidate v_user and v_post
@@ -2453,6 +2480,7 @@ mod result_tests {
                 vec!["v_user".to_string(), "v_post".to_string()],
                 None,
                 None,
+                None,
             )
             .unwrap();
 
@@ -2467,7 +2495,9 @@ mod result_tests {
     fn test_invalidate_nonexistent_view() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // Invalidate view that doesn't exist
         let invalidated = cache.invalidate_views(&[ViewName::from("v_nonexistent")]).unwrap();
@@ -2485,8 +2515,12 @@ mod result_tests {
     fn test_clear() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
-        cache.put(2_u64, test_result(), vec!["v_post".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(2_u64, test_result(), vec!["v_post".to_string()], None, None, None)
+            .unwrap();
 
         cache.clear().unwrap();
 
@@ -2512,7 +2546,9 @@ mod result_tests {
         cache.get(999_u64).unwrap();
 
         // Put
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         // Hit
         cache.get(1_u64).unwrap();
@@ -2597,10 +2633,24 @@ mod result_tests {
 
         // Cache User A and User B as separate entries
         cache
-            .put(1_u64, entity_result("uuid-a"), vec!["v_user".to_string()], None, Some("User"))
+            .put(
+                1_u64,
+                entity_result("uuid-a"),
+                vec!["v_user".to_string()],
+                None,
+                Some("User"),
+                None,
+            )
             .unwrap();
         cache
-            .put(2_u64, entity_result("uuid-b"), vec!["v_user".to_string()], None, Some("User"))
+            .put(
+                2_u64,
+                entity_result("uuid-b"),
+                vec!["v_user".to_string()],
+                None,
+                Some("User"),
+                None,
+            )
             .unwrap();
 
         // Invalidate User A — User B must remain
@@ -2616,7 +2666,14 @@ mod result_tests {
 
         // Cache a single-entity entry (entity_ref uses first row's id)
         cache
-            .put(1_u64, entity_result("uuid-a"), vec!["v_user".to_string()], None, Some("User"))
+            .put(
+                1_u64,
+                entity_result("uuid-a"),
+                vec!["v_user".to_string()],
+                None,
+                Some("User"),
+                None,
+            )
             .unwrap();
 
         // Invalidate by User A
@@ -2637,6 +2694,7 @@ mod result_tests {
                 vec!["v_user".to_string()],
                 None,
                 Some("User"),
+                None,
             )
             .unwrap();
         cache
@@ -2646,6 +2704,7 @@ mod result_tests {
                 vec!["v_post".to_string()],
                 None,
                 Some("Post"),
+                None,
             )
             .unwrap();
 
@@ -2661,7 +2720,14 @@ mod result_tests {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
         cache
-            .put(1_u64, entity_result("uuid-1"), vec!["v_user".to_string()], None, Some("User"))
+            .put(
+                1_u64,
+                entity_result("uuid-1"),
+                vec!["v_user".to_string()],
+                None,
+                Some("User"),
+                None,
+            )
             .unwrap();
 
         // Invalidating by uuid-1 should evict the entry
@@ -2681,6 +2747,7 @@ mod result_tests {
                 vec!["v_user".to_string()],
                 None,
                 None, // no entity type
+                None,
             )
             .unwrap();
 
@@ -2704,14 +2771,18 @@ mod result_tests {
     fn test_put_indexes_all_entities_in_list() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
         let rows = list_result(&["uuid-A", "uuid-B", "uuid-C"]);
-        cache.put(0xABC, rows, vec!["v_user".to_string()], None, Some("User")).unwrap();
+        cache
+            .put(0xABC, rows, vec!["v_user".to_string()], None, Some("User"), None)
+            .unwrap();
 
         let evicted_a = cache.invalidate_by_entity("User", "uuid-A").unwrap();
         assert_eq!(evicted_a, 1, "uuid-A must be indexed and evictable");
 
         // Re-insert to test uuid-C
         let rows2 = list_result(&["uuid-A", "uuid-B", "uuid-C"]);
-        cache.put(0xDEF, rows2, vec!["v_user".to_string()], None, Some("User")).unwrap();
+        cache
+            .put(0xDEF, rows2, vec!["v_user".to_string()], None, Some("User"), None)
+            .unwrap();
         let evicted_c = cache.invalidate_by_entity("User", "uuid-C").unwrap();
         assert_eq!(evicted_c, 1, "uuid-C at position 2 must also be indexed");
     }
@@ -2720,7 +2791,9 @@ mod result_tests {
     fn test_update_evicts_list_query_via_non_first_entity() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
         let rows = list_result(&["uuid-A", "uuid-B"]);
-        cache.put(0x111, rows, vec!["v_user".to_string()], None, Some("User")).unwrap();
+        cache
+            .put(0x111, rows, vec!["v_user".to_string()], None, Some("User"), None)
+            .unwrap();
 
         // uuid-B is at position 1 — must still be evicted
         let evicted = cache.invalidate_by_entity("User", "uuid-B").unwrap();
@@ -2740,13 +2813,17 @@ mod result_tests {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
         let empty: Vec<JsonbValue> = vec![];
-        cache.put(0x001, empty, vec!["v_user".to_string()], None, Some("User")).unwrap();
+        cache
+            .put(0x001, empty, vec!["v_user".to_string()], None, Some("User"), None)
+            .unwrap();
         let single = vec![JsonbValue::new(serde_json::json!({"id": "uuid-X"}))];
         cache
-            .put(0x002, single, vec!["v_user".to_string()], None, Some("User"))
+            .put(0x002, single, vec!["v_user".to_string()], None, Some("User"), None)
             .unwrap();
         let list = list_result(&["uuid-A", "uuid-B"]);
-        cache.put(0x003, list, vec!["v_user".to_string()], None, Some("User")).unwrap();
+        cache
+            .put(0x003, list, vec!["v_user".to_string()], None, Some("User"), None)
+            .unwrap();
 
         let evicted = cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
         assert_eq!(evicted, 3, "zero-, one- and multi-row entries are all evicted");
@@ -2767,7 +2844,9 @@ mod result_tests {
     fn test_eviction_listener_cleans_all_entity_refs() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
         let rows = list_result(&["uuid-A", "uuid-B"]);
-        cache.put(0x001, rows, vec!["v_user".to_string()], None, Some("User")).unwrap();
+        cache
+            .put(0x001, rows, vec!["v_user".to_string()], None, Some("User"), None)
+            .unwrap();
 
         // Force eviction via invalidate_views
         cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
@@ -2797,7 +2876,7 @@ mod result_tests {
                 let cache_clone = cache.clone();
                 thread::spawn(move || {
                     cache_clone
-                        .put(key, test_result(), vec!["v_user".to_string()], None, None)
+                        .put(key, test_result(), vec!["v_user".to_string()], None, None, None)
                         .unwrap();
                     cache_clone.get(key).unwrap();
                 })
@@ -2834,7 +2913,9 @@ mod result_tests {
             JsonbValue::new(json!({"id": 1})),
             JsonbValue::new(json!({"id": 2})),
         ];
-        cache.put(1_u64, two_rows, vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, two_rows, vec!["v_user".to_string()], None, None, None)
+            .unwrap();
         assert!(
             cache.get(1_u64).unwrap().is_none(),
             "multi-row result must not be cached when cache_list_queries=false"
@@ -2855,7 +2936,7 @@ mod result_tests {
 
         // One-row result: must be stored
         let one_row = vec![JsonbValue::new(json!({"id": 1}))];
-        cache.put(1_u64, one_row, vec!["v_user".to_string()], None, None).unwrap();
+        cache.put(1_u64, one_row, vec!["v_user".to_string()], None, None, None).unwrap();
         assert!(
             cache.get(1_u64).unwrap().is_some(),
             "single-row result must be cached even when cache_list_queries=false"
@@ -2875,7 +2956,9 @@ mod result_tests {
         let cache = QueryResultCache::new(config);
 
         // A typical row serialises to far more than 10 bytes
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
         assert!(cache.get(1_u64).unwrap().is_none(), "oversized entry must be silently skipped");
     }
 
@@ -2891,7 +2974,9 @@ mod result_tests {
         };
         let cache = QueryResultCache::new(config);
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
         assert!(
             cache.get(1_u64).unwrap().is_some(),
             "small entry must be cached when within max_entry_bytes"
@@ -2910,7 +2995,9 @@ mod result_tests {
         };
         let cache = QueryResultCache::new(config);
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
         assert!(
             cache.get(1_u64).unwrap().is_none(),
             "entry must be skipped when max_total_bytes budget is already exhausted"
@@ -2934,7 +3021,7 @@ mod result_tests {
         // Insert many entries
         for i in 0_u64..200 {
             let view = if i % 2 == 0 { "v_user" } else { "v_post" };
-            cache.put(i, test_result(), vec![view.to_string()], None, None).unwrap();
+            cache.put(i, test_result(), vec![view.to_string()], None, None, None).unwrap();
         }
 
         // Invalidate v_user — should remove exactly 100 entries
@@ -2970,6 +3057,7 @@ mod result_tests {
                     vec!["v_user".to_string()],
                     None,
                     Some("User"),
+                    None,
                 )
                 .unwrap();
         }
@@ -2982,6 +3070,7 @@ mod result_tests {
                 vec!["v_user".to_string()],
                 None,
                 Some("User"),
+                None,
             )
             .unwrap();
 
@@ -3001,7 +3090,9 @@ mod result_tests {
         let cache = QueryResultCache::new(config);
 
         for i in 0_u64..200 {
-            cache.put(i, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+            cache
+                .put(i, test_result(), vec!["v_user".to_string()], None, None, None)
+                .unwrap();
         }
 
         cache.clear().unwrap();
@@ -3020,8 +3111,12 @@ mod result_tests {
     fn test_memory_bytes_tracked() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v".to_string()], None, None).unwrap();
-        cache.put(2_u64, test_result(), vec!["v".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v".to_string()], None, None, None)
+            .unwrap();
+        cache
+            .put(2_u64, test_result(), vec!["v".to_string()], None, None, None)
+            .unwrap();
 
         let before = cache.metrics().unwrap().memory_bytes;
         assert!(before > 0, "memory_bytes should be tracked");
@@ -3032,7 +3127,9 @@ mod result_tests {
     fn test_memory_bytes_decreases_on_clear() {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
-        cache.put(1_u64, test_result(), vec!["v_user".to_string()], None, None).unwrap();
+        cache
+            .put(1_u64, test_result(), vec!["v_user".to_string()], None, None, None)
+            .unwrap();
 
         let before = cache.metrics().unwrap().memory_bytes;
         assert!(before > 0);
@@ -3086,7 +3183,7 @@ mod result_tests {
         let key = 42_u64;
         let expected = test_result();
         cache
-            .put(key, expected.clone(), vec!["v_user".to_string()], None, None)
+            .put(key, expected.clone(), vec!["v_user".to_string()], None, None, None)
             .unwrap();
 
         // Single-threaded baseline.
@@ -3163,10 +3260,10 @@ mod eviction_lifecycle_tests {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
         cache
-            .put(42, one_row(), vec!["v_user".to_string()], Some(0), Some("User"))
+            .put(42, one_row(), vec!["v_user".to_string()], Some(0), Some("User"), None)
             .unwrap();
         cache
-            .put(42, one_row(), vec!["v_user".to_string()], Some(0), Some("User"))
+            .put(42, one_row(), vec!["v_user".to_string()], Some(0), Some("User"), None)
             .unwrap();
         cache.run_pending_tasks();
 
@@ -3187,10 +3284,10 @@ mod eviction_lifecycle_tests {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
         cache
-            .put(43, one_row(), vec!["v_user".to_string()], Some(0), Some("User"))
+            .put(43, one_row(), vec!["v_user".to_string()], Some(0), Some("User"), None)
             .unwrap();
         cache
-            .put(43, one_row(), vec!["v_user".to_string()], Some(0), Some("User"))
+            .put(43, one_row(), vec!["v_user".to_string()], Some(0), Some("User"), None)
             .unwrap();
         cache.run_pending_tasks();
 
@@ -3213,7 +3310,7 @@ mod eviction_lifecycle_tests {
         let cache = QueryResultCache::new(CacheConfig::enabled());
 
         cache
-            .put(44, one_row(), vec!["v_user".to_string()], Some(0), Some("User"))
+            .put(44, one_row(), vec!["v_user".to_string()], Some(0), Some("User"), None)
             .unwrap();
         cache.run_pending_tasks();
         assert_eq!(cache.invalidate_views(&[ViewName::from("v_user")]).unwrap(), 1);
@@ -3243,8 +3340,8 @@ mod eviction_lifecycle_tests {
         });
         let body = Arc::new(json!({"data": {"users": []}}));
 
-        cache.put(7, 0, Arc::clone(&body), vec!["v_user".to_string()]).unwrap();
-        cache.put(7, 0, Arc::clone(&body), vec!["v_user".to_string()]).unwrap();
+        cache.put(7, 0, Arc::clone(&body), vec!["v_user".to_string()], None).unwrap();
+        cache.put(7, 0, Arc::clone(&body), vec!["v_user".to_string()], None).unwrap();
         cache.run_pending_tasks();
 
         assert_eq!(
@@ -3371,6 +3468,189 @@ mod response_cache_key_tests {
         assert_eq!(
             key_of("{ users { id name } }", None),
             key_of("{\n  users {\n    id\n    name\n  }\n}", None),
+        );
+    }
+}
+
+// ── invalidation_fence_tests ────────────────────────────────────────────────
+
+/// #1079: a cache write whose read straddled an invalidation must be discarded.
+///
+/// A read is `get` → miss → **await the database** → `put`. An invalidation landing
+/// inside that await evicts nothing — the key is not registered yet — and the `put` then
+/// stores rows fetched *before* the mutation committed. The client that just wrote sees
+/// its own write vanish on the next read.
+///
+/// #740's "register the key before inserting" note makes the key *visible* to a concurrent
+/// `invalidate_views`, but it does not fence the insert: an invalidation landing between
+/// registration and `store.insert` collects a key that is not in the store yet — a no-op —
+/// and the insert lands stale anyway. So the fence has to cover the insert itself.
+///
+/// These tests drive the interleaving **as a sequence, not a sleep**: the invalidation is
+/// performed between the snapshot and the put, exactly where the race puts it. A
+/// probabilistic version would be a flake in CI and a false green on a fast runner.
+mod invalidation_fence_tests {
+    use std::sync::Arc;
+
+    use fraiseql_db::ViewName;
+
+    use crate::cache::{
+        CacheConfig, QueryResultCache, ResponseCache, response_cache::ResponseCacheConfig,
+    };
+
+    fn row_cache() -> QueryResultCache {
+        QueryResultCache::new(CacheConfig::enabled())
+    }
+
+    fn rows() -> Vec<crate::db::types::JsonbValue> {
+        vec![crate::db::types::JsonbValue::new(
+            serde_json::json!({"id": "u-1", "n": "pre"}),
+        )]
+    }
+
+    /// The defect, in one sequence.
+    #[test]
+    fn a_read_that_straddles_an_invalidation_does_not_cache() {
+        let cache = row_cache();
+
+        // The read snapshots, then awaits the database…
+        let fence = cache.invalidation_generation();
+
+        // …and while it is awaiting, a mutation commits and invalidates. Nothing is
+        // evicted: this key is not in the reverse index yet.
+        let evicted = cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
+        assert_eq!(evicted, 0, "precondition: the racing invalidation evicts nothing");
+
+        // …then the read returns and stores its pre-mutation rows.
+        cache
+            .put(1_u64, rows(), vec!["v_user".to_string()], None, None, Some(fence))
+            .unwrap();
+
+        assert!(
+            cache.get(1_u64).unwrap().is_none(),
+            "a read whose round trip straddled an invalidation must not populate the cache — \
+             storing it re-caches pre-mutation rows and the client's own write disappears (#1079)"
+        );
+    }
+
+    /// The counterweight: with nothing invalidating, the write must still land.
+    ///
+    /// Without this, a fence that refused *every* write would satisfy the test above and
+    /// silently disable the cache.
+    #[test]
+    fn an_uncontended_read_still_caches() {
+        let cache = row_cache();
+        let fence = cache.invalidation_generation();
+
+        cache
+            .put(1_u64, rows(), vec!["v_user".to_string()], None, None, Some(fence))
+            .unwrap();
+
+        assert!(
+            cache.get(1_u64).unwrap().is_some(),
+            "an uncontended read must still be cached — the fence must not cost hit rate \
+             when nothing raced it"
+        );
+    }
+
+    /// A refused write must leave no index rows behind, or the next invalidation walks
+    /// references to a key that was never stored.
+    #[test]
+    fn a_fenced_out_write_deregisters_itself() {
+        let cache = row_cache();
+        let fence = cache.invalidation_generation();
+        cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
+        cache
+            .put(1_u64, rows(), vec!["v_user".to_string()], None, None, Some(fence))
+            .unwrap();
+
+        // If the refused write left its registration behind, this invalidation would
+        // report evicting an entry that does not exist.
+        let evicted = cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
+        assert_eq!(
+            evicted, 0,
+            "a fenced-out write must deregister itself; a stale index row makes the next \
+             invalidation count a key that was never stored"
+        );
+    }
+
+    /// `invalidate_by_entity` and `clear` move the generation too — an entity-level
+    /// invalidation races a read exactly as a view-level one does.
+    #[test]
+    fn entity_invalidation_and_clear_both_move_the_generation() {
+        let cache = row_cache();
+
+        let before = cache.invalidation_generation();
+        cache.invalidate_by_entity("User", "u-1").unwrap();
+        assert_ne!(
+            cache.invalidation_generation(),
+            before,
+            "invalidate_by_entity must move the fence generation"
+        );
+
+        let before = cache.invalidation_generation();
+        cache.clear().unwrap();
+        assert_ne!(
+            cache.invalidation_generation(),
+            before,
+            "clear must move the fence generation — a read in flight across a clear must \
+             not repopulate it"
+        );
+    }
+
+    // ── the same defect, one layer up ───────────────────────────────────────
+    //
+    // The mutation runner invalidates both caches in the same block, so the identical
+    // window strands whole GraphQL responses, not just row sets. Fixing only the row
+    // cache would leave the user-visible half live.
+
+    fn response_cache() -> ResponseCache {
+        ResponseCache::new(ResponseCacheConfig {
+            enabled: true,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn a_response_written_across_an_invalidation_is_discarded() {
+        let cache = response_cache();
+        let fence = cache.invalidation_generation();
+        cache.invalidate_views(&[ViewName::from("v_user")]).unwrap();
+
+        cache
+            .put(
+                7,
+                0,
+                Arc::new(serde_json::json!({"data": {"user": {"name": "pre"}}})),
+                vec!["v_user".to_string()],
+                Some(fence),
+            )
+            .unwrap();
+
+        assert!(
+            cache.get(7, 0).unwrap().is_none(),
+            "a response computed from pre-mutation rows must not be cached (#1079)"
+        );
+    }
+
+    #[test]
+    fn an_uncontended_response_still_caches() {
+        let cache = response_cache();
+        let fence = cache.invalidation_generation();
+
+        cache
+            .put(
+                7,
+                0,
+                Arc::new(serde_json::json!({"data": {"user": {"name": "n"}}})),
+                vec!["v_user".to_string()],
+                Some(fence),
+            )
+            .unwrap();
+
+        assert!(
+            cache.get(7, 0).unwrap().is_some(),
+            "an uncontended response must still be cached"
         );
     }
 }

--- a/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
+++ b/crates/fraiseql-core/src/runtime/executor/runners/query_regular.rs
@@ -315,6 +315,13 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             None
         };
 
+        // Snapshot before the miss path does any work (#1079). A mutation that commits
+        // and invalidates while this request executes would otherwise be undone by the
+        // put at the end of this function, which would store a response computed from
+        // pre-mutation rows.
+        let response_cache_fence =
+            self.ctx.response_cache.as_ref().map(|rc| rc.invalidation_generation());
+
         if let (Some((query_key, sec_hash)), Some(rc)) =
             (response_cache_key, self.ctx.response_cache.as_ref())
         {
@@ -658,7 +665,8 @@ impl<A: DatabaseAdapter> QueryRunner<A> {
             // same definition the row cache registers under (#761).
             let accessed = crate::cache::extract_accessed_views(&query_match.query_def);
             let cached = Arc::new(response);
-            let _ = rc.put(query_key, sec_hash, Arc::clone(&cached), accessed);
+            let _ =
+                rc.put(query_key, sec_hash, Arc::clone(&cached), accessed, response_cache_fence);
             return Ok(Arc::unwrap_or_clone(cached));
         }
 

--- a/crates/fraiseql-core/tests/pipeline_cache_invalidation_test.rs
+++ b/crates/fraiseql-core/tests/pipeline_cache_invalidation_test.rs
@@ -205,6 +205,7 @@ async fn mutation_invalidates_listed_views_in_cache() {
                 vec![view.clone()],
                 None,
                 None,
+                None,
             )
             .expect("pre-population must succeed");
         assert!(
@@ -256,6 +257,7 @@ async fn failed_mutation_does_not_invalidate_cache() {
                 key,
                 vec![JsonbValue::new(json!({"valid": true}))],
                 vec![view.clone()],
+                None,
                 None,
                 None,
             )


### PR DESCRIPTION
**P06 of the v2.15.0 release program — the last of the three HIGHs decision H selected, and the
last code fix in the program.**

## The defect

A cached read is `get` → miss → **await the database** → `put`. A mutation that committed and
invalidated *while a read was awaiting the database* evicted nothing — the read's key is not in
the reverse index yet — and the read's `put` then stored rows fetched **before** the mutation.
The client that had just written saw its own write vanish on the next read.

#740's "register the key before inserting" makes the key **visible** to a concurrent
`invalidate_views`, but it does not fence the insert: an invalidation landing between
registration and `store.insert` collects a key that is not in the store yet — a no-op — and the
insert lands stale regardless. **So the fence has to cover the insert itself**, which is why it
sits after registration rather than replacing it.

**Not "permanent", and the changelog says so.** Unlike #740 the stale entry *is* registered in
the indexes, so the next invalidation touching that view, a size eviction, a schema reload or a
restart clears it. The honest harm is a **read-your-writes violation**.

**Preconditions:** `CacheConfig::enabled` is `false` by default and the view must carry a
`cache_ttl_seconds` annotation; session-variable reads bypass the cache entirely. Default
deployments were unaffected — the readiness pass's "caching on" framing overstated it.

## Design — global counter, chosen deliberately

A monotonic `invalidation_generation` per cache, bumped by `invalidate_views`,
`invalidate_by_entity` and `clear`. The read snapshots it **before** the round trip; the put
refuses if it moved.

Global rather than per-view: a skipped cache write costs one uncached read, a stale entry costs
correctness, and a per-view map inherits every lifetime question `view_index` already has. If a
benchmark ever shows the hit-rate loss matters, refine it *then*, with a measurement.

The bump happens **before** collecting keys, so the window can only be too wide (a refused
write), never too narrow (a stale entry). The refusal is **silent** — a raced read still returns
its rows, it is simply not cached; erroring would turn a benign race into a request failure.

## Three put sites, not the two the phase named

`fact_table_cache` has the identical `get` → miss → await → put shape and is fenced too. The
response cache mattered because the mutation runner invalidates both in the same block — fixing
only the row cache would have left the **user-visible** half live.

A fenced-out write **deregisters itself**, symmetrically with the eviction listener and using
the same `(cache_key, epoch)` reference, so no index row survives pointing at a key that was
never stored. No moka call is made while a DashMap guard is held — the listener runs
synchronously on the calling thread and re-enters `view_index`, which is the deadlock
`invalidate_views`' existing comment warns about.

## RED — a sequence, not a sleep

Six tests drive the interleaving by performing the invalidation *between* the snapshot and the
put, exactly where the race puts it. A probabilistic version would be a flake in CI and a false
green on a fast runner.

**Each fence is independently pinned:**

| mutation | what fails |
|---|---|
| row-cache fence disabled | `a_read_that_straddles_an_invalidation_does_not_cache` + `a_fenced_out_write_deregisters_itself` — **and nothing else** |
| response-cache fence disabled | `a_response_written_across_an_invalidation_is_discarded` — **and nothing else** |

The counterweights (`an_uncontended_read_still_caches`, `an_uncontended_response_still_caches`)
mean a fence that refused *every* write cannot pass — it would satisfy the race tests while
silently disabling the cache.

## The real-system half

`tests/cache_transparency_invariant.rs` — *"every read served from the cache must equal the read
the same sequence serves with caching switched off"*, against real PostgreSQL — passes with the
fence in place. That property subsumes the whole staleness class.

⚠ **That test skips when `DATABASE_URL` is unset, and a skip still prints `ok`.** Verified it
actually executed by running it both ways: skipping prints `SKIP: …` and finishes in **0.00s**;
the real run printed no SKIP and took **0.15s**.

## Breaking

`QueryResultCache::put` / `put_arc` and `ResponseCache::put` take a trailing
`fence: Option<u64>`. Pass `Some(cache.invalidation_generation())` snapshotted before the work
whose result is being stored; `None` stores unconditionally and is only correct when the value
cannot have raced a mutation.

Making it a **parameter** rather than adding a second fenced method is deliberate: an unfenced
overload left in place is a fail-open default every future caller can reach for by accident.

## Verification

```
✅ cargo test -p fraiseql-core --features test-postgres -- --test-threads=1
      EXIT 0 — 76 suites, 0 failures, DATABASE_URL set
✅ cargo test -p fraiseql-core --doc            240 passed
✅ cargo check --workspace --all-targets --all-features   exit 0
✅ two independent revert-checks, each failing only its own site
✅ the pg transparency invariant confirmed EXECUTING, not skipping
✅ make preflight                                green
✅ pre-commit run --from-ref dev --to-ref HEAD   clean
```

⚠ **Three measurement traps hit while doing this, all mine, all recorded:**

1. `grep '^error'` on cargo output false-cleaned **twice** — ANSI codes precede `error`. The
   second time it hid 74 broken call sites. Everything above is now verified by **exit code**.
2. `cargo check --all-targets` does **not** compile doctests — two rustdoc examples were left
   broken by the signature change and only surfaced in the full run.
3. A 0.15s pass on a pg test looked like a skip; the discriminator had to be measured rather
   than assumed.

Closes #1079
