### PR TITLE
fix(test): production_safety_test's FRAISEQL_ENV mutations stop racing each other

### DIFF
--- a/crates/fraiseql-server/tests/production_safety_test.rs
+++ b/crates/fraiseql-server/tests/production_safety_test.rs
@@ -7,7 +7,12 @@
 //!
 //! **Execution engine:** none
 //! **Infrastructure:** none
-//! **Parallelism:** safe
+//! **Parallelism:** safe — but only because every `FRAISEQL_ENV` mutation below goes
+//! through `temp_env`, whose internal mutex serialises them. This header claimed
+//! "safe" while two tests set and unset that process-global variable with bare
+//! `std::env::set_var`/`remove_var`, so one test's `remove_var` could land between
+//! the other's `set_var` and the `validate()` that reads it. Do not reintroduce a
+//! bare mutation here: it is invisible until it reddens a release gate at random.
 #![allow(clippy::unwrap_used, clippy::panic)] // Reason: test code, panics acceptable
 #![allow(clippy::cast_precision_loss)] // Reason: test metrics use usize/u64→f64 for reporting
 #![allow(clippy::cast_sign_loss)] // Reason: test data uses small positive integers
@@ -57,27 +62,22 @@ fn test_playground_can_be_enabled() {
 fn test_production_mode_default() {
     // When FRAISEQL_ENV is not set, defaults to production mode.
     // When set to "development"/"dev", returns false.
-    let original = std::env::var("FRAISEQL_ENV").ok();
+    //
+    // Both states go through `temp_env`, whose internal mutex is the only thing
+    // serialising these mutations against the other FRAISEQL_ENV test in this binary.
+    temp_env::with_var_unset("FRAISEQL_ENV", || {
+        assert!(
+            ServerConfig::is_production_mode(),
+            "without FRAISEQL_ENV, must default to production mode"
+        );
+    });
 
-    // Simulate unset: production
-    std::env::remove_var("FRAISEQL_ENV");
-    assert!(
-        ServerConfig::is_production_mode(),
-        "without FRAISEQL_ENV, must default to production mode"
-    );
-
-    // Simulate development mode
-    std::env::set_var("FRAISEQL_ENV", "development");
-    assert!(
-        !ServerConfig::is_production_mode(),
-        "FRAISEQL_ENV=development must not be production mode"
-    );
-
-    // Restore original env state
-    match original {
-        Some(v) => std::env::set_var("FRAISEQL_ENV", v),
-        None => std::env::remove_var("FRAISEQL_ENV"),
-    }
+    temp_env::with_var("FRAISEQL_ENV", Some("development"), || {
+        assert!(
+            !ServerConfig::is_production_mode(),
+            "FRAISEQL_ENV=development must not be production mode"
+        );
+    });
 }
 
 // =============================================================================
@@ -134,24 +134,21 @@ fn test_cors_multiple_origins_passes_validation() {
 #[test]
 fn test_development_allows_playground_and_empty_cors() {
     // In development mode, playground=true with empty cors_origins must pass validation.
-    let original = std::env::var("FRAISEQL_ENV").ok();
-    std::env::set_var("FRAISEQL_ENV", "development");
+    //
+    // `validate()` reads FRAISEQL_ENV, so the read must happen INSIDE the closure that
+    // holds temp_env's lock — a set-then-validate pair outside it is what raced.
+    temp_env::with_var("FRAISEQL_ENV", Some("development"), || {
+        let config = ServerConfig {
+            playground_enabled: true,
+            cors_enabled: true,
+            cors_origins: vec![], // Empty origins are acceptable in development
+            ..ServerConfig::default()
+        };
 
-    let config = ServerConfig {
-        playground_enabled: true,
-        cors_enabled: true,
-        cors_origins: vec![], // Empty origins are acceptable in development
-        ..ServerConfig::default()
-    };
-
-    config.validate().unwrap_or_else(|e| {
-        panic!("in development mode, playground + empty cors_origins must pass validation: {e}")
+        config.validate().unwrap_or_else(|e| {
+            panic!("in development mode, playground + empty cors_origins must pass validation: {e}")
+        });
     });
-
-    match original {
-        Some(v) => std::env::set_var("FRAISEQL_ENV", v),
-        None => std::env::remove_var("FRAISEQL_ENV"),
-    }
 }
 
 // =============================================================================


### PR DESCRIPTION
`Dagger — test (stable)` went red on dev `d9b5efbd2` while gating the v2.15.0 cut. This is the fix; the failure is a pre-existing flake, not a regression.

```
thread 'test_development_allows_playground_and_empty_cors' panicked at
crates/fraiseql-server/tests/production_safety_test.rs:148:9:
  in development mode, playground + empty cors_origins must pass validation:
  playground_enabled is true in production mode.
```

## The race

Nothing in that commit range touches Rust — the merge before it was `release.yml`, a Makefile target, a Go line and two new gate files. `test (msrv)` passed in the same run, and the immediately preceding head `e9b86f8d7` passed. Two tests in this **one binary** mutate the process-global `FRAISEQL_ENV` with bare `set_var`/`remove_var`, unsynchronised, on separate threads:

| test | does |
|---|---|
| `test_production_mode_default` | `remove_var("FRAISEQL_ENV")` (:63, :79) |
| `test_development_allows_playground_and_empty_cors` | `set_var(…,"development")` (:138) → `validate()` (:147) |

`validate()` reads `FRAISEQL_ENV`. When the first test's `remove_var` lands between the second's `set_var` and its `validate()`, validation sees an unset variable, defaults to production mode and rejects the playground — exactly the observed panic.

## The fix

Both tests now mutate through `temp_env`, already a dev-dependency here. temp-env 0.3.6 holds a process-wide `static SERIAL_TEST: ReentrantMutex<()>` and locks it for the whole closure, so all `with_var*` callers serialise; reentrancy makes the two sequential calls safe. The read moves **inside** the lock-holding closure — a set-then-read pair outside it is precisely what raced.

The module header claimed `**Parallelism:** safe` while it was true of neither test. It now says why it is safe and warns against reintroducing a bare mutation.

## Verification — RED proven, then GREEN

My first attempt at proof was worthless, and I'm recording it so nobody repeats it: running the **whole binary** 200× passed on *both* versions, because 16 tests dilute the overlap. So did 300× under `taskset -c 0,1 --test-threads=16`. Running only the two racing tests on two threads makes them reliably concurrent:

```
$BIN test_production_mode_default test_development_allows_playground_and_empty_cors \
     --test-threads=2       # ×3000

racing (HEAD~1 content):   213 failures / 3000   (7.1%)
fixed  (this branch):        0 failures / 3000
fixed, full binary:          0 failures /  300
```

Same binary path, same command, only the file's content swapped — the delta is the fix, not the harness.

- ✅ builds clean with the CI `SERVER_FEATURES` set
- ✅ no `std::env::set_var(` / `remove_var(` call remains in the file
- ✅ `pre-commit run` → exit 0, no autofix drift

## Context

`d9b5efbd2` is green on `preflight`, `security`, `feature matrix` and `integration` — the last being its first uninterrupted run since 2026-08-15. This flake was the only red standing between the release content and a fully green head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)