### PR TITLE
fix(cli): state_encryption stops defaulting on, so a project that never asked for it boots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2804,6 +2804,41 @@ disagreed, and the promise was the part that was wrong.
 
 ### Fixed
 
+- **`state_encryption` no longer defaults on, so a project that never asked for it still
+  boots (#1151).** `fraiseql-cli`'s `StateEncryptionConfig::default()` was `enabled: true`
+  while `fraiseql-core`'s — the documented contract, "off unless asked for" — was `false`.
+  The cli's is the one that reaches the compiled artifact. Because the field is not an
+  `Option` and its enclosing `SecurityConfig` carries `#[serde(default)]`, a config with no
+  `[fraiseql.security.state_encryption]` table compiled an artifact **declaring the control
+  enabled**, and the server then refused to start:
+
+  ```text
+  Error: Configuration error: state_encryption enabled but key env var
+  'STATE_ENCRYPTION_KEY' failed: env var STATE_ENCRYPTION_KEY not set
+  ```
+
+  The value had been `true` since well before 2.14: it simply never reached a reader,
+  because the compiled key was emitted as `stateEncryption` while the runtime read
+  `state_encryption`. Fixing that casing (#893/#977/#983) is correct and stays — but it
+  converted a silent no-op into a hard boot failure for every deployment that never opted
+  in. **This was found by a beta tester against `release/2.15.0` before the tag; it would
+  have shipped otherwise.**
+
+  Scope, measured rather than assumed: the two compile workflows use different structs, and
+  only one was affected. `fraiseql compile fraiseql.toml` (top-level tables) emitted
+  `state_encryption: null` throughout and never had the defect. `fraiseql compile
+  schema.json` with a `fraiseql.toml` in the working directory — the path the Python and
+  TypeScript SDKs feed, since they emit `schema.json` — is the one that lowered
+  `enabled: true`.
+
+  Also fixed: the PKCE boot error told operators to supply the key via
+  `FRAISEQL_STATE_ENCRYPTION_KEY`, a name nothing reads. The reader resolves `key_env`,
+  defaulting to `STATE_ENCRYPTION_KEY`, and the message now says so.
+
+  ⚠ A test asserted the wrong default (`assert!(config.state_encryption.enabled)`), which is
+  how the divergence survived review — the defect had a test holding it in place. That
+  assertion is inverted, and two regression tests were added: one on the **lowered artifact**
+  rather than the struct field, and one pinning the cli default equal to `fraiseql-core`'s.
 - **The generated TypeScript and Python clients type a half-precision or sparse vector
   field (#959).** Both renderers learned `Vector` and `BitVector` when those landed and
   not `HalfVector` or `SparseVector`, which fell through a wildcard arm to `unknown` /

--- a/crates/fraiseql-cli/src/config/security.rs
+++ b/crates/fraiseql-cli/src/config/security.rs
@@ -213,7 +213,14 @@ pub struct StateEncryptionConfig {
 impl Default for StateEncryptionConfig {
     fn default() -> Self {
         Self {
-            enabled:   true,
+            // Off unless the operator asks for it, matching
+            // `fraiseql_core::schema::StateEncryptionConfig` (#1151). This field is not an
+            // `Option` and the enclosing `SecurityConfig` carries `#[serde(default)]`, so an
+            // absent `[security.state_encryption]` table lands here and is lowered verbatim
+            // into the compiled artifact. Defaulting it on therefore enabled a control the
+            // operator never chose, and the server refuses to boot when the key env var is
+            // unset — a hard upgrade failure for every project that never opted in.
+            enabled:   false,
             algorithm: "chacha20-poly1305".to_string(),
         }
     }

--- a/crates/fraiseql-cli/src/config/tests.rs
+++ b/crates/fraiseql-cli/src/config/tests.rs
@@ -471,14 +471,70 @@ ssl_mode = "require"
 mod security_tests {
     use super::super::security::*;
 
+    /// #1151 — a project that never mentions `[fraiseql.security.state_encryption]` must not
+    /// compile an artifact declaring it enabled.
+    ///
+    /// This struct's `state_encryption` field is **not** an `Option` and the struct carries
+    /// `#[serde(default)]`, so an absent table becomes `StateEncryptionConfig::default()`. When
+    /// that default was `enabled: true`, `to_json()` lowered `enabled: true` into the compiled
+    /// artifact, and the server refused to boot:
+    ///
+    /// ```text
+    /// Error: Configuration error: state_encryption enabled but key env var
+    /// 'STATE_ENCRYPTION_KEY' failed: env var STATE_ENCRYPTION_KEY not set
+    /// ```
+    ///
+    /// The value had been `true` since before 2.14, but the compiled key was emitted as
+    /// `stateEncryption` while the runtime read `state_encryption`, so nothing ever read it.
+    /// Fixing that casing (#893/#977/#983) turned a silent no-op into a hard boot failure — so
+    /// the assertion that matters is on the **lowered artifact**, not just the struct field.
+    #[test]
+    fn state_encryption_is_off_unless_the_operator_asks_for_it() {
+        let lowered = SecurityConfig::default().to_json();
+        let enabled = lowered
+            .get("state_encryption")
+            .and_then(|se| se.get("enabled"))
+            .and_then(serde_json::Value::as_bool);
+
+        assert_ne!(
+            enabled,
+            Some(true),
+            "a config that never mentions state_encryption compiled an artifact enabling it; \
+             the server then refuses to boot without STATE_ENCRYPTION_KEY (#1151). Lowered: {lowered}"
+        );
+    }
+
+    /// #1151 — the two structs named `StateEncryptionConfig` must agree on the default.
+    ///
+    /// `fraiseql-core`'s is the documented contract ("off unless asked for"); this crate's is the
+    /// one that reaches the artifact. They disagreed silently, which is what made the divergence
+    /// survive: each looked correct on its own.
+    #[test]
+    fn state_encryption_default_agrees_with_fraiseql_core() {
+        assert_eq!(
+            StateEncryptionConfig::default().enabled,
+            fraiseql_core::schema::StateEncryptionConfig::default().enabled,
+            "fraiseql-cli and fraiseql-core disagree on the state_encryption default; the cli's \
+             is the one compiled into the artifact (#1151)"
+        );
+    }
+
     #[test]
     fn test_default_security_config() {
         let config = SecurityConfig::default();
         assert!(config.audit_logging.enabled);
         assert!(config.error_sanitization.enabled);
         assert!(config.rate_limiting.enabled);
-        assert!(config.state_encryption.enabled);
         assert!(config.constant_time.enabled);
+        // state_encryption is deliberately NOT in the on-by-default list. This test used to
+        // assert it was, which is how the divergence from fraiseql-core survived review: the
+        // wrong default had a test pinning it in place (#1151). The controls above are inert
+        // without further configuration; state encryption is not — enabling it demands a key,
+        // and demanding a key the operator never configured stops the server from booting.
+        assert!(
+            !config.state_encryption.enabled,
+            "state encryption must stay off until asked for — see #1151"
+        );
     }
 
     /// #983 — the four `[fraiseql.security.error_sanitization]` keys that reached no

--- a/crates/fraiseql-server/src/server/initialization.rs
+++ b/crates/fraiseql-server/src/server/initialization.rs
@@ -447,7 +447,11 @@ pub(super) fn pkce_state_encryption_check(
                 "  To fix, enable state encryption:\n",
                 "    [security.state_encryption]\n",
                 "    enabled = true\n",
-                "    # 32-byte key supplied via FRAISEQL_STATE_ENCRYPTION_KEY\n\n",
+                // The reader is `fraiseql_auth::state_encryption`, which resolves
+                // `key_env` and falls back to STATE_ENCRYPTION_KEY — never the
+                // FRAISEQL_-prefixed name this message used to print (#1151).
+                "    # 32-byte hex key supplied via STATE_ENCRYPTION_KEY\n",
+                "    # (or set key_env to name a different variable)\n\n",
                 "  For local development only:\n",
                 "    Set FRAISEQL_ENV=development to downgrade this to a warning.",
             )


### PR DESCRIPTION
Closes #1151. Found by a beta tester against `release/2.15.0` (`f9c7bab5f`) **before the tag** — reproduced end to end here, then fixed. It would otherwise have shipped in 2.15.0.

## The defect

`fraiseql-cli`'s `StateEncryptionConfig::default()` was `enabled: true`; `fraiseql-core`'s — the documented contract, *"off unless asked for"* — is `false`. The cli's is the one that reaches the compiled artifact.

The field is not an `Option`, and its enclosing `SecurityConfig` carries `#[serde(default)]`. So a config with **no** `[fraiseql.security.state_encryption]` table lands on that default and lowers it verbatim:

```json
"state_encryption": {"enabled": true, "algorithm": "chacha20-poly1305",
                     "key_source": "env", "key_env": "STATE_ENCRYPTION_KEY"}
```

and the server refuses to start:

```
Error: Configuration error: state_encryption enabled but key env var
'STATE_ENCRYPTION_KEY' failed: env var STATE_ENCRYPTION_KEY not set
```

The value has been `true` since well before 2.14 — it just never reached a reader, because the compiled key was emitted as `stateEncryption` while the runtime read `state_encryption`. Fixing that casing (#893/#977/#983) is right and stays. It converted a silent no-op into a hard boot failure on a control the operator never chose.

## Scope — measured with the real binary, not assumed

| workflow | artifact | |
|---|---|---|
| `compile fraiseql.toml` (top-level tables) | `state_encryption: null` | unaffected |
| `compile schema.json` + cwd `fraiseql.toml` | **`enabled: true`** | affected |

The affected path is `commands/compile.rs:266` (`config.fraiseql.security.to_json()`) — the one the Python and TypeScript SDKs feed, since they emit `schema.json`. Both branches were compiled and inspected; the issue does not distinguish them, and a fix aimed at the other struct would have changed nothing.

## Changes

- `StateEncryptionConfig::default()` → `enabled: false`, agreeing with `fraiseql-core`.
- The PKCE boot error told operators to set `FRAISEQL_STATE_ENCRYPTION_KEY` — **a name nothing reads**. The reader resolves `key_env`, defaulting to `STATE_ENCRYPTION_KEY`. Message corrected.

## ⚠ A test was pinning the defect

`test_default_security_config` asserted `config.state_encryption.enabled`. That is how the divergence survived review — the wrong default had a test holding it in place, so correcting it would have read as a regression. Inverted, with the reason recorded inline.

Two regression tests added, both **red-proven before the fix**:
- `state_encryption_is_off_unless_the_operator_asks_for_it` — asserts on the **lowered artifact**, not the struct field. The struct field is not what boots a server.
- `state_encryption_default_agrees_with_fraiseql_core` — pins the two same-named structs together so they cannot drift apart silently again.

## Verification

Before: both new tests fail, the artifact assertion printing the full lowered JSON. After:

```
$ fraiseql compile schema.json          # cwd fraiseql.toml, no state_encryption
state_encryption = {"enabled": false, ...}
$ fraiseql-server --schema-path ...     # STATE_ENCRYPTION_KEY unset
... Starting FraiseQL server bind_addr=127.0.0.1:8000    # boots past the gate
```

- ✅ `cargo test -p fraiseql-cli` → 735 passed, 0 failed (full suite, not just `--lib`)
- ✅ `cargo test -p fraiseql-auth` → 907 passed, 0 failed
- ✅ `cargo clippy --workspace --all-features --all-targets -- -D warnings` → 0
- ✅ `cargo +nightly fmt --check` → 0 · `check-changelog-issues` → 0 · `pre-commit` → 0

## Noted, not fixed here

`docker/e2e/schema.compiled.json` carries **no `security` block at all**, so `release-smoke` — the gate for "compiles but panics on boot" — cannot reach this class of failure. Its green said nothing about #1151. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)