### PR TITLE
docs(release): ship one version claim, and keep the release commit's required gate green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,30 @@
 
 All notable changes to FraiseQL are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+**Versioning — read this before upgrading.** FraiseQL uses
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) *numbering*, but does **not** offer
+SemVer's compatibility guarantee. Breaking changes ship in minor releases, documented under
+`### Breaking`; they are not deferred to a major. That section is the upgrade contract — a minor
+bump is not a signal that nothing broke.
+
+This file previously said the project "adheres to Semantic Versioning" while shipping releases
+whose `### Breaking` sections ran to well over a hundred entries. The number and the promise
+disagreed, and the promise was the part that was wrong.
 
 ## [Unreleased]
 
 ### Breaking
+
+- **The cache put methods take a fence argument (#1079).** `QueryResultCache::put` /
+  `put_arc` and `ResponseCache::put` gained a trailing `fence: Option<u64>`. Pass
+  `Some(cache.invalidation_generation())`, snapshotted **before** the work whose result is
+  being stored; `None` stores unconditionally and is only correct when the value cannot have
+  raced a mutation — a fixture, or a synchronous re-population. This is a parameter rather
+  than a second "fenced" method on purpose: an unfenced overload left in place is a fail-open
+  default that every future caller can reach for by accident. See `### Fixed` for the race it
+  closes.
 
 - **`fraiseql_core::schema::BUILTIN_SCALARS` is now the compiler's own table, and the
   list it replaces is gone (#959).** It was `&[&str]`; it is now
@@ -4116,12 +4134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `false` by default) **and the view annotated** with `cache_ttl_seconds`; session-variable
   reads bypass the cache entirely. The fix covers the row cache, the response cache — the
   mutation runner invalidates both in the same block, so whole GraphQL responses were
-  stranded too — and the fact-table cache, which has the same shape.
-  **Breaking for library embedders:** `QueryResultCache::put` / `put_arc` and
-  `ResponseCache::put` take an additional trailing `fence: Option<u64>`. Pass
-  `Some(cache.invalidation_generation())` snapshotted before the work whose result is being
-  stored; `None` stores unconditionally and is only correct when the value cannot have raced
-  a mutation.
+  stranded too — and the fact-table cache, which has the same shape. The API change this
+  required is under `### Breaking`.
 - **The in-memory rate limiter evicts stale buckets, so `max_buckets` is a cap and not a
   lockout (#1080).** `InMemoryRateLimiter::cleanup()` and the `cleanup_interval_secs` knob both
   existed and the knob's documentation promised a background task — but **nothing ever called
@@ -4915,6 +4929,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   federation's `query_plan_cache` — key on `String`, whose `Drop` cannot panic, so the
   trigger was never reachable here; the lockfile bump clears the advisory outright, with no
   `deny.toml` exception.
+
+
+### Known issues
+
+Shipped knowingly, with preconditions, so an operator can decide rather than discover. Every
+number below is open at the time of this release.
+
+- **Twelve HIGH-severity findings from the 2026-08-09 audit remain unfixed**: #1065 #1066
+  #1067 #1071 #1072 #1073 #1074 #1075 #1076 #1077 #1078 #1082. ⚠ They are **provisionally
+  ranked**: their severity rests on the audit's own text and has not been re-verified against
+  source. That caveat is not boilerplate — of the findings this release *did* act on, one
+  (#1068) turned out to be **already fixed**, and two others' stated impact was wrong in the
+  issue body. Treat the list as a place to look, not as a verified account.
+- **`examples/` largely does not build or run** — #1050 #1051 #1052 #1053 #1054 #1071 #1072
+  #1073 #1074. The 2026-08-09 pass was the first audit to examine `examples/` at all. Nothing
+  in the shipped crates depends on them, but a reader following an example may not get a
+  working result.
+- **A cluster of CI gates cannot fail** — among them #1071–#1075 (an `examples/ci` check whose
+  exit code is never set, a `check-test-imports.sh` whose BRE escapes turn literal parens into
+  a capture group, a health gate that reads "unhealthy" as healthy, a Dockerfile hiding a
+  compile failure behind `|| true`) and #1082 (`check-suite-coverage` is blind to a file-level
+  `#![cfg(feature)]`, so a suite can run **zero** tests and read green). This release fixed
+  three gates of the same family (#1127, #1128, #1129) and added four more; the cluster above
+  is not yet done.
+- **Rate-limiter bucket exhaustion is still cheap to cause (#1143).** #1080's fix means a full
+  bucket map recovers instead of locking out new clients permanently — it does **not** stop one
+  unauthenticated client from filling the map: `X-Tenant-ID` is folded into the bucket key
+  without validation and the JWT `sub` is decoded without signature verification, both before
+  the request is rejected downstream. Affects deployments that enabled rate limiting.
+- **A queryless federation entity cannot declare tenant scoping (#1142).** Its `requires_role`
+  *is* enforced; there is simply nowhere to declare `inject_params`, and the author gets no
+  signal. DB-native RLS still scopes rows.
+- **Eight of the eleven official SDKs are not versioned with this release (#1130)** — C#, Dart,
+  Elixir, F#, Go, Java, PHP and Ruby remain at 2.1.6, because `tools/release.sh` bumps only the
+  Rust, Python and TypeScript manifests. Only those three are released here.
+- **Config-loader fuzzing has a shorter evidence window than the rest (#1128).** The scheduled
+  libFuzzer matrix named `toml_config` in the wrong crate, so that one target never built. ⚠ The
+  other **12 of 13 targets were green every week** — `fail-fast: false` meant the broken row
+  never aborted them — so this is one target's missing coverage plus a permanently-red run that
+  could not have reported a *second* leg breaking. Fixed in this release; the matrix is green
+  end to end for the first time in its visible history.
+
+**Gaps this release states rather than omits:**
+
+- **No performance comparison accompanies this release.** The benchmark harness's trustworthy
+  load generator is still outstanding, and the previous Python one understated results by 2–3×,
+  so republishing it would be worse than publishing nothing.
+- **`release-smoke.yml` cannot run before a `release/*` branch or tag exists.** Its absence in
+  the pre-cut checks is not a green result; it runs at the cut.
 
 ## [2.14.1] - 2026-07-24
 

--- a/tools/changelog-exempt-issues.txt
+++ b/tools/changelog-exempt-issues.txt
@@ -40,4 +40,4 @@
 #1001  test-only: flight_e2e_test's "end-to-end DoGet" tests called no Flight RPC
 #1010  test infra: fraiseql-guard log-capture tests raced on process-global env
 #1103  CI: deny.toml advisory deadlines that would redden the required preflight check on a date; no shipped behaviour change
-#1128  CI: the Fuzz workflow named a target in the wrong crate, so the run was permanently red (12 of 13 legs were green — fail-fast is off); workflow wiring only, no shipped behaviour change
+#1134  release tooling: tools/release.sh did not update the doc status lines check-docs-version.sh enforces, so the release commit failed a required gate; no shipped behaviour change

--- a/tools/lib/release_helpers.sh
+++ b/tools/lib/release_helpers.sh
@@ -170,6 +170,37 @@ bump_deploy_artifacts() {
     sed -i -E "s/^( *)tag: \"[^\"]*\"/\1tag: \"${version}\"/" "$values"
 }
 
+# Rewrite the `vX.Y.Z released` status lines in docs/ that tools/check-docs-version.sh
+# enforces.
+#
+# Without this, `make release VERSION=<n>` bumps Cargo.toml and leaves those lines naming
+# the PREVIOUS release — and check-docs-version.sh runs in ShellGates, which is part of the
+# REQUIRED preflight check. So the release commit itself turned a required gate red, and the
+# release branch could not pass CI until someone edited four files by hand (#1134). The gate
+# had been green for a year only because docs and Cargo.toml had only ever been edited
+# together by hand; the first automated bump is what broke it.
+#
+# ⚠ Deliberately narrow. check-docs-version.sh's own header says HISTORICAL references
+# ("removed in v2.15.0") are legitimate and must not be rewritten — only the two *status*
+# shapes it greps for:
+#
+#     **Status**: v2.14.1 released                 →  `vX.Y.Z released`
+#     **FraiseQL** (v2.14.1 released) ships …      →  `(vX.Y.Z released)`
+#
+# Both reduce to the same token, so one substitution covers them; what matters is that it is
+# anchored on the word `released` and not on a bare version shape.
+#
+# Usage: bump_doc_status_lines <version> <file...>
+bump_doc_status_lines() {
+    local version="$1"
+    shift
+    local f
+    for f in "$@"; do
+        [ -f "$f" ] || continue
+        sed -i -E "s/v[0-9]+\.[0-9]+\.[0-9]+ released/v${version} released/g" "$f"
+    done
+}
+
 # Honesty gate for the SDK publish jobs: refuse to publish when the SDK manifest
 # version does not match the release version being published. This is the exact
 # frozen state — the manifest stuck at 2.1.6 while v2.3.0–v2.6.0 tags were cut —

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -112,6 +112,14 @@ bump_deploy_artifacts "$VERSION" \
     deploy/kubernetes/helm/fraiseql/values.yaml
 echo "      Bumped Dockerfile label + Helm chart/values."
 
+# Rewrite the docs' `vX.Y.Z released` status lines. tools/check-docs-version.sh enforces
+# them and runs in ShellGates → the REQUIRED preflight check, so without this the release
+# commit turns that gate red and the release branch cannot pass CI (#1134).
+bump_doc_status_lines "$VERSION" \
+    docs/value-proposition.md \
+    docs/architecture/overview.md
+echo "      Bumped docs status lines."
+
 echo "      Done."
 
 # ── Step 2: Update CHANGELOG.md ───────────────────────────────────────────────
@@ -175,6 +183,8 @@ RELEASE_FILES=(
     Dockerfile
     deploy/kubernetes/helm/fraiseql/Chart.yaml
     deploy/kubernetes/helm/fraiseql/values.yaml
+    docs/value-proposition.md
+    docs/architecture/overview.md
     "$CHANGELOG"
     "$README"
 )

--- a/tools/tests/release_helpers_test.sh
+++ b/tools/tests/release_helpers_test.sh
@@ -276,6 +276,40 @@ check "bump-deploy: values repository untouched" \
 check "bump-deploy: unrelated version-shaped value untouched" \
     "$(grep -c 'memory: 2.0.0Gi' "$WORK/values.yaml")" "1"
 
+# ── bump_doc_status_lines (#1134) ──────────────────────────────────────────────
+#
+# The fixture carries BOTH shapes check-docs-version.sh greps for and, crucially, a
+# HISTORICAL reference on the same page. That gate's own header says historical mentions
+# ("removed in vX.Y.Z") are legitimate; a helper that rewrote them would silently falsify
+# the record of when something was removed — and nothing downstream would ever say so.
+
+cat > "$WORK/value-proposition.md" <<'EOF'
+# Value proposition
+
+**Status**: v2.14.1 released
+
+MySQL support was removed in v2.15.0 and will not return.
+
+**FraiseQL** (v2.14.1 released) ships a production-ready core:
+EOF
+
+bump_doc_status_lines 2.16.0 "$WORK/value-proposition.md"
+
+check "bump-docs: **Status** line rewritten" \
+    "$(grep -c '^\*\*Status\*\*: v2.16.0 released$' "$WORK/value-proposition.md")" "1"
+check "bump-docs: parenthesised status form rewritten" \
+    "$(grep -c '(v2.16.0 released)' "$WORK/value-proposition.md")" "1"
+# The one that matters: a historical mention is not a status claim.
+check "bump-docs: historical 'removed in v2.15.0' untouched" \
+    "$(grep -c 'removed in v2.15.0' "$WORK/value-proposition.md")" "1"
+check "bump-docs: no stale released-version claim remains" \
+    "$(grep -c 'v2.14.1 released' "$WORK/value-proposition.md")" "0"
+
+# A file that does not exist is skipped, not a hard error: RELEASE_FILES and the helper's
+# argument list are maintained by hand and a rename should not abort a release mid-bump.
+bump_doc_status_lines 2.16.0 "$WORK/does-not-exist.md"
+check "bump-docs: a missing file is skipped, not fatal" "$?" "0"
+
 # ── Summary ────────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
**P08 of the v2.15.0 release program — the last phase before the cut.** Executes decision **V**
(2.15.0, Branch A) and closes the trap that would have turned the release commit itself red.

## The version claim — one, not two

Decision V was 2.15.0, and 2.15.0 carries an obligation: the header claimed **SemVer
adherence** while `[Unreleased]` runs to **164 `### Breaking` bullets**. The number and the
promise disagreed, and the promise was the part that was wrong.

The header now states what is actually offered — SemVer *numbering*, no SemVer compatibility
guarantee, breaks shipped in minors and documented under `### Breaking`, that section named as
the upgrade contract.

## `bump_doc_status_lines` — closes #1134

`check-docs-version.sh` runs in ShellGates → **preflight**, a required check. `release.sh`
bumped manifests, changelog and README — **not** the four `vX.Y.Z released` status lines.

**Reproduced before fixing**, in a scratch worktree under `/home`:

```
$ make release VERSION=2.15.0 SKIP_RELEASE_VALIDATE=1     # exit 0
$ bash tools/check-docs-version.sh
ERROR: docs claim a released version that is not the workspace version (v2.15.0):
docs/architecture/overview.md:5,842 … v2.14.1 released …
docs/value-proposition.md:3,407     … v2.14.1 released …
exit 1
```

**And green after**, on the same path:

```
$ make release VERSION=2.15.0 SKIP_RELEASE_VALIDATE=1
$ bash tools/check-docs-version.sh
OK: every 'vX.Y.Z released' status line in docs/ matches Cargo.toml (v2.15.0).
$ bash tools/check-deploy-versions.sh
OK: deploy artifacts all name v2.15.0, and the chart image is a published one.
```

That second line is a bonus: it confirms P03's `bump_deploy_artifacts` works in the **real**
release path, not just its unit tests.

The helper is anchored on the word `released`, not on a version shape, because
`check-docs-version.sh`'s own header says **historical** references ("removed in v2.15.0") are
legitimate. Five unit tests, **red-proven** — widening it to a blanket rewrite fails:

```
FAIL: bump-docs: historical 'removed in v2.15.0' untouched — expected [1], got [0]
```

Both doc files added to `RELEASE_FILES`, or the edit lands unstaged and the release commit
ships without it.

## `### Known issues`

Twelve HIGH findings remain unfixed — enumerated **against the tracker**, not inherited from
the plan — and flagged **provisionally ranked**, because their severity rests on the audit's
own text. That caveat is load-bearing: of the three this release acted on, **#1068 turned out
to be already fixed**, and two others' stated impact was wrong in the issue body.

Also named: the `examples/` cluster, the gates-that-cannot-fail cluster, #1143, #1142, the SDK
position (#1130 — the notes claim three SDKs released, not eleven), and the fuzzing evidence
window (#1128) stated **accurately**: 12 of 13 targets were green weekly, so the loss was one
target plus a permanently-red run that could not report a second failure.

Gaps stated rather than omitted: no performance comparison ships with this release, and
`release-smoke.yml` cannot run before a `release/*` branch exists — its absence pre-cut is not
a green result.

## This PR's own gates caught two things

- `### Stated gaps` was rejected as a **ninth heading** → folded into `### Known issues`.
- `#1128` became a **stale exemption** the moment the notes documented it → exemption removed.

Both are the P01 gate working on its author, which is the best evidence it works at all.

## Rule 6: filed, not fixed — #1146

The rehearsal showed `release.sh`'s README step printing *"README.md badge already at v2.15.0
— skipping"*. Investigating: the guard is satisfied by a **historical** mention on
`README.md:79`, so the step no-ops; and `README.md:103` pins `fraiseql = { version = "2.8" }`
against a 2.14.1 crate, which that step's `sed` could never match anyway (no `v` prefix, two
components). When the guard *does* miss, the same `sed` blanket-rewrites every `vX.Y.Z`
including the historical sentence. Either a no-op or a corruption, decided by prose elsewhere
in the file.

## Verification

```
✅ make test-release-tooling            44 checks, 5 new, one red-proven
✅ bash tools/check-changelog-issues.sh OK — 8 headings, no stale exemption
✅ RED → GREEN rehearsal on the real `make release` path
✅ make preflight                       green
✅ pre-commit run --from-ref dev --to-ref HEAD   clean
✅ rehearsal tag deleted and worktree removed — `git tag -l 'v2.15.0'` empty
```

Closes #1134
