### PR TITLE
fix(release): the workflow that publishes and the gate that checks it name the same crates

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -262,6 +262,13 @@ func (m *FraiseqlCi) ShellGates(
 		// Every fuzz.yml matrix row must name a target that exists in the crate it
 		// names. One-directional: targets on disk need not be in the matrix (#1128).
 		"bash tools/check-fuzz-targets.sh",
+		// Every publishable crate is published by release.yml, in the order this
+		// file's legacyPublishOrder dry-runs and self-tests. fraiseql-cdc-sinks
+		// (#382) was in the workspace and in legacyPublishOrder but in neither the
+		// publish steps nor the CRATES lists; as an OPTIONAL dependency of
+		// fraiseql-server it was tolerated by the pre-tag dry-run and fatal to the
+		// real publish. Nothing compared the two lists before this gate.
+		"python3 tools/check-publish-parity.py",
 		"bash tools/check-internal-flag-sites.sh",
 		"bash tools/check-value-json-seam.sh",
 		"bash tools/check-graphql-parse-sites.sh",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
           # Plain (uncoloured) cargo output so the log greps below match reliably.
           export CARGO_TERM_COLOR=never
           CRATES="fraiseql-guard fraiseql-error fraiseql-auth fraiseql-webhooks fraiseql-wire \
+                  fraiseql-cdc-sinks \
                   fraiseql-db fraiseql-storage fraiseql-federation fraiseql-core \
                   fraiseql-codegen fraiseql-arrow fraiseql-secrets fraiseql-observers \
                   fraiseql-functions fraiseql-server fraiseql-cli fraiseql"
@@ -537,6 +538,27 @@ jobs:
       - name: Wait for crates.io indexing (Tier 1)
         run: bash tools/wait-for-crates-index.sh "${GITHUB_REF#refs/tags/v}" fraiseql-guard fraiseql-error fraiseql-auth fraiseql-webhooks fraiseql-wire
 
+      # Tier 1.5: Depends on fraiseql-guard (Tier 1), and nothing else.
+      #
+      # fraiseql-server carries this crate as an *optional* dependency behind its
+      # `cdc-outbound` feature (#382, added after v2.14.1). An optional dependency
+      # still has to resolve on crates.io at publish time, so leaving it out of this
+      # job does not merely skip it — it fails the fraiseql-server publish outright
+      # with "no matching package named `fraiseql-cdc-sinks` found", taking
+      # fraiseql-cli and the fraiseql umbrella down with it.
+      - name: Publish fraiseql-cdc-sinks
+        id: publish-cdc-sinks
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "$(curl -s -o /dev/null -w '%{http_code}' -H 'User-Agent: fraiseql-ci' "https://crates.io/api/v1/crates/fraiseql-cdc-sinks/$VERSION")" = "200" ]; then
+            echo "fraiseql-cdc-sinks $VERSION already published, skipping"
+          else
+            cargo publish --package fraiseql-cdc-sinks --token ${{ secrets.CARGO_TOKEN }}
+          fi
+
+      - name: Wait for crates.io indexing (Tier 1.5)
+        run: bash tools/wait-for-crates-index.sh "${GITHUB_REF#refs/tags/v}" fraiseql-cdc-sinks
+
       # Tier 2: Depends on Tier 1 (fraiseql-error, fraiseql-wire)
       - name: Publish fraiseql-db
         id: publish-db
@@ -699,10 +721,12 @@ jobs:
         run: |
           FAILED=0
           for step_outcome in \
+            "${{ steps.publish-guard.outcome }}" \
             "${{ steps.publish-error.outcome }}" \
             "${{ steps.publish-auth.outcome }}" \
             "${{ steps.publish-webhooks.outcome }}" \
             "${{ steps.publish-wire.outcome }}" \
+            "${{ steps.publish-cdc-sinks.outcome }}" \
             "${{ steps.publish-db.outcome }}" \
             "${{ steps.publish-storage.outcome }}" \
             "${{ steps.publish-federation.outcome }}" \
@@ -736,6 +760,7 @@ jobs:
           [ "${{ steps.publish-auth.outcome }}" = "success" ] && echo "- ✅ fraiseql-auth" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-auth" >> "$GITHUB_STEP_SUMMARY"
           [ "${{ steps.publish-webhooks.outcome }}" = "success" ] && echo "- ✅ fraiseql-webhooks" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-webhooks" >> "$GITHUB_STEP_SUMMARY"
           [ "${{ steps.publish-wire.outcome }}" = "success" ] && echo "- ✅ fraiseql-wire" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-wire" >> "$GITHUB_STEP_SUMMARY"
+          [ "${{ steps.publish-cdc-sinks.outcome }}" = "success" ] && echo "- ✅ fraiseql-cdc-sinks" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-cdc-sinks" >> "$GITHUB_STEP_SUMMARY"
           [ "${{ steps.publish-db.outcome }}" = "success" ] && echo "- ✅ fraiseql-db" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-db" >> "$GITHUB_STEP_SUMMARY"
           [ "${{ steps.publish-storage.outcome }}" = "success" ] && echo "- ✅ fraiseql-storage" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-storage" >> "$GITHUB_STEP_SUMMARY"
           [ "${{ steps.publish-federation.outcome }}" = "success" ] && echo "- ✅ fraiseql-federation" >> "$GITHUB_STEP_SUMMARY" || echo "- ❌ fraiseql-federation" >> "$GITHUB_STEP_SUMMARY"
@@ -851,6 +876,7 @@ jobs:
           # list in the validate-release "Dry-run publish" step. The old step checked
           # only `fraiseql` (1 of 16) and soft-passed a miss as "indexing in progress".
           CRATES="fraiseql-guard fraiseql-error fraiseql-auth fraiseql-webhooks fraiseql-wire \
+                  fraiseql-cdc-sinks \
                   fraiseql-db fraiseql-storage fraiseql-federation fraiseql-core \
                   fraiseql-codegen fraiseql-arrow fraiseql-secrets fraiseql-observers \
                   fraiseql-functions fraiseql-server fraiseql-cli fraiseql"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4199,6 +4199,11 @@ disagreed, and the promise was the part that was wrong.
   It also caught a second silent omission: the "Verify all crates published" roll-up
   never checked `publish-guard`, so a failed `fraiseql-guard` publish was reported as a
   success.
+  ⚠ Consequence worth stating plainly: **`fraiseql-cdc-sinks` becomes installable for the
+  first time in this release.** It was announced in v2.9.0 as "a new, additive,
+  off-by-default crate" and has never been on crates.io in any release since — the
+  workspace built it, the release never shipped it. `fraiseql-guard`, the other crate new
+  since v2.14.1, was already in the publish list and is unaffected.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4187,6 +4187,14 @@ disagreed, and the promise was the part that was wrong.
   fraiseql-server` fails outright with ``no matching package named `fraiseql-cdc-sinks`
   found``, taking `fraiseql-cli` and the `fraiseql` umbrella with it — three of eighteen
   crates, discovered only after the tag exists.
+  ⚠ It would have failed **mid-sequence, as a partial publish**, not before the first
+  upload. `cargo` reports only the *first* unsatisfiable requirement, and at the release
+  floors that is `fraiseql-arrow = "^2.15.0"` — a sibling the tolerance forgives — so
+  `validate-release`'s dry-run never names `fraiseql-cdc-sinks` and goes green. Tiers 1
+  through 6.5 then publish **14 of the 18 crates irreversibly**, and Tier 7 is the first
+  step that fails. Re-running the job cannot fix it: `release.yml` runs from the tag, and
+  the repair is a workflow change. This is the v2.5.0 partial-publish class the tier
+  waits were written for, reached by a different route.
   The pre-tag gate was structurally unable to see it. `dry_run_failure_is_tolerable`
   forgives an unresolved sibling when that sibling appears in the crate list it was
   handed, and `legacyPublishOrder` contained it — so the dry-run went green on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4177,6 +4177,28 @@ disagreed, and the promise was the part that was wrong.
   documented, and enforces one heading per type in the newest section. It runs on push and
   on pull request, and blocks `release.yml`'s `validate-release`, so a tag cannot be cut on
   an incomplete changelog.
+- **`release.yml` publishes every crate the workspace has, and a gate keeps its list and
+  the pre-tag gate's list identical.** `fraiseql-cdc-sinks` entered the workspace with the
+  outbound-CDC work (#382) and became an **optional** dependency of `fraiseql-server`
+  *after* v2.14.1. It reached `.dagger/release.go`'s `legacyPublishOrder` — what
+  `make release-validate` dry-runs and topologically self-tests — but never reached
+  `release.yml`, which is what actually publishes. An optional dependency still has to
+  resolve on crates.io, so this was not one skipped crate: `cargo publish -p
+  fraiseql-server` fails outright with ``no matching package named `fraiseql-cdc-sinks`
+  found``, taking `fraiseql-cli` and the `fraiseql` umbrella with it — three of eighteen
+  crates, discovered only after the tag exists.
+  The pre-tag gate was structurally unable to see it. `dry_run_failure_is_tolerable`
+  forgives an unresolved sibling when that sibling appears in the crate list it was
+  handed, and `legacyPublishOrder` contained it — so the dry-run went green on the
+  promise that the ordered publish would ship it first, a promise `release.yml` did not
+  make. Nothing compared the two lists. `tools/check-publish-parity.py` (ShellGates →
+  the required preflight check) now fails unless every publishable workspace crate
+  appears in `legacyPublishOrder`, in release.yml's publish steps **in the same order**,
+  in every `CRATES=` list, and behind an index wait — the order equality being what
+  carries `PublishOrderSelftest`'s topological proof onto the job that publishes.
+  It also caught a second silent omission: the "Verify all crates published" roll-up
+  never checked `publish-guard`, so a failed `fraiseql-guard` publish was reported as a
+  success.
 
 ### Security
 

--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,7 @@ lint-tests-layout:
 test-release-tooling:
 	@bash tools/tests/release_helpers_test.sh
 	@bash tools/tests/dry_run_tolerance_test.sh
+	@bash tools/tests/publish_parity_test.sh
 
 # Unit tests for the advisory-deadline gate. Its boundary behaviour is worth
 # pinning: an off-by-one is a day on which every open branch is blocked by a
@@ -514,6 +515,17 @@ lint-deploy-versions:
 lint-fuzz-targets:
 	@bash tools/check-fuzz-targets.sh
 
+# Gate: every publishable workspace crate is published by release.yml, in the same
+# order .dagger/release.go dry-runs and topologically self-tests. fraiseql-cdc-sinks
+# (#382) reached the workspace and legacyPublishOrder but never reached release.yml;
+# because it is an OPTIONAL dependency of fraiseql-server, the pre-tag dry-run
+# tolerated the gap (its tolerance forgives a sibling that is in the list it was
+# handed) while the real publish could not resolve it at all. Nothing compared the
+# two lists until this gate.
+.PHONY: lint-publish-parity
+lint-publish-parity:
+	@python3 tools/check-publish-parity.py
+
 # Gate: pin the set of production files that READ TypeDefinition.internal (#665), so a
 # property-named flag cannot silently grow new consumers. See tools/check-internal-flag-sites.sh.
 .PHONY: lint-internal-flag
@@ -578,7 +590,7 @@ lint-sdk-dead-surface:
 # test suite or service-backed integration tests — those are `make test` and the
 # separate Dagger test/integration legs.
 .PHONY: preflight
-preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-deploy-versions lint-fuzz-targets lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
+preflight: fmt-check lint-sdk-dead-surface lint-tests-layout lint-expect lint-async-trait lint-gate-db lint-gate-core lint-deadlines lint-deploy-security lint-deploy-versions lint-fuzz-targets lint-publish-parity lint-routes lint-guard-parity lint-internal-flag lint-value-json lint-graphql-parse lint-docs-env-vars lint-docs-version lint-config-loaders lint-examples-postgres-only lint-suite-coverage lint-snapshot-pairing lint-empty-tests test-release-tooling test-changelog-gate
 	@echo "=== preflight: lint-unwrap (UNWRAP_ALLOW_LIMIT=3) ==="
 	@$(MAKE) --no-print-directory lint-unwrap UNWRAP_ALLOW_LIMIT=3
 	@echo "=== preflight: check-test-imports ==="

--- a/tools/check-publish-parity.py
+++ b/tools/check-publish-parity.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Gate: every publishable workspace crate is actually published, in one agreed order.
+
+The release ships crates.io artifacts from `.github/workflows/release.yml`, but the
+publish *order* is authored twice — once as the ordered `cargo publish --package`
+steps in that workflow, and once as `legacyPublishOrder` in `.dagger/release.go`,
+which is what the pre-tag gate (`make release-validate`) dry-runs and topologically
+self-tests. Nothing compared the two, and they drifted:
+
+`fraiseql-cdc-sinks` (#382) was added to the workspace and to `fraiseql-server`'s
+optional `cdc-outbound` dependency after v2.14.1. It reached `legacyPublishOrder`
+but never reached `release.yml`. Because an optional dependency still has to resolve
+on crates.io, that omission does not skip one crate — it fails `fraiseql-server`
+outright ("no matching package named `fraiseql-cdc-sinks` found") and takes
+`fraiseql-cli` and the `fraiseql` umbrella with it.
+
+The pre-tag gate could not see it: `dry_run_failure_is_tolerable` forgives an
+unresolved sibling *when the sibling is in the list it was handed*, and
+`legacyPublishOrder` did contain it. So the dry-run went green on the promise that
+the ordered publish would ship it first — a promise `release.yml` did not keep.
+
+This gate is that missing comparison. It is pure text parsing: no cargo, no git, so
+it runs in the toolchain-free ShellGates container.
+
+Checks:
+  1. The publishable workspace crates, `legacyPublishOrder`, the ordered publish
+     steps, and every `CRATES=` list in release.yml all name the same set.
+  2. The publish steps run in exactly `legacyPublishOrder`'s order — this is what
+     transfers PublishOrderSelftest's topological proof onto what actually ships.
+  3. Every published crate except the last is waited on by
+     `tools/wait-for-crates-index.sh` after it is published.
+  4. The publish-outcome roll-up names every publish step, so a failed publish
+     cannot be reported as a success.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+def repo_root() -> Path:
+    """The tree to check. argv[1] overrides it so the self-test can use fixtures."""
+    if len(sys.argv) > 1:
+        return Path(sys.argv[1]).resolve()
+    return Path(__file__).resolve().parent.parent
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+def section_of(line: str, current: str) -> str:
+    """Track the current TOML table header; returns the new current section."""
+    stripped = line.strip()
+    if stripped.startswith("[") and not stripped.startswith("[["):
+        return stripped
+    if stripped.startswith("[["):
+        return stripped
+    return current
+
+
+def workspace_members(manifest: Path) -> list[str]:
+    """Quoted paths inside the root [workspace] members array."""
+    text = manifest.read_text(encoding="utf-8")
+    match = re.search(r"^\[workspace\]\s*$(.*?)^\[", text, re.S | re.M)
+    block = match.group(1) if match else text
+    members = re.search(r"members\s*=\s*\[(.*?)\]", block, re.S)
+    if not members:
+        return []
+    return re.findall(r'"([^"]+)"', members.group(1))
+
+
+def package_name_and_publishable(manifest: Path) -> tuple[str | None, bool]:
+    """Read [package].name and whether the crate is publishable."""
+    name: str | None = None
+    publishable = True
+    current = ""
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        current = section_of(line, current)
+        if current != "[package]":
+            continue
+        if name is None:
+            m = re.match(r'\s*name\s*=\s*"([^"]+)"', line)
+            if m:
+                name = m.group(1)
+        m = re.match(r"\s*publish\s*=\s*(.+)", line)
+        if m:
+            value = m.group(1).split("#")[0].strip()
+            publishable = value not in ("false", "[]")
+    return name, publishable
+
+
+def publishable_workspace_crates(root: Path) -> list[str]:
+    found = []
+    for member in workspace_members(root / "Cargo.toml"):
+        manifest = root / member / "Cargo.toml"
+        if not manifest.is_file():
+            fail(f"workspace member {member!r} has no Cargo.toml at {manifest}")
+            sys.exit(1)
+        name, publishable = package_name_and_publishable(manifest)
+        if name is None:
+            fail(f"{manifest} has no [package] name")
+            sys.exit(1)
+        if publishable:
+            found.append(name)
+    return found
+
+
+def legacy_publish_order(release_go: Path) -> list[str]:
+    text = release_go.read_text(encoding="utf-8")
+    match = re.search(r"legacyPublishOrder\s*=\s*\[\]string\{(.*?)\n\}", text, re.S)
+    if not match:
+        fail(f"could not find legacyPublishOrder in {release_go}")
+        sys.exit(1)
+    body = re.sub(r"//[^\n]*", "", match.group(1))
+    return re.findall(r'"([^"]+)"', body)
+
+
+def yml_publish_order(text: str) -> list[str]:
+    return re.findall(r"cargo publish --package ([A-Za-z0-9_-]+)", text)
+
+
+def yml_crates_lists(text: str) -> list[tuple[int, list[str]]]:
+    """Every CRATES="..." assignment, with its 1-based line number.
+
+    The value spans continuation lines, so read to the closing quote.
+    """
+    out: list[tuple[int, list[str]]] = []
+    for match in re.finditer(r'CRATES="([^"]*)"', text, re.S):
+        line_no = text.count("\n", 0, match.start()) + 1
+        value = match.group(1).replace("\\\n", " ")
+        out.append((line_no, value.split()))
+    return out
+
+
+def crate_publish_step_ids(text: str) -> dict[str, str]:
+    """Map each published crate to the step id that publishes it.
+
+    The owning step of a `cargo publish --package X` command is the one whose `id:`
+    most recently precedes it, which pairs the two without assuming the id spells the
+    crate name (`fraiseql` is published by `publish-root`).
+    """
+    ids = [(m.start(), m.group(1)) for m in re.finditer(r"id:\s*(publish-[A-Za-z0-9_-]+)", text)]
+    out: dict[str, str] = {}
+    for match in re.finditer(r"cargo publish --package ([A-Za-z0-9_-]+)", text):
+        preceding = [step_id for pos, step_id in ids if pos < match.start()]
+        if preceding:
+            out[match.group(1)] = preceding[-1]
+    return out
+
+
+def yml_wait_lines(text: str) -> list[tuple[int, list[str]]]:
+    """Every wait-for-crates-index.sh invocation, with its 1-based line number.
+
+    The crate names are the bare trailing arguments. The leading version argument is
+    always quoted (`"${GITHUB_REF#refs/tags/v}"`), so filtering to bare identifiers
+    drops it without hardcoding a crate-name prefix.
+    """
+    out: list[tuple[int, list[str]]] = []
+    for match in re.finditer(r"wait-for-crates-index\.sh([^\n]*)", text):
+        line_no = text.count("\n", 0, match.start()) + 1
+        names = [
+            token
+            for token in match.group(1).split()
+            if re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", token)
+        ]
+        out.append((line_no, names))
+    return out
+
+
+def describe(label: str, got: set[str], want: set[str]) -> list[str]:
+    problems = []
+    missing = sorted(want - got)
+    extra = sorted(got - want)
+    if missing:
+        problems.append(f"{label} is missing: {', '.join(missing)}")
+    if extra:
+        problems.append(f"{label} names non-publishable/unknown crates: {', '.join(extra)}")
+    return problems
+
+
+def main() -> int:
+    root = repo_root()
+    release_yml = root / ".github/workflows/release.yml"
+    release_go = root / ".dagger/release.go"
+    for path in (release_yml, release_go, root / "Cargo.toml"):
+        if not path.is_file():
+            fail(f"missing {path}")
+            return 1
+
+    text = release_yml.read_text(encoding="utf-8")
+    crates = publishable_workspace_crates(root)
+    want = set(crates)
+    legacy = legacy_publish_order(release_go)
+    published = yml_publish_order(text)
+
+    problems: list[str] = []
+    problems += describe(f"{release_go.name} legacyPublishOrder", set(legacy), want)
+    problems += describe("release.yml publish steps", set(published), want)
+
+    crates_lists = yml_crates_lists(text)
+    if not crates_lists:
+        problems.append('release.yml has no CRATES="..." list — the parser or the file changed')
+    for line_no, names in crates_lists:
+        problems += describe(f"release.yml CRATES list at line {line_no}", set(names), want)
+
+    # Order parity: the ordered publish steps ARE legacyPublishOrder. PublishOrderSelftest
+    # proves that order is topologically valid against the real dependency graph; this
+    # equality is what carries that proof over to the job that actually publishes.
+    if set(published) == set(legacy) and published != legacy:
+        problems.append(
+            "release.yml publishes in a different order than legacyPublishOrder:\n"
+            f"    release.yml: {' -> '.join(published)}\n"
+            f"    release.go : {' -> '.join(legacy)}"
+        )
+
+    # Index waits: a crate published without a later wait can be missing from the sparse
+    # index when a dependent tries to resolve it. The final crate has no dependents.
+    waits = yml_wait_lines(text)
+    publish_lines = {
+        name: text.count("\n", 0, m.start()) + 1
+        for m in re.finditer(r"cargo publish --package ([A-Za-z0-9_-]+)", text)
+        for name in [m.group(1)]
+    }
+    for name in published[:-1]:
+        if not any(name in names and line_no > publish_lines[name] for line_no, names in waits):
+            problems.append(
+                f"{name} is published but never waited on by wait-for-crates-index.sh afterwards"
+            )
+
+    # The roll-up that decides whether the publish job succeeded must name every crate
+    # step. Scope this to that one step: the human-readable summary below it lists the
+    # same ids, and unioning the two would let the deciding list stay incomplete.
+    # `publish-pypi` lives in another job and is deliberately not in scope.
+    step_ids = crate_publish_step_ids(text)
+    verify = re.search(
+        r"- name: Verify all crates published\n(.*?)\n      - name: ", text, re.S
+    )
+    if not verify:
+        problems.append("release.yml has no 'Verify all crates published' step")
+    else:
+        outcomes = set(re.findall(r"steps\.(publish-[A-Za-z0-9_-]+)\.outcome", verify.group(1)))
+        unreported = sorted(set(step_ids.values()) - outcomes)
+        if unreported:
+            problems.append(
+                "publish steps whose outcome the 'Verify all crates published' roll-up never "
+                "checks (a failed publish would read as success): " + ", ".join(unreported)
+            )
+
+    if problems:
+        print("Publish parity gate FAILED:\n", file=sys.stderr)
+        for problem in problems:
+            fail(problem)
+        print(
+            "\nEvery publishable workspace crate must appear, in one agreed order, in:\n"
+            "  - .dagger/release.go        legacyPublishOrder\n"
+            "  - .github/workflows/release.yml   the ordered `cargo publish --package` steps,\n"
+            "                                   every CRATES= list, and an index wait\n"
+            "A crate that is only in one of them passes the pre-tag dry-run and fails the\n"
+            "real publish — see this file's docstring for how #382 did exactly that.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: {len(crates)} publishable crates; release.yml and legacyPublishOrder agree "
+        f"on membership and order, every crate but the last is index-waited, and all "
+        f"{len(step_ids)} crate publish steps are outcome-checked."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/publish_parity_test.sh
+++ b/tools/tests/publish_parity_test.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Unit tests for tools/check-publish-parity.py.
+#
+# Run directly:  bash tools/tests/publish_parity_test.sh
+# Exits non-zero if any assertion fails.
+#
+# The gate reads four files and compares them, so its fixtures are just a tree with
+# those four files in it — no toolchain, no git history. It therefore runs in Dagger
+# ShellGates alongside the gate itself.
+#
+# What is worth pinning here, in order of how badly each would hurt:
+#
+#   1. **A crate published nowhere.** This is the defect the gate was written for:
+#      `fraiseql-cdc-sinks` reached `legacyPublishOrder` and the workspace but never
+#      reached release.yml, and because it is an *optional* dependency of
+#      fraiseql-server the pre-tag dry-run tolerated it while the real publish could
+#      not. A gate that misses this direction is the gate we already had.
+#   2. **Order drift.** Membership parity alone is not enough: PublishOrderSelftest
+#      proves `legacyPublishOrder` is topologically valid, and only order *equality*
+#      carries that proof onto the steps that actually publish.
+#   3. **A missing index wait.** The sparse index lags; a dependent that resolves
+#      before its dependency is indexed fails the publish mid-run, which is the
+#      expensive, half-published failure mode.
+#   4. **An unchecked outcome.** The roll-up decides whether the job succeeded. A
+#      publish step missing from it reports a failed publish as a success — how
+#      `publish-guard` sat unchecked until this gate was written.
+#   5. **Green must be reachable.** A gate that fails on everything teaches people
+#      to skip it, so the untouched fixture must pass.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GATE="$REPO_ROOT/tools/check-publish-parity.py"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Fixture tree ─────────────────────────────────────────────────────────────
+# A miniature of the real layout: three publishable crates (a → b → c, published
+# in that order) plus one publish = false crate that must be ignored throughout.
+mk_tree() {
+    local dir="$WORK/$1"
+    mkdir -p "$dir/.github/workflows" "$dir/.dagger"
+    mkdir -p "$dir/crates/crate-a" "$dir/crates/crate-b" "$dir/crates/crate-c" "$dir/crates/crate-priv"
+
+    cat > "$dir/Cargo.toml" <<'EOF'
+[workspace]
+members = [
+  "crates/crate-a",
+  "crates/crate-b",
+  "crates/crate-c",
+  "crates/crate-priv"
+]
+EOF
+
+    for c in a b c; do
+        cat > "$dir/crates/crate-$c/Cargo.toml" <<EOF
+[package]
+name = "crate-$c"
+version = "1.0.0"
+EOF
+    done
+    cat > "$dir/crates/crate-priv/Cargo.toml" <<'EOF'
+[package]
+name = "crate-priv"
+version = "1.0.0"
+publish = false
+EOF
+
+    cat > "$dir/.dagger/release.go" <<'EOF'
+var legacyPublishOrder = []string{
+	// Tier 1.
+	"crate-a", "crate-b",
+	// Tier 2.
+	"crate-c",
+}
+EOF
+
+    cat > "$dir/.github/workflows/release.yml" <<'EOF'
+jobs:
+  validate-release:
+    steps:
+      - name: Dry-run publish for every publishable crate
+        run: |
+          CRATES="crate-a crate-b \
+                  crate-c"
+  publish-crates:
+    steps:
+      - name: Publish crate-a
+        id: publish-a
+        run: cargo publish --package crate-a --token X
+      - name: Wait for crates.io indexing (Tier 1)
+        run: bash tools/wait-for-crates-index.sh "$V" crate-a
+      - name: Publish crate-b
+        id: publish-b
+        run: cargo publish --package crate-b --token X
+      - name: Wait for crates.io indexing (Tier 2)
+        run: bash tools/wait-for-crates-index.sh "$V" crate-b
+      - name: Publish crate-c
+        id: publish-c
+        run: cargo publish --package crate-c --token X
+      - name: Verify all crates published
+        run: |
+          for step_outcome in \
+            "${{ steps.publish-a.outcome }}" \
+            "${{ steps.publish-b.outcome }}" \
+            "${{ steps.publish-c.outcome }}"; do
+            echo "$step_outcome"
+          done
+      - name: Report crates.io publishing results
+        run: echo done
+EOF
+    echo "$dir"
+}
+
+# assert_gate <expect-pass|expect-fail> <name> <tree-dir> [expected-substring]
+assert_gate() {
+    local mode="$1" name="$2" dir="$3" needle="${4:-}"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local out status
+    out="$(python3 "$GATE" "$dir" 2>&1)" && status=0 || status=$?
+
+    if [ "$mode" = "expect-pass" ] && [ "$status" -ne 0 ]; then
+        echo "FAIL: $name — expected exit 0, got $status"
+        echo "$out" | sed 's/^/       /'
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return
+    fi
+    if [ "$mode" = "expect-fail" ]; then
+        if [ "$status" -eq 0 ]; then
+            echo "FAIL: $name — expected a non-zero exit, gate passed"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            return
+        fi
+        # The gate must fail for the stated reason, not incidentally.
+        if [ -n "$needle" ] && ! printf '%s' "$out" | grep -qF "$needle"; then
+            echo "FAIL: $name — failed, but not for the expected reason"
+            echo "       wanted substring: $needle"
+            echo "$out" | sed 's/^/       /'
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            return
+        fi
+    fi
+    echo "ok: $name"
+}
+
+# ── 5. The untouched fixture passes ──────────────────────────────────────────
+base="$(mk_tree base)"
+assert_gate expect-pass "an aligned tree passes" "$base"
+
+# ── 1. A crate in the workspace + legacyPublishOrder but not in release.yml ──
+# This is #382 exactly: the crate exists and is ordered, but nothing publishes it.
+t="$(mk_tree missing_publish)"
+python3 - "$t" <<'PY'
+import re, sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".github/workflows/release.yml"
+text = p.read_text()
+text = text.replace("""      - name: Publish crate-b
+        id: publish-b
+        run: cargo publish --package crate-b --token X
+""", "")
+text = text.replace('            "${{ steps.publish-b.outcome }}" \\\n', "")
+text = text.replace("crate-a crate-b \\", "crate-a \\")
+p.write_text(text)
+PY
+assert_gate expect-fail "a crate published nowhere is caught" "$t" \
+    "release.yml publish steps is missing: crate-b"
+
+# ── 1b. …and the mirror: a crate dropped from legacyPublishOrder ─────────────
+t="$(mk_tree missing_legacy)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".dagger/release.go"
+p.write_text(p.read_text().replace('"crate-a", "crate-b",', '"crate-a",'))
+PY
+assert_gate expect-fail "a crate missing from legacyPublishOrder is caught" "$t" \
+    "legacyPublishOrder is missing: crate-b"
+
+# ── 1c. A CRATES= list that forgot one ───────────────────────────────────────
+t="$(mk_tree missing_crates_list)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".github/workflows/release.yml"
+p.write_text(p.read_text().replace('CRATES="crate-a crate-b \\', 'CRATES="crate-a \\'))
+PY
+assert_gate expect-fail "a CRATES= list that forgot a crate is caught" "$t" \
+    "CRATES list at line"
+
+# ── 2. Order drift between release.yml and legacyPublishOrder ────────────────
+t="$(mk_tree order_drift)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".dagger/release.go"
+p.write_text(p.read_text().replace('"crate-a", "crate-b",', '"crate-b", "crate-a",'))
+PY
+assert_gate expect-fail "order drift is caught" "$t" \
+    "different order than legacyPublishOrder"
+
+# ── 3. A published crate with no index wait after it ─────────────────────────
+t="$(mk_tree missing_wait)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".github/workflows/release.yml"
+text = p.read_text().replace("""      - name: Wait for crates.io indexing (Tier 1)
+        run: bash tools/wait-for-crates-index.sh "$V" crate-a
+""", "")
+p.write_text(text)
+PY
+assert_gate expect-fail "a publish with no index wait is caught" "$t" \
+    "crate-a is published but never waited on"
+
+# ── 3b. A wait that exists but runs BEFORE the publish it claims to cover ────
+# Ordering matters: a wait above its publish step observes the previous release's
+# version and returns immediately.
+t="$(mk_tree wait_before_publish)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".github/workflows/release.yml"
+text = p.read_text()
+text = text.replace("""      - name: Publish crate-a
+        id: publish-a
+        run: cargo publish --package crate-a --token X
+      - name: Wait for crates.io indexing (Tier 1)
+        run: bash tools/wait-for-crates-index.sh "$V" crate-a
+""", """      - name: Wait for crates.io indexing (Tier 1)
+        run: bash tools/wait-for-crates-index.sh "$V" crate-a
+      - name: Publish crate-a
+        id: publish-a
+        run: cargo publish --package crate-a --token X
+""")
+p.write_text(text)
+PY
+assert_gate expect-fail "an index wait placed before its publish is caught" "$t" \
+    "crate-a is published but never waited on"
+
+# ── 4. A publish step the success roll-up never checks ───────────────────────
+t="$(mk_tree unchecked_outcome)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".github/workflows/release.yml"
+p.write_text(p.read_text().replace('            "${{ steps.publish-b.outcome }}" \\\n', ""))
+PY
+assert_gate expect-fail "an unchecked publish outcome is caught" "$t" \
+    "publish-b"
+
+# ── 4b. The summary listing it does NOT satisfy the roll-up ──────────────────
+# The human-readable summary names the same ids; unioning the two would let the
+# deciding list stay incomplete while the gate reported green.
+t="$(mk_tree outcome_only_in_summary)"
+python3 - "$t" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1]) / ".github/workflows/release.yml"
+text = p.read_text()
+text = text.replace('            "${{ steps.publish-b.outcome }}" \\\n', "")
+text = text.replace("      - name: Report crates.io publishing results\n        run: echo done",
+                    '      - name: Report crates.io publishing results\n'
+                    '        run: echo "${{ steps.publish-b.outcome }}"')
+p.write_text(text)
+PY
+assert_gate expect-fail "an outcome named only in the summary is still caught" "$t" \
+    "publish-b"
+
+# ── A publish = false crate is not demanded anywhere ─────────────────────────
+# The fixture's crate-priv is absent from every list and the base case passes, so
+# this is already covered; assert it explicitly so a parser change cannot start
+# demanding that private crates be published.
+t="$(mk_tree private_crate_ignored)"
+assert_gate expect-pass "a publish = false crate is not demanded" "$t"
+
+echo ""
+echo "publish-parity gate self-test: $((TESTS_RUN - TESTS_FAILED))/$TESTS_RUN passed"
+[ "$TESTS_FAILED" -eq 0 ] || exit 1


### PR DESCRIPTION
Found while running P09's preconditions for the v2.15.0 cut. **This blocks the release.**

## The defect

`fraiseql-cdc-sinks` entered the workspace with the outbound-CDC work (#382) and became an **optional** dependency of `fraiseql-server` after v2.14.1. It reached `.dagger/release.go`'s `legacyPublishOrder` — what `make release-validate` dry-runs and topologically self-tests — but never reached `release.yml`, which is what actually publishes. Nothing compared the two lists.

An optional dependency still has to resolve on crates.io, so this is not one skipped crate. Reproduced on `origin/dev`, before any fix:

```
$ cargo package -p fraiseql-server --no-verify
error: failed to prepare local package for uploading
Caused by:
  no matching package named `fraiseql-cdc-sinks` found
  location searched: crates.io index
  required by package `fraiseql-server v2.14.1`
$ echo $?
101
```

`fraiseql-cli` and the `fraiseql` umbrella follow it down — three of eighteen crates.

## Why the pre-tag gate could not see it

`dry_run_failure_is_tolerable` forgives an unresolved sibling **when that sibling is in the crate list it was handed** — and `legacyPublishOrder` contained it. So `make release-validate` goes green on the promise that the ordered publish ships it first, a promise `release.yml` never made.

**Correction to my first reading of this PR**: I initially wrote that `validate-release` would have caught it at tag time, fail-closed. Measured at the real 2.15.0 floors in a scratch worktree, it would not.

`cargo` reports only the *first* unsatisfiable requirement. At the release floors that is `fraiseql-arrow = "^2.15.0"` — a sibling the tolerance forgives — so the `fraiseql-server` dry-run log never names `fraiseql-cdc-sinks` at all:

```
$ grep -c cdc-sinks <fraiseql-server dry-run log at 2.15.0 floors>
0
$ dry_run_failure_is_tolerable <log> "<the OLD crate list>"
tolerated (unresolved siblings: fraiseql-arrow)
```

So `validate-release` goes **green**, tiers 1 through 6.5 publish **14 of the 18 crates irreversibly**, and Tier 7 is the first step that fails. Re-running cannot repair it: `release.yml` runs from the tag, and the fix is a workflow change. This is the v2.5.0 partial-publish class, reached by a different route — the defect is more severe than this PR first stated, not less.

## Changes

- **`release.yml`**: new **Tier 1.5** publishing `fraiseql-cdc-sinks` after the Tier 1 index wait (it depends on `fraiseql-guard` and nothing else), with its own index wait; added to both `CRATES=` lists, the publish-outcome roll-up and the summary.
- **`tools/check-publish-parity.py`** (new): the comparison nobody was making. Pure text parsing — no cargo, no git — so it runs in the toolchain-free ShellGates container. Wired into ShellGates and `make preflight` as `lint-publish-parity`.
- **A second silent omission it caught**: the "Verify all crates published" roll-up never checked `steps.publish-guard.outcome`, so a failed `fraiseql-guard` publish was reported as a success.
- **`tools/tests/publish_parity_test.sh`** (new): 10 cases, each asserting the gate fails *for the stated reason*.

The order-equality check is the load-bearing part: `PublishOrderSelftest` proves `legacyPublishOrder` is topologically valid against the real dependency graph, and only equality carries that proof onto the job that actually publishes.

## Verification

- ✅ **Red-proven against the real defect**, not only fixtures: run against a tree whose sole difference is `origin/dev`'s `release.yml`, the gate reports the three missing list entries plus the unchecked outcome, exit 1.
- ✅ `python3 tools/check-publish-parity.py` → OK, 18 crates
- ✅ `make test-release-tooling` → exit 0 (release helpers, dry-run tolerance, 10/10 parity)
- ✅ `cd .dagger && go vet ./...` → exit 0; `gofmt -l .dagger/` → clean
- ✅ `pre-commit run` → exit 0 (actionlint passed on the workflow edits), no autofix drift
- ✅ `bash tools/check-changelog-issues.sh` → exit 0

## Two crates are published for the first time in v2.15.0

Checked against crates.io: of the 18 publishable crates, exactly two are absent.

| crate | new since | in `release.yml` before this PR? |
|---|---|---|
| `fraiseql-guard` | v2.14.1 | ✅ yes — Tier 1, unaffected |
| `fraiseql-cdc-sinks` | announced **v2.9.0**, never published | ❌ no — this PR |

`fraiseql-cdc-sinks` has been announced since v2.9.0 (2026-06-22) while never being installable. Both names are free on crates.io and claiming them is permanent; publishing `fraiseql-cdc-sinks` was confirmed with the maintainer before this PR.

⚠ **Operational precondition for the tag**: `CARGO_TOKEN` must be allowed to publish *new* crates. A token scoped to `publish-update`, or restricted to the existing crate list, will 403 on both of these. This is not introduced by this PR — `fraiseql-guard` already faced it — but it is worth confirming before the tag rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
